### PR TITLE
SwiftSyntax version in new macro template has trailing period in dependency version, causing error reading manifest

### DIFF
--- a/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
+++ b/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
@@ -25,7 +25,7 @@ public struct InstalledSwiftPMConfiguration: Codable {
         }
 
         public var description: String {
-            return "\(major).\(minor).\(patch).\(prereleaseIdentifier.map { "-\($0)" } ?? "")"
+            return "\(major).\(minor).\(patch)\(prereleaseIdentifier.map { "-\($0)" } ?? "")"
         }
     }
 

--- a/Tests/PackageModelTests/InstalledSwiftPMConfigurationTests.swift
+++ b/Tests/PackageModelTests/InstalledSwiftPMConfigurationTests.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+@testable import PackageModel
+
+final class InstalledSwiftPMConfigurationTests: XCTestCase {
+    func testVersionDescription() {
+        do {
+            let version = InstalledSwiftPMConfiguration.Version(major: 509, minor: 0, patch: 0)
+            XCTAssertEqual(version.description, "509.0.0")
+        }
+        do {
+            let version = InstalledSwiftPMConfiguration.Version(major: 509, minor: 0, patch: 0, prereleaseIdentifier: "alpha1")
+            XCTAssertEqual(version.description, "509.0.0-alpha1")
+        }
+        do {
+            let version = InstalledSwiftPMConfiguration.Version(major: 509, minor: 0, patch: 0, prereleaseIdentifier: "beta.1")
+            XCTAssertEqual(version.description, "509.0.0-beta.1")
+        }
+    }
+}


### PR DESCRIPTION
This fixes a regression I believe was introduced in #6774 where the new macro package template has its dependency on swift-syntax expressed as `from: "509.0.0."`, including an unncessary trailing period character. This causes an error reading the manifest.

I have not tested this, but I experienced the bug and from source inspection believe this is likely the issue.

Resolves rdar://117132800
