### PR TITLE
small cleanup after 7092

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1092,7 +1092,7 @@ private class GitFileSystemView: FileSystem {
         case .blob:
             return try self.repository.readBlob(hash: hash)
         default:
-            throw InternalError("unsupported git entry type \(entry.type)")
+            throw InternalError("unsupported git entry type \(entry.type) at path \(path)")
         }
     }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1088,11 +1088,11 @@ private class GitFileSystemView: FileSystem {
         switch entry.type {
         case .symlink:
             let path = try repository.readLink(hash: hash)
-            return try readFileContents(TSCAbsolutePath(validating: path))
+            return try readFileContents(AbsolutePath(validating: path))
         case .blob:
             return try self.repository.readBlob(hash: hash)
         default:
-            fatalError()
+            throw InternalError("unsupported git entry type \(entry.type)")
         }
     }
 


### PR DESCRIPTION
motivation: do not use fatalError (which will crash the program) with no additional information

changes:
* throw InternalError instead of fatalError
* use correct version of AbsolutePath
