### PR TITLE
Codesign w/ debugging entitlement for backtraces on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Swift Next
 
   In packages that specify resources using a future tools version, the generated resource bundle accessor will import `Foundation.Bundle` for its own implementation only. _Clients_ of such packages therefore no longer silently import `Foundation`, preventing inadvertent use of Foundation extensions to standard library APIs, which helps to avoid unexpected code size increases.
 
+* [#7010]
+
+  On macOS, `swift build` and `swift run` now produce binaries that allow backtraces in debug builds. Pass `SWIFT_BACKTRACE=enable=yes` environment variable to enable backtraces on such binaries when running them.
 
 Swift 5.9
 -----------

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -367,6 +367,10 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
         return flags
     }
+
+    func codeSigningArguments(plistPath: AbsolutePath, binaryPath: AbsolutePath) -> [String] {
+        ["codesign", "--force", "--sign", "-", "--entitlements", plistPath.pathString, binaryPath.pathString]
+    }
 }
 
 extension SortedArray where Element == AbsolutePath {

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -148,7 +148,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     }
 
     /// The arguments to link and create this product.
-    public func linkArguments(outputPathSuffix: String = "") throws -> [String] {
+    public func linkArguments() throws -> [String] {
         var args = [buildParameters.toolchain.swiftCompilerPath.pathString]
         args += self.buildParameters.sanitizers.linkSwiftFlags()
         args += self.additionalFlags
@@ -164,7 +164,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         }
 
         args += ["-L", self.buildParameters.buildPath.pathString]
-        args += try ["-o", binaryPath.pathString + outputPathSuffix]
+        args += try ["-o", binaryPath.pathString]
         args += ["-module-name", self.product.name.spm_mangledToC99ExtendedIdentifier()]
         args += self.dylibs.map { "-l" + $0.product.name }
 

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -148,7 +148,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     }
 
     /// The arguments to link and create this product.
-    public func linkArguments() throws -> [String] {
+    public func linkArguments(outputPathSuffix: String = "") throws -> [String] {
         var args = [buildParameters.toolchain.swiftCompilerPath.pathString]
         args += self.buildParameters.sanitizers.linkSwiftFlags()
         args += self.additionalFlags
@@ -164,7 +164,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         }
 
         args += ["-L", self.buildParameters.buildPath.pathString]
-        args += try ["-o", binaryPath.pathString]
+        args += try ["-o", binaryPath.pathString + outputPathSuffix]
         args += ["-module-name", self.product.name.spm_mangledToC99ExtendedIdentifier()]
         args += self.dylibs.map { "-l" + $0.product.name }
 

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
@@ -56,6 +56,25 @@ extension LLBuildManifestBuilder {
                 outputs: [.file(buildProduct.binaryPath)],
                 arguments: try buildProduct.linkArguments()
             )
+
+            if buildParameters.debuggingParameters.shouldEnableDebuggingEntitlement {
+                let basename = try buildProduct.binaryPath.basename
+                let plistPath = try buildProduct.binaryPath.parentDirectory
+                    .appending(component: "\(basename)-entitlement.plist")
+                self.manifest.addEntitlementPlistCommand(
+                    entitlement: "com.apple.security.get-task-allow",
+                    outputPath: plistPath
+                )
+
+                let cmdName = try buildProduct.product.getCommandName(config: self.buildConfig)
+                try self.manifest.addShellCmd(
+                    name: "\(cmdName)-entitlements",
+                    description: "Applying debug entitlements to \(buildProduct.binaryPath.prettyPath())",
+                    inputs: [buildProduct.binaryPath, plistPath].map(Node.file),
+                    outputs: <#T##[Node]#>,
+                    arguments: <#T##[String]#>
+                )
+            }
         }
 
         // Create a phony node to represent the entire target.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
@@ -92,9 +92,9 @@ extension LLBuildManifestBuilder {
                 )
 
                 try self.manifest.addShellCmd(
-                    name: "\(cmdName)-entitlements",
+                    name: "\(cmdName)-codesigning",
                     description: "Applying debug entitlements to \(buildProduct.binaryPath.prettyPath())",
-                    inputs: [.virtual(targetName + "-CodeSigning")],
+                    inputs: [codeSigningOutput],
                     outputs: [.file(buildProduct.binaryPath)],
                     arguments: ["mv", linkedBinaryPath.pathString, buildProduct.binaryPath.pathString]
                 )

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -22,6 +22,7 @@ import struct TSCBasic.ByteString
 import enum TSCBasic.ProcessEnv
 import func TSCBasic.topologicalSort
 
+/// High-level interface to ``LLBuildManifest`` and ``LLBuildManifestWriter``.
 public class LLBuildManifestBuilder {
     public enum TargetKind {
         case main
@@ -42,7 +43,7 @@ public class LLBuildManifestBuilder {
     public let disableSandboxForPluginCommands: Bool
 
     /// File system reference.
-    let fileSystem: FileSystem
+    let fileSystem: any FileSystem
 
     /// ObservabilityScope with which to emit diagnostics
     public let observabilityScope: ObservabilityScope
@@ -60,7 +61,7 @@ public class LLBuildManifestBuilder {
     public init(
         _ plan: BuildPlan,
         disableSandboxForPluginCommands: Bool = false,
-        fileSystem: FileSystem,
+        fileSystem: any FileSystem,
         observabilityScope: ObservabilityScope
     ) {
         self.plan = plan

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -477,22 +477,11 @@ public struct BuildOptions: ParsableArguments {
     )
     public var linkTimeOptimizationMode: LinkTimeOptimizationMode?
 
-    /// Whether to enable debugging capabilities for code built by SwiftPM.
-    @Flag(
-        help: """
-        Whether to enable unsafe debugging and backtraces for code built by SwiftPM. \
-        Currently has an effect only on macOS.
-        """
-    )
-    public var enableUnsafeDebugging: Bool = false
+    @Flag(help: .hidden)
+    public var enableGetTaskAllowEntitlement: Bool = false
 
-    /// Whether to disable debugging capabilities for code built by SwiftPM.
-    @Flag(help: """
-        Whether to disable unsafe debugging and backtraces for code built by SwiftPM. \
-        Currently has an effect only on macOS.
-        """
-    )
-    public var disableUnsafeDebugging: Bool = false
+    @Flag(help: .hidden)
+    public var disableGetTaskAllowEntitlement: Bool = false
 
     // @Flag works best when there is a default value present
     // if true, false aren't enough and a third state is needed

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -477,6 +477,23 @@ public struct BuildOptions: ParsableArguments {
     )
     public var linkTimeOptimizationMode: LinkTimeOptimizationMode?
 
+    /// Whether to enable debugging capabilities for code built by SwiftPM.
+    @Flag(
+        help: """
+        Whether to enable unsafe debugging and backtraces for code built by SwiftPM. \
+        Currently has an effect only on macOS.
+        """
+    )
+    public var enableUnsafeDebugging: Bool = false
+
+    /// Whether to disable debugging capabilities for code built by SwiftPM.
+    @Flag(help: """
+        Whether to disable unsafe debugging and backtraces for code built by SwiftPM. \
+        Currently has an effect only on macOS.
+        """
+    )
+    public var disableUnsafeDebugging: Bool = false
+
     // @Flag works best when there is a default value present
     // if true, false aren't enough and a third state is needed
     // nil should not be the goto. Instead create an enum

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -664,6 +664,11 @@ public final class SwiftTool {
         return buildSystem
     }
 
+    static let entitlementsMacOSWarning = """
+    `--disable-get-task-allow-entitlement` and `--disable-get-task-allow-entitlement` only have an effect \
+    when building on macOS.
+    """
+
     private func _buildParams(toolchain: UserToolchain) throws -> BuildParameters {
         let hostTriple = try self.getHostToolchain().targetTriple
         let targetTriple = toolchain.targetTriple
@@ -671,6 +676,12 @@ public final class SwiftTool {
         let dataPath = self.scratchDirectory.appending(
             component: targetTriple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
         )
+
+        if !targetTriple.isMacOSX && (
+            options.build.disableGetTaskAllowEntitlement || options.build.enableGetTaskAllowEntitlement
+        ) {
+            observabilityScope.emit(warning: Self.entitlementsMacOSWarning)
+        }
 
         return try BuildParameters(
             dataPath: dataPath,

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -689,8 +689,8 @@ public final class SwiftTool {
                 debugInfoFormat: options.build.debugInfoFormat.buildParameter,
                 targetTriple: targetTriple,
                 shouldEnableDebuggingEntitlement:
-                    (options.build.configuration == .debug && !options.build.disableUnsafeDebugging) ||
-                    (options.build.enableUnsafeDebugging && !options.build.disableUnsafeDebugging)
+                    (options.build.configuration == .debug && !options.build.disableGetTaskAllowEntitlement) ||
+                    (options.build.enableGetTaskAllowEntitlement && !options.build.disableGetTaskAllowEntitlement)
             ),
             driverParameters: .init(
                 canRenameEntrypointFunctionName: driverSupport.checkSupportedFrontendFlags(

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -685,7 +685,13 @@ public final class SwiftTool {
             sanitizers: options.build.enabledSanitizers,
             indexStoreMode: options.build.indexStoreMode.buildParameter,
             isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
-            debugInfoFormat: options.build.debugInfoFormat.buildParameter,
+            debuggingParameters: .init(
+                debugInfoFormat: options.build.debugInfoFormat.buildParameter,
+                targetTriple: targetTriple,
+                shouldEnableDebuggingEntitlement:
+                    (options.build.configuration == .debug && !options.build.disableUnsafeDebugging) ||
+                    (options.build.enableUnsafeDebugging && !options.build.disableUnsafeDebugging)
+            ),
             driverParameters: .init(
                 canRenameEntrypointFunctionName: driverSupport.checkSupportedFrontendFlags(
                     flags: ["entry-point-function-name"],

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2020-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct Basics.Triple
+
+extension BuildParameters {
+    public struct Debugging: Encodable {
+        public init(
+            debugInfoFormat: DebugInfoFormat = .dwarf,
+            targetTriple: Triple,
+            shouldEnableDebuggingEntitlement: Bool
+        ) {
+            self.debugInfoFormat = debugInfoFormat
+
+            // Per rdar://112065568 for backtraces to work on macOS a special entitlement needs to be granted on the final
+            // executable.
+            self.shouldEnableDebuggingEntitlement = targetTriple.isMacOSX && shouldEnableDebuggingEntitlement
+        }
+
+        public var debugInfoFormat: DebugInfoFormat
+        
+        /// Whether the produced executable
+        public var shouldEnableDebuggingEntitlement: Bool
+    }
+
+    /// Represents the debugging strategy.
+    ///
+    /// Swift binaries requires the swiftmodule files in order for lldb to work.
+    /// On Darwin, linker can directly take the swiftmodule file path using the
+    /// -add_ast_path flag. On other platforms, we convert the swiftmodule into
+    /// an object file using Swift's modulewrap tool.
+    public enum DebuggingStrategy {
+        case swiftAST
+        case modulewrap
+    }
+
+    /// The debugging strategy according to the current build parameters.
+    public var debuggingStrategy: DebuggingStrategy? {
+        guard configuration == .debug else {
+            return nil
+        }
+
+        if targetTriple.isApple() {
+            return .swiftAST
+        }
+        return .modulewrap
+    }
+
+    /// Represents the debug information format.
+    ///
+    /// The debug information format controls the format of the debug information
+    /// that the compiler generates.  Some platforms support debug information
+    // formats other than DWARF.
+    public enum DebugInfoFormat: String, Encodable {
+        /// DWARF debug information format, the default format used by Swift.
+        case dwarf
+        /// CodeView debug information format, used on Windows.
+        case codeview
+        /// No debug information to be emitted.
+        case none
+    }
+
+}

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
@@ -28,7 +28,8 @@ extension BuildParameters {
 
         public var debugInfoFormat: DebugInfoFormat
         
-        /// Whether the produced executable
+        /// Whether the produced executable should be codesigned with the debugging entitlement, enabling enhanced
+        /// backtraces on macOS.
         public var shouldEnableDebuggingEntitlement: Bool
     }
 

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import struct Basics.Triple
+import enum PackageModel.BuildConfiguration
 
 extension BuildParameters {
     public struct Debugging: Encodable {

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -132,20 +132,24 @@ public struct BuildParameters: Encodable {
         indexStoreMode: IndexStoreMode = .auto,
         isXcodeBuildSystemEnabled: Bool = false,
         shouldSkipBuilding: Bool = false,
-        debuggingParameters: Debugging = .init(),
+        debuggingParameters: Debugging? = nil,
         driverParameters: Driver = .init(),
         linkingParameters: Linking = .init(),
         outputParameters: Output = .init(),
         testingParameters: Testing? = nil
     ) throws {
         let targetTriple = try targetTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
+        self.debuggingParameters = debuggingParameters ?? .init(
+            targetTriple: targetTriple,
+            shouldEnableDebuggingEntitlement: configuration == .debug
+        )
 
         self.dataPath = dataPath
         self.configuration = configuration
         self._toolchain = _Toolchain(toolchain: toolchain)
         self.hostTriple = try hostTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
         self.targetTriple = targetTriple
-        switch debuggingParameters.debugInfoFormat {
+        switch self.debuggingParameters.debugInfoFormat {
         case .dwarf:
             var flags = flags
             // DWARF requires lld as link.exe expects CodeView debug info.
@@ -182,7 +186,6 @@ public struct BuildParameters: Encodable {
         self.indexStoreMode = indexStoreMode
         self.isXcodeBuildSystemEnabled = isXcodeBuildSystemEnabled
         self.shouldSkipBuilding = shouldSkipBuilding
-        self.debuggingParameters = debuggingParameters
         self.driverParameters = driverParameters
         self.linkingParameters = linkingParameters
         self.outputParameters = outputParameters

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_library(SPMBuildCore
   BinaryTarget+Extensions.swift
   BuildParameters/BuildParameters.swift
+  BuildParameters/BuildParameters+Debugging.swift
   BuildParameters/BuildParameters+Driver.swift
   BuildParameters/BuildParameters+Linking.swift
   BuildParameters/BuildParameters+Output.swift

--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -1,0 +1,117 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2015-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@testable import Build
+import Basics
+import class TSCBasic.InMemoryFileSystem
+import PackageGraph
+import PackageModel
+import struct SPMBuildCore.BuildParameters
+import LLBuildManifest
+import SPMTestSupport
+import XCTest
+
+final class LLBuildManifestBuilderTests: XCTestCase {
+    func testCreateProductCommand() throws {
+        let pkg = AbsolutePath("/pkg")
+        let fs = InMemoryFileSystem(emptyFiles:
+            pkg.appending(components: "Sources", "exe", "main.swift").pathString
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: try .init(validating: pkg.pathString),
+                    targets: [
+                        TargetDescription(name: "exe"),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        var buildParameters = mockBuildParameters(environment: BuildEnvironment(
+            platform: .macOS,
+            configuration: .release
+        ))
+        var plan = try BuildPlan(
+            buildParameters: buildParameters,
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        var result = try BuildPlanResult(plan: plan)
+        var buildProduct = try result.buildProduct(for: "exe")
+
+        var llbuild = LLBuildManifestBuilder(plan, fileSystem: localFileSystem, observabilityScope: observability.topScope)
+        try llbuild.createProductCommand(buildProduct)
+
+        XCTAssertEqual(
+            llbuild.manifest.commands.map(\.key).sorted(),
+            [
+                "/path/to/build/release/exe.product/Objects.LinkFileList",
+                "<exe-release.exe>",
+                "C.exe-release.exe",
+            ]
+        )
+
+        buildParameters.debuggingParameters.shouldEnableDebuggingEntitlement = true
+        plan = try BuildPlan(
+            buildParameters: buildParameters,
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        result = try BuildPlanResult(plan: plan)
+        buildProduct = try result.buildProduct(for: "exe")
+
+        llbuild = LLBuildManifestBuilder(plan, fileSystem: localFileSystem, observabilityScope: observability.topScope)
+        try llbuild.createProductCommand(buildProduct)
+
+        let entitlementsCommandName = "C.exe-release.exe-entitlements"
+
+        XCTAssertEqual(
+            llbuild.manifest.commands.map(\.key).sorted(),
+            [
+                "/path/to/build/release/exe-entitlement.plist",
+                "/path/to/build/release/exe.product/Objects.LinkFileList",
+                "<exe-release.exe>",
+                "C.exe-release.exe",
+                entitlementsCommandName,
+            ]
+        )
+
+        guard let entitlementsCommand = llbuild.manifest.commands[entitlementsCommandName]?.tool as? ShellTool else {
+            XCTFail("unexpected entitlements command type")
+            return
+        }
+
+        XCTAssertEqual(
+            entitlementsCommand.inputs,
+            [
+                .file("/path/to/build/release/exe", isMutated: true),
+                .file("/path/to/build/release/exe-entitlement.plist")
+            ]
+        )
+        XCTAssertEqual(
+            entitlementsCommand.outputs,
+            [
+                .virtual("exe-release.exe-CodeSigning"),
+            ]
+        )
+    }
+}

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -118,7 +118,7 @@ func mockBuildParameters(environment: BuildEnvironment) -> BuildParameters {
         fatalError("unsupported platform in tests")
     }
 
-    return mockBuildParameters(config: environment.configuration ?? .debug,     targetTriple: triple)
+    return mockBuildParameters(config: environment.configuration ?? .debug, targetTriple: triple)
 }
 
 enum BuildError: Swift.Error {

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -12,6 +12,7 @@
 
 import Basics
 @testable import Commands
+@testable import CoreCommands
 import PackageGraph
 import PackageLoading
 import PackageModel
@@ -599,7 +600,7 @@ final class BuildToolTests: CommandsTestCase {
 
             XCTAssertNoMatch(output, .contains("codesign --force --sign - --entitlements"))
             #else
-            output = try self.build(["-v"], packagePath: fixturePath).output
+            var output = try self.build(["-v"], packagePath: fixturePath).output
 
             XCTAssertNoMatch(output, .contains("codesign --force --sign - --entitlements"))
 

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -616,7 +616,7 @@ final class BuildToolTests: CommandsTestCase {
             )
 
             XCTAssertNoMatch(buildResult.stdout, .contains("codesign --force --sign - --entitlements"))
-            XCTAssertMatch(buildResult.stdout, .contains(SwiftTool.entitlementsMacOSWarning))
+            XCTAssertMatch(buildResult.stderr, .contains(SwiftTool.entitlementsMacOSWarning))
 
             buildResult = try self.build(
                 ["--enable-get-task-allow-entitlement", "-v"],

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -30,27 +30,32 @@ final class BuildToolTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String] = [],
-        environment: [String : String]? = nil,
+        environment: [String: String]? = nil,
         packagePath: AbsolutePath? = nil
     ) throws -> (stdout: String, stderr: String) {
-        return try SwiftPM.Build.execute(args, packagePath: packagePath, env: environment)
+        try SwiftPM.Build.execute(args, packagePath: packagePath, env: environment)
     }
 
-    func build(_ args: [String], packagePath: AbsolutePath? = nil) throws -> BuildResult {
-        let (output, _) = try execute(args, packagePath: packagePath)
+    func build(_ args: [String], packagePath: AbsolutePath? = nil, isRelease: Bool = false) throws -> BuildResult {
+        let buildConfigurationArguments = isRelease ? ["-c", "release"] : []
+        let (output, _) = try execute(args + buildConfigurationArguments, packagePath: packagePath)
         defer { try! SwiftPM.Package.execute(["clean"], packagePath: packagePath) }
-        let (binPathOutput, _) = try execute(["--show-bin-path"], packagePath: packagePath)
+        let (binPathOutput, _) = try execute(
+            ["--show-bin-path"] + buildConfigurationArguments,
+            packagePath: packagePath
+        )
         let binPath = try AbsolutePath(validating: binPathOutput.trimmingCharacters(in: .whitespacesAndNewlines))
         let binContents = try localFileSystem.getDirectoryContents(binPath).filter {
             guard let contents = try? localFileSystem.getDirectoryContents(binPath.appending(component: $0)) else {
                 return true
             }
-            // Filter directories which only contain an output file map since we didn't build anything for those which is what `binContents` is meant to represent.
+            // Filter directories which only contain an output file map since we didn't build anything for those which
+            // is what `binContents` is meant to represent.
             return contents != ["output-file-map.json"]
         }
         return BuildResult(binPath: binPath, output: output, binContents: binContents)
     }
-    
+
     func testUsage() throws {
         let stdout = try execute(["-help"]).stdout
         XCTAssertMatch(stdout, .contains("USAGE: swift build"))
@@ -80,38 +85,62 @@ final class BuildToolTests: CommandsTestCase {
         // Verify the warning flow
         try fixture(name: "Miscellaneous/ImportOfMissingDependency") { path in
             let fullPath = try resolveSymlinks(path)
-            XCTAssertThrowsError(try build(["--explicit-target-dependency-import-check=warn"], packagePath: fullPath)) { error in
+            XCTAssertThrowsError(try self.build(
+                ["--explicit-target-dependency-import-check=warn"],
+                packagePath: fullPath
+            )) { error in
                 guard case SwiftPMError.executionFailure(_, let stdout, let stderr) = error else {
                     XCTFail()
                     return
                 }
 
-                XCTAssertTrue(stderr.contains("warning: Target A imports another target (B) in the package without declaring it a dependency."), "got stdout: \(stdout), stderr: \(stderr)")
+                XCTAssertTrue(
+                    stderr
+                        .contains(
+                            "warning: Target A imports another target (B) in the package without declaring it a dependency."
+                        ),
+                    "got stdout: \(stdout), stderr: \(stderr)"
+                )
             }
         }
 
         // Verify the error flow
         try fixture(name: "Miscellaneous/ImportOfMissingDependency") { path in
             let fullPath = try resolveSymlinks(path)
-            XCTAssertThrowsError(try build(["--explicit-target-dependency-import-check=error"], packagePath: fullPath)) { error in
+            XCTAssertThrowsError(try self.build(
+                ["--explicit-target-dependency-import-check=error"],
+                packagePath: fullPath
+            )) { error in
                 guard case SwiftPMError.executionFailure(_, _, let stderr) = error else {
                     XCTFail()
                     return
                 }
 
-                XCTAssertTrue(stderr.contains("error: Target A imports another target (B) in the package without declaring it a dependency."), "got stdout: \(stdout), stderr: \(stderr)")
+                XCTAssertTrue(
+                    stderr
+                        .contains(
+                            "error: Target A imports another target (B) in the package without declaring it a dependency."
+                        ),
+                    "got stdout: \(stdout), stderr: \(stderr)"
+                )
             }
         }
 
         // Verify that the default does not run the check
         try fixture(name: "Miscellaneous/ImportOfMissingDependency") { path in
             let fullPath = try resolveSymlinks(path)
-            XCTAssertThrowsError(try build([], packagePath: fullPath)) { error in
+            XCTAssertThrowsError(try self.build([], packagePath: fullPath)) { error in
                 guard case SwiftPMError.executionFailure(_, _, let stderr) = error else {
                     XCTFail()
                     return
                 }
-                XCTAssertFalse(stderr.contains("warning: Target A imports another target (B) in the package without declaring it a dependency."), "got stdout: \(stdout), stderr: \(stderr)")
+                XCTAssertFalse(
+                    stderr
+                        .contains(
+                            "warning: Target A imports another target (B) in the package without declaring it a dependency."
+                        ),
+                    "got stdout: \(stdout), stderr: \(stderr)"
+                )
             }
         }
     }
@@ -119,31 +148,52 @@ final class BuildToolTests: CommandsTestCase {
     func testBinPathAndSymlink() throws {
         try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             let fullPath = try resolveSymlinks(fixturePath)
-            let targetPath = fullPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent)
+            let targetPath = try fullPath.appending(
+                components: ".build",
+                UserToolchain.default.targetTriple.platformBuildPathComponent
+            )
             let xcbuildTargetPath = fullPath.appending(components: ".build", "apple")
-            XCTAssertEqual(try execute(["--show-bin-path"], packagePath: fullPath).stdout,
-                           "\(targetPath.appending("debug").pathString)\n")
-            XCTAssertEqual(try execute(["-c", "release", "--show-bin-path"], packagePath: fullPath).stdout,
-                           "\(targetPath.appending("release").pathString)\n")
+            XCTAssertEqual(
+                try self.execute(["--show-bin-path"], packagePath: fullPath).stdout,
+                "\(targetPath.appending("debug").pathString)\n"
+            )
+            XCTAssertEqual(
+                try self.execute(["-c", "release", "--show-bin-path"], packagePath: fullPath).stdout,
+                "\(targetPath.appending("release").pathString)\n"
+            )
 
             // Print correct path when building with XCBuild.
-            let xcodeDebugOutput = try execute(["--build-system", "xcode", "--show-bin-path"], packagePath: fullPath).stdout
-            let xcodeReleaseOutput = try execute(["--build-system", "xcode", "-c", "release", "--show-bin-path"], packagePath: fullPath).stdout
-          #if os(macOS)
-            XCTAssertEqual(xcodeDebugOutput, "\(xcbuildTargetPath.appending(components: "Products", "Debug").pathString)\n")
-            XCTAssertEqual(xcodeReleaseOutput, "\(xcbuildTargetPath.appending(components: "Products", "Release").pathString)\n")
-          #else
+            let xcodeDebugOutput = try execute(["--build-system", "xcode", "--show-bin-path"], packagePath: fullPath)
+                .stdout
+            let xcodeReleaseOutput = try execute(
+                ["--build-system", "xcode", "-c", "release", "--show-bin-path"],
+                packagePath: fullPath
+            ).stdout
+            #if os(macOS)
+            XCTAssertEqual(
+                xcodeDebugOutput,
+                "\(xcbuildTargetPath.appending(components: "Products", "Debug").pathString)\n"
+            )
+            XCTAssertEqual(
+                xcodeReleaseOutput,
+                "\(xcbuildTargetPath.appending(components: "Products", "Release").pathString)\n"
+            )
+            #else
             XCTAssertEqual(xcodeDebugOutput, "\(targetPath.appending("debug").pathString)\n")
             XCTAssertEqual(xcodeReleaseOutput, "\(targetPath.appending("release").pathString)\n")
-          #endif
+            #endif
 
             // Test symlink.
-            try execute(packagePath: fullPath)
-            XCTAssertEqual(try resolveSymlinks(fullPath.appending(components: ".build", "debug")),
-                           targetPath.appending("debug"))
-            try execute(["-c", "release"], packagePath: fullPath)
-            XCTAssertEqual(try resolveSymlinks(fullPath.appending(components: ".build", "release")),
-                           targetPath.appending("release"))
+            try self.execute(packagePath: fullPath)
+            XCTAssertEqual(
+                try resolveSymlinks(fullPath.appending(components: ".build", "debug")),
+                targetPath.appending("debug")
+            )
+            try self.execute(["-c", "release"], packagePath: fullPath)
+            XCTAssertEqual(
+                try resolveSymlinks(fullPath.appending(components: ".build", "release")),
+                targetPath.appending("release")
+            )
         }
     }
 
@@ -160,7 +210,12 @@ final class BuildToolTests: CommandsTestCase {
             do {
                 let (_, stderr) = try execute(["--product", "lib1"], packagePath: fullPath)
                 try SwiftPM.Package.execute(["clean"], packagePath: fullPath)
-                XCTAssertMatch(stderr, .contains("'--product' cannot be used with the automatic product 'lib1'; building the default target instead"))
+                XCTAssertMatch(
+                    stderr,
+                    .contains(
+                        "'--product' cannot be used with the automatic product 'lib1'; building the default target instead"
+                    )
+                )
             }
 
             do {
@@ -169,32 +224,53 @@ final class BuildToolTests: CommandsTestCase {
                 XCTAssertNoMatch(result.binContents, ["exec1"])
             }
 
-            XCTAssertThrowsCommandExecutionError(try execute(["--product", "exec1", "--target", "exec2"], packagePath: fixturePath)) { error in
+            XCTAssertThrowsCommandExecutionError(try self.execute(
+                ["--product", "exec1", "--target", "exec2"],
+                packagePath: fixturePath
+            )) { error in
                 XCTAssertMatch(error.stderr, .contains("error: '--product' and '--target' are mutually exclusive"))
             }
 
-            XCTAssertThrowsCommandExecutionError(try execute(["--product", "exec1", "--build-tests"], packagePath: fixturePath)) { error in
+            XCTAssertThrowsCommandExecutionError(try self.execute(
+                ["--product", "exec1", "--build-tests"],
+                packagePath: fixturePath
+            )) { error in
                 XCTAssertMatch(error.stderr, .contains("error: '--product' and '--build-tests' are mutually exclusive"))
             }
 
-            XCTAssertThrowsCommandExecutionError(try execute(["--build-tests", "--target", "exec2"], packagePath: fixturePath)) { error in
+            XCTAssertThrowsCommandExecutionError(try self.execute(
+                ["--build-tests", "--target", "exec2"],
+                packagePath: fixturePath
+            )) { error in
                 XCTAssertMatch(error.stderr, .contains("error: '--target' and '--build-tests' are mutually exclusive"))
             }
 
-            XCTAssertThrowsCommandExecutionError(try execute(["--build-tests", "--target", "exec2", "--product", "exec1"], packagePath: fixturePath)) { error in
-                XCTAssertMatch(error.stderr, .contains("error: '--product', '--target', and '--build-tests' are mutually exclusive"))
+            XCTAssertThrowsCommandExecutionError(try self.execute(
+                ["--build-tests", "--target", "exec2", "--product", "exec1"],
+                packagePath: fixturePath
+            )) { error in
+                XCTAssertMatch(
+                    error.stderr,
+                    .contains("error: '--product', '--target', and '--build-tests' are mutually exclusive")
+                )
             }
 
-            XCTAssertThrowsCommandExecutionError(try execute(["--product", "UnkownProduct"], packagePath: fixturePath)){ error in
+            XCTAssertThrowsCommandExecutionError(try self.execute(
+                ["--product", "UnkownProduct"],
+                packagePath: fixturePath
+            )) { error in
                 XCTAssertMatch(error.stderr, .contains("error: no product named 'UnkownProduct'"))
             }
 
-            XCTAssertThrowsCommandExecutionError(try execute(["--target", "UnkownTarget"], packagePath: fixturePath)) { error in
+            XCTAssertThrowsCommandExecutionError(try self.execute(
+                ["--target", "UnkownTarget"],
+                packagePath: fixturePath
+            )) { error in
                 XCTAssertMatch(error.stderr, .contains("error: no target named 'UnkownTarget'"))
             }
         }
     }
-    
+
     func testAtMainSupport() throws {
         try fixture(name: "Miscellaneous/AtMainSupport") { fixturePath in
             let fullPath = try resolveSymlinks(fixturePath)
@@ -239,7 +315,9 @@ final class BuildToolTests: CommandsTestCase {
                 XCTAssertNoMatch(result.binContents, ["BLibrary.a"])
 
                 // FIXME: We create the modulemap during build planning, hence this uglyness.
-                let bTargetBuildDir = ((try? localFileSystem.getDirectoryContents(result.binPath.appending("BTarget1.build"))) ?? []).filter{ $0 != moduleMapFilename }
+                let bTargetBuildDir =
+                    ((try? localFileSystem.getDirectoryContents(result.binPath.appending("BTarget1.build"))) ?? [])
+                        .filter { $0 != moduleMapFilename }
                 XCTAssertTrue(bTargetBuildDir.isEmpty, "bTargetBuildDir should be empty")
 
                 XCTAssertNoMatch(result.binContents, ["cexec"])
@@ -290,7 +368,7 @@ final class BuildToolTests: CommandsTestCase {
 
             do {
                 // test second time, to stabilize the cache
-                try execute(packagePath: fixturePath)
+                try self.execute(packagePath: fixturePath)
             }
 
             do {
@@ -322,22 +400,30 @@ final class BuildToolTests: CommandsTestCase {
         try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")
         #endif
         try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
-            // Try building using XCBuild with default parameters.  This should succeed.  We build verbosely so we get full command lines.
+            // Try building using XCBuild with default parameters.  This should succeed.  We build verbosely so we get
+            // full command lines.
             let defaultOutput = try execute(["-c", "debug", "-v"], packagePath: fixturePath).stdout
-            
+
             // Look for certain things in the output from XCBuild.
-            XCTAssertMatch(defaultOutput, .contains("-target \(try UserToolchain.default.targetTriple.tripleString(forPlatformVersion: ""))"))
+            XCTAssertMatch(
+                defaultOutput,
+                try .contains("-target \(UserToolchain.default.targetTriple.tripleString(forPlatformVersion: ""))")
+            )
         }
     }
 
     func testXcodeBuildSystemWithAdditionalBuildFlags() throws {
-        try XCTSkipIf(true, "Disabled for now because it is hitting 'IR generation failure: Cannot read legacy layout file' in CI (rdar://88828632)")
+        try XCTSkipIf(
+            true,
+            "Disabled for now because it is hitting 'IR generation failure: Cannot read legacy layout file' in CI (rdar://88828632)"
+        )
 
         #if !os(macOS)
         try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")
         #endif
         try fixture(name: "ValidLayouts/SingleModule/ExecutableMixed") { fixturePath in
-            // Try building using XCBuild with additional flags.  This should succeed.  We build verbosely so we get full command lines.
+            // Try building using XCBuild with additional flags.  This should succeed.  We build verbosely so we get
+            // full command lines.
             let defaultOutput = try execute(
                 [
                     "--build-system", "xcode",
@@ -363,16 +449,22 @@ final class BuildToolTests: CommandsTestCase {
         try XCTSkipIf(true, "test requires `xcbuild` and is therefore only supported on macOS")
         #endif
         try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
-            // Try building using XCBuild without specifying overrides.  This should succeed, and should use the default compiler path.
+            // Try building using XCBuild without specifying overrides.  This should succeed, and should use the default
+            // compiler path.
             let defaultOutput = try execute(["-c", "debug", "--vv"], packagePath: fixturePath).stdout
-            XCTAssertMatch(defaultOutput, .contains(try UserToolchain.default.swiftCompilerPath.pathString))
+            XCTAssertMatch(defaultOutput, try .contains(UserToolchain.default.swiftCompilerPath.pathString))
 
-            // Now try building using XCBuild while specifying a faulty compiler override.  This should fail.  Note that we need to set the executable to use for the manifest itself to the default one, since it defaults to SWIFT_EXEC if not provided.
+            // Now try building using XCBuild while specifying a faulty compiler override.  This should fail.  Note that
+            // we need to set the executable to use for the manifest itself to the default one, since it defaults to
+            // SWIFT_EXEC if not provided.
             var overriddenOutput = ""
             XCTAssertThrowsCommandExecutionError(
-                try execute(
+                try self.execute(
                     ["-c", "debug", "--vv"],
-                    environment: ["SWIFT_EXEC": "/usr/bin/false", "SWIFT_EXEC_MANIFEST": UserToolchain.default.swiftCompilerPath.pathString],
+                    environment: [
+                        "SWIFT_EXEC": "/usr/bin/false",
+                        "SWIFT_EXEC_MANIFEST": UserToolchain.default.swiftCompilerPath.pathString,
+                    ],
                     packagePath: fixturePath
                 )
             ) { error in
@@ -388,12 +480,19 @@ final class BuildToolTests: CommandsTestCase {
             XCTAssertMatch(output, .prefix("digraph Jobs {"))
         }
     }
-    
+
     func testSwiftDriverRawOutputGetsNewlines() throws {
         try fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
-            // Building with `-wmo` should result in a `remark: Incremental compilation has been disabled: it is not compatible with whole module optimization` message, which should have a trailing newline.  Since that message won't be there at all when the legacy compiler driver is used, we gate this check on whether the remark is there in the first place.
+            // Building with `-wmo` should result in a `remark: Incremental compilation has been disabled: it is not
+            // compatible with whole module optimization` message, which should have a trailing newline.  Since that
+            // message won't be there at all when the legacy compiler driver is used, we gate this check on whether the
+            // remark is there in the first place.
             let result = try execute(["-c", "release", "-Xswiftc", "-wmo"], packagePath: fixturePath)
-            if result.stdout.contains("remark: Incremental compilation has been disabled: it is not compatible with whole module optimization") {
+            if result.stdout
+                .contains(
+                    "remark: Incremental compilation has been disabled: it is not compatible with whole module optimization"
+                )
+            {
                 XCTAssertMatch(result.stdout, .contains("optimization\n"))
                 XCTAssertNoMatch(result.stdout, .contains("optimization["))
                 XCTAssertNoMatch(result.stdout, .contains("optimizationremark"))
@@ -420,10 +519,14 @@ final class BuildToolTests: CommandsTestCase {
                 "CUSTOM_SWIFT_VERSION": "1.0",
             ]
 
-            // Build with a swiftc that returns version 1.0, we expect a successful build which compiles our one source file.
+            // Build with a swiftc that returns version 1.0, we expect a successful build which compiles our one source
+            // file.
             do {
                 let result = try execute(["--verbose"], environment: environment, packagePath: fixturePath)
-                XCTAssertTrue(result.stdout.contains("\(dummySwiftcPath.pathString) -module-name"), "compilation task missing from build result: \(result.stdout)")
+                XCTAssertTrue(
+                    result.stdout.contains("\(dummySwiftcPath.pathString) -module-name"),
+                    "compilation task missing from build result: \(result.stdout)"
+                )
                 XCTAssertTrue(result.stdout.contains("Build complete!"), "unexpected build result: \(result.stdout)")
                 let swiftGetVersionFilePath = try findSwiftGetVersionFile()
                 XCTAssertEqual(try String(contentsOfFile: swiftGetVersionFilePath.pathString).spm_chomp(), "1.0")
@@ -432,7 +535,10 @@ final class BuildToolTests: CommandsTestCase {
             // Build again with that same version, we do not expect any compilation tasks.
             do {
                 let result = try execute(["--verbose"], environment: environment, packagePath: fixturePath)
-                XCTAssertFalse(result.stdout.contains("\(dummySwiftcPath.pathString) -module-name"), "compilation task present in build result: \(result.stdout)")
+                XCTAssertFalse(
+                    result.stdout.contains("\(dummySwiftcPath.pathString) -module-name"),
+                    "compilation task present in build result: \(result.stdout)"
+                )
                 XCTAssertTrue(result.stdout.contains("Build complete!"), "unexpected build result: \(result.stdout)")
                 let swiftGetVersionFilePath = try findSwiftGetVersionFile()
                 XCTAssertEqual(try String(contentsOfFile: swiftGetVersionFilePath.pathString).spm_chomp(), "1.0")
@@ -442,11 +548,92 @@ final class BuildToolTests: CommandsTestCase {
             do {
                 environment["CUSTOM_SWIFT_VERSION"] = "2.0"
                 let result = try execute(["--verbose"], environment: environment, packagePath: fixturePath)
-                XCTAssertTrue(result.stdout.contains("\(dummySwiftcPath.pathString) -module-name"), "compilation task missing from build result: \(result.stdout)")
+                XCTAssertTrue(
+                    result.stdout.contains("\(dummySwiftcPath.pathString) -module-name"),
+                    "compilation task missing from build result: \(result.stdout)"
+                )
                 XCTAssertTrue(result.stdout.contains("Build complete!"), "unexpected build result: \(result.stdout)")
                 let swiftGetVersionFilePath = try findSwiftGetVersionFile()
                 XCTAssertEqual(try String(contentsOfFile: swiftGetVersionFilePath.pathString).spm_chomp(), "2.0")
             }
+        }
+    }
+
+    func testGetTaskAllowEntitlement() throws {
+        try fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
+            #if os(macOS)
+            // Try building with default parameters.  This should succeed. We build verbosely so we get full command
+            // lines.
+            var output = try build(["-v"], packagePath: fixturePath).output
+
+            XCTAssertMatch(output, .contains("codesign --force --sign - --entitlements"))
+
+            output = try self.build(["-c", "debug", "-v"], packagePath: fixturePath).output
+
+            XCTAssertMatch(output, .contains("codesign --force --sign - --entitlements"))
+
+            // Build with different combinations of the entitlement flag and debug/release build configurations.
+
+            output = try self.build(
+                ["--enable-get-task-allow-entitlement", "-v"],
+                packagePath: fixturePath,
+                isRelease: true
+            ).output
+
+            XCTAssertMatch(output, .contains("codesign --force --sign - --entitlements"))
+
+            output = try self.build(
+                ["-c", "debug", "--enable-get-task-allow-entitlement", "-v"],
+                packagePath: fixturePath
+            ).output
+
+            XCTAssertMatch(output, .contains("codesign --force --sign - --entitlements"))
+
+            output = try self.build(
+                ["-c", "debug", "--disable-get-task-allow-entitlement", "-v"],
+                packagePath: fixturePath
+            ).output
+
+            XCTAssertNoMatch(output, .contains("codesign --force --sign - --entitlements"))
+
+            output = try self.build(
+                ["--disable-get-task-allow-entitlement", "-v"],
+                packagePath: fixturePath,
+                isRelease: true
+            ).output
+
+            XCTAssertNoMatch(output, .contains("codesign --force --sign - --entitlements"))
+            #else
+            output = try self.build(["-v"], packagePath: fixturePath).output
+
+            XCTAssertNoMatch(output, .contains("codesign --force --sign - --entitlements"))
+
+            output = try self.build(["-v"], packagePath: fixturePath, isRelease: true).output
+
+            XCTAssertNoMatch(output, .contains("codesign --force --sign - --entitlements"))
+
+            output = try self.build(
+                ["--disable-get-task-allow-entitlement", "-v"],
+                packagePath: fixturePath,
+                isRelease: true
+            ).output
+
+            XCTAssertNoMatch(output, .contains("codesign --force --sign - --entitlements"))
+            XCTAssertMatch(output, .contains(SwiftTool.entitlementsMacOSWarning))
+
+            output = try self.build(
+                ["--enable-get-task-allow-entitlement", "-v"],
+                packagePath: fixturePath,
+                isRelease: true
+            ).output
+
+            XCTAssertNoMatch(output, .contains("codesign --force --sign - --entitlements"))
+            XCTAssertMatch(output, .contains(SwiftTool.entitlementsMacOSWarning))
+            #endif
+
+            output = try self.build(["-c", "release", "-v"], packagePath: fixturePath, isRelease: true).output
+
+            XCTAssertNoMatch(output, .contains("codesign --force --sign - --entitlements"))
         }
     }
 }

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -95,10 +95,9 @@ final class BuildToolTests: CommandsTestCase {
                 }
 
                 XCTAssertTrue(
-                    stderr
-                        .contains(
-                            "warning: Target A imports another target (B) in the package without declaring it a dependency."
-                        ),
+                    stderr.contains(
+                        "warning: Target A imports another target (B) in the package without declaring it a dependency."
+                    ),
                     "got stdout: \(stdout), stderr: \(stderr)"
                 )
             }
@@ -117,10 +116,9 @@ final class BuildToolTests: CommandsTestCase {
                 }
 
                 XCTAssertTrue(
-                    stderr
-                        .contains(
-                            "error: Target A imports another target (B) in the package without declaring it a dependency."
-                        ),
+                    stderr.contains(
+                        "error: Target A imports another target (B) in the package without declaring it a dependency."
+                    ),
                     "got stdout: \(stdout), stderr: \(stderr)"
                 )
             }
@@ -135,10 +133,9 @@ final class BuildToolTests: CommandsTestCase {
                     return
                 }
                 XCTAssertFalse(
-                    stderr
-                        .contains(
-                            "warning: Target A imports another target (B) in the package without declaring it a dependency."
-                        ),
+                    stderr.contains(
+                        "warning: Target A imports another target (B) in the package without declaring it a dependency."
+                    ),
                     "got stdout: \(stdout), stderr: \(stderr)"
                 )
             }
@@ -488,11 +485,9 @@ final class BuildToolTests: CommandsTestCase {
             // message won't be there at all when the legacy compiler driver is used, we gate this check on whether the
             // remark is there in the first place.
             let result = try execute(["-c", "release", "-Xswiftc", "-wmo"], packagePath: fixturePath)
-            if result.stdout
-                .contains(
-                    "remark: Incremental compilation has been disabled: it is not compatible with whole module optimization"
-                )
-            {
+            if result.stdout.contains(
+                "remark: Incremental compilation has been disabled: it is not compatible with whole module optimization"
+            ) {
                 XCTAssertMatch(result.stdout, .contains("optimization\n"))
                 XCTAssertNoMatch(result.stdout, .contains("optimization["))
                 XCTAssertNoMatch(result.stdout, .contains("optimizationremark"))


### PR DESCRIPTION
### Motivation:

The new Swift backtracer will only function on macOS if:

1. `SWIFT_BACKTRACE` environment variable has its `enable` option set to `yes` or `tty`, and

2. The program you are running was signed with the `com.apple.security.get-task-allow` entitlement.

Xcode automatically signs all local builds with that entitlement by default; without it the Swift backtracer won't work.

SwiftPM should sign Debug binaries with the entitlement by default. It should also have an _option_ to sign Release binaries with the entitlement, noting that they should not be distributed in that state but that crashes may only manifest in release builds (where the optimizer is fully enabled).

### Modifications:

Added new `--enable-get-task-allow-entitlement` and `--disable-get-task-allow-entitlement` CLI flags. Made it enabled by default for debug builds on macOS. When enabled, applying codesigning with `com.apple.security.get-task-allow` in `LLBuildManifestBuilder+Product.swift`.

### Result:

Backtraces work on macOS when built with SwiftPM.

Resolves rdar://112065568.