### PR TITLE
Tests: mitigate progressivity issue in LegacyHTTPClientTests

### DIFF
--- a/Tests/BasicsTests/LegacyHTTPClientTests.swift
+++ b/Tests/BasicsTests/LegacyHTTPClientTests.swift
@@ -596,7 +596,7 @@ final class LegacyHTTPClientTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
         let cancellator = Cancellator(observabilityScope: observability.topScope)
 
-        let total = 10
+        let total = min(10, ProcessInfo.processInfo.activeProcessorCount / 2)
         // this DispatchGroup is used to wait for the requests to start before calling cancel
         let startGroup = DispatchGroup()
         // this DispatchGroup is used to park the delayed threads that would be cancelled


### PR DESCRIPTION
The legacy client can block several threads by semaphore and the test case itself blocks a thread per request. The test case waits until all requests go in the middle of the process, but some of requests won't be started due to a lack of available threads on a machine with a few cores. Reducing the number of concurrent requests does not solve the root issue (it ultimately requires lock/wait free implementation and I think it's not worth it just for legacy one), but should be enough to repair CI.
