### PR TITLE
build: simplify the build rules with newer CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,30 +6,17 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-cmake_minimum_required(VERSION 3.15.1)
+cmake_minimum_required(VERSION 3.19)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 project(SwiftPM LANGUAGES C Swift)
 
-set(SWIFT_VERSION 5)
-set(CMAKE_Swift_LANGUAGE_VERSION ${SWIFT_VERSION})
-if(CMAKE_VERSION VERSION_LESS 3.16)
-    add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-swift-version$<SEMICOLON>${SWIFT_VERSION}>)
-    set(CMAKE_LINK_LIBRARY_FLAG "-l")
-endif()
-
-add_compile_options(-DUSE_IMPL_ONLY_IMPORTS)
-
+set(CMAKE_Swift_LANGUAGE_VERSION 5)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
-if(CMAKE_VERSION VERSION_LESS 3.16 AND CMAKE_SYSTEM_NAME STREQUAL Windows)
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-else()
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-endif()
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
@@ -43,6 +30,8 @@ option(USE_CMAKE_INSTALL
 if(BUILD_SHARED_LIBS)
   set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 endif()
+
+add_compile_options(-DUSE_IMPL_ONLY_IMPORTS)
 
 if(FIND_PM_DEPS)
   find_package(SwiftSystem CONFIG REQUIRED)


### PR DESCRIPTION
Swift now requires CMake 3.19.6 to build.  Update the CMake requirement to 3.19 to allow us to simplify the build logic by removing the workarounds for older releases.