### PR TITLE
Disable CMake bootstrap by default

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -131,6 +131,7 @@ def add_build_args(parser):
     parser.add_argument(
         "--skip-cmake-bootstrap",
         action="store_true",
+        default=True,
         help="build with prebuilt package manager in toolchain if it exists")
     parser.add_argument(
         "--libswiftpm-install-dir",


### PR DESCRIPTION
It sounds as if we shouldn't need this anymore.
