### PR TITLE
[NFC] Remove unused imports of `TSCUtility.Diagnostics{Engine,}`

### DIFF
--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -17,7 +17,6 @@ import PackageModel
 import SPMTestSupport
 import XCTest
 
-import class TSCBasic.DiagnosticsEngine
 import class TSCBasic.InMemoryFileSystem
 import enum TSCBasic.PathValidationError
 
@@ -774,11 +773,5 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             XCTAssertFalse(observability.hasErrorDiagnostics, observability.diagnostics.description)
         }
 #endif
-    }
-}
-
-extension DiagnosticsEngine {
-    public var hasWarnings: Bool {
-        return diagnostics.contains(where: { $0.message.behavior == .warning })
     }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -26,7 +26,6 @@ import XCTest
 import struct TSCBasic.ByteString
 import class TSCBasic.InMemoryFileSystem
 
-import enum TSCUtility.Diagnostics
 import struct TSCUtility.Version
 
 final class WorkspaceTests: XCTestCase {


### PR DESCRIPTION
Since TSC is deprecated, we should avoid redundant imports for its modules and types.