### PR TITLE
use resolved location when managed dependencies and resolved graph do not agree

### DIFF
--- a/Sources/Workspace/Workspace+Pinning.swift
+++ b/Sources/Workspace/Workspace+Pinning.swift
@@ -30,10 +30,16 @@ extension Workspace {
         for dependency in requiredDependencies {
             if let managedDependency = self.state.dependencies[comparingLocation: dependency] {
                 dependenciesToPin.append(managedDependency)
+            } else if let managedDependency = self.state.dependencies[dependency.identity] {
+                observabilityScope
+                    .emit(
+                        info: "required dependency '\(dependency.identity)' from '\(dependency.locationString)' was not found in managed dependencies, using alternative location '\(managedDependency.packageRef.locationString)' instead"
+                    )
+                dependenciesToPin.append(ManagedDependency(packageRef: dependency, state: managedDependency.state, subpath: managedDependency.subpath))
             } else {
                 observabilityScope
                     .emit(
-                        warning: "required dependency \(dependency.identity) (\(dependency.locationString)) was not found in managed dependencies and will not be recorded in resolved file"
+                        warning: "required dependency '\(dependency.identity)' from '\(dependency.locationString)' was not found in managed dependencies and will not be recorded in resolved file"
                     )
             }
         }


### PR DESCRIPTION
motivation: avoid removing entries from resolved file when managed dependencies has an older location (URL) of a dependency

changes:
* when managed dependencies have an older / different URL from the one resolved, use the resolved one for the resolved file
* add test

rdar://117381924