### PR TITLE
Improve diagnostics if `testPackageContextName` fails

### DIFF
--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -208,7 +208,9 @@ class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(observability.diagnostics)
         XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let name = parsedManifest.parentDirectory?.pathString ?? ""
+        XCTAssertNotNil(parsedManifest)
+        XCTAssertNotNil(parsedManifest.parentDirectory)
+        let name = try XCTUnwrap(parsedManifest.parentDirectory).pathString
         XCTAssertEqual(manifest.displayName, name)
     }
 


### PR DESCRIPTION
rdar://116490917