### PR TITLE
Avoid use of `temp_await` in `PackageRegistryToolTests.swift`

### DIFF
--- a/Sources/Basics/Archiver/Archiver.swift
+++ b/Sources/Basics/Archiver/Archiver.swift
@@ -67,7 +67,7 @@ extension Archiver {
         }
     }    
 
-    /// Asynchronously compress the contents of a directory to a destination archive.
+    /// Asynchronously compresses the contents of a directory to a destination archive.
     ///
     /// - Parameters:
     ///   - directory: The `AbsolutePath` to the archive to extract.

--- a/Sources/Basics/Archiver/Archiver.swift
+++ b/Sources/Basics/Archiver/Archiver.swift
@@ -53,12 +53,43 @@ public protocol Archiver {
 }
 
 extension Archiver {
+    /// Asynchronously extracts the contents of an archive to a destination folder.
+    ///
+    /// - Parameters:
+    ///   - archivePath: The `AbsolutePath` to the archive to extract.
+    ///   - destinationPath: The `AbsolutePath` to the directory to extract to.
     public func extract(
         from archivePath: AbsolutePath,
         to destinationPath: AbsolutePath
     ) async throws {
         try await withCheckedThrowingContinuation {
             self.extract(from: archivePath, to: destinationPath, completion: $0.resume(with:))
+        }
+    }    
+
+    /// Asynchronously compress the contents of a directory to a destination archive.
+    ///
+    /// - Parameters:
+    ///   - directory: The `AbsolutePath` to the archive to extract.
+    ///   - destinationPath: The `AbsolutePath` to the directory to extract to.
+    public func compress(
+        directory: AbsolutePath,
+        to destinationPath: AbsolutePath
+    ) async throws {
+        try await withCheckedThrowingContinuation {
+            self.compress(directory: directory, to: destinationPath, completion: $0.resume(with:))
+        }
+    }
+
+    /// Asynchronously validates if a file is an archive.
+    ///
+    /// - Parameters:
+    ///   - path: The `AbsolutePath` to the archive to validate.
+    public func validate(
+        path: AbsolutePath
+    ) async throws -> Bool {
+        try await withCheckedThrowingContinuation {
+            self.validate(path: path, completion: $0.resume(with:))
         }
     }
 }

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -279,7 +279,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
 
     // TODO: Test example with login and password
 
-    func testArchiving() throws {
+    func testArchiving() async throws {
         #if os(Linux)
         // needed for archiving
         guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
@@ -293,7 +293,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         let metadataFilename = SwiftPackageRegistryTool.Publish.metadataFilename
 
         // git repo
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             let packageDirectory = temporaryDirectory.appending("MyPackage")
             try localFileSystem.createDirectory(packageDirectory)
 
@@ -320,12 +320,12 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 observabilityScope: observability.topScope
             )
 
-            try validatePackageArchive(at: archivePath)
+            try await validatePackageArchive(at: archivePath)
             XCTAssertTrue(archivePath.isDescendant(of: workingDirectory))
         }
 
         // not a git repo
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             let packageDirectory = temporaryDirectory.appending("MyPackage")
             try localFileSystem.createDirectory(packageDirectory)
 
@@ -350,11 +350,11 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 observabilityScope: observability.topScope
             )
 
-            try validatePackageArchive(at: archivePath)
+            try await validatePackageArchive(at: archivePath)
         }
 
         // canonical metadata location
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             let packageDirectory = temporaryDirectory.appending("MyPackage")
             try localFileSystem.createDirectory(packageDirectory)
 
@@ -385,17 +385,17 @@ final class PackageRegistryToolTests: CommandsTestCase {
                 observabilityScope: observability.topScope
             )
 
-            let extractedPath = try validatePackageArchive(at: archivePath)
+            let extractedPath = try await validatePackageArchive(at: archivePath)
             XCTAssertFileExists(extractedPath.appending(component: metadataFilename))
         }
 
         @discardableResult
-        func validatePackageArchive(at archivePath: AbsolutePath) throws -> AbsolutePath {
+        func validatePackageArchive(at archivePath: AbsolutePath) async throws -> AbsolutePath {
             XCTAssertFileExists(archivePath)
             let archiver = ZipArchiver(fileSystem: localFileSystem)
             let extractPath = archivePath.parentDirectory.appending(component: UUID().uuidString)
             try localFileSystem.createDirectory(extractPath)
-            try temp_await { archiver.extract(from: archivePath, to: extractPath, completion: $0) }
+            try await archiver.extract(from: archivePath, to: extractPath)
             try localFileSystem.stripFirstLevel(of: extractPath)
             XCTAssertFileExists(extractPath.appending("Package.swift"))
             return extractPath
@@ -550,7 +550,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
             let archiver = ZipArchiver(fileSystem: localFileSystem)
             let extractPath = archivePath.parentDirectory.appending(component: UUID().uuidString)
             try localFileSystem.createDirectory(extractPath)
-            try temp_await { archiver.extract(from: archivePath, to: extractPath, completion: $0) }
+            try await archiver.extract(from: archivePath, to: extractPath)
             try localFileSystem.stripFirstLevel(of: extractPath)
 
             let manifestInArchive = try localFileSystem.readFileContents(extractPath.appending(manifestFile)).contents
@@ -963,7 +963,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
         let archiver = ZipArchiver(fileSystem: localFileSystem)
         let extractPath = archivePath.parentDirectory.appending(component: UUID().uuidString)
         try localFileSystem.createDirectory(extractPath)
-        try temp_await { archiver.extract(from: archivePath, to: extractPath, completion: $0) }
+        try await archiver.extract(from: archivePath, to: extractPath)
         try localFileSystem.stripFirstLevel(of: extractPath)
 
         let manifestSignature = try ManifestSignatureParser.parse(


### PR DESCRIPTION
Follow up to https://github.com/apple/swift-package-manager/pull/7009, which provides the detailed motivation: we should avoid `temp_await` as it can lead to deadlocks when combined with Swift Concurrency.
