### PR TITLE
Infer properties of derived test target.

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -86,8 +86,8 @@ extension BuildPlan {
                 let discoveryResolvedTarget = ResolvedTarget(
                     target: discoveryTarget,
                     dependencies: testProduct.targets.map { .target($0, conditions: []) },
-                    defaultLocalization: .none, // safe since this is a derived target
-                    platforms: .init(declared: [], derivedXCTestPlatformProvider: .none) // safe since this is a derived target
+                    defaultLocalization: testProduct.defaultLocalization,
+                    platforms: testProduct.platforms
                 )
                 let discoveryTargetBuildDescription = try SwiftTargetBuildDescription(
                     package: package,
@@ -119,8 +119,8 @@ extension BuildPlan {
                 let entryPointResolvedTarget = ResolvedTarget(
                     target: entryPointTarget,
                     dependencies: testProduct.targets.map { .target($0, conditions: []) } + [.target(discoveryResolvedTarget, conditions: [])],
-                    defaultLocalization: .none, // safe since this is a derived target
-                    platforms: .init(declared: [], derivedXCTestPlatformProvider: .none) // safe since this is a derived target
+                    defaultLocalization: testProduct.defaultLocalization,
+                    platforms: testProduct.platforms
                 )
                 return try SwiftTargetBuildDescription(
                     package: package,
@@ -148,8 +148,8 @@ extension BuildPlan {
                         let entryPointResolvedTarget = ResolvedTarget(
                             target: entryPointTarget,
                             dependencies: entryPointResolvedTarget.dependencies + [.target(discoveryTargets.resolved, conditions: [])],
-                            defaultLocalization: .none, // safe since this is a derived target
-                            platforms: .init(declared: [], derivedXCTestPlatformProvider: .none) // safe since this is a derived target
+                            defaultLocalization: testProduct.defaultLocalization,
+                            platforms: testProduct.platforms
                         )
                         let entryPointTargetBuildDescription = try SwiftTargetBuildDescription(
                             package: package,

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -66,11 +66,16 @@ public final class ResolvedProduct {
                                           dependencies: dependencies,
                                           packageAccess: true, // entry point target so treated as a part of the package
                                           testEntryPointPath: testEntryPointPath)
+            let (defaultLocalization, platforms) = if let firstTarget = targets.first {
+                (firstTarget.defaultLocalization, firstTarget.platforms)
+            } else {
+                (.none, .init(declared: [], derivedXCTestPlatformProvider: .none)) // safe since this is a derived product
+            }
             return ResolvedTarget(
                 target: swiftTarget,
                 dependencies: targets.map { .target($0, conditions: []) },
-                defaultLocalization: targets[0].defaultLocalization,
-                platforms: targets[0].platforms
+                defaultLocalization: defaultLocalization,
+                platforms: platforms
             )
         }
 

--- a/Sources/PackageGraph/ResolvedProduct.swift
+++ b/Sources/PackageGraph/ResolvedProduct.swift
@@ -69,8 +69,8 @@ public final class ResolvedProduct {
             return ResolvedTarget(
                 target: swiftTarget,
                 dependencies: targets.map { .target($0, conditions: []) },
-                defaultLocalization: .none, // safe since this is a derived product
-                platforms: .init(declared: [], derivedXCTestPlatformProvider: .none) // safe since this is a derived product
+                defaultLocalization: targets[0].defaultLocalization,
+                platforms: targets[0].platforms
             )
         }
 


### PR DESCRIPTION
Right now, when we construct the derived test target used on Linux/Windows with corelibs-xctest, we don't preserve the `platforms` property. The toolchain then infers a value for it based on the current OS. Since Swift doesn't currently support versioning on those platforms, the end result is the same.

However, if we want to start using a derived test target with swift-testing on Apple platforms, we need to propagate this information correctly. This PR does that.