### PR TITLE
Revert "Ensure Xcode SDK paths are set when running test targets."

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -108,7 +108,7 @@ enum TestingSupport {
         #if os(macOS)
         let data: String = try withTemporaryFile { tempFile in
             args = [try Self.xctestHelperPath(swiftTool: swiftTool).pathString, path.pathString, tempFile.path.pathString]
-            let env = try Self.constructTestEnvironment(
+            var env = try Self.constructTestEnvironment(
                 toolchain: try swiftTool.getTargetToolchain(),
                 buildParameters: swiftTool.buildParametersForTest(
                     enableCodeCoverage: enableCodeCoverage,
@@ -117,6 +117,12 @@ enum TestingSupport {
                 ),
                 sanitizers: sanitizers
             )
+
+            // Add the sdk platform path if we have it. If this is not present, we might always end up failing.
+            let sdkPlatformFrameworksPath = try SwiftSDK.sdkPlatformFrameworkPaths()
+            // appending since we prefer the user setting (if set) to the one we inject
+            env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
+            env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)
 
             try TSCBasic.Process.checkNonZeroExit(arguments: args, environment: env)
             // Read the temporary file's content.
@@ -174,12 +180,6 @@ enum TestingSupport {
         #endif
         return env
         #else
-        // Add the sdk platform path if we have it. If this is not present, we might always end up failing.
-        let sdkPlatformFrameworksPath = try SwiftSDK.sdkPlatformFrameworkPaths()
-        // appending since we prefer the user setting (if set) to the one we inject
-        env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
-        env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)
-
         // Fast path when no sanitizers are enabled.
         if sanitizers.isEmpty {
             return env


### PR DESCRIPTION
Reverts apple/swift-package-manager#7040

This is very speculative revert at this point since I am unable to reproduce, but since last Wednesday, we have been seeing this issue on the nightly toolchain CI:

```
error: error while executing `/Applications/Xcode.app/Contents/Developer/usr/bin/xctest -XCTest WorkspaceTests.PinsStoreTests/testLoadingSchema2 /Users/ec2-user/jenkins/workspace/oss-swift-package-macos/build/buildbot_osx/swiftpm-macosx-x86_64/apple/Products/Release/WorkspaceTests.xctest`: close error: Bad file descriptor (9)
```

and this change seems to fit in timeline wise and also as it affects testing, so it becomes the most relevant candidate for a speculative revert. The process invocation code hasn't changed in a meaningful way in a long time, so it seems unlikely that the logic there is the culprit.

rdar://117927523