### PR TITLE
SourceControl: add basic support for symlinks

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -917,8 +917,10 @@ public final class GitRepository: Repository, WorkingCheckout {
 
     /// Read a symbolic link.
     func readLink(hash: Hash) throws -> String {
-        return try callGit("cat-file", "-p", String(describing: hash.bytes),
-                           failureMessage: "Couldn't read '\(String(describing: hash.bytes))'")
+        return try callGit(
+            "cat-file", "-p", String(describing: hash.bytes),
+            failureMessage: "Couldn't read '\(String(describing: hash.bytes))'"
+        )
     }
 }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -914,6 +914,12 @@ public final class GitRepository: Repository, WorkingCheckout {
             }
         }
     }
+
+    /// Read a symbolic link.
+    func readLink(hash: Hash) throws -> String {
+        return try callGit("cat-file", "-p", String(describing: hash.bytes),
+                           failureMessage: "Couldn't read '\(String(describing: hash.bytes))'")
+    }
 }
 
 // MARK: - GitFileSystemView
@@ -1074,13 +1080,18 @@ private class GitFileSystemView: FileSystem {
         guard entry.type != .tree else {
             throw FileSystemError(.isDirectory, path)
         }
-        guard entry.type != .symlink else {
-            throw InternalError("symlinks not supported")
-        }
         guard case .hash(let hash) = entry.location else {
             throw InternalError("only hash locations supported")
         }
-        return try self.repository.readBlob(hash: hash)
+        switch entry.type {
+        case .symlink:
+            let path = try repository.readLink(hash: hash)
+            return try readFileContents(TSCAbsolutePath(validating: path))
+        case .blob:
+            return try self.repository.readBlob(hash: hash)
+        default:
+            fatalError()
+        }
     }
 
     // MARK: Unsupported methods.


### PR DESCRIPTION
The contents of a symlink is the path to which it points.  We can simply read the contents as a new path, and use `getEntry` to get the contents of the symbolic link.  This implementation should also fully traverse any path that is a series of symbolic link.  This does allow for a DoS attack by creating a recursive symbolic link cycle (e.g. `a` -> `b` -> `a`).

Fixes: #7081