### PR TITLE
Disallow static linking core libraries in `swift test`

### DIFF
--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -131,6 +131,7 @@ public struct SwiftBuildTool: SwiftCommand {
         }
         let buildSystem = try swiftTool.createBuildSystem(
             explicitProduct: options.product,
+            shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib,
             // command result output goes on stdout
             // ie "swift build" should output to stdout
             customOutputStream: TSCBasic.stdoutStream

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -85,6 +85,10 @@ struct BuildToolOptions: ParsableArguments {
     /// Specific product to build.
     @Option(help: "Build the specified product")
     var product: String?
+
+    /// If should link the Swift stdlib statically.
+    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
+    public var shouldLinkStaticSwiftStdlib: Bool = false
 }
 
 /// swift-build tool namespace

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -39,7 +39,6 @@ private enum TestError: Swift.Error {
     case testProductNotFound(productName: String)
     case productIsNotTest(productName: String)
     case multipleTestProducts([String])
-    case staticLinkingNotSupported
     case xctestNotAvailable
 }
 
@@ -57,8 +56,6 @@ extension TestError: CustomStringConvertible {
             return "invalid list test JSON structure, produced by \(context)\(underlying)"
         case .multipleTestProducts(let products):
             return "found multiple test products: \(products.joined(separator: ", ")); use --test-product to select one"
-        case .staticLinkingNotSupported:
-            return "static linking for Swift runtime and core libraries is currently not supported in test products"
         case .xctestNotAvailable:
             return "XCTest not available"
         }
@@ -195,10 +192,6 @@ public struct SwiftTestTool: SwiftCommand {
         do {
             // Validate commands arguments
             try self.validateArguments(observabilityScope: swiftTool.observabilityScope)
-
-            guard !self.globalOptions.linker.shouldLinkStaticSwiftStdlib else {
-                throw TestError.staticLinkingNotSupported
-            }
 
             // validate XCTest available on darwin based systems
             let toolchain = try swiftTool.getTargetToolchain()

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -39,6 +39,7 @@ private enum TestError: Swift.Error {
     case testProductNotFound(productName: String)
     case productIsNotTest(productName: String)
     case multipleTestProducts([String])
+    case staticLinkingNotSupported
     case xctestNotAvailable
 }
 
@@ -56,6 +57,8 @@ extension TestError: CustomStringConvertible {
             return "invalid list test JSON structure, produced by \(context)\(underlying)"
         case .multipleTestProducts(let products):
             return "found multiple test products: \(products.joined(separator: ", ")); use --test-product to select one"
+        case .staticLinkingNotSupported:
+            return "static linking for Swift runtime and core libraries is currently not supported in test products"
         case .xctestNotAvailable:
             return "XCTest not available"
         }
@@ -192,6 +195,10 @@ public struct SwiftTestTool: SwiftCommand {
         do {
             // Validate commands arguments
             try self.validateArguments(observabilityScope: swiftTool.observabilityScope)
+
+            guard !self.globalOptions.linker.shouldLinkStaticSwiftStdlib else {
+                throw TestError.staticLinkingNotSupported
+            }
 
             // validate XCTest available on darwin based systems
             let toolchain = try swiftTool.getTargetToolchain()

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -529,10 +529,6 @@ public struct LinkerOptions: ParsableArguments {
     )
     public var linkerDeadStrip: Bool = true
 
-    /// If should link the Swift stdlib statically.
-    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
-    public var shouldLinkStaticSwiftStdlib: Bool = false
-
     /// Disables adding $ORIGIN/@loader_path to the rpath, useful when deploying
     @Flag(name: .customLong("disable-local-rpath"), help: "Disable adding $ORIGIN/@loader_path to the rpath by default")
     public var shouldDisableLocalRpath: Bool = false

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -641,6 +641,7 @@ public final class SwiftTool {
         explicitBuildSystem: BuildSystemProvider.Kind? = .none,
         explicitProduct: String? = .none,
         cacheBuildManifest: Bool = true,
+        shouldLinkStaticSwiftStdlib: Bool = false,
         customBuildParameters: BuildParameters? = .none,
         customPackageGraphLoader: (() throws -> PackageGraph)? = .none,
         customOutputStream: OutputByteStream? = .none,
@@ -650,6 +651,9 @@ public final class SwiftTool {
         guard let buildSystemProvider else {
             fatalError("build system provider not initialized")
         }
+
+        var buildParameters = try customBuildParameters ?? self.buildParameters()
+        buildParameters.linkingParameters.shouldLinkStaticSwiftStdlib = shouldLinkStaticSwiftStdlib
 
         let buildSystem = try buildSystemProvider.createBuildSystem(
             kind: explicitBuildSystem ?? options.build.buildSystem,
@@ -718,8 +722,7 @@ public final class SwiftTool {
             linkingParameters: .init(
                 linkerDeadStrip: options.linker.linkerDeadStrip,
                 linkTimeOptimizationMode: options.build.linkTimeOptimizationMode?.buildParameter,
-                shouldDisableLocalRpath: options.linker.shouldDisableLocalRpath,
-                shouldLinkStaticSwiftStdlib: options.linker.shouldLinkStaticSwiftStdlib
+                shouldDisableLocalRpath: options.linker.shouldDisableLocalRpath
             ),
             outputParameters: .init(
                 isVerbose: self.logLevel <= .info


### PR DESCRIPTION
This is currently not supported and we should show a proper error message in this case.

Resolves rdar://117908112.
