### PR TITLE
Replace some uses of `temp_await` with `await` in tests

### DIFF
--- a/Sources/Basics/Archiver/Archiver.swift
+++ b/Sources/Basics/Archiver/Archiver.swift
@@ -23,6 +23,7 @@ public protocol Archiver {
     ///   - archivePath: The `AbsolutePath` to the archive to extract.
     ///   - destinationPath: The `AbsolutePath` to the directory to extract to.
     ///   - completion: The completion handler that will be called when the operation finishes to notify of its success.
+    @available(*, noasync, message: "Use the async alternative")
     func extract(
         from archivePath: AbsolutePath,
         to destinationPath: AbsolutePath,
@@ -35,6 +36,7 @@ public protocol Archiver {
     ///   - directory: The `AbsolutePath` to the archive to extract.
     ///   - destinationPath: The `AbsolutePath` to the directory to extract to.
     ///   - completion: The completion handler that will be called when the operation finishes to notify of its success.
+    @available(*, noasync, message: "Use the async alternative")
     func compress(
         directory: AbsolutePath,
         to destinationPath: AbsolutePath,
@@ -46,6 +48,7 @@ public protocol Archiver {
     /// - Parameters:
     ///   - path: The `AbsolutePath` to the archive to validate.
     ///   - completion: The completion handler that will be called when the operation finishes to notify of its success.
+    @available(*, noasync, message: "Use the async alternative")
     func validate(
         path: AbsolutePath,
         completion: @escaping (Result<Bool, Error>) -> Void
@@ -57,8 +60,25 @@ extension Archiver {
         from archivePath: AbsolutePath,
         to destinationPath: AbsolutePath
     ) async throws {
-        try await withCheckedThrowingContinuation {
-            self.extract(from: archivePath, to: destinationPath, completion: $0.resume(with:))
+        try await safe_async {
+            self.extract(from: archivePath, to: destinationPath, completion: $0)
+        }
+    }
+
+    public func compress(
+        directory: AbsolutePath,
+        to: AbsolutePath
+    ) async throws {
+        try await safe_async {
+            self.compress(directory: directory, to: to, completion: $0)
+        }
+    }
+
+    public func validate(
+        path: AbsolutePath
+    ) async throws -> Bool {
+        try await safe_async {
+            self.validate(path: path, completion: $0)
         }
     }
 }

--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -23,6 +23,7 @@ public protocol AuthorizationProvider {
 }
 
 public protocol AuthorizationWriter {
+    @available(*, noasync, message: "Use the async alternative")
     func addOrUpdate(
         for url: URL,
         user: String,
@@ -31,7 +32,32 @@ public protocol AuthorizationWriter {
         callback: @escaping (Result<Void, Error>) -> Void
     )
 
+    @available(*, noasync, message: "Use the async alternative")
     func remove(for url: URL, callback: @escaping (Result<Void, Error>) -> Void)
+}
+
+public extension AuthorizationWriter {
+    func addOrUpdate(
+        for url: URL,
+        user: String,
+        password: String,
+        persist: Bool = true
+    ) async throws {
+        try await safe_async {
+            self.addOrUpdate(
+                for: url,
+                user: user,
+                password: password, 
+                persist: persist,
+                callback: $0)
+        }
+    }
+
+    func remove(for url: URL) async throws {
+        try await safe_async {
+            self.remove(for: url, callback: $0)
+        }
+    }
 }
 
 public enum AuthorizationProviderError: Error {

--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _Concurrency
 import Dispatch
 import class Foundation.NSLock
 import class Foundation.ProcessInfo

--- a/Sources/SPMTestSupport/XCTAssertHelpers.swift
+++ b/Sources/SPMTestSupport/XCTAssertHelpers.swift
@@ -49,6 +49,23 @@ public func XCTSkipIfCI(file: StaticString = #filePath, line: UInt = #line) thro
     }
 }
 
+/// An `async`-friendly replacement for `XCTAssertThrowsError`.
+public func XCTAssertAsyncThrowsError<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ errorHandler: (_ error: any Error) -> Void = { _ in }
+) async {
+    do {
+        _ = try await expression()
+        XCTFail(message(), file: file, line: line)
+    } catch {
+        errorHandler(error)
+    }
+}
+
+
 public func XCTAssertBuilds(
     _ path: AbsolutePath,
     configurations: Set<Configuration> = [.Debug, .Release],
@@ -131,6 +148,26 @@ public func XCTAssertEqual<T: CustomStringConvertible>(
         actual[identifier] = binding
     }
     XCTAssertEqual(actual, expected, file: file, line: line)
+}
+
+public func XCTAssertAsyncTrue(
+    _ expression: @autoclosure () async throws -> Bool,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async rethrows {
+    let result = try await expression()
+    XCTAssertTrue(result, message(), file: file, line: line)
+}
+
+public func XCTAssertAsyncFalse(
+    _ expression: @autoclosure () async throws -> Bool,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async rethrows {
+    let result = try await expression()
+    XCTAssertFalse(result, message(), file: file, line: line)
 }
 
 public func XCTAssertThrowsCommandExecutionError<T>(

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -24,8 +24,8 @@ final class AuthorizationProviderTests: XCTestCase {
         self.assertAuthentication(provider, for: url, expected: (user, password))
     }
 
-    func testNetrc() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testNetrc() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let netrcPath = tmpPath.appending(".netrc")
 
             let provider = try NetrcAuthorizationProvider(path: netrcPath, fileSystem: localFileSystem)
@@ -39,20 +39,14 @@ final class AuthorizationProviderTests: XCTestCase {
             let otherPassword = UUID().uuidString
 
             // Add
-            XCTAssertNoThrow(try temp_await { callback in
-                provider.addOrUpdate(for: url, user: user, password: password, callback: callback)
-            })
-            XCTAssertNoThrow(try temp_await { callback in
-                provider.addOrUpdate(for: otherURL, user: user, password: otherPassword, callback: callback)
-            })
+            try await provider.addOrUpdate(for: url, user: user, password: password)
+            try await provider.addOrUpdate(for: otherURL, user: user, password: otherPassword)
 
             self.assertAuthentication(provider, for: url, expected: (user, password))
 
             // Update - the new password is appended to the end of file
             let newPassword = UUID().uuidString
-            XCTAssertNoThrow(try temp_await { callback in
-                provider.addOrUpdate(for: url, user: user, password: newPassword, callback: callback)
-            })
+            try await provider.addOrUpdate(for: url, user: user, password: newPassword)
 
             // .netrc file now contains two entries for `url`: one with `password` and the other with `newPassword`.
             // `NetrcAuthorizationProvider` returns the last entry it finds.
@@ -140,36 +134,30 @@ final class AuthorizationProviderTests: XCTestCase {
         let httpsPassword = UUID().uuidString
 
         // Add
-        XCTAssertNoThrow(try temp_await { callback in
-            provider.addOrUpdate(for: httpURL, user: user, password: httpPassword, callback: callback)
-        })
-        XCTAssertNoThrow(try temp_await { callback in
-            provider.addOrUpdate(for: httpsURL, user: user, password: httpsPassword, callback: callback)
-        })
+        try await provider.addOrUpdate(for: httpURL, user: user, password: httpPassword)
+        try await provider.addOrUpdate(for: httpsURL, user: user, password: httpsPassword)
 
         self.assertAuthentication(provider, for: httpURL, expected: (user, httpPassword))
         self.assertAuthentication(provider, for: httpsURL, expected: (user, httpsPassword))
 
         // Update
         let newHTTPPassword = UUID().uuidString
-        XCTAssertNoThrow(try temp_await { callback in
-            provider.addOrUpdate(for: httpURL, user: user, password: newHTTPPassword, callback: callback)
-        })
+        try await provider.addOrUpdate(for: httpURL, user: user, password: newHTTPPassword)
+
         let newHTTPSPassword = UUID().uuidString
-        XCTAssertNoThrow(try temp_await { callback in
-            provider.addOrUpdate(for: httpsURL, user: user, password: newHTTPSPassword, callback: callback)
-        })
+        try await provider.addOrUpdate(for: httpsURL, user: user, password: newHTTPSPassword)
+
 
         // Existing password is updated
         self.assertAuthentication(provider, for: httpURL, expected: (user, newHTTPPassword))
         self.assertAuthentication(provider, for: httpsURL, expected: (user, newHTTPSPassword))
 
         // Delete
-        XCTAssertNoThrow(try temp_await { callback in provider.remove(for: httpURL, callback: callback) })
+        try await provider.remove(for: httpURL)
         XCTAssertNil(provider.authentication(for: httpURL))
         self.assertAuthentication(provider, for: httpsURL, expected: (user, newHTTPSPassword))
 
-        XCTAssertNoThrow(try temp_await { callback in provider.remove(for: httpsURL, callback: callback) })
+        try await provider.remove(for: httpsURL)
         XCTAssertNil(provider.authentication(for: httpsURL))
         #endif
     }
@@ -189,36 +177,29 @@ final class AuthorizationProviderTests: XCTestCase {
         let portPassword = UUID().uuidString
 
         // Add
-        XCTAssertNoThrow(try temp_await { callback in
-            provider.addOrUpdate(for: noPortURL, user: user, password: noPortPassword, callback: callback)
-        })
-        XCTAssertNoThrow(try temp_await { callback in
-            provider.addOrUpdate(for: portURL, user: user, password: portPassword, callback: callback)
-        })
+        try await provider.addOrUpdate(for: noPortURL, user: user, password: noPortPassword)
+        try await provider.addOrUpdate(for: portURL, user: user, password: portPassword)
 
         self.assertAuthentication(provider, for: noPortURL, expected: (user, noPortPassword))
         self.assertAuthentication(provider, for: portURL, expected: (user, portPassword))
 
         // Update
         let newPortPassword = UUID().uuidString
-        XCTAssertNoThrow(try temp_await { callback in
-            provider.addOrUpdate(for: portURL, user: user, password: newPortPassword, callback: callback)
-        })
+        try await provider.addOrUpdate(for: portURL, user: user, password: newPortPassword)
+
         let newNoPortPassword = UUID().uuidString
-        XCTAssertNoThrow(try temp_await { callback in
-            provider.addOrUpdate(for: noPortURL, user: user, password: newNoPortPassword, callback: callback)
-        })
+        try await provider.addOrUpdate(for: noPortURL, user: user, password: newNoPortPassword)
 
         // Existing password is updated
         self.assertAuthentication(provider, for: portURL, expected: (user, newPortPassword))
         self.assertAuthentication(provider, for: noPortURL, expected: (user, newNoPortPassword))
 
         // Delete
-        XCTAssertNoThrow(try temp_await { callback in provider.remove(for: noPortURL, callback: callback) })
+        try await provider.remove(for: noPortURL)
         XCTAssertNil(provider.authentication(for: noPortURL))
         self.assertAuthentication(provider, for: portURL, expected: (user, newPortPassword))
 
-        XCTAssertNoThrow(try temp_await { callback in provider.remove(for: portURL, callback: callback) })
+        try await provider.remove(for: portURL)
         XCTAssertNil(provider.authentication(for: portURL))
         #endif
     }


### PR DESCRIPTION
Start using async/await in testing

### Motivation:

This should start to make easier to adopt async/await by reducing the number non-async callers

### Modifications:

1 commit which adds async/await bridges
1 commit which adopts the bridges in a test target (BasicTests)

### Result:

reduce usage of temp_await
