### PR TITLE
Tests: adjust for sorting and path representation

### DIFF
--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -67,14 +67,14 @@ final class LLBuildManifestBuilderTests: XCTestCase {
         try llbuild.createProductCommand(buildProduct)
 
         let basicReleaseCommandNames = [
-            "/path/to/build/release/exe.product/Objects.LinkFileList",
+            AbsolutePath("/path/to/build/release/exe.product/Objects.LinkFileList").pathString,
             "<exe-release.exe>",
             "C.exe-release.exe",
         ]
 
         XCTAssertEqual(
             llbuild.manifest.commands.map(\.key).sorted(),
-            basicReleaseCommandNames
+            basicReleaseCommandNames.sorted()
         )
 
         // macOS, debug build
@@ -98,18 +98,17 @@ final class LLBuildManifestBuilderTests: XCTestCase {
 
         let entitlementsCommandName = "C.exe-debug.exe-entitlements"
         let basicDebugCommandNames = [
-            "/path/to/build/debug/exe.product/Objects.LinkFileList",
+            AbsolutePath("/path/to/build/debug/exe.product/Objects.LinkFileList").pathString,
             "<exe-debug.exe>",
             "C.exe-debug.exe",
         ]
 
         XCTAssertEqual(
             llbuild.manifest.commands.map(\.key).sorted(),
-            [
-                "/path/to/build/debug/exe-entitlement.plist",
-            ] + basicDebugCommandNames + [
+            (basicDebugCommandNames + [
+                AbsolutePath("/path/to/build/debug/exe-entitlement.plist").pathString,
                 entitlementsCommandName,
-            ]
+            ]).sorted()
         )
 
         guard let entitlementsCommand = llbuild.manifest.commands[entitlementsCommandName]?.tool as? ShellTool else {
@@ -152,7 +151,7 @@ final class LLBuildManifestBuilderTests: XCTestCase {
 
         XCTAssertEqual(
             llbuild.manifest.commands.map(\.key).sorted(),
-            basicReleaseCommandNames
+            basicReleaseCommandNames.sorted()
         )
 
         // Linux, debug build
@@ -176,7 +175,7 @@ final class LLBuildManifestBuilderTests: XCTestCase {
 
         XCTAssertEqual(
             llbuild.manifest.commands.map(\.key).sorted(),
-            basicDebugCommandNames
+            basicDebugCommandNames.sorted()
         )
     }
 }

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -4692,7 +4692,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
             XCTFail("unexpectedly resolved the package graph successfully")
         } catch {
-            XCTAssertEqual(error.interpolationDescription, "multiple products named 'SomeProduct' in: 'other' (at '/Other'), 'some' (at '/Some')")
+            XCTAssertEqual(error.interpolationDescription, "multiple products named 'SomeProduct' in: 'other' (at '\(AbsolutePath("/Other"))'), 'some' (at '\(AbsolutePath("/Some"))')")
         }
         XCTAssertEqual(observability.diagnostics.map { $0.description }.sorted(), ["[warning]: product aliasing requires tools-version 5.2 or later, so it is not supported by \'other\'", "[warning]: product aliasing requires tools-version 5.2 or later, so it is not supported by \'some\'"])
     }


### PR DESCRIPTION
The expectations sort differently on Windows due to the path separator being different. This also impacts the expectations. Adjust the path spellings to use `AbsolutePath(_:)` to get the canonical path spelling for the platform.