### PR TITLE
Tests: avoid abnormal exit on failure

### DIFF
--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5017,7 +5017,7 @@ final class WorkspaceTests: XCTestCase {
         do {
             let ws = try workspace.getOrCreateWorkspace()
             let pinsStore = try ws.pinsStore.load()
-            let fooPin = pinsStore.pins.values.first(where: { $0.packageRef.identity.description == "foo" })!
+            let fooPin = try XCTUnwrap(pinsStore.pins.values.first(where: { $0.packageRef.identity.description == "foo" }))
 
             let fooRepo = workspace.repositoryProvider
                 .specifierMap[RepositorySpecifier(path: try AbsolutePath(


### PR DESCRIPTION
Rather than using the forced unwrap, use `XCTUnwrap` to allow the test suite to continue in the case of a failure.