### PR TITLE
[NFC] Build: remove unused `TestBuildCommand.indent` function

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -19,7 +19,6 @@ import SPMBuildCore
 import SPMLLBuild
 
 import struct TSCBasic.ByteString
-import protocol TSCBasic.ByteStreamable
 import struct TSCBasic.Format
 import class TSCBasic.LocalFileOutputByteStream
 import protocol TSCBasic.OutputByteStream

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -270,15 +270,6 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
 
 private protocol TestBuildCommand {}
 
-/// Functionality common to all build commands related to test targets.
-extension TestBuildCommand {
-    /// Returns a value containing `spaces` number of space characters.
-    /// Intended to facilitate indenting generated code a specified number of levels.
-    fileprivate func indent(_ spaces: Int) -> ByteStreamable {
-        Format.asRepeating(string: " ", count: spaces)
-    }
-}
-
 private final class InProcessTool: Tool {
     let context: BuildExecutionContext
     let type: CustomLLBuildCommand.Type


### PR DESCRIPTION
This function is unused and refers to `Format.asRepeating` from TSC, which itself should be deprecated.

This also removes our single use of `TSCBasic.ByteStreamable` and allows us to deprecate it in TSC.