### PR TITLE
Disable branch name validation

### DIFF
--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -221,13 +221,8 @@ public struct ManifestValidator {
         // validate source control ref
         switch dependency.requirement {
         case .branch(let name):
-            do {
-                if try !self.sourceControlValidator.isValidRefFormat(name) {
-                    diagnostics.append(.invalidSourceControlBranchName(name))
-                }
-            } catch {
-                diagnostics.append(.invalidSourceControlBranchName(name, underlyingError: error))
-            }
+            // FIXME: removed this validation because it is applied unconditionally, rdar://117442643 tracks restoring it once we can do it right
+            break
         case .revision(let revision):
             do {
                 if try !self.sourceControlValidator.isValidRefFormat(revision) {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -338,6 +338,8 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testInvalidRefsValidation() throws {
+        try XCTSkipIf(true, "skipping since we disabled the validation, see rdar://117442643")
+
         try fixture(name: "Miscellaneous/InvalidRefs", createGitRepo: false) { fixturePath in
             do {
                 XCTAssertThrowsError(try SwiftPM.Build.execute(packagePath: fixturePath.appending("InvalidBranch"))) { error in


### PR DESCRIPTION
This validation happens unconditionally after parsing a manifest, so even if a dependency may be unused or overidden which is undesirable and unexpected. We need to either provide context or move the validation, but this currently breaks builds in environments where the validation doesn't succeed, so to unblock, we can disable it.

rdar://117330410