### PR TITLE
llbuild: Support `is-mutated`/`is-command-timestamp` nodes

### DIFF
--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -17,7 +17,7 @@ import struct Basics.AbsolutePath
 import struct Basics.RelativePath
 import struct Basics.TSCAbsolutePath
 import struct LLBuildManifest.Node
-import struct LLBuildManifest.BuildManifest
+import struct LLBuildManifest.LLBuildManifest
 import struct SPMBuildCore.BuildParameters
 import class PackageGraph.ResolvedTarget
 import protocol TSCBasic.FileSystem

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -109,7 +109,7 @@ public class LLBuildManifestBuilder {
             try self.createProductCommand(description)
         }
 
-        try ManifestWriter(fileSystem: self.fileSystem).write(self.manifest, at: path)
+        try ManifestWriter.write(self.manifest, at: path, self.fileSystem)
         return self.manifest
     }
 

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -47,7 +47,7 @@ public class LLBuildManifestBuilder {
     /// ObservabilityScope with which to emit diagnostics
     public let observabilityScope: ObservabilityScope
 
-    public internal(set) var manifest: BuildManifest = .init()
+    public internal(set) var manifest: LLBuildManifest = .init()
 
     var buildConfig: String { self.buildParameters.configuration.dirname }
     var buildParameters: BuildParameters { self.plan.buildParameters }
@@ -73,7 +73,7 @@ public class LLBuildManifestBuilder {
 
     /// Generate manifest at the given path.
     @discardableResult
-    public func generateManifest(at path: AbsolutePath) throws -> BuildManifest {
+    public func generateManifest(at path: AbsolutePath) throws -> LLBuildManifest {
         self.swiftGetVersionFiles.removeAll()
 
         self.manifest.createTarget(TargetKind.main.targetName)
@@ -109,7 +109,7 @@ public class LLBuildManifestBuilder {
             try self.createProductCommand(description)
         }
 
-        try ManifestWriter.write(self.manifest, at: path, self.fileSystem)
+        try LLBuildManifestWriter.write(self.manifest, at: path, fileSystem: self.fileSystem)
         return self.manifest
     }
 

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -164,7 +164,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         }
     }
 
-    public func getBuildManifest() throws -> LLBuildManifest.BuildManifest {
+    public func getBuildManifest() throws -> LLBuildManifest {
         return try self.plan().manifest
     }
 
@@ -418,7 +418,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     }
 
     /// Create the build plan and return the build description.
-    private func plan() throws -> (description: BuildDescription, manifest: LLBuildManifest.BuildManifest) {
+    private func plan() throws -> (description: BuildDescription, manifest: LLBuildManifest) {
         // Load the package graph.
         let graph = try getPackageGraph()
 
@@ -703,7 +703,7 @@ extension BuildOperation {
 }
 
 extension BuildDescription {
-    static func create(with plan: BuildPlan, disableSandboxForPluginCommands: Bool, fileSystem: Basics.FileSystem, observabilityScope: ObservabilityScope) throws -> (BuildDescription, LLBuildManifest.BuildManifest) {
+    static func create(with plan: BuildPlan, disableSandboxForPluginCommands: Bool, fileSystem: Basics.FileSystem, observabilityScope: ObservabilityScope) throws -> (BuildDescription, LLBuildManifest) {
         // Generate the llbuild manifest.
         let llbuild = LLBuildManifestBuilder(plan, disableSandboxForPluginCommands: disableSandboxForPluginCommands, fileSystem: fileSystem, observabilityScope: observabilityScope)
         let buildManifest = try llbuild.generateManifest(at: plan.buildParameters.llbuildManifest)

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -300,22 +300,22 @@ public struct BuildDescription: Codable {
     public typealias CommandLineFlag = String
 
     /// The Swift compiler invocation targets.
-    let swiftCommands: [BuildManifest.CmdName: SwiftCompilerTool]
+    let swiftCommands: [LLBuildManifest.CmdName: SwiftCompilerTool]
 
     /// The Swift compiler frontend invocation targets.
-    let swiftFrontendCommands: [BuildManifest.CmdName: SwiftFrontendTool]
+    let swiftFrontendCommands: [LLBuildManifest.CmdName: SwiftFrontendTool]
 
     /// The map of test discovery commands.
-    let testDiscoveryCommands: [BuildManifest.CmdName: LLBuildManifest.TestDiscoveryTool]
+    let testDiscoveryCommands: [LLBuildManifest.CmdName: LLBuildManifest.TestDiscoveryTool]
 
     /// The map of test entry point commands.
-    let testEntryPointCommands: [BuildManifest.CmdName: LLBuildManifest.TestEntryPointTool]
+    let testEntryPointCommands: [LLBuildManifest.CmdName: LLBuildManifest.TestEntryPointTool]
 
     /// The map of copy commands.
-    let copyCommands: [BuildManifest.CmdName: LLBuildManifest.CopyTool]
+    let copyCommands: [LLBuildManifest.CmdName: LLBuildManifest.CopyTool]
 
     /// The map of write commands.
-    let writeCommands: [BuildManifest.CmdName: LLBuildManifest.WriteAuxiliaryFile]
+    let writeCommands: [LLBuildManifest.CmdName: LLBuildManifest.WriteAuxiliaryFile]
 
     /// A flag that indicates this build should perform a check for whether targets only import
     /// their explicitly-declared dependencies
@@ -338,12 +338,12 @@ public struct BuildDescription: Codable {
 
     public init(
         plan: BuildPlan,
-        swiftCommands: [BuildManifest.CmdName: SwiftCompilerTool],
-        swiftFrontendCommands: [BuildManifest.CmdName: SwiftFrontendTool],
-        testDiscoveryCommands: [BuildManifest.CmdName: LLBuildManifest.TestDiscoveryTool],
-        testEntryPointCommands: [BuildManifest.CmdName: LLBuildManifest.TestEntryPointTool],
-        copyCommands: [BuildManifest.CmdName: LLBuildManifest.CopyTool],
-        writeCommands: [BuildManifest.CmdName: LLBuildManifest.WriteAuxiliaryFile],
+        swiftCommands: [LLBuildManifest.CmdName: SwiftCompilerTool],
+        swiftFrontendCommands: [LLBuildManifest.CmdName: SwiftFrontendTool],
+        testDiscoveryCommands: [LLBuildManifest.CmdName: LLBuildManifest.TestDiscoveryTool],
+        testEntryPointCommands: [LLBuildManifest.CmdName: LLBuildManifest.TestEntryPointTool],
+        copyCommands: [LLBuildManifest.CmdName: LLBuildManifest.CopyTool],
+        writeCommands: [LLBuildManifest.CmdName: LLBuildManifest.WriteAuxiliaryFile],
         pluginDescriptions: [PluginDescription]
     ) throws {
         self.swiftCommands = swiftCommands

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -109,7 +109,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
         try fileSystem.writeFileContents(path, string: content)
     }
 
-    private func execute(fileSystem: Basics.FileSystem, tool: LLBuildManifest.TestDiscoveryTool) throws {
+    private func execute(fileSystem: Basics.FileSystem, tool: TestDiscoveryTool) throws {
         let index = self.context.buildParameters.indexStore
         let api = try self.context.indexStoreAPI.get()
         let store = try IndexStore.open(store: TSCAbsolutePath(index), api: api)
@@ -121,7 +121,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
         let testsByModule = Dictionary(grouping: tests, by: { $0.module.spm_mangledToC99ExtendedIdentifier() })
 
         func isMainFile(_ path: AbsolutePath) -> Bool {
-            path.basename == LLBuildManifest.TestDiscoveryTool.mainFileName
+            path.basename == TestDiscoveryTool.mainFileName
         }
 
         var maybeMainFile: AbsolutePath?
@@ -153,7 +153,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
         }
 
         guard let mainFile = maybeMainFile else {
-            throw InternalError("main output (\(LLBuildManifest.TestDiscoveryTool.mainFileName)) not found")
+            throw InternalError("main output (\(TestDiscoveryTool.mainFileName)) not found")
         }
 
         let testsKeyword = tests.isEmpty ? "let" : "var"
@@ -201,7 +201,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
 }
 
 final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
-    private func execute(fileSystem: Basics.FileSystem, tool: LLBuildManifest.TestEntryPointTool) throws {
+    private func execute(fileSystem: Basics.FileSystem, tool: TestEntryPointTool) throws {
         // Find the inputs, which are the names of the test discovery module(s)
         let inputs = tool.inputs.compactMap { try? AbsolutePath(validating: $0.name) }
         let discoveryModuleNames = inputs.map(\.basenameWithoutExt)
@@ -210,9 +210,9 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
 
         // Find the main output file
         guard let mainFile = outputs.first(where: { path in
-            path.basename == LLBuildManifest.TestEntryPointTool.mainFileName
+            path.basename == TestEntryPointTool.mainFileName
         }) else {
-            throw InternalError("main file output (\(LLBuildManifest.TestEntryPointTool.mainFileName)) not found")
+            throw InternalError("main file output (\(TestEntryPointTool.mainFileName)) not found")
         }
 
         let testObservabilitySetup: String
@@ -306,16 +306,16 @@ public struct BuildDescription: Codable {
     let swiftFrontendCommands: [LLBuildManifest.CmdName: SwiftFrontendTool]
 
     /// The map of test discovery commands.
-    let testDiscoveryCommands: [LLBuildManifest.CmdName: LLBuildManifest.TestDiscoveryTool]
+    let testDiscoveryCommands: [LLBuildManifest.CmdName: TestDiscoveryTool]
 
     /// The map of test entry point commands.
-    let testEntryPointCommands: [LLBuildManifest.CmdName: LLBuildManifest.TestEntryPointTool]
+    let testEntryPointCommands: [LLBuildManifest.CmdName: TestEntryPointTool]
 
     /// The map of copy commands.
-    let copyCommands: [LLBuildManifest.CmdName: LLBuildManifest.CopyTool]
+    let copyCommands: [LLBuildManifest.CmdName: CopyTool]
 
     /// The map of write commands.
-    let writeCommands: [LLBuildManifest.CmdName: LLBuildManifest.WriteAuxiliaryFile]
+    let writeCommands: [LLBuildManifest.CmdName: WriteAuxiliaryFile]
 
     /// A flag that indicates this build should perform a check for whether targets only import
     /// their explicitly-declared dependencies
@@ -340,10 +340,10 @@ public struct BuildDescription: Codable {
         plan: BuildPlan,
         swiftCommands: [LLBuildManifest.CmdName: SwiftCompilerTool],
         swiftFrontendCommands: [LLBuildManifest.CmdName: SwiftFrontendTool],
-        testDiscoveryCommands: [LLBuildManifest.CmdName: LLBuildManifest.TestDiscoveryTool],
-        testEntryPointCommands: [LLBuildManifest.CmdName: LLBuildManifest.TestEntryPointTool],
-        copyCommands: [LLBuildManifest.CmdName: LLBuildManifest.CopyTool],
-        writeCommands: [LLBuildManifest.CmdName: LLBuildManifest.WriteAuxiliaryFile],
+        testDiscoveryCommands: [LLBuildManifest.CmdName: TestDiscoveryTool],
+        testEntryPointCommands: [LLBuildManifest.CmdName: TestEntryPointTool],
+        copyCommands: [LLBuildManifest.CmdName: CopyTool],
+        writeCommands: [LLBuildManifest.CmdName: WriteAuxiliaryFile],
         pluginDescriptions: [PluginDescription]
     ) throws {
         self.swiftCommands = swiftCommands

--- a/Sources/Commands/Utilities/DOTManifestSerializer.swift
+++ b/Sources/Commands/Utilities/DOTManifestSerializer.swift
@@ -18,10 +18,10 @@ import protocol TSCBasic.OutputByteStream
 public struct DOTManifestSerializer {
     var kindCounter = [String: Int]()
     var hasEmittedStyling = Set<String>()
-    let manifest: LLBuildManifest.LLBuildManifest
+    let manifest: LLBuildManifest
 
     /// Creates a serializer that will serialize the given manifest.
-    public init(manifest: LLBuildManifest.LLBuildManifest) {
+    public init(manifest: LLBuildManifest) {
         self.manifest = manifest
     }
 

--- a/Sources/Commands/Utilities/DOTManifestSerializer.swift
+++ b/Sources/Commands/Utilities/DOTManifestSerializer.swift
@@ -18,10 +18,10 @@ import protocol TSCBasic.OutputByteStream
 public struct DOTManifestSerializer {
     var kindCounter = [String: Int]()
     var hasEmittedStyling = Set<String>()
-    let manifest: LLBuildManifest.BuildManifest
+    let manifest: LLBuildManifest.LLBuildManifest
 
     /// Creates a serializer that will serialize the given manifest.
-    public init(manifest: LLBuildManifest.BuildManifest) {
+    public init(manifest: LLBuildManifest.LLBuildManifest) {
         self.manifest = manifest
     }
 

--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -7,9 +7,9 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(LLBuildManifest STATIC
-  BuildManifest.swift
   Command.swift
-  ManifestWriter.swift
+  LLBuildManifest.swift
+  LLBuildManifestWriter.swift
   Node.swift
   Target.swift
   Tools.swift)

--- a/Sources/LLBuildManifest/LLBuildManifest.swift
+++ b/Sources/LLBuildManifest/LLBuildManifest.swift
@@ -161,7 +161,7 @@ public enum WriteAuxiliary {
     }
 }
 
-public struct BuildManifest {
+public struct LLBuildManifest {
     public typealias TargetName = String
     public typealias CmdName = String
 

--- a/Sources/LLBuildManifest/LLBuildManifestWriter.swift
+++ b/Sources/LLBuildManifest/LLBuildManifestWriter.swift
@@ -14,8 +14,8 @@ import Basics
 
 private let namesToExclude = [".git", ".build"]
 
-public struct ManifestWriter {
-    private let manifest: BuildManifest
+public struct LLBuildManifestWriter {
+    private let manifest: LLBuildManifest
     private var buffer = """
     client:
       name: basic
@@ -23,7 +23,7 @@ public struct ManifestWriter {
 
     """
 
-    init(manifest: BuildManifest) {
+    private init(manifest: LLBuildManifest) {
         self.manifest = manifest
 
         self.render(targets: manifest.targets)
@@ -35,13 +35,13 @@ public struct ManifestWriter {
         self.render(commands: manifest.commands)
     }
 
-    public static func write(_ manifest: BuildManifest, at path: AbsolutePath, _ fileSystem: FileSystem) throws {
-        let writer = ManifestWriter(manifest: manifest)
+    public static func write(_ manifest: LLBuildManifest, at path: AbsolutePath, fileSystem: FileSystem) throws {
+        let writer = LLBuildManifestWriter(manifest: manifest)
 
         try fileSystem.writeFileContents(path, string: writer.buffer)
     }
 
-    private mutating func render(targets: [BuildManifest.TargetName: Target]) {
+    private mutating func render(targets: [LLBuildManifest.TargetName: Target]) {
         self.buffer += "targets:\n"
         for (_, target) in targets.sorted(by: { $0.key < $1.key }) {
             self.buffer += "  \(target.name.asJSON): \(target.nodes.map(\.name).sorted().asJSON)\n"
@@ -99,7 +99,7 @@ public struct ManifestWriter {
         """
     }
 
-    private mutating func render(commands: [BuildManifest.CmdName: Command]) {
+    private mutating func render(commands: [LLBuildManifest.CmdName: Command]) {
         self.buffer += "commands:\n"
         for (_, command) in commands.sorted(by: { $0.key < $1.key }) {
             self.buffer += "  \(command.name.asJSON):\n"

--- a/Sources/LLBuildManifest/LLBuildManifestWriter.swift
+++ b/Sources/LLBuildManifest/LLBuildManifestWriter.swift
@@ -16,6 +16,8 @@ private let namesToExclude = [".git", ".build"]
 
 public struct LLBuildManifestWriter {
     private let manifest: LLBuildManifest
+    // FIXME: since JSON is a superset of YAML and we don't need to parse these manifests,
+    // we should just use `JSONEncoder` instead.
     private var buffer = """
     client:
       name: basic

--- a/Sources/LLBuildManifest/ManifestWriter.swift
+++ b/Sources/LLBuildManifest/ManifestWriter.swift
@@ -23,14 +23,8 @@ public struct ManifestWriter {
 
     """
 
-    init(manifest: BuildManifest, buffer: String = """
-    client:
-      name: basic
-    tools: {}
-
-    """) {
+    init(manifest: BuildManifest) {
         self.manifest = manifest
-        self.buffer = buffer
 
         self.render(targets: manifest.targets)
 

--- a/Sources/LLBuildManifest/Node.swift
+++ b/Sources/LLBuildManifest/Node.swift
@@ -20,15 +20,23 @@ public struct Node: Hashable, Codable {
         case directoryStructure
     }
 
+    struct Attributes: Hashable, Codable {
+        var isMutated = false
+        var isCommandTimestamp = false
+    }
+
     /// The name used to identify the node.
     public var name: String
 
     /// The kind of node.
     public var kind: Kind
 
-    private init(name: String, kind: Kind) {
+    let attributes: Attributes?
+
+    private init(name: String, kind: Kind, attributes: Attributes? = nil) {
         self.name = name
         self.kind = kind
+        self.attributes = attributes
     }
     
     /// Extracts `name` property if this node was constructed as `Node//virtual`.
@@ -37,13 +45,25 @@ public struct Node: Hashable, Codable {
         return String(self.name.dropFirst().dropLast())
     }
 
-    public static func virtual(_ name: String) -> Node {
+    public static func virtual(_ name: String, isCommandTimestamp: Bool = false) -> Node {
         precondition(name.first != "<" && name.last != ">", "<> will be inserted automatically")
-        return Node(name: "<" + name + ">", kind: .virtual)
+        return Node(
+            name: "<" + name + ">",
+            kind: .virtual,
+            attributes: isCommandTimestamp ? .init(isCommandTimestamp: isCommandTimestamp) : nil
+        )
     }
 
     public static func file(_ name: AbsolutePath) -> Node {
         Node(name: name.pathString, kind: .file)
+    }
+
+    public static func file(_ name: AbsolutePath, isMutated: Bool) -> Node {
+        Node(
+            name: name.pathString,
+            kind: .file,
+            attributes: .init(isMutated: isMutated)
+        )
     }
 
     public static func directory(_ name: AbsolutePath) -> Node {

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -27,13 +27,13 @@ public protocol ToolProtocol: Codable {
     var outputs: [Node] { get }
 
     /// Write a description of the tool to the given output `stream`.
-    func write(to stream: ManifestToolStream)
+    func write(to stream: inout ManifestToolStream)
 }
 
 extension ToolProtocol {
     public var alwaysOutOfDate: Bool { return false }
 
-    public func write(to stream: ManifestToolStream) {}
+    public func write(to stream: inout ManifestToolStream) {}
 }
 
 public struct PhonyTool: ToolProtocol {
@@ -85,7 +85,7 @@ public struct CopyTool: ToolProtocol {
         self.outputs = outputs
     }
 
-    public func write(to stream: ManifestToolStream) {
+    public func write(to stream: inout ManifestToolStream) {
         stream["description"] = "Copying \(inputs[0].name)"
     }
 }
@@ -105,7 +105,7 @@ public struct PackageStructureTool: ToolProtocol {
         self.outputs = outputs
     }
 
-    public func write(to stream: ManifestToolStream) {
+    public func write(to stream: inout ManifestToolStream) {
         stream["description"] = "Planning build"
         stream["allow-missing-inputs"] = true
     }
@@ -140,7 +140,7 @@ public struct ShellTool: ToolProtocol {
         self.allowMissingInputs = allowMissingInputs
     }
 
-    public func write(to stream: ManifestToolStream) {
+    public func write(to stream: inout ManifestToolStream) {
         stream["description"] = description
         stream["args"] = arguments
         if !environment.isEmpty {
@@ -172,7 +172,7 @@ public struct WriteAuxiliaryFile: Equatable, ToolProtocol {
         return [.file(outputFilePath)]
     }
 
-    public func write(to stream: ManifestToolStream) {
+    public func write(to stream: inout ManifestToolStream) {
         stream["description"] = "Write auxiliary file \(outputFilePath.pathString)"
     }
 }
@@ -200,7 +200,7 @@ public struct ClangTool: ToolProtocol {
         self.dependencies = dependencies
     }
 
-    public func write(to stream: ManifestToolStream) {
+    public func write(to stream: inout ManifestToolStream) {
         stream["description"] = description
         stream["args"] = arguments
         if let dependencies {
@@ -245,9 +245,8 @@ public struct SwiftFrontendTool: ToolProtocol {
         self.arguments = arguments
     }
 
-    public func write(to stream: ManifestToolStream) {
-      ShellTool(description: description, inputs: inputs, outputs: outputs, arguments: arguments)
-        .write(to: stream)
+    public func write(to stream: inout ManifestToolStream) {
+      ShellTool(description: description, inputs: inputs, outputs: outputs, arguments: arguments).write(to: &stream)
     }
 }
 
@@ -342,7 +341,7 @@ public struct SwiftCompilerTool: ToolProtocol {
         return arguments
     }
 
-    public func write(to stream: ManifestToolStream) {
-        ShellTool(description: description, inputs: inputs, outputs: outputs, arguments: arguments).write(to: stream)
+    public func write(to stream: inout ManifestToolStream) {
+        ShellTool(description: description, inputs: inputs, outputs: outputs, arguments: arguments).write(to: &stream)
     }
 }

--- a/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
+++ b/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
@@ -31,7 +31,7 @@ final class LLBuildManifestTests: XCTestCase {
         let decodedEntitlements = try decoder.decode([String: Bool].self, from: .init(contents.utf8))
         XCTAssertEqual(decodedEntitlements, [testEntitlement: true])
 
-        var manifest = BuildManifest()
+        var manifest = LLBuildManifest()
         let outputPath = AbsolutePath("/test.plist")
         manifest.addEntitlementPlistCommand(entitlement: testEntitlement, outputPath: outputPath)
 
@@ -44,7 +44,7 @@ final class LLBuildManifestTests: XCTestCase {
     }
 
     func testBasics() throws {
-        var manifest = BuildManifest()
+        var manifest = LLBuildManifest()
 
         let root: AbsolutePath = "/some"
 
@@ -62,7 +62,7 @@ final class LLBuildManifestTests: XCTestCase {
         manifest.addNode(.virtual("Foo"), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try ManifestWriter.write(manifest, at: "/manifest.yaml", fs)
+        try LLBuildManifestWriter.write(manifest, at: "/manifest.yaml", fs)
 
         let contents: String = try fs.readFileContents("/manifest.yaml")
 
@@ -90,7 +90,7 @@ final class LLBuildManifestTests: XCTestCase {
     }
 
     func testShellCommands() throws {
-        var manifest = BuildManifest()
+        var manifest = LLBuildManifest()
 
         let root: AbsolutePath = .root
 
@@ -118,7 +118,7 @@ final class LLBuildManifestTests: XCTestCase {
         manifest.addNode(.file("/file.out"), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try ManifestWriter.write(manifest, at: "/manifest.yaml", fs)
+        try LLBuildManifestWriter.write(manifest, at: "/manifest.yaml", fs)
 
         let contents: String = try fs.readFileContents("/manifest.yaml")
 
@@ -147,7 +147,7 @@ final class LLBuildManifestTests: XCTestCase {
     }
 
     func testMutatedNodes() throws {
-        var manifest = BuildManifest()
+        var manifest = LLBuildManifest()
 
         let root: AbsolutePath = .root
 
@@ -182,7 +182,7 @@ final class LLBuildManifestTests: XCTestCase {
         )
 
         let fs = InMemoryFileSystem()
-        try ManifestWriter.write(manifest, at: "/manifest.yaml", fs)
+        try LLBuildManifestWriter.write(manifest, at: "/manifest.yaml", fs)
 
         let contents: String = try fs.readFileContents("/manifest.yaml")
 

--- a/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
+++ b/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
@@ -62,7 +62,7 @@ final class LLBuildManifestTests: XCTestCase {
         manifest.addNode(.virtual("Foo"), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try LLBuildManifestWriter.write(manifest, at: "/manifest.yaml", fs)
+        try LLBuildManifestWriter.write(manifest, at: "/manifest.yaml", fileSystem: fs)
 
         let contents: String = try fs.readFileContents("/manifest.yaml")
 
@@ -118,7 +118,7 @@ final class LLBuildManifestTests: XCTestCase {
         manifest.addNode(.file("/file.out"), toTarget: "main")
 
         let fs = InMemoryFileSystem()
-        try LLBuildManifestWriter.write(manifest, at: "/manifest.yaml", fs)
+        try LLBuildManifestWriter.write(manifest, at: "/manifest.yaml", fileSystem: fs)
 
         let contents: String = try fs.readFileContents("/manifest.yaml")
 
@@ -182,7 +182,7 @@ final class LLBuildManifestTests: XCTestCase {
         )
 
         let fs = InMemoryFileSystem()
-        try LLBuildManifestWriter.write(manifest, at: "/manifest.yaml", fs)
+        try LLBuildManifestWriter.write(manifest, at: "/manifest.yaml", fileSystem: fs)
 
         let contents: String = try fs.readFileContents("/manifest.yaml")
 


### PR DESCRIPTION
Dependency of https://github.com/apple/swift-package-manager/pull/7010.

Added per the llbuild documentation at https://github.com/apple/swift-llbuild/blob/a3b8d34be319f1b3ba8de53c434386419dec1f4f/docs/buildsystem.rst#L387 and a corresponding test at https://github.com/apple/swift-llbuild/blob/a3b8d34be319f1b3ba8de53c434386419dec1f4f/tests/BuildSystem/Build/mutable-outputs.llbuild#L66.

Newly introduced attributes are not used anywhere yet in this PR, so technically it is NFC.

I also took the opportunity to get rid of deprecated TSC dependencies in `ManifestWriter.swift`, replacing it with string interpolation instead.