### PR TITLE
Skip `testDownloadDefaultAuthenticationSuccess` on CI

### DIFF
--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -356,6 +356,7 @@ final class URLSessionHTTPClientTest: XCTestCase {
         // https://github.com/apple/swift-corelibs-foundation/pull/2593 tries to address the latter part
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
+        try XCTSkipIfCI()
         let netrcContent = "default login default password default"
         let netrc = try NetrcAuthorizationWrapper(underlying: NetrcParser.parse(netrcContent))
         let authData = Data("default:default".utf8)


### PR DESCRIPTION
Seems like this tends to be flaky on CI.

rdar://118135091