### PR TITLE
Revert "Disable CMake bootstrap by default"

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -131,7 +131,6 @@ def add_build_args(parser):
     parser.add_argument(
         "--skip-cmake-bootstrap",
         action="store_true",
-        default=True,
         help="build with prebuilt package manager in toolchain if it exists")
     parser.add_argument(
         "--libswiftpm-install-dir",


### PR DESCRIPTION
Reverts apple/swift-package-manager#7089

This is incomplete and needs a significant amount of work to actually do what we want.