### PR TITLE
Do not validate unused SCM dependencies

### DIFF
--- a/Examples/package-info/Sources/package-info/example.swift
+++ b/Examples/package-info/Sources/package-info/example.swift
@@ -22,9 +22,9 @@ struct Example {
 
         let workspace = try Workspace(forRootPackage: packagePath)
 
-        let manifest = try await workspace.loadRootManifest(at: packagePath, observabilityScope: observability.topScope)
+        let manifest = try await workspace.loadRootManifest(at: packagePath, rootPackageIdentities: [], observabilityScope: observability.topScope)
 
-        let package = try await workspace.loadRootPackage(at: packagePath, observabilityScope: observability.topScope)
+        let package = try await workspace.loadRootPackage(at: packagePath, rootPackageIdentities: [], observabilityScope: observability.topScope)
 
         let graph = try workspace.loadPackageGraph(rootPath: packagePath, observabilityScope: observability.topScope)
         

--- a/Sources/Commands/PackageTools/Describe.swift
+++ b/Sources/Commands/PackageTools/Describe.swift
@@ -39,6 +39,7 @@ extension SwiftPackageTool {
             let package = try temp_await {
                 workspace.loadRootPackage(
                     at: packagePath,
+                    rootPackageIdentities: [PackageIdentity(path: packagePath)],
                     observabilityScope: swiftTool.observabilityScope,
                     completion: $0
                 )

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -100,6 +100,7 @@ struct DumpPackage: SwiftCommand {
         let rootManifests = try temp_await {
             workspace.loadRootManifests(
                 packages: root.packages,
+                rootPackageIdentities: root.packages.map { PackageIdentity(path: $0) },
                 observabilityScope: swiftTool.observabilityScope,
                 completion: $0
             )

--- a/Sources/Commands/PackageTools/EditCommands.swift
+++ b/Sources/Commands/PackageTools/EditCommands.swift
@@ -45,6 +45,7 @@ extension SwiftPackageTool {
                 path: path,
                 revision: revision,
                 checkoutBranch: checkoutBranch,
+                rootPackageIdentities: [],
                 observabilityScope: swiftTool.observabilityScope
             )
         }

--- a/Sources/Commands/PackageTools/Format.swift
+++ b/Sources/Commands/PackageTools/Format.swift
@@ -51,6 +51,7 @@ extension SwiftPackageTool {
             let package = try temp_await {
                 workspace.loadRootPackage(
                     at: packagePath,
+                    rootPackageIdentities: [PackageIdentity(path: packagePath)],
                     observabilityScope: swiftTool.observabilityScope,
                     completion: $0
                 )

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -402,6 +402,7 @@ public struct SwiftTestTool: SwiftCommand {
         let rootManifests = try temp_await {
             workspace.loadRootManifests(
                 packages: root.packages,
+                rootPackageIdentities: root.packages.map { PackageIdentity(path: $0) },
                 observabilityScope: swiftTool.observabilityScope,
                 completion: $0
             )
@@ -517,6 +518,7 @@ extension SwiftTestTool {
              let rootManifests = try temp_await {
                  workspace.loadRootManifests(
                      packages: root.packages,
+                     rootPackageIdentities: root.packages.map { PackageIdentity(path: $0) },
                      observabilityScope: swiftTool.observabilityScope,
                      completion: $0
                  )

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -348,6 +348,7 @@ public final class MockWorkspace {
                 path: path,
                 revision: revision,
                 checkoutBranch: checkoutBranch,
+                rootPackageIdentities: [],
                 observabilityScope: observability.topScope
             )
         }
@@ -516,7 +517,7 @@ public final class MockWorkspace {
         let pinsStore = try workspace.pinsStore.load()
 
         let rootInput = PackageGraphRootInput(packages: try rootPaths(for: roots.map { $0.name }), dependencies: [])
-        let rootManifests = try temp_await { workspace.loadRootManifests(packages: rootInput.packages, observabilityScope: observability.topScope, completion: $0) }
+        let rootManifests = try temp_await { workspace.loadRootManifests(packages: rootInput.packages, rootPackageIdentities: [], observabilityScope: observability.topScope, completion: $0) }
         let root = PackageGraphRoot(input: rootInput, manifests: rootManifests, observabilityScope: observability.topScope)
 
         let dependencyManifests = try workspace.loadDependencyManifests(root: root, observabilityScope: observability.topScope)
@@ -732,7 +733,7 @@ public final class MockWorkspace {
         let rootInput = PackageGraphRootInput(
             packages: try rootPaths(for: roots), dependencies: dependencies
         )
-        let rootManifests = try temp_await { workspace.loadRootManifests(packages: rootInput.packages, observabilityScope: observability.topScope, completion: $0) }
+        let rootManifests = try temp_await { workspace.loadRootManifests(packages: rootInput.packages, rootPackageIdentities: [], observabilityScope: observability.topScope, completion: $0) }
         let graphRoot = PackageGraphRoot(input: rootInput, manifests: rootManifests, observabilityScope: observability.topScope)
         let manifests = try workspace.loadDependencyManifests(root: graphRoot, observabilityScope: observability.topScope)
         result(manifests, observability.diagnostics)

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -70,6 +70,7 @@ extension Workspace {
         // Load the root manifests and currently checked out manifests.
         let rootManifests = try temp_await { self.loadRootManifests(
             packages: root.packages,
+            rootPackageIdentities: root.packages.map { PackageIdentity(path: $0) },
             observabilityScope: observabilityScope,
             completion: $0
         ) }
@@ -333,6 +334,7 @@ extension Workspace {
         // FIXME: this should not block
         let rootManifests = try temp_await { self.loadRootManifests(
             packages: root.packages,
+            rootPackageIdentities: root.packages.map { PackageIdentity(path: $0) },
             observabilityScope: observabilityScope,
             completion: $0
         ) }
@@ -481,6 +483,7 @@ extension Workspace {
         // Load the root manifests and currently checked out manifests.
         let rootManifests = try temp_await { self.loadRootManifests(
             packages: root.packages,
+            rootPackageIdentities: root.packages.map { PackageIdentity(path: $0) },
             observabilityScope: observabilityScope,
             completion: $0
         ) }

--- a/Sources/Workspace/Workspace+Editing.swift
+++ b/Sources/Workspace/Workspace+Editing.swift
@@ -18,6 +18,8 @@ import struct PackageGraph.PackageGraphRootInput
 import struct SourceControl.Revision
 import class TSCBasic.InMemoryFileSystem
 
+import PackageModel
+
 extension Workspace {
     /// Edit implementation.
     func _edit(
@@ -25,6 +27,7 @@ extension Workspace {
         path: AbsolutePath? = nil,
         revision: Revision? = nil,
         checkoutBranch: String? = nil,
+        rootPackageIdentities: [PackageIdentity],
         observabilityScope: ObservabilityScope
     ) throws {
         // Look up the dependency and check if we can edit it.
@@ -70,6 +73,7 @@ extension Workspace {
                     packageKind: .fileSystem(destination),
                     packagePath: destination,
                     packageLocation: dependency.packageRef.locationString,
+                    rootPackageIdentities: rootPackageIdentities,
                     observabilityScope: observabilityScope,
                     completion: $0
                 )

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2956,6 +2956,7 @@ final class PackageToolTests: CommandsTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -367,6 +367,7 @@ class PluginTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -550,6 +551,7 @@ class PluginTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -647,6 +649,7 @@ class PluginTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -943,6 +946,7 @@ class PluginTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -115,7 +115,7 @@ class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
             throw StringError("Invalid manifest version")
         }
 
-        let validator = ManifestValidator(manifest: manifest, sourceControlValidator: NOOPManifestSourceControlValidator(), fileSystem: fileSystem)
+        let validator = ManifestValidator(manifest: manifest, sourceControlValidator: NOOPManifestSourceControlValidator(), dependencyMapper: NOOPDependencyMapper(), rootPackageIdentities: [], fileSystem: fileSystem)
         let diagnostics = validator.validate()
         return (manifest: manifest, diagnostics: diagnostics)
     }
@@ -196,5 +196,19 @@ fileprivate struct NOOPManifestSourceControlValidator: ManifestSourceControlVali
 
     func isValidDirectory(_ path: AbsolutePath) -> Bool {
         true
+    }
+}
+
+fileprivate struct NOOPDependencyMapper: DependencyMapper {
+    func mappedDependency(for dependency: PackageDependency, fileSystem: FileSystem) throws -> PackageDependency {
+        return dependency
+    }
+    
+    func mappedDependency(packageKind: PackageReference.Kind?, at location: String, nameForTargetDependencyResolutionOnly: String?, requirement: PackageDependency.Registry.Requirement, productFilter: ProductFilter, fileSystem: FileSystem) throws -> PackageDependency {
+        fatalError("not implemented")
+    }
+    
+    func mappedDependency(packageKind: PackageReference.Kind?, at location: String, nameForTargetDependencyResolutionOnly: String?, requirement: PackageDependency.SourceControl.Requirement, productFilter: ProductFilter, fileSystem: FileSystem) throws -> PackageDependency {
+        fatalError("not implemented")
     }
 }

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -288,6 +288,7 @@ class PluginInvocationTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -678,6 +679,7 @@ class PluginInvocationTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -757,6 +759,7 @@ class PluginInvocationTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -867,6 +870,7 @@ class PluginInvocationTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -1051,6 +1055,7 @@ class PluginInvocationTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -1195,6 +1200,7 @@ class PluginInvocationTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -246,6 +246,7 @@ final class WorkspaceTests: XCTestCase {
             let rootManifests = try temp_await {
                 workspace.loadRootManifests(
                     packages: rootInput.packages,
+                    rootPackageIdentities: rootInput.packages.map { PackageIdentity(path: $0) },
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -5249,6 +5250,7 @@ final class WorkspaceTests: XCTestCase {
             let manifest = try temp_await {
                 workspace.loadRootManifest(
                     at: packagePath,
+                    rootPackageIdentities: [PackageIdentity(path: packagePath)],
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -5259,6 +5261,7 @@ final class WorkspaceTests: XCTestCase {
             let package = try temp_await {
                 workspace.loadRootPackage(
                     at: packagePath,
+                    rootPackageIdentities: [PackageIdentity(path: packagePath)],
                     observabilityScope: observability.topScope,
                     completion: $0
                 )
@@ -8803,8 +8806,10 @@ final class WorkspaceTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
         let wks = try workspace.getOrCreateWorkspace()
         XCTAssertNoThrow(try temp_await {
+            let path = workspace.rootsDir.appending("Root")
             wks.loadRootPackage(
-                at: workspace.rootsDir.appending("Root"),
+                at: path,
+                rootPackageIdentities: [PackageIdentity(path: path)],
                 observabilityScope: observability.topScope,
                 completion: $0
             )


### PR DESCRIPTION
Currently, we are doing unconditional validation of any SCM dependencies which can lead to unexpected and confusing results, e.g. the branch of a SCM dependency that is overidden by a root failing validation and breaking builds. We should only validate what we actually use.

rdar://117442643