### PR TITLE
Allow tar.xz archives

### DIFF
--- a/Sources/Basics/Archiver/TarArchiver.swift
+++ b/Sources/Basics/Archiver/TarArchiver.swift
@@ -17,7 +17,7 @@ import class TSCBasic.Process
 
 /// An `Archiver` that handles Tar archives using the command-line `tar` tool.
 public struct TarArchiver: Archiver {
-    public let supportedExtensions: Set<String> = ["tar", "tar.gz"]
+    public let supportedExtensions: Set<String> = ["tar", "tar.gz", "tar.xz"]
 
     /// The file-system implementation used for various file-system operations and checks.
     private let fileSystem: FileSystem


### PR DESCRIPTION
Allow tar.xz archives

### Motivation:

Better compression, [important](https://code.videolan.org/videolan/VLCKit/-/merge_requests/127#:~:text=I%27m%20not%20super%20happy%20that%20SPM%20does%20seem%20to%20support%20.zip%20archives%20only%20as%20this%20noticeably%20increases%20the%20download%20size%20compared%20to%20.xz.) for projects such as VLC

### Modifications:

All I had to do was add to list of allowed extensions, so system tar can handle it.

### Result:

Tar.xz are allowed
