### PR TITLE
Revert "Update bootstrap script to disable --parallel for testing by default"

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -163,7 +163,7 @@ def add_test_args(parser):
         "--parallel",
         action="store_true",
         help="whether to run tests in parallel",
-        default=False)
+        default=True)
     parser.add_argument(
         "--filter",
         action="append",


### PR DESCRIPTION
This reverts commit a38a0b705730851e241411b53293ab2877677d95.

The root cause of the issue was identified to lie outside of SwiftPM, so we can re-enable this.
