### PR TITLE
Remove outdated check for Ubuntu 14.04 and Clang 3.6

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -122,12 +122,6 @@ public struct SwiftBuildTool: SwiftCommand {
             return
         }
 
-        #if os(Linux)
-        // Emit warning if clang is older than version 3.6 on Linux.
-        // See: <rdar://problem/28108951> SR-2299 Swift isn't using Gold by default on stock 14.04.
-        checkClangVersion(observabilityScope: swiftTool.observabilityScope)
-        #endif
-
         guard let subset = options.buildSubset(observabilityScope: swiftTool.observabilityScope) else {
             throw ExitCode.failure
         }
@@ -141,20 +135,6 @@ public struct SwiftBuildTool: SwiftCommand {
             try buildSystem.build(subset: subset)
         } catch _ as Diagnostics {
             throw ExitCode.failure
-        }
-    }
-
-    private func checkClangVersion(observabilityScope: ObservabilityScope) {
-        // We only care about this on Ubuntu 14.04
-        guard let uname = try? TSCBasic.Process.checkNonZeroExit(args: "lsb_release", "-r").spm_chomp(),
-              uname.hasSuffix("14.04"),
-              let clangVersionOutput = try? TSCBasic.Process.checkNonZeroExit(args: "clang", "--version").spm_chomp(),
-              let clang = getClangVersion(versionOutput: clangVersionOutput) else {
-            return
-        }
-
-        if clang < Version(3, 6, 0) {
-            observabilityScope.emit(warning: "minimum recommended clang is version 3.6, otherwise you may encounter linker errors.")
         }
     }
 


### PR DESCRIPTION
Swift no longer supports Ubuntu 14.04, the latest supported version is 18.04, so this check should no longer be needed.
