### PR TITLE
Revert "Generate Clang module maps during the build"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -167,10 +167,7 @@ let package = Package(
         .target(
             /** The llbuild manifest model */
             name: "LLBuildManifest",
-            dependencies: [
-                "Basics",
-                "PackageLoading",
-            ],
+            dependencies: ["Basics"],
             exclude: ["CMakeLists.txt"]
         ),
 

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -155,9 +155,17 @@ public final class ClangTargetBuildDescription {
             if case .custom(let path) = clangTarget.moduleMapType {
                 self.moduleMap = path
             }
-            // If a generated module map is needed, set the path accordingly.
-            else if clangTarget.moduleMapType.generatedModuleMapType != nil {
-                self.moduleMap = tempsPath.appending(component: moduleMapFilename)
+            // If a generated module map is needed, generate one now in our temporary directory.
+            else if let generatedModuleMapType = clangTarget.moduleMapType.generatedModuleMapType {
+                let path = tempsPath.appending(component: moduleMapFilename)
+                let moduleMapGenerator = ModuleMapGenerator(
+                    targetName: clangTarget.name,
+                    moduleName: clangTarget.c99name,
+                    publicHeadersDir: clangTarget.includeDir,
+                    fileSystem: fileSystem
+                )
+                try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType, at: path)
+                self.moduleMap = path
             }
             // Otherwise there is no module map, and we leave `moduleMap` unset.
         }

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
@@ -45,9 +45,9 @@ extension LLBuildManifestBuilder {
             outputs.append(output)
         }
 
-        return self.addPhonyCommand(
-            targetName: target.target.getLLBuildResourcesCmdName(config: self.buildConfig),
-            inputs: outputs
-        )
+        let cmdName = target.target.getLLBuildResourcesCmdName(config: self.buildConfig)
+        self.manifest.addPhonyCmd(name: cmdName, inputs: outputs, outputs: [.virtual(cmdName)])
+
+        return .virtual(cmdName)
     }
 }

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -431,7 +431,6 @@ extension LLBuildManifestBuilder {
             case .swift(let target)?:
                 inputs.append(file: target.moduleOutputPath)
             case .clang(let target)?:
-                inputs.append(.virtual(target.target.getLLBuildModulesReadyCmdName(config: self.buildConfig)))
                 for object in try target.objects {
                     inputs.append(file: object)
                 }
@@ -488,11 +487,15 @@ extension LLBuildManifestBuilder {
     /// Adds a top-level phony command that builds the entire target.
     private func addTargetCmd(_ target: SwiftTargetBuildDescription, cmdOutputs: [Node]) {
         // Create a phony node to represent the entire target.
-        let targetOutput = self.addPhonyCommand(
-            targetName: target.target.getLLBuildTargetName(config: self.buildConfig),
-            inputs: cmdOutputs
-        )
+        let targetName = target.target.getLLBuildTargetName(config: self.buildConfig)
+        let targetOutput: Node = .virtual(targetName)
 
+        self.manifest.addNode(targetOutput, toTarget: targetName)
+        self.manifest.addPhonyCmd(
+            name: targetOutput.name,
+            inputs: cmdOutputs,
+            outputs: [targetOutput]
+        )
         if self.plan.graph.isInRootPackages(target.target, satisfying: self.buildEnvironment) {
             if !target.isTestTarget {
                 self.addNode(targetOutput, toTarget: .main)

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -292,10 +292,6 @@ extension ResolvedTarget {
     public func getLLBuildResourcesCmdName(config: String) -> String {
         "\(name)-\(config).module-resources"
     }
-
-    public func getLLBuildModulesReadyCmdName(config: String) -> String {
-        "\(name)-\(config).modules-ready"
-    }
 }
 
 extension ResolvedProduct {
@@ -348,18 +344,6 @@ extension LLBuildManifestBuilder {
 
     func destinationPath(forBinaryAt path: AbsolutePath) -> AbsolutePath {
         self.plan.buildParameters.buildPath.appending(component: path.basename)
-    }
-
-    /// Adds a phony command and a corresponding virtual node as output.
-    func addPhonyCommand(targetName: String, inputs: [Node]) -> Node {
-        let output: Node = .virtual(targetName)
-        self.manifest.addNode(output, toTarget: targetName)
-        self.manifest.addPhonyCmd(
-            name: output.name,
-            inputs: inputs,
-            outputs: [output]
-        )
-        return output
     }
 }
 

--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -15,7 +15,6 @@ add_library(LLBuildManifest STATIC
   Tools.swift)
 target_link_libraries(LLBuildManifest PUBLIC
   TSCBasic
-  PackageLoading
   Basics)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/Sources/LLBuildManifest/LLBuildManifest.swift
+++ b/Sources/LLBuildManifest/LLBuildManifest.swift
@@ -12,7 +12,6 @@
 
 import Basics
 import Foundation
-import PackageLoading
 
 import class TSCBasic.Process
 
@@ -24,7 +23,6 @@ public protocol AuxiliaryFileType {
 
 public enum WriteAuxiliary {
     public static let fileTypes: [AuxiliaryFileType.Type] = [
-        ClangModuleMap.self,
         EntitlementPlist.self,
         LinkFileList.self,
         SourcesFileList.self,
@@ -53,58 +51,6 @@ public enum WriteAuxiliary {
 
         private enum Error: Swift.Error {
             case undefinedEntitlementName
-        }
-    }
-
-    public struct ClangModuleMap: AuxiliaryFileType {
-        public static let name = "modulemap"
-
-        private enum GeneratedModuleMapType: String {
-            case umbrellaDirectory
-            case umbrellaHeader
-        }
-
-        public static func computeInputs(
-            targetName: String, 
-            moduleName: String, 
-            publicHeadersDir: AbsolutePath, 
-            type: PackageLoading.GeneratedModuleMapType
-        ) -> [Node] {
-            let typeNodes: [Node]
-            switch type {
-            case .umbrellaDirectory(let path):
-                typeNodes = [.virtual(GeneratedModuleMapType.umbrellaDirectory.rawValue), .directory(path)]
-            case .umbrellaHeader(let path):
-                typeNodes = [.virtual(GeneratedModuleMapType.umbrellaHeader.rawValue), .file(path)]
-            }
-            return [.virtual(Self.name), .virtual(targetName), .virtual(moduleName), .directory(publicHeadersDir)] + typeNodes
-        }
-
-        public static func getFileContents(inputs: [Node]) throws -> String {
-            guard inputs.count == 5 else {
-                throw StringError("invalid module map generation task, inputs: \(inputs)")
-            }
-
-            let generator = ModuleMapGenerator(
-                targetName: inputs[0].extractedVirtualNodeName,
-                moduleName: inputs[1].extractedVirtualNodeName,
-                publicHeadersDir: try AbsolutePath(validating: inputs[2].name),
-                fileSystem: localFileSystem
-            )
-
-            let declaredType = inputs[3].extractedVirtualNodeName
-            let path = try AbsolutePath(validating: inputs[4].name)
-            let type: PackageLoading.GeneratedModuleMapType
-            switch declaredType {
-            case GeneratedModuleMapType.umbrellaDirectory.rawValue:
-                type = .umbrellaDirectory(path)
-            case GeneratedModuleMapType.umbrellaHeader.rawValue:
-                type = .umbrellaHeader(path)
-            default:
-                throw StringError("invalid module map type in generation task: \(declaredType)")
-            }
-
-            return try generator.generateModuleMap(type: type)
         }
     }
 
@@ -329,24 +275,6 @@ public struct LLBuildManifest {
 
     public mutating func addWriteInfoPlistCommand(principalClass: String, outputPath: AbsolutePath) {
         let inputs = WriteAuxiliary.XCTestInfoPlist.computeInputs(principalClass: principalClass)
-        let tool = WriteAuxiliaryFile(inputs: inputs, outputFilePath: outputPath)
-        let name = outputPath.pathString
-        commands[name] = Command(name: name, tool: tool)
-    }
-
-    public mutating func addWriteClangModuleMapCommand(
-        targetName: String,
-        moduleName: String,
-        publicHeadersDir: AbsolutePath,
-        type: GeneratedModuleMapType,
-        outputPath: AbsolutePath
-    ) {
-        let inputs = WriteAuxiliary.ClangModuleMap.computeInputs(
-            targetName: targetName,
-            moduleName: moduleName,
-            publicHeadersDir: publicHeadersDir,
-            type: type
-        )
         let tool = WriteAuxiliaryFile(inputs: inputs, outputFilePath: outputPath)
         let name = outputPath.pathString
         commands[name] = Command(name: name, tool: tool)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4034,7 +4034,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("""
               "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
                 tool: clang
-                inputs: ["<Bar-debug.modules-ready>","<Foo-debug.modules-ready>","\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+                inputs: ["\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
                 outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
                 description: "Compiling Bar main.m"
             """))
@@ -4108,7 +4108,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("""
                "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
                  tool: clang
-                 inputs: ["<Bar-debug.modules-ready>","<Foo-debug.modules-ready>","\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+                 inputs: ["\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
                  outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
                  description: "Compiling Bar main.m"
              """))
@@ -4188,7 +4188,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("""
                "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
                  tool: clang
-                 inputs: ["<Bar-debug.modules-ready>","\(buildPath.appending(components: "\(dynamicLibraryPrefix)Foo\(dynamicLibraryExtension)").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+                 inputs: ["\(buildPath.appending(components: "\(dynamicLibraryPrefix)Foo\(dynamicLibraryExtension)").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
                  outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
                  description: "Compiling Bar main.m"
              """))

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -190,11 +190,10 @@ func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fi
     let generatedModuleMapPath = AbsolutePath.root.appending(components: "module.modulemap")
     observability.topScope.trap {
         if let generatedModuleMapType = moduleMapType.generatedModuleMapType {
-            let contents = try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType)
-            try fileSystem.writeIfChanged(path: generatedModuleMapPath, string: contents)
+            try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType, at: generatedModuleMapPath)
         }
     }
-
+    
     // Invoke the closure to check the results.
     let result = ModuleMapResult(diagnostics: observability.diagnostics, path: generatedModuleMapPath, fs: fileSystem)
     body(result)


### PR DESCRIPTION
Reverts apple/swift-package-manager#6983

We're seeing errors like

```
fatal error: module map file '/Users/ec2-user/jenkins/workspace/swift-PR-macos-smoke-test/branch-main/build/buildbot_incremental/swiftdriver-macosx-x86_64/x86_64-apple-macosx/release/llbuildBasic.build/module.modulemap' not found
```

on various CI jobs and should revert this to unblock.