### PR TITLE
Add trailing newlines consistently in `InitPackage.swift`

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -573,6 +573,7 @@ public final class InitPackage {
                     print("Hello, world!")
                 }
             }
+
             """
         case .macro:
             content = """
@@ -587,6 +588,7 @@ public final class InitPackage {
             /// produces a tuple `(x + y, "x + y")`.
             @freestanding(expression)
             public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "\(moduleName)Macros", type: "StringifyMacro")
+
             """
 
         case .empty, .buildToolPlugin, .commandPlugin:


### PR DESCRIPTION
`swift package init` creates files without a trailing newline, so if you create a git repository when instantiating the template, there is an immediate diff.

Resolves rdar://111333801.
