### PR TITLE
Bring back "Generate Clang module maps during the build"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -167,7 +167,10 @@ let package = Package(
         .target(
             /** The llbuild manifest model */
             name: "LLBuildManifest",
-            dependencies: ["Basics"],
+            dependencies: [
+                "Basics",
+                "PackageLoading",
+            ],
             exclude: ["CMakeLists.txt"]
         ),
 

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -155,17 +155,9 @@ public final class ClangTargetBuildDescription {
             if case .custom(let path) = clangTarget.moduleMapType {
                 self.moduleMap = path
             }
-            // If a generated module map is needed, generate one now in our temporary directory.
-            else if let generatedModuleMapType = clangTarget.moduleMapType.generatedModuleMapType {
-                let path = tempsPath.appending(component: moduleMapFilename)
-                let moduleMapGenerator = ModuleMapGenerator(
-                    targetName: clangTarget.name,
-                    moduleName: clangTarget.c99name,
-                    publicHeadersDir: clangTarget.includeDir,
-                    fileSystem: fileSystem
-                )
-                try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType, at: path)
-                self.moduleMap = path
+            // If a generated module map is needed, set the path accordingly.
+            else if clangTarget.moduleMapType.generatedModuleMapType != nil {
+                self.moduleMap = tempsPath.appending(component: moduleMapFilename)
             }
             // Otherwise there is no module map, and we leave `moduleMap` unset.
         }

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
@@ -36,7 +36,30 @@ extension LLBuildManifestBuilder {
             inputs.append(resourcesNode)
         }
 
+        var modulesReadyInputs = [Node]()
+
+        // If the given target needs a generated module map, set up the dependency and required task to write out the module map.
+        if let type = target.clangTarget.moduleMapType.generatedModuleMapType, let moduleMapPath = target.moduleMap {
+            modulesReadyInputs.append(.file(moduleMapPath))
+
+            self.manifest.addWriteClangModuleMapCommand(
+                targetName: target.clangTarget.name,
+                moduleName: target.clangTarget.c99name,
+                publicHeadersDir: target.clangTarget.includeDir,
+                type: type,
+                outputPath: moduleMapPath
+            )
+        }
+
+        let modulesReady = self.addPhonyCommand(
+            targetName: target.target.getLLBuildModulesReadyCmdName(config: self.buildConfig),
+            inputs: modulesReadyInputs
+        )
+        inputs.append(modulesReady)
+
         func addStaticTargetInputs(_ target: ResolvedTarget) {
+            inputs.append(.virtual(target.getLLBuildModulesReadyCmdName(config: self.buildConfig)))
+
             if case .swift(let desc)? = self.plan.targetMap[target], target.type == .library {
                 inputs.append(file: desc.moduleOutputPath)
             }
@@ -116,14 +139,9 @@ extension LLBuildManifestBuilder {
         try addBuildToolPlugins(.clang(target))
 
         // Create a phony node to represent the entire target.
-        let targetName = target.target.getLLBuildTargetName(config: self.buildConfig)
-        let output: Node = .virtual(targetName)
-
-        self.manifest.addNode(output, toTarget: targetName)
-        self.manifest.addPhonyCmd(
-            name: output.name,
-            inputs: objectFileNodes,
-            outputs: [output]
+        let output = self.addPhonyCommand(
+            targetName: target.target.getLLBuildTargetName(config: self.buildConfig),
+            inputs: objectFileNodes
         )
 
         if self.plan.graph.isInRootPackages(target.target, satisfying: self.buildEnvironment) {

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
@@ -45,9 +45,9 @@ extension LLBuildManifestBuilder {
             outputs.append(output)
         }
 
-        let cmdName = target.target.getLLBuildResourcesCmdName(config: self.buildConfig)
-        self.manifest.addPhonyCmd(name: cmdName, inputs: outputs, outputs: [.virtual(cmdName)])
-
-        return .virtual(cmdName)
+        return self.addPhonyCommand(
+            targetName: target.target.getLLBuildResourcesCmdName(config: self.buildConfig),
+            inputs: outputs
+        )
     }
 }

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -292,6 +292,10 @@ extension ResolvedTarget {
     public func getLLBuildResourcesCmdName(config: String) -> String {
         "\(name)-\(config).module-resources"
     }
+
+    public func getLLBuildModulesReadyCmdName(config: String) -> String {
+        "\(name)-\(config).modules-ready"
+    }
 }
 
 extension ResolvedProduct {
@@ -344,6 +348,18 @@ extension LLBuildManifestBuilder {
 
     func destinationPath(forBinaryAt path: AbsolutePath) -> AbsolutePath {
         self.plan.buildParameters.buildPath.appending(component: path.basename)
+    }
+
+    /// Adds a phony command and a corresponding virtual node as output.
+    func addPhonyCommand(targetName: String, inputs: [Node]) -> Node {
+        let output: Node = .virtual(targetName)
+        self.manifest.addNode(output, toTarget: targetName)
+        self.manifest.addPhonyCmd(
+            name: output.name,
+            inputs: inputs,
+            outputs: [output]
+        )
+        return output
     }
 }
 

--- a/Sources/LLBuildManifest/CMakeLists.txt
+++ b/Sources/LLBuildManifest/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(LLBuildManifest STATIC
   Tools.swift)
 target_link_libraries(LLBuildManifest PUBLIC
   TSCBasic
+  PackageLoading
   Basics)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -173,8 +173,8 @@ public struct ModuleMapGenerator {
         return .umbrellaDirectory(publicHeadersDir)
     }
 
-    /// Generates a module map based of the specified type, throwing an error if anything goes wrong.  Any diagnostics are added to the receiver's diagnostics engine.
-    public func generateModuleMap(type: GeneratedModuleMapType, at path: AbsolutePath) throws {
+    /// Generates a module map based of the specified type, throwing an error if anything goes wrong.
+    public func generateModuleMap(type: GeneratedModuleMapType) throws -> String {
         var moduleMap = "module \(moduleName) {\n"
         switch type {
         case .umbrellaHeader(let hdr):
@@ -189,16 +189,7 @@ public struct ModuleMapGenerator {
 
             """
         )
-
-        // FIXME: This doesn't belong here.
-        try fileSystem.createDirectory(path.parentDirectory, recursive: true)
-
-        // If the file exists with the identical contents, we don't need to rewrite it.
-        // Otherwise, compiler will recompile even if nothing else has changed.
-        if let contents = try? fileSystem.readFileContents(path).validDescription, contents == moduleMap {
-            return
-        }
-        try fileSystem.writeFileContents(path, string: moduleMap)
+        return moduleMap
     }
 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4111,7 +4111,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("""
               "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
                 tool: clang
-                inputs: ["\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+                inputs: ["<Bar-debug.modules-ready>","<Foo-debug.modules-ready>","\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
                 outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
                 description: "Compiling Bar main.m"
             """))
@@ -4185,7 +4185,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("""
                "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
                  tool: clang
-                 inputs: ["\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+                 inputs: ["<Bar-debug.modules-ready>","<Foo-debug.modules-ready>","\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
                  outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
                  description: "Compiling Bar main.m"
              """))
@@ -4265,7 +4265,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("""
                "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
                  tool: clang
-                 inputs: ["\(buildPath.appending(components: "\(dynamicLibraryPrefix)Foo\(dynamicLibraryExtension)").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+                 inputs: ["<Bar-debug.modules-ready>","\(buildPath.appending(components: "\(dynamicLibraryPrefix)Foo\(dynamicLibraryExtension)").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
                  outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
                  description: "Compiling Bar main.m"
              """))

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -190,10 +190,11 @@ func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fi
     let generatedModuleMapPath = AbsolutePath.root.appending(components: "module.modulemap")
     observability.topScope.trap {
         if let generatedModuleMapType = moduleMapType.generatedModuleMapType {
-            try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType, at: generatedModuleMapPath)
+            let contents = try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType)
+            try fileSystem.writeIfChanged(path: generatedModuleMapPath, string: contents)
         }
     }
-    
+
     // Invoke the closure to check the results.
     let result = ModuleMapResult(diagnostics: observability.diagnostics, path: generatedModuleMapPath, fs: fileSystem)
     body(result)


### PR DESCRIPTION
This reverts commit https://github.com/apple/swift-package-manager/commit/173355bf60301d8bccb542deb82e9bbce77f60ef.