### PR TITLE
Disable `testPackageNameFlag`

### DIFF
--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -527,9 +527,10 @@ final class BuildPlanTests: XCTestCase {
     }
 
     func testPackageNameFlag() throws {
+        try XCTSkipIfCI() // test is disabled because it isn't stable, see rdar://118239206
         let isFlagSupportedInDriver = try DriverSupport.checkToolchainDriverFlags(flags: ["package-name"], toolchain: UserToolchain.default, fileSystem: localFileSystem)
         try fixture(name: "Miscellaneous/PackageNameFlag") { fixturePath in
-            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("appPkg"), extraArgs: ["-v"])
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("appPkg"), extraArgs: ["-vv"])
             XCTAssertMatch(stdout, .contains("-module-name Foo"))
             XCTAssertMatch(stdout, .contains("-module-name Zoo"))
             XCTAssertMatch(stdout, .contains("-module-name Bar"))


### PR DESCRIPTION
We're seeing errors like

```
error: Failed to clone repository /private/var/folders/7n/r31lzfjx6556jgc6vg55_cg80000gn/T/Miscellaneous_PackageNameFlag.qKbjHI/barPkg:
    fatal: destination path '/private/var/folders/7n/r31lzfjx6556jgc6vg55_cg80000gn/T/Miscellaneous_PackageNameFlag.qKbjHI/appPkg/.build/repositories/barPkg-5f2fb998' already exists and is not an empty directory.
```

on CI that are currently unexplained.