### PR TITLE
remove graph loading on package update

### DIFF
--- a/Sources/Commands/PackageTools/Update.swift
+++ b/Sources/Commands/PackageTools/Update.swift
@@ -42,14 +42,6 @@ extension SwiftPackageTool {
                 observabilityScope: swiftTool.observabilityScope
             )
 
-            // try to load the graph which will emit any errors
-            if !swiftTool.observabilityScope.errorsReported {
-                _ = try workspace.loadPackageGraph(
-                    rootInput: swiftTool.getWorkspaceRoot(),
-                    observabilityScope: swiftTool.observabilityScope
-                )
-            }
-
             if self.dryRun, let changes = changes, let pinsStore = swiftTool.observabilityScope.trap({ try workspace.pinsStore.load() }){
                 self.logPackageChanges(changes: changes, pins: pinsStore)
             }


### PR DESCRIPTION
motivation: consistent behavior between pacakge update and package resolve

changes: do not attempt to load the dependencies graph (which performs additional validations), this means validation is deferred until build is attempted

rdar://113413552

