### PR TITLE
[NFC] CoreCommands: simplify `*get-task-allow-entitlement` flags

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -477,11 +477,8 @@ public struct BuildOptions: ParsableArguments {
     )
     public var linkTimeOptimizationMode: LinkTimeOptimizationMode?
 
-    @Flag(help: .hidden)
-    public var enableGetTaskAllowEntitlement: Bool = false
-
-    @Flag(help: .hidden)
-    public var disableGetTaskAllowEntitlement: Bool = false
+    @Flag(inversion: .prefixedEnableDisable, help: .hidden)
+    public var getTaskAllowEntitlement: Bool? = nil
 
     // @Flag works best when there is a default value present
     // if true, false aren't enough and a third state is needed

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -677,9 +677,7 @@ public final class SwiftTool {
             component: targetTriple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
         )
 
-        if !targetTriple.isMacOSX && (
-            options.build.disableGetTaskAllowEntitlement || options.build.enableGetTaskAllowEntitlement
-        ) {
+        if options.build.getTaskAllowEntitlement != nil && !targetTriple.isMacOSX {
             observabilityScope.emit(warning: Self.entitlementsMacOSWarning)
         }
 
@@ -700,8 +698,7 @@ public final class SwiftTool {
                 debugInfoFormat: options.build.debugInfoFormat.buildParameter,
                 targetTriple: targetTriple,
                 shouldEnableDebuggingEntitlement:
-                    (options.build.configuration == .debug && !options.build.disableGetTaskAllowEntitlement) ||
-                    (options.build.enableGetTaskAllowEntitlement && !options.build.disableGetTaskAllowEntitlement)
+                    options.build.getTaskAllowEntitlement ?? (options.build.configuration == .debug)
             ),
             driverParameters: .init(
                 canRenameEntrypointFunctionName: driverSupport.checkSupportedFrontendFlags(


### PR DESCRIPTION
### Motivation:

Following up on feedback to https://github.com/apple/swift-package-manager/pull/7010, it's better to have a single optional boolean flag than two non-optional booleans.

### Modifications:

Replaced `var enableGetTaskAllowEntitlement = false` and `var disableGetTaskAllowEntitlement = false` with `var getTaskAllowEntitlement: Bool? = nil`, which has an additional `inversion: .prefixedEnableDisable` configuration.

### Result:

Code that handles these flags is simpler and easier to read.
