### PR TITLE
Revert "Only show command output in verbose mode (#7078)"

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -810,10 +810,8 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         queue.async {
             if let buffer = self.nonSwiftMessageBuffers[command.name] {
                 self.progressAnimation.clear()
-                if self.logLevel.isVerbose {
-                    self.outputStream.send(buffer)
-                    self.outputStream.flush()
-                }
+                self.outputStream.send(buffer)
+                self.outputStream.flush()
                 self.nonSwiftMessageBuffers[command.name] = nil
             }
         }


### PR DESCRIPTION
### Motivation:

With recent changes linker/compiler errors are silently consumed and don't appear in stdout or stderr.

### Modifications:

This reverts commit 4c3549144733d8042a0c08d59938b505431cf12c.

### Result:

Resolves https://github.com/apple/swift-package-manager/issues/7114.