### PR TITLE
Move .swiftmodule output directory

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -103,13 +103,16 @@ public final class SwiftTargetBuildDescription {
         }
     }
 
+    var modulesPath: AbsolutePath {
+        return self.buildParameters.buildPath.appending(component: "Modules")
+    }
+
     /// The path to the swiftmodule file after compilation.
-    var moduleOutputPath: AbsolutePath {
+    public var moduleOutputPath: AbsolutePath { // note: needs to be public because of sourcekit-lsp
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
         let allowLinkingAgainstExecutables = (buildParameters.targetTriple.isDarwin() || self.buildParameters.targetTriple
             .isLinux() || self.buildParameters.targetTriple.isWindows()) && self.toolsVersion >= .v5_5
-        let dirPath = (target.type == .executable && !allowLinkingAgainstExecutables) ? self.tempsPath : self
-            .buildParameters.buildPath
+        let dirPath = (target.type == .executable && !allowLinkingAgainstExecutables) ? self.tempsPath : self.modulesPath
         return dirPath.appending(component: self.target.c99name + ".swiftmodule")
     }
 
@@ -122,7 +125,7 @@ public final class SwiftTargetBuildDescription {
 
     /// The path to the swifinterface file after compilation.
     var parseableModuleInterfaceOutputPath: AbsolutePath {
-        self.buildParameters.buildPath.appending(component: self.target.c99name + ".swiftinterface")
+        self.modulesPath.appending(component: self.target.c99name + ".swiftinterface")
     }
 
     /// Path to the resource Info.plist file, if generated.
@@ -638,7 +641,7 @@ public final class SwiftTargetBuildDescription {
         result.append(contentsOf: self.sources.map(\.pathString))
 
         result.append("-I")
-        result.append(self.buildParameters.buildPath.pathString)
+        result.append(self.modulesPath.pathString)
 
         result += try self.compileArguments()
         return result

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -380,7 +380,7 @@ extension LLBuildManifestBuilder {
             moduleName: target.target.c99name,
             moduleAliases: target.target.moduleAliases,
             moduleOutputPath: target.moduleOutputPath,
-            importPath: target.buildParameters.buildPath,
+            importPath: target.modulesPath,
             tempsPath: target.tempsPath,
             objects: try target.objects,
             otherArguments: try target.compileArguments(),

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -467,10 +467,11 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
         arguments += extraSwiftCFlags
 
-        // Add the search path to the directory containing the modulemap file.
+        // Add search paths to the directories containing module maps and Swift modules.
         for target in targets {
             switch target {
-            case .swift: break
+            case .swift(let targetDescription):
+                arguments += ["-I", targetDescription.moduleOutputPath.parentDirectory.pathString]
             case .clang(let targetDescription):
                 if let includeDir = targetDescription.moduleMap?.parentDirectory {
                     arguments += ["-I", includeDir.pathString]

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -78,11 +78,12 @@ struct DumpSymbolGraph: SwiftCommand {
             )
 
             if result.exitStatus != .terminated(code: 0) {
+                let commandline = "\nUsing commandline: \(result.arguments)"
                 switch result.output {
                 case .success(let value):
-                    swiftTool.observabilityScope.emit(error: "Failed to emit symbol graph for '\(target.c99name)': \(String(decoding: value, as: UTF8.self))")
+                    swiftTool.observabilityScope.emit(error: "Failed to emit symbol graph for '\(target.c99name)': \(String(decoding: value, as: UTF8.self))\(commandline)")
                 case .failure(let error):
-                    swiftTool.observabilityScope.emit(error: "Internal error while emitting symbol graph for '\(target.c99name)': \(error)")
+                    swiftTool.observabilityScope.emit(error: "Internal error while emitting symbol graph for '\(target.c99name)': \(error)\(commandline)")
                 }
             }
         }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -645,8 +645,8 @@ final class BuildPlanTests: XCTestCase {
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
             "-target", defaultTargetTriple,
+            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Modules", "lib.swiftmodule").pathString,
             "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "exe.build", "exe.swiftmodule").pathString,
-            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "lib.swiftmodule").pathString,
             "-g",
         ]
       #elseif os(Windows)
@@ -869,7 +869,7 @@ final class BuildPlanTests: XCTestCase {
             let contents: String = try fs.readFileContents(yaml)
             let swiftGetVersionFilePath = try XCTUnwrap(llbuild.swiftGetVersionFiles.first?.value)
             XCTAssertMatch(contents, .contains("""
-                    inputs: ["\(Pkg.appending(components: "Sources", "exe", "main.swift").escapedPathString)","\(swiftGetVersionFilePath.escapedPathString)","\(buildPath.appending(components: "PkgLib.swiftmodule").escapedPathString)","\(buildPath.appending(components: "exe.build", "sources").escapedPathString)"]
+                    inputs: ["\(Pkg.appending(components: "Sources", "exe", "main.swift").escapedPathString)","\(swiftGetVersionFilePath.escapedPathString)","\(buildPath.appending(components: "Modules", "PkgLib.swiftmodule").escapedPathString)","\(buildPath.appending(components: "exe.build", "sources").escapedPathString)"]
                 """))
 
         }
@@ -1736,8 +1736,8 @@ final class BuildPlanTests: XCTestCase {
             "@\(buildPath.appending(components: "PkgPackageTests.product", "Objects.LinkFileList"))"] +
             rpathsForBackdeployment +
             ["-target", "\(hostTriple.tripleString(forPlatformVersion: version))",
-            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Foo.swiftmodule").pathString,
-            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "FooTests.swiftmodule").pathString,
+            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Modules", "Foo.swiftmodule").pathString,
+            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Modules", "FooTests.swiftmodule").pathString,
             "-g",
         ])
       #elseif os(Windows)
@@ -2313,7 +2313,7 @@ final class BuildPlanTests: XCTestCase {
             "@\(buildPath.appending(components: "Bar-Baz.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
             "-target", defaultTargetTriple,
-            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Bar.swiftmodule").pathString,
+            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Modules", "Bar.swiftmodule").pathString,
             "-g",
         ])
       #elseif os(Windows)
@@ -2432,7 +2432,7 @@ final class BuildPlanTests: XCTestCase {
                 "@\(buildPath.appending(components: "lib.product", "Objects.LinkFileList"))",
                 "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
                 "-target", defaultTargetTriple,
-                "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "lib.swiftmodule").pathString,
+                "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Modules", "lib.swiftmodule").pathString,
                 "-g",
             ]
         #elseif os(Windows)
@@ -4110,7 +4110,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("""
               "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
                 tool: clang
-                inputs: ["\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+                inputs: ["\(buildPath.appending(components: "Modules", "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
                 outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
                 description: "Compiling Bar main.m"
             """))
@@ -4184,7 +4184,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("""
                "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
                  tool: clang
-                 inputs: ["\(buildPath.appending(components: "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+                 inputs: ["\(buildPath.appending(components: "Modules", "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
                  outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
                  description: "Compiling Bar main.m"
              """))
@@ -4322,10 +4322,10 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(contents, .contains("""
               "\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)":
                 tool: shell
-                inputs: ["\(buildPath.appending(components: "lib.swiftmodule").escapedPathString)"]
+                inputs: ["\(buildPath.appending(components: "Modules", "lib.swiftmodule").escapedPathString)"]
                 outputs: ["\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)"]
                 description: "Wrapping AST for lib for debugging"
-                args: ["\(result.plan.buildParameters.toolchain.swiftCompilerPath.escapedPathString)","-modulewrap","\(buildPath.appending(components: "lib.swiftmodule").escapedPathString)","-o","\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)","-target","x86_64-unknown-linux-gnu"]
+                args: ["\(result.plan.buildParameters.toolchain.swiftCompilerPath.escapedPathString)","-modulewrap","\(buildPath.appending(components: "Modules", "lib.swiftmodule").escapedPathString)","-o","\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)","-target","x86_64-unknown-linux-gnu"]
             """))
     }
 
@@ -4958,7 +4958,7 @@ final class BuildPlanTests: XCTestCase {
 
         let yamlContents: String = try fs.readFileContents(yaml)
         let inputs: SerializedJSON = """
-            inputs: ["\(AbsolutePath("/Pkg/Snippets/ASnippet.swift"))","\(swiftGetVersionFilePath)","\(AbsolutePath("/Pkg/.build/debug/Lib.swiftmodule"))"
+            inputs: ["\(AbsolutePath("/Pkg/Snippets/ASnippet.swift"))","\(swiftGetVersionFilePath)","\(AbsolutePath("/Pkg/.build/debug/Modules/Lib.swiftmodule"))"
         """
         XCTAssertMatch(yamlContents, .contains(inputs.underlying))
     }
@@ -5173,8 +5173,8 @@ final class BuildPlanTests: XCTestCase {
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
             "-target", defaultTargetTriple,
+            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "Modules", "lib.swiftmodule").pathString,
             "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "exe.build", "exe.swiftmodule").pathString,
-            "-Xlinker", "-add_ast_path", "-Xlinker", buildPath.appending(components: "lib.swiftmodule").pathString,
             "-g",
         ]
       #elseif os(Windows)

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -26,6 +26,7 @@ struct BuildResult {
     let stdout: String
     let stderr: String
     let binContents: [String]
+    let moduleContents: [String]
 }
 
 final class BuildToolTests: CommandsTestCase {
@@ -55,7 +56,14 @@ final class BuildToolTests: CommandsTestCase {
             // is what `binContents` is meant to represent.
             return contents != ["output-file-map.json"]
         }
-        return BuildResult(binPath: binPath, stdout: stdout, stderr: stderr, binContents: binContents)
+        let moduleContents = (try? localFileSystem.getDirectoryContents(binPath.appending(component: "Modules"))) ?? []
+        return BuildResult(
+            binPath: binPath,
+            stdout: stdout,
+            stderr: stderr,
+            binContents: binContents,
+            moduleContents: moduleContents
+        )
     }
 
     func testUsage() throws {
@@ -325,9 +333,9 @@ final class BuildToolTests: CommandsTestCase {
                 // Also make sure we didn't emit parseable module interfaces
                 // (do this here to avoid doing a second build in
                 // testParseableInterfaces().
-                XCTAssertNoMatch(result.binContents, ["ATarget.swiftinterface"])
-                XCTAssertNoMatch(result.binContents, ["BTarget.swiftinterface"])
-                XCTAssertNoMatch(result.binContents, ["CTarget.swiftinterface"])
+                XCTAssertNoMatch(result.moduleContents, ["ATarget.swiftinterface"])
+                XCTAssertNoMatch(result.moduleContents, ["BTarget.swiftinterface"])
+                XCTAssertNoMatch(result.moduleContents, ["CTarget.swiftinterface"])
             }
         }
     }
@@ -336,8 +344,8 @@ final class BuildToolTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/ParseableInterfaces") { fixturePath in
             do {
                 let result = try build(["--enable-parseable-module-interfaces"], packagePath: fixturePath)
-                XCTAssertMatch(result.binContents, ["A.swiftinterface"])
-                XCTAssertMatch(result.binContents, ["B.swiftinterface"])
+                XCTAssertMatch(result.moduleContents, ["A.swiftinterface"])
+                XCTAssertMatch(result.moduleContents, ["B.swiftinterface"])
             } catch SwiftPMError.executionFailure(_, _, let stderr) {
                 XCTFail(stderr)
             }
@@ -348,8 +356,8 @@ final class BuildToolTests: CommandsTestCase {
         try fixture(name: "Miscellaneous/LibraryEvolution") { fixturePath in
             do {
                 let result = try build([], packagePath: fixturePath)
-                XCTAssertMatch(result.binContents, ["A.swiftinterface"])
-                XCTAssertMatch(result.binContents, ["B.swiftinterface"])
+                XCTAssertMatch(result.moduleContents, ["A.swiftinterface"])
+                XCTAssertMatch(result.moduleContents, ["B.swiftinterface"])
             }
         }
     }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -54,8 +54,8 @@ class MiscellaneousTestCase: XCTestCase {
             XCTAssertBuilds(fixturePath.appending("app"))
             let buildDir = fixturePath.appending(components: "app", ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
             XCTAssertFileExists(buildDir.appending("FooExec"))
-            XCTAssertFileExists(buildDir.appending("FooLib1.swiftmodule"))
-            XCTAssertFileExists(buildDir.appending("FooLib2.swiftmodule"))
+            XCTAssertFileExists(buildDir.appending(components: "Modules", "FooLib1.swiftmodule"))
+            XCTAssertFileExists(buildDir.appending(components: "Modules", "FooLib2.swiftmodule"))
         }
     }
 

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -25,8 +25,8 @@ class ModuleAliasingFixtureTests: XCTestCase {
             let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
             XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
             XCTAssertFileExists(buildPath.appending(components: "App"))
-            XCTAssertFileExists(buildPath.appending(components: "GameUtils.swiftmodule"))
-            XCTAssertFileExists(buildPath.appending(components: "Utils.swiftmodule"))
+            XCTAssertFileExists(buildPath.appending(components: "Modules", "GameUtils.swiftmodule"))
+            XCTAssertFileExists(buildPath.appending(components: "Modules", "Utils.swiftmodule"))
             _ = try SwiftPM.Build.execute(packagePath: pkgPath)
         }
     }
@@ -37,8 +37,8 @@ class ModuleAliasingFixtureTests: XCTestCase {
             let buildPath = pkgPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug")
             XCTAssertBuilds(pkgPath, extraArgs: ["--vv"])
             XCTAssertFileExists(buildPath.appending(components: "App"))
-            XCTAssertFileExists(buildPath.appending(components: "AUtils.swiftmodule"))
-            XCTAssertFileExists(buildPath.appending(components: "BUtils.swiftmodule"))
+            XCTAssertFileExists(buildPath.appending(components: "Modules", "AUtils.swiftmodule"))
+            XCTAssertFileExists(buildPath.appending(components: "Modules", "BUtils.swiftmodule"))
             _ = try SwiftPM.Build.execute(packagePath: pkgPath)
         }
     }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -94,7 +94,7 @@ class InitTests: XCTestCase {
 #else
             XCTAssertFileExists(binPath.appending("Foo"))
 #endif
-            XCTAssertFileExists(binPath.appending(components: "Foo.swiftmodule"))
+            XCTAssertFileExists(binPath.appending(components: "Modules", "Foo.swiftmodule"))
         }
     }
 
@@ -145,7 +145,7 @@ class InitTests: XCTestCase {
             // Try building it
             XCTAssertBuilds(path)
             let triple = try UserToolchain.default.targetTriple
-            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Foo.swiftmodule"))
+            XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
         }
     }
         
@@ -243,7 +243,7 @@ class InitTests: XCTestCase {
             // Try building it.
             XCTAssertBuilds(packageRoot)
             let triple = try UserToolchain.default.targetTriple
-            XCTAssertFileExists(packageRoot.appending(components: ".build", triple.platformBuildPathComponent, "debug", "some_package.swiftmodule"))
+            XCTAssertFileExists(packageRoot.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "some_package.swiftmodule"))
         }
     }
     

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -450,19 +450,23 @@ def install_dylib(args, library_name, install_dir, module_names):
     for module in module_names:
         # If we're cross-compiling, we expect the .swiftmodule to be a directory that contains everything.
         if args.cross_compile_hosts:
-            install_binary(args, module + ".swiftmodule", install_dir, ['Project', '*.swiftmodule'])
+            install_binary(args, module + ".swiftmodule", install_dir, ['Project', '*.swiftmodule'], subpath="Modules")
         else:
             # Otherwise we have either a .swiftinterface or a .swiftmodule, plus a .swiftdoc.
             if os.path.exists(os.path.join(args.bin_dir, module + ".swiftinterface")):
-                install_binary(args, module + ".swiftinterface", install_dir)
+                install_binary(args, module + ".swiftinterface", install_dir, subpath="Modules")
             else:
-                install_binary(args, module + ".swiftmodule", install_dir)
-            install_binary(args, module + ".swiftdoc", install_dir)
+                install_binary(args, module + ".swiftmodule", install_dir, subpath="Modules")
+            install_binary(args, module + ".swiftdoc", install_dir, subpath="Modules")
 
 
 # Helper function that installs a single built artifact to a particular directory. The source may be either a file or a directory.
-def install_binary(args, binary, destination, destination_is_directory=True, ignored_patterns=[]):
-    src = os.path.join(args.bin_dir, binary)
+def install_binary(args, binary, destination, destination_is_directory=True, ignored_patterns=[], subpath=None):
+    if subpath:
+        basepath = os.path.join(args.bin_dir, subpath)
+    else:
+        basepath = args.bin_dir
+    src = os.path.join(basepath, binary)
     install_file(args, src, destination, destination_is_directory=destination_is_directory, ignored_patterns=ignored_patterns)
 
 def install_file(args, src, destination, destination_is_directory=True, ignored_patterns=[]):


### PR DESCRIPTION
While working on #7090, we noticed that any builds of Swift sources will currently find lots of unrelated module maps because of the structure of the build arena. We pass a `-I` to the top-level of the arena which leads to *everything* being recursively searched for modules, so the compiler will find module maps that aren't intended to be included at all.

Changing this so that the search paths won't include random module maps should actually solve various issues around seeing incomplete module maps, such as ones referring to ObjC compatibility headers that haven't been written, yet.

rdar://89082987
