### PR TITLE
Remove discovery target in swift-testing case

### DIFF
--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -117,7 +117,9 @@ public class LLBuildManifestBuilder {
             }
         }
 
-        try self.addTestDiscoveryGenerationCommand()
+        if self.buildParameters.testingParameters.library == .xctest {
+            try self.addTestDiscoveryGenerationCommand()
+        }
         try self.addTestEntryPointGenerationCommand()
 
         // Create command for all products in the plan.

--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -104,7 +104,10 @@ extension BuildPlan {
 
             /// Generates a synthesized test entry point target, consisting of a single "main" file which calls the test entry
             /// point API and leverages the test discovery target to reference which tests to run.
-            func generateSynthesizedEntryPointTarget(discoveryTarget: SwiftTarget, discoveryResolvedTarget: ResolvedTarget) throws -> SwiftTargetBuildDescription {
+            func generateSynthesizedEntryPointTarget(
+                swiftTargetDependencies: [Target.Dependency],
+                resolvedTargetDependencies: [ResolvedTarget.Dependency]
+            ) throws -> SwiftTargetBuildDescription {
                 let entryPointDerivedDir = buildParameters.buildPath.appending(components: "\(testProduct.name).derived")
                 let entryPointMainFile = entryPointDerivedDir.appending(component: TestEntryPointTool.mainFileName)
                 let entryPointSources = Sources(paths: [entryPointMainFile], root: entryPointDerivedDir)
@@ -112,13 +115,13 @@ extension BuildPlan {
                 let entryPointTarget = SwiftTarget(
                     name: testProduct.name,
                     type: .library,
-                    dependencies: testProduct.underlyingProduct.targets.map { .target($0, conditions: []) } + [.target(discoveryTarget, conditions: [])],
+                    dependencies: testProduct.underlyingProduct.targets.map { .target($0, conditions: []) } + swiftTargetDependencies,
                     packageAccess: true, // test target is allowed access to package decls
                     testEntryPointSources: entryPointSources
                 )
                 let entryPointResolvedTarget = ResolvedTarget(
                     target: entryPointTarget,
-                    dependencies: testProduct.targets.map { .target($0, conditions: []) } + [.target(discoveryResolvedTarget, conditions: [])],
+                    dependencies: testProduct.targets.map { .target($0, conditions: []) } + resolvedTargetDependencies,
                     defaultLocalization: testProduct.defaultLocalization,
                     platforms: testProduct.platforms
                 )
@@ -133,21 +136,34 @@ extension BuildPlan {
                 )
             }
 
+            let discoveryTargets: (target: SwiftTarget, resolved: ResolvedTarget, buildDescription: SwiftTargetBuildDescription)?
+            let swiftTargetDependencies: [Target.Dependency]
+            let resolvedTargetDependencies: [ResolvedTarget.Dependency]
+
+            switch buildParameters.testingParameters.library {
+            case .xctest:
+                discoveryTargets = try generateDiscoveryTargets()
+                swiftTargetDependencies = [.target(discoveryTargets!.target, conditions: [])]
+                resolvedTargetDependencies = [.target(discoveryTargets!.resolved, conditions: [])]
+            case .swiftTesting:
+                discoveryTargets = nil
+                swiftTargetDependencies = testProduct.targets.map { .target($0.underlyingTarget, conditions: []) }
+                resolvedTargetDependencies = testProduct.targets.map { .target($0, conditions: []) }
+            }
+
             if let entryPointResolvedTarget = testProduct.testEntryPointTarget {
                 if isEntryPointPathSpecifiedExplicitly || explicitlyEnabledDiscovery {
-                    let discoveryTargets = try generateDiscoveryTargets()
-
                     if isEntryPointPathSpecifiedExplicitly {
                         // Allow using the explicitly-specified test entry point target, but still perform test discovery and thus declare a dependency on the discovery targets.
                         let entryPointTarget = SwiftTarget(
                             name: entryPointResolvedTarget.underlyingTarget.name,
-                            dependencies: entryPointResolvedTarget.underlyingTarget.dependencies + [.target(discoveryTargets.target, conditions: [])],
+                            dependencies: entryPointResolvedTarget.underlyingTarget.dependencies + swiftTargetDependencies,
                             packageAccess: entryPointResolvedTarget.packageAccess,
                             testEntryPointSources: entryPointResolvedTarget.underlyingTarget.sources
                         )
                         let entryPointResolvedTarget = ResolvedTarget(
                             target: entryPointTarget,
-                            dependencies: entryPointResolvedTarget.dependencies + [.target(discoveryTargets.resolved, conditions: [])],
+                            dependencies: entryPointResolvedTarget.dependencies + resolvedTargetDependencies,
                             defaultLocalization: testProduct.defaultLocalization,
                             platforms: testProduct.platforms
                         )
@@ -161,11 +177,14 @@ extension BuildPlan {
                             observabilityScope: observabilityScope
                         )
 
-                        result.append((testProduct, discoveryTargets.buildDescription, entryPointTargetBuildDescription))
+                        result.append((testProduct, discoveryTargets?.buildDescription, entryPointTargetBuildDescription))
                     } else {
                         // Ignore test entry point and synthesize one, declaring a dependency on the test discovery targets created above.
-                        let entryPointTargetBuildDescription = try generateSynthesizedEntryPointTarget(discoveryTarget: discoveryTargets.target, discoveryResolvedTarget: discoveryTargets.resolved)
-                        result.append((testProduct, discoveryTargets.buildDescription, entryPointTargetBuildDescription))
+                        let entryPointTargetBuildDescription = try generateSynthesizedEntryPointTarget(
+                            swiftTargetDependencies: swiftTargetDependencies,
+                            resolvedTargetDependencies: resolvedTargetDependencies
+                        )
+                        result.append((testProduct, discoveryTargets?.buildDescription, entryPointTargetBuildDescription))
                     }
                 } else {
                     // Use the test entry point as-is, without performing test discovery.
@@ -182,9 +201,11 @@ extension BuildPlan {
                 }
             } else {
                 // Synthesize a test entry point target, declaring a dependency on the test discovery targets.
-                let discoveryTargets = try generateDiscoveryTargets()
-                let entryPointTargetBuildDescription = try generateSynthesizedEntryPointTarget(discoveryTarget: discoveryTargets.target, discoveryResolvedTarget: discoveryTargets.resolved)
-                result.append((testProduct, discoveryTargets.buildDescription, entryPointTargetBuildDescription))
+                let entryPointTargetBuildDescription = try generateSynthesizedEntryPointTarget(
+                    swiftTargetDependencies: swiftTargetDependencies,
+                    resolvedTargetDependencies: resolvedTargetDependencies
+                )
+                result.append((testProduct, discoveryTargets?.buildDescription, entryPointTargetBuildDescription))
             }
         }
 


### PR DESCRIPTION
This PR removes the empty test discovery target created when running swift-testing-based tests. This target is necessary on ~Linux~ non-Darwin targets when running XCTest-based tests, but since swift-testing performs all its own discovery, it's just overhead there.

Fixed by @neonichu, editorialized here by @grynspan (in case GitHub gets confused about it.)