### PR TITLE
[NFC] XCBuildSupport: fix comment typo in `PIFBuilder.swift`

### DIFF
--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1643,7 +1643,7 @@ extension PIF.PlatformFilter {
         .init(platform: "openbsd"),
     ]
 
-    /// Web Assembly platform filters.
+    /// WebAssembly platform filters.
     public static let webAssemblyFilters: [PIF.PlatformFilter] = [
         .init(platform: "wasi"),
     ]


### PR DESCRIPTION
`Web Assembly` -> `WebAssembly`