### PR TITLE
`isValidDirectory` and `isValidRefFormat` should be throwing

### DIFF
--- a/Sources/Commands/PackageTools/ArchiveSource.swift
+++ b/Sources/Commands/PackageTools/ArchiveSource.swift
@@ -67,7 +67,7 @@ extension SwiftPackageTool {
     ) throws  {
         let gitRepositoryProvider = GitRepositoryProvider()
         if gitRepositoryProvider.repositoryExists(at: packageDirectory) &&
-            gitRepositoryProvider.isValidDirectory(packageDirectory){
+            (try? gitRepositoryProvider.isValidDirectory(packageDirectory)) == true {
             let repository = GitRepository(path: packageDirectory, cancellator: cancellator)
             try repository.archive(to: archivePath)
         } else {

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -221,12 +221,20 @@ public struct ManifestValidator {
         // validate source control ref
         switch dependency.requirement {
         case .branch(let name):
-            if !self.sourceControlValidator.isValidRefFormat(name) {
-                diagnostics.append(.invalidSourceControlBranchName(name))
+            do {
+                if try !self.sourceControlValidator.isValidRefFormat(name) {
+                    diagnostics.append(.invalidSourceControlBranchName(name))
+                }
+            } catch {
+                diagnostics.append(.invalidSourceControlBranchName(name, underlyingError: error))
             }
         case .revision(let revision):
-            if !self.sourceControlValidator.isValidRefFormat(revision) {
-                diagnostics.append(.invalidSourceControlRevision(revision))
+            do {
+                if try !self.sourceControlValidator.isValidRefFormat(revision) {
+                    diagnostics.append(.invalidSourceControlRevision(revision))
+                }
+            } catch {
+                diagnostics.append(.invalidSourceControlRevision(revision, underlyingError: error))
             }
         default:
             break
@@ -235,11 +243,15 @@ public struct ManifestValidator {
         // there is a case to be made to throw early (here) if the path does not exists
         // but many of our tests assume they can pass a non existent path
         if case .local(let localPath) = dependency.location, self.fileSystem.exists(localPath) {
-            if !self.sourceControlValidator.isValidDirectory(localPath) {
-                // Provides better feedback when mistakingly using url: for a dependency that
-                // is a local package. Still allows for using url with a local package that has
-                // also been initialized by git
-                diagnostics.append(.invalidSourceControlDirectory(localPath))
+            do {
+                if try !self.sourceControlValidator.isValidDirectory(localPath) {
+                    // Provides better feedback when mistakingly using url: for a dependency that
+                    // is a local package. Still allows for using url with a local package that has
+                    // also been initialized by git
+                    diagnostics.append(.invalidSourceControlDirectory(localPath))
+                }
+            } catch {
+                diagnostics.append(.invalidSourceControlDirectory(localPath, underlyingError: error))
             }
         }
         return diagnostics
@@ -247,8 +259,8 @@ public struct ManifestValidator {
 }
 
 public protocol ManifestSourceControlValidator {
-    func isValidRefFormat(_ revision: String) -> Bool
-    func isValidDirectory(_ path: AbsolutePath) -> Bool
+    func isValidRefFormat(_ revision: String) throws -> Bool
+    func isValidDirectory(_ path: AbsolutePath) throws -> Bool
 }
 
 extension Basics.Diagnostic {
@@ -304,16 +316,24 @@ extension Basics.Diagnostic {
             """)
     }
 
-    static func invalidSourceControlBranchName(_ name: String) -> Self {
-        .error("invalid branch name: '\(name)'")
+    static func errorSuffix(_ error: Error?) -> String {
+        if let error {
+            return ": \(error.interpolationDescription)"
+        } else {
+            return ""
+        }
     }
 
-    static func invalidSourceControlRevision(_ revision: String) -> Self {
-        .error("invalid revision: '\(revision)'")
+    static func invalidSourceControlBranchName(_ name: String, underlyingError: Error? = nil) -> Self {
+        .error("invalid branch name: '\(name)'\(errorSuffix(underlyingError))")
     }
 
-    static func invalidSourceControlDirectory(_ path: AbsolutePath) -> Self {
-        .error("cannot clone from local directory \(path)\nPlease git init or use \"path:\" for \(path)")
+    static func invalidSourceControlRevision(_ revision: String, underlyingError: Error? = nil) -> Self {
+        .error("invalid revision: '\(revision)'\(errorSuffix(underlyingError))")
+    }
+
+    static func invalidSourceControlDirectory(_ path: AbsolutePath, underlyingError: Error? = nil) -> Self {
+        .error("cannot clone from local directory \(path)\nPlease git init or use \"path:\" for \(path)\(errorSuffix(underlyingError))")
     }
 }
 

--- a/Sources/PackageMetadata/PackageMetadata.swift
+++ b/Sources/PackageMetadata/PackageMetadata.swift
@@ -253,7 +253,7 @@ public struct PackageSearchClient {
                             to: tempPath,
                             progressHandler: nil
                         )
-                        if self.repositoryProvider.isValidDirectory(tempPath),
+                        if try self.repositoryProvider.isValidDirectory(tempPath),
                            let repository = try self.repositoryProvider.open(
                                repository: repositorySpecifier,
                                at: tempPath

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -482,11 +482,11 @@ public final class InMemoryGitRepositoryProvider: RepositoryProvider {
         return checkout
     }
 
-    public func isValidDirectory(_ directory: AbsolutePath) -> Bool {
+    public func isValidDirectory(_ directory: AbsolutePath) throws -> Bool {
         return true
     }
 
-    public func isValidRefFormat(_ ref: String) -> Bool {
+    public func isValidRefFormat(_ ref: String) throws -> Bool {
         return true
     }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -205,23 +205,15 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
         return localFileSystem.isDirectory(directory)
     }
 
-    public func isValidDirectory(_ directory: Basics.AbsolutePath) -> Bool {
-        do {
-            let result = try self.git.run(["-C", directory.pathString, "rev-parse", "--git-dir"])
-            return result == ".git" || result == "." || result == directory.pathString
-        } catch {
-            return false
-        }
+    public func isValidDirectory(_ directory: Basics.AbsolutePath) throws -> Bool {
+        let result = try self.git.run(["-C", directory.pathString, "rev-parse", "--git-dir"])
+        return result == ".git" || result == "." || result == directory.pathString
     }
 
     /// Returns true if the git reference name is well formed.
-    public func isValidRefFormat(_ ref: String) -> Bool {
-        do {
-            _ = try self.git.run(["check-ref-format", "--allow-onelevel", ref])
-            return true
-        } catch {
-            return false
-        }
+    public func isValidRefFormat(_ ref: String) throws -> Bool {
+        _ = try self.git.run(["check-ref-format", "--allow-onelevel", ref])
+        return true
     }
 
     public func copy(from sourcePath: Basics.AbsolutePath, to destinationPath: Basics.AbsolutePath) throws {

--- a/Sources/SourceControl/Repository.swift
+++ b/Sources/SourceControl/Repository.swift
@@ -143,10 +143,10 @@ public protocol RepositoryProvider: Cancellable {
     func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws
 
     /// Returns true if the directory is valid git location.
-    func isValidDirectory(_ directory: AbsolutePath) -> Bool
+    func isValidDirectory(_ directory: AbsolutePath) throws -> Bool
 
     /// Returns true if the git reference name is well formed.
-    func isValidRefFormat(_ ref: String) -> Bool
+    func isValidRefFormat(_ ref: String) throws -> Bool
 }
 
 /// Abstract repository operations.

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -216,7 +216,7 @@ public class RepositoryManager: Cancellable {
                     self.delegate?.didUpdate(package: package, repository: handle.repository, duration: duration)
                 }
                 return handle
-            } else if self.provider.isValidDirectory(repositoryPath) {
+            } else if try self.provider.isValidDirectory(repositoryPath) {
                 return handle
             }
         }
@@ -334,7 +334,7 @@ public class RepositoryManager: Cancellable {
                 }
             } catch {
                 // If we are offline and have a valid cached repository, use the cache anyway.
-                if isOffline(error) && self.provider.isValidDirectory(cachedRepositoryPath) {
+                if try isOffline(error) && self.provider.isValidDirectory(cachedRepositoryPath) {
                     // For the first offline use in the lifetime of this repository manager, emit a warning.
                     if self.emitNoConnectivityWarning.get(default: false) {
                         self.emitNoConnectivityWarning.put(false)
@@ -422,13 +422,13 @@ public class RepositoryManager: Cancellable {
     }
 
     /// Returns true if the directory is valid git location.
-    public func isValidDirectory(_ directory: AbsolutePath) -> Bool {
-        self.provider.isValidDirectory(directory)
+    public func isValidDirectory(_ directory: AbsolutePath) throws -> Bool {
+        try self.provider.isValidDirectory(directory)
     }
 
     /// Returns true if the git reference name is well formed.
-    public func isValidRefFormat(_ ref: String) -> Bool {
-        self.provider.isValidRefFormat(ref)
+    public func isValidRefFormat(_ ref: String) throws -> Bool {
+        try self.provider.isValidRefFormat(ref)
     }
 
     /// Reset the repository manager.

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -190,11 +190,11 @@ final class ManifestTestDelegate: ManifestLoaderDelegate {
 }
 
 fileprivate struct NOOPManifestSourceControlValidator: ManifestSourceControlValidator {
-    func isValidRefFormat(_ revision: String) -> Bool {
+    func isValidRefFormat(_ revision: String) throws -> Bool {
         true
     }
 
-    func isValidDirectory(_ path: AbsolutePath) -> Bool {
+    func isValidDirectory(_ path: AbsolutePath) throws -> Bool {
         true
     }
 }

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -557,11 +557,11 @@ class RepositoryManagerTests: XCTestCase {
                 fatalError("should not be called")
             }
 
-            func isValidDirectory(_ directory: AbsolutePath) -> Bool {
+            func isValidDirectory(_ directory: AbsolutePath) throws -> Bool {
                 fatalError("should not be called")
             }
 
-            func isValidRefFormat(_ ref: String) -> Bool {
+            func isValidRefFormat(_ ref: String) throws -> Bool {
                 fatalError("should not be called")
             }
 
@@ -640,11 +640,11 @@ private class DummyRepository: Repository {
         fatalError("unexpected API call")
     }
 
-    func isValidDirectory(_ directory: AbsolutePath) -> Bool {
+    func isValidDirectory(_ directory: AbsolutePath) throws -> Bool {
         fatalError("unexpected API call")
     }
 
-    func isValidRefFormat(_ ref: String) -> Bool {
+    func isValidRefFormat(_ ref: String) throws -> Bool {
         fatalError("unexpected API call")
     }
 
@@ -724,11 +724,11 @@ private class DummyRepositoryProvider: RepositoryProvider {
         return DummyWorkingCheckout(at: path)
     }
 
-    func isValidDirectory(_ directory: AbsolutePath) -> Bool {
+    func isValidDirectory(_ directory: AbsolutePath) throws -> Bool {
         return true
     }
 
-    func isValidRefFormat(_ ref: String) -> Bool {
+    func isValidRefFormat(_ ref: String) throws -> Bool {
         return true
     }
 

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -146,11 +146,11 @@ private class MockRepositories: RepositoryProvider {
         fatalError("unexpected API call")
     }
 
-    func isValidDirectory(_ directory: AbsolutePath) -> Bool {
+    func isValidDirectory(_ directory: AbsolutePath) throws -> Bool {
         return true
     }
 
-    func isValidRefFormat(_ ref: String) -> Bool {
+    func isValidRefFormat(_ ref: String) throws -> Bool {
         return true
     }
 


### PR DESCRIPTION
Currently, it is impossible to figure out any failures of these, despite them stopping any package operations entirely if they fail. Instead, we should make them throwing and bubble up any errors.

rdar://117442702
