### PR TITLE
Revert "refine location comparison when pre-loading package (#7002)"

### DIFF
--- a/Sources/PackageGraph/PubGrub/ContainerProvider.swift
+++ b/Sources/PackageGraph/PubGrub/ContainerProvider.swift
@@ -62,14 +62,14 @@ final class ContainerProvider {
         completion: @escaping (Result<PubGrubPackageContainer, Error>) -> Void
     ) {
         // Return the cached container, if available.
-        if let container = self.containersCache[comparingLocation: package] {
+        if let container = self.containersCache[package], package.equalsIncludingLocation(container.package) {
             return completion(.success(container))
         }
 
         if let prefetchSync = self.prefetches[package] {
             // If this container is already being prefetched, wait for that to complete
             prefetchSync.notify(queue: .sharedConcurrent) {
-                if let container = self.containersCache[comparingLocation: package] {
+                if let container = self.containersCache[package], package.equalsIncludingLocation(container.package) {
                     // should be in the cache once prefetch completed
                     return completion(.success(container))
                 } else {
@@ -123,14 +123,5 @@ final class ContainerProvider {
                 }
             }
         }
-    }
-}
-
-extension ThreadSafeKeyValueStore where Key == PackageReference, Value == PubGrubPackageContainer {
-    subscript(comparingLocation package: PackageReference) -> PubGrubPackageContainer? {
-        if let container = self[package], container.package.equalsIncludingLocation(package) {
-            return container
-        }
-        return .none
     }
 }

--- a/Sources/PackageModel/PackageIdentity.swift
+++ b/Sources/PackageModel/PackageIdentity.swift
@@ -424,7 +424,7 @@ public struct CanonicalPackageLocation: Equatable, CustomStringConvertible {
 }
 
 /// Similar to `CanonicalPackageLocation` but differentiates based on the scheme.
-public struct CanonicalPackageURL: Equatable, CustomStringConvertible {
+public struct CanonicalPackageURL: CustomStringConvertible {
     public let description: String
     public let scheme: String?
 

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -161,24 +161,7 @@ extension PackageReference: Equatable {
 
     // TODO: consider rolling into Equatable
     public func equalsIncludingLocation(_ other: PackageReference) -> Bool {
-        if self.identity != other.identity {
-            return false
-        }
-        if self.canonicalLocation != other.canonicalLocation {
-            return false
-        }
-        switch (self.kind, other.kind) {
-        case (.remoteSourceControl(let lurl), .remoteSourceControl(let rurl)):
-            return lurl.canonicalURL == rurl.canonicalURL
-        default:
-            return true
-        }
-    }
-}
-
-extension SourceControlURL {
-    var canonicalURL: CanonicalPackageURL {
-        CanonicalPackageURL(self.absoluteString)
+        return self.identity == other.identity && self.canonicalLocation == other.canonicalLocation
     }
 }
 

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -196,7 +196,7 @@ extension Workspace {
 
         // When loading manifests in Workspace, there are cases where we must also compare the location
         // as it may attempt to load manifests for dependencies that have the same identity but from a different location
-        // (e.g. dependency is changed to a fork with the same identity)
+        // (e.g. dependency is changed to  a fork with the same identity)
         public subscript(comparingLocation package: PackageReference) -> ManagedDependency? {
             if let dependency = self.dependencies[package.identity], dependency.packageRef.equalsIncludingLocation(package) {
                 return dependency

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -859,8 +859,9 @@ extension Workspace {
             // a required dependency that is already loaded (managed) should be represented in the pins store.
             // also comparing location as it may have changed at this point
             if requiredDependencies.contains(where: { $0.equalsIncludingLocation(dependency.packageRef) }) {
+                let pin = pinsStore.pins[dependency.packageRef.identity]
                 // if pin not found, or location is different (it may have changed at this point) pin it
-                if pinsStore.pins[comparingLocation: dependency.packageRef] == .none {
+                if !(pin?.packageRef.equalsIncludingLocation(dependency.packageRef) ?? false) {
                     pinsStore.pin(dependency)
                 }
             } else if let pin = pinsStore.pins[dependency.packageRef.identity] {

--- a/Sources/Workspace/Workspace+Pinning.swift
+++ b/Sources/Workspace/Workspace+Pinning.swift
@@ -49,8 +49,8 @@ extension Workspace {
                 needsUpdate = true
             } else {
                 for dependency in dependenciesToPin {
-                    if let pin = storedPinStore.pins[comparingLocation: dependency.packageRef] {
-                        if pin.state != PinsStore.Pin(dependency)?.state {
+                    if let pin = storedPinStore.pins.first(where: { $0.value.packageRef.equalsIncludingLocation(dependency.packageRef) }) {
+                        if pin.value.state != PinsStore.Pin(dependency)?.state {
                             needsUpdate = true
                             break
                         }
@@ -178,14 +178,5 @@ extension PinsStore.PinState {
         default:
             return false
         }
-    }
-}
-
-extension PinsStore.Pins {
-    subscript(comparingLocation package: PackageReference) -> PinsStore.Pin? {
-        if let pin = self[package.identity], pin.packageRef.equalsIncludingLocation(package) {
-            return pin
-        }
-        return .none
     }
 }


### PR DESCRIPTION
I've verified that the reverted commit removes required packages from `Package.resolved` in certain dependency graphs.

This reverts commit 1491d340eb995aa3f5c0950e4587f64014522683.

```
# Conflicts:
#	Sources/Workspace/Workspace+Manifests.swift
#	Sources/Workspace/Workspace.swift
```

Resolves rdar://117381924.
