### PR TITLE
PackageModel: make `Toolset.init(toolchainBinDir:buildFlags:)` public

### DIFF
--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -157,7 +157,7 @@ extension Toolset {
         }
     }
 
-    init(toolchainBinDir: AbsolutePath, buildFlags: BuildFlags) {
+    public init(toolchainBinDir: AbsolutePath, buildFlags: BuildFlags = .init()) {
         self.rootPaths = [toolchainBinDir]
         self.knownTools = [
             .cCompiler: .init(extraCLIOptions: buildFlags.cCompilerFlags),

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -157,6 +157,10 @@ extension Toolset {
         }
     }
 
+    /// Initialize a new ad-hoc toolset that wasn't previously serialized, but created in memory.
+    /// - Parameters:
+    ///   - toolchainBinDir: absolute path to the toolchain binaries directory, which are used in this toolset.
+    ///   - buildFlags: flags provided to each tool as CLI options.
     public init(toolchainBinDir: AbsolutePath, buildFlags: BuildFlags = .init()) {
         self.rootPaths = [toolchainBinDir]
         self.knownTools = [


### PR DESCRIPTION
Previously the only available initializer allowed creating toolsets from serialized form stored on a file system. This initializer allows creating `Toolset` values directly with given build flags and toolchain binaries directory path, which may be needed by libSwiftPM clients.
