### PR TITLE
Async package registry tests

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -48,7 +48,7 @@ extension DispatchQueue {
 }
 
 /// Bridges between potentially blocking methods that take a result completion closure and async/await
-public func safe_async<T, ErrorType: Error>(_ body: @escaping (@escaping (Result<T, ErrorType>) -> Void) -> Void) async throws -> T {
+public func safe_async<T, ErrorType: Error>(_ body: @Sendable @escaping (@Sendable @escaping (Result<T, ErrorType>) -> Void) -> Void) async throws -> T {
     try await withCheckedThrowingContinuation { continuation in
         // It is possible that body make block indefinitely on a lock, sempahore,
         // or similar then synchrously call the completion handler. For full safety

--- a/Sources/Basics/FileSystem/TemporaryFile.swift
+++ b/Sources/Basics/FileSystem/TemporaryFile.swift
@@ -66,6 +66,7 @@ public func withTemporaryDirectory<Result>(
 ///             return value for the `withTemporaryDirectory` function.
 ///
 /// - Throws: An error when creating directory and rethrows all errors from `body`.
+@discardableResult
 public func withTemporaryDirectory<Result>(
     fileSystem: FileSystem = localFileSystem,
     dir: AbsolutePath? = nil,

--- a/Sources/PackageRegistry/ChecksumTOFU.swift
+++ b/Sources/PackageRegistry/ChecksumTOFU.swift
@@ -36,7 +36,30 @@ struct PackageVersionChecksumTOFU {
     }
 
     // MARK: - source archive
-
+    func validateSourceArchive(
+        registry: Registry,
+        package: PackageIdentity.RegistryIdentity,
+        version: Version,
+        checksum: String,
+        timeout: DispatchTimeInterval?,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws {
+        try await safe_async {
+            self.validateSourceArchive(
+                registry: registry,
+                package: package,
+                version: version,
+                checksum: checksum,
+                timeout: timeout,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
+    
+    @available(*, noasync, message: "Use the async alternative")
     func validateSourceArchive(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
@@ -135,7 +158,31 @@ struct PackageVersionChecksumTOFU {
     }
 
     // MARK: - manifests
-
+    func validateManifest(
+        registry: Registry,
+        package: PackageIdentity.RegistryIdentity,
+        version: Version,
+        toolsVersion: ToolsVersion?,
+        checksum: String,
+        timeout: DispatchTimeInterval?,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws {
+        try await safe_async {
+            self.validateManifest(
+                registry: registry,
+                package: package,
+                version: version,
+                toolsVersion: toolsVersion,
+                checksum: checksum,
+                timeout: timeout,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue, 
+                completion: $0
+            )
+        }
+    }
+    @available(*, noasync, message: "Use the async alternative")
     func validateManifest(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -147,7 +147,25 @@ public final class RegistryClient: Cancellable {
             callback: completion
         )
     }
+    
+    public func getPackageMetadata(
+        package: PackageIdentity,
+        timeout: DispatchTimeInterval? = .none,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> PackageMetadata {
+        try await safe_async {
+            self.getPackageMetadata(
+                package: package,
+                timeout: timeout,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     public func getPackageMetadata(
         package: PackageIdentity,
         timeout: DispatchTimeInterval? = .none,
@@ -260,7 +278,29 @@ public final class RegistryClient: Cancellable {
             )
         }
     }
+    
+    public func getPackageVersionMetadata(
+        package: PackageIdentity,
+        version: Version,
+        timeout: DispatchTimeInterval? = .none,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> PackageVersionMetadata {
+        try await safe_async {
+            self.getPackageVersionMetadata(
+                package: package,
+                version: version,
+                timeout: timeout,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     public func getPackageVersionMetadata(
         package: PackageIdentity,
         version: Version,
@@ -462,6 +502,26 @@ public final class RegistryClient: Cancellable {
         }
     }
 
+    public func getAvailableManifests(
+        package: PackageIdentity,
+        version: Version,
+        timeout: DispatchTimeInterval? = .none,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> [String: (toolsVersion: ToolsVersion, content: String?)]{
+        try await safe_async {
+            self.getAvailableManifests(
+                package: package,
+                version: version,
+                timeout: timeout,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
+    
+    @available(*, noasync, message: "Use the async alternative")
     public func getAvailableManifests(
         package: PackageIdentity,
         version: Version,
@@ -689,7 +749,28 @@ public final class RegistryClient: Cancellable {
             }
         }
     }
-
+    public func getManifestContent(
+        package: PackageIdentity,
+        version: Version,
+        customToolsVersion: ToolsVersion?,
+        timeout: DispatchTimeInterval? = .none,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> String {
+        try await safe_async {
+            self.getManifestContent(
+                package: package,
+                version: version,
+                customToolsVersion: customToolsVersion, 
+                timeout: timeout,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
+    
+    @available(*, noasync, message: "Use the async alternative")
     public func getManifestContent(
         package: PackageIdentity,
         version: Version,
@@ -898,7 +979,32 @@ public final class RegistryClient: Cancellable {
             }
         }
     }
+    public func downloadSourceArchive(
+        package: PackageIdentity,
+        version: Version,
+        destinationPath: AbsolutePath,
+        progressHandler: ((_ bytesReceived: Int64, _ totalBytes: Int64?) -> Void)?,
+        timeout: DispatchTimeInterval? = .none,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws {
+        try await safe_async {
+            self.downloadSourceArchive(
+                package: package,
+                version: version,
+                destinationPath: destinationPath,
+                progressHandler: progressHandler,
+                timeout: timeout,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     public func downloadSourceArchive(
         package: PackageIdentity,
         version: Version,
@@ -1189,7 +1295,25 @@ public final class RegistryClient: Cancellable {
             }
         }
     }
+    
+    public func lookupIdentities(
+        scmURL: SourceControlURL,
+        timeout: DispatchTimeInterval? = .none,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> Set<PackageIdentity> {
+        try await safe_async {
+            self.lookupIdentities(
+                scmURL: scmURL,
+                timeout: timeout,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     public func lookupIdentities(
         scmURL: SourceControlURL,
         timeout: DispatchTimeInterval? = .none,
@@ -1294,7 +1418,25 @@ public final class RegistryClient: Cancellable {
             )
         }
     }
+    
+    public func login(
+        loginURL: URL,
+        timeout: DispatchTimeInterval? = .none,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws {
+        try await safe_async {
+            self.login(
+                loginURL: loginURL,
+                timeout: timeout,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     public func login(
         loginURL: URL,
         timeout: DispatchTimeInterval? = .none,
@@ -1331,7 +1473,41 @@ public final class RegistryClient: Cancellable {
             }
         }
     }
+    
+    public func publish(
+        registryURL: URL,
+        packageIdentity: PackageIdentity,
+        packageVersion: Version,
+        packageArchive: AbsolutePath,
+        packageMetadata: AbsolutePath?,
+        signature: [UInt8]?,
+        metadataSignature: [UInt8]?,
+        signatureFormat: SignatureFormat?,
+        timeout: DispatchTimeInterval? = .none,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> PublishResult  {
+        try await safe_async {
+            self.publish(
+                registryURL: registryURL,
+                packageIdentity: packageIdentity,
+                packageVersion: packageVersion,
+                packageArchive: packageArchive,
+                packageMetadata: packageMetadata,
+                signature: signature,
+                metadataSignature: metadataSignature,
+                signatureFormat: signatureFormat,
+                timeout: timeout,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     public func publish(
         registryURL: URL,
         packageIdentity: PackageIdentity,
@@ -1499,8 +1675,26 @@ public final class RegistryClient: Cancellable {
             )
         }
     }
+    
+    func checkAvailability(
+        registry: Registry,
+        timeout: DispatchTimeInterval? = .none,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> AvailabilityStatus {
+        try await safe_async {
+            self.checkAvailability(
+                registry: registry,
+                timeout: timeout,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
     // marked internal for testing
+    @available(*, noasync, message: "Use the async alternative")
     func checkAvailability(
         registry: Registry,
         timeout: DispatchTimeInterval? = .none,

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -43,7 +43,27 @@ public class RegistryDownloadsManager: Cancellable {
         self.registryClient = registryClient
         self.delegate = delegate
     }
+    
+    public func lookup(
+        package: PackageIdentity,
+        version: Version,
+        observabilityScope: ObservabilityScope,
+        delegateQueue: DispatchQueue,
+        callbackQueue: DispatchQueue
+    ) async throws -> AbsolutePath {
+        try await safe_async {
+            self.lookup(
+                package: package,
+                version: version,
+                observabilityScope: observabilityScope,
+                delegateQueue: delegateQueue,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     public func lookup(
         package: PackageIdentity,
         version: Version,

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -53,7 +53,34 @@ struct SignatureValidation {
     }
 
     // MARK: - source archive
-
+    func validate(
+        registry: Registry,
+        package: PackageIdentity.RegistryIdentity,
+        version: Version,
+        content: Data,
+        configuration: RegistryConfiguration.Security.Signing,
+        timeout: DispatchTimeInterval?,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> SigningEntity? {
+        try await safe_async {
+            self.validate(
+                registry: registry,
+                package: package,
+                version: version, 
+                content: content,
+                configuration: configuration,
+                timeout: timeout,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope, 
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
+    
+    @available(*, noasync, message: "Use the async alternative")
     func validate(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,
@@ -285,7 +312,36 @@ struct SignatureValidation {
     }
 
     // MARK: - manifests
+    func validate(
+        registry: Registry,
+        package: PackageIdentity.RegistryIdentity,
+        version: Version,
+        toolsVersion: ToolsVersion?,
+        manifestContent: String,
+        configuration: RegistryConfiguration.Security.Signing,
+        timeout: DispatchTimeInterval?,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> SigningEntity? {
+        try await safe_async {
+            self.validate(
+                registry: registry,
+                package: package,
+                version: version,
+                toolsVersion: toolsVersion,
+                manifestContent: manifestContent,
+                configuration: configuration,
+                timeout: timeout,
+                fileSystem:fileSystem,
+                observabilityScope: observabilityScope, 
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     func validate(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,

--- a/Sources/PackageRegistry/SigningEntityTOFU.swift
+++ b/Sources/PackageRegistry/SigningEntityTOFU.swift
@@ -29,7 +29,29 @@ struct PackageSigningEntityTOFU {
         self.signingEntityStorage = signingEntityStorage
         self.signingEntityCheckingMode = signingEntityCheckingMode
     }
+    
+    func validate(
+        registry: Registry,
+        package: PackageIdentity.RegistryIdentity,
+        version: Version,
+        signingEntity: SigningEntity?,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws {
+        try await safe_async {
+            self.validate(
+                registry: registry,
+                package: package,
+                version: version,
+                signingEntity: signingEntity,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     func validate(
         registry: Registry,
         package: PackageIdentity.RegistryIdentity,

--- a/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
@@ -20,6 +20,7 @@ import struct TSCUtility.Version
 
 public protocol PackageSigningEntityStorage {
     /// For a given package, return the signing entities and the package versions that each of them signed.
+    @available(*, noasync, message: "Use the async alternative")
     func get(
         package: PackageIdentity,
         observabilityScope: ObservabilityScope,
@@ -31,6 +32,7 @@ public protocol PackageSigningEntityStorage {
     ///
     /// This throws `PackageSigningEntityStorageError.conflict` if `signingEntity`
     /// of the package version is different from that in storage.
+    @available(*, noasync, message: "Use the async alternative")
     func put(
         package: PackageIdentity,
         version: Version,
@@ -46,6 +48,7 @@ public protocol PackageSigningEntityStorage {
     /// If the package version already has other `SigningEntity`s in storage, this
     /// API **adds** `signingEntity` to the package version's signers rather than
     /// throwing an error.
+    @available(*, noasync, message: "Use the async alternative")
     func add(
         package: PackageIdentity,
         version: Version,
@@ -57,6 +60,7 @@ public protocol PackageSigningEntityStorage {
     )
 
     /// Make `signingEntity` the package's expected signer starting from the given version.
+    @available(*, noasync, message: "Use the async alternative")
     func changeSigningEntityFromVersion(
         package: PackageIdentity,
         version: Version,
@@ -71,6 +75,7 @@ public protocol PackageSigningEntityStorage {
     ///
     /// This API deletes all other existing signers from storage, therefore making
     /// `signingEntity` the package's sole signer.
+    @available(*, noasync, message: "Use the async alternative")
     func changeSigningEntityForAllVersions(
         package: PackageIdentity,
         version: Version,
@@ -80,6 +85,107 @@ public protocol PackageSigningEntityStorage {
         callbackQueue: DispatchQueue,
         callback: @escaping (Result<Void, Error>) -> Void
     )
+}
+
+public extension PackageSigningEntityStorage {
+    func get(
+        package: PackageIdentity,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> PackageSigners {
+        try await safe_async {
+            self.get(
+                package: package,
+                observabilityScope: observabilityScope, 
+                callbackQueue: callbackQueue,
+                callback: $0
+            )
+        }
+    }
+
+    func put(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws {
+        try await safe_async {
+            self.put(
+                package: package,
+                version: version,
+                signingEntity: signingEntity,
+                origin: origin,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                callback: $0
+            )
+        }
+    }
+
+    func add(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws {
+        try await safe_async {
+            self.add(
+                package: package,
+                version: version,
+                signingEntity: signingEntity,
+                origin: origin,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                callback: $0
+            )
+        }
+    }
+
+    func changeSigningEntityFromVersion(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws {
+        try await safe_async {
+            self.changeSigningEntityFromVersion(
+                package: package,
+                version: version,
+                signingEntity: signingEntity,
+                origin: origin,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                callback: $0
+            )
+        }
+    }
+
+    func changeSigningEntityForAllVersions(
+        package: PackageIdentity,
+        version: Version,
+        signingEntity: SigningEntity,
+        origin: SigningEntity.Origin,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws {
+        try await safe_async {
+            self.changeSigningEntityForAllVersions(
+                package: package,
+                version: version,
+                signingEntity: signingEntity,
+                origin: origin,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                callback: $0
+            )
+        }
+    }
 }
 
 // MARK: - Models

--- a/Sources/SPMTestSupport/MockPackageSigningEntityStorage.swift
+++ b/Sources/SPMTestSupport/MockPackageSigningEntityStorage.swift
@@ -25,7 +25,23 @@ public class MockPackageSigningEntityStorage: PackageSigningEntityStorage {
     public init(_ packageSigners: [PackageIdentity: PackageSigners] = [:]) {
         self.packageSigners = packageSigners
     }
+    
+    public func get(
+        package: PackageIdentity,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue
+    ) async throws -> PackageSigners {
+        try await safe_async {
+            self.get(
+                package: package,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                callback: $0
+            )
+        }
+    }
 
+    @available(*, noasync, message: "Use the async alternative")
     public func get(
         package: PackageIdentity,
         observabilityScope: ObservabilityScope,

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -946,13 +946,10 @@ final class PackageToolTests: CommandsTestCase {
     func testPinning() throws {
         try fixture(name: "Miscellaneous/PackageEdit") { fixturePath in
             let fooPath = fixturePath.appending("foo")
-            func build() throws -> String {
-                return try SwiftPM.Build.execute(packagePath: fooPath).stdout
-            }
             let exec = [fooPath.appending(components: ".build", try UserToolchain.default.targetTriple.platformBuildPathComponent, "debug", "foo").pathString]
 
             // Build and check.
-            _ = try build()
+            _ = try SwiftPM.Build.execute(packagePath: fooPath)
             XCTAssertEqual(try TSCBasic.Process.checkNonZeroExit(arguments: exec).spm_chomp(), "\(5)")
 
             // Get path to bar checkout.

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -22,7 +22,7 @@ import XCTest
 import struct TSCUtility.Version
 
 final class PackageSigningEntityTOFUTests: XCTestCase {
-    func testSigningEntitySeenForTheFirstTime() throws {
+    func testSigningEntitySeenForTheFirstTime() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -43,30 +43,25 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // Package doesn't have any recorded signer.
         // It should be ok to assign one.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity
         )
 
         // `signingEntity` meets requirement to be used for TOFU
         // (i.e., it's .recognized), so it should be saved to storage.
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[signingEntity]?.versions, [version])
     }
 
-    func testNilSigningEntityShouldNotBeSaved() throws {
+    func testNilSigningEntityShouldNotBeSaved() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -81,28 +76,23 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // Package doesn't have any recorded signer.
         // It should be ok to continue not to have one.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: .none
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: .none
         )
 
         // `signingEntity` is nil, so it should not be saved to storage.
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertTrue(packageSigners.isEmpty)
     }
 
-    func testUnrecognizedSigningEntityShouldNotBeSaved() throws {
+    func testUnrecognizedSigningEntityShouldNotBeSaved() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -122,28 +112,23 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // Package doesn't have any recorded signer.
         // It should be ok to continue not to have one.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity
         )
 
         // `signingEntity` is not .recognized, so it should not be saved to storage.
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertTrue(packageSigners.isEmpty)
     }
 
-    func testSigningEntityMatchesStorageForSameVersion() throws {
+    func testSigningEntityMatchesStorageForSameVersion() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -173,17 +158,15 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // Storage has "J. Appleseed" as signer for package version.
         // Signer remaining the same should be ok.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity
         )
     }
 
-    func testSigningEntityDoesNotMatchStorageForSameVersion_strictMode() throws {
+    func testSigningEntityDoesNotMatchStorageForSameVersion_strictMode() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -219,8 +202,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // Storage has "J. Smith" as signer for package version.
         // The given signer "J. Appleseed" is different so it should fail.
-        XCTAssertThrowsError(
-            try tofu.validate(
+        await XCTAssertAsyncThrowsError(
+            try await tofu.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -235,19 +218,16 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [version])
     }
 
-    func testSigningEntityDoesNotMatchStorageForSameVersion_warnMode() throws {
+    func testSigningEntityDoesNotMatchStorageForSameVersion_warnMode() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -286,14 +266,12 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         // Storage has "J. Smith" as signer for package version.
         // The given signer "J. Appleseed" is different, but because
         // of .warn mode, no error is thrown.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                observabilityScope: observability.topScope
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity,
+            observabilityScope: observability.topScope
         )
 
         // But there should be a warning
@@ -302,19 +280,16 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [version])
     }
 
-    func testPackageVersionLosingSigningEntity_strictMode() throws {
+    func testPackageVersionLosingSigningEntity_strictMode() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -344,8 +319,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // Storage has "J. Smith" as signer for package version.
         // The given signer is nil which is different so it should fail.
-        XCTAssertThrowsError(
-            try tofu.validate(
+        await XCTAssertAsyncThrowsError(
+            try await tofu.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -360,19 +335,16 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [version])
     }
 
-    func testSigningEntityMatchesStorageForDifferentVersion() throws {
+    func testSigningEntityMatchesStorageForDifferentVersion() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -403,29 +375,24 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // Storage has "J. Appleseed" as signer for package v2.0.0.
         // Signer remaining the same should be ok.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity
         )
 
         // Storage should be updated with version 1.1.1 added
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[signingEntity]?.versions, [existingVersion, version])
     }
 
-    func testSigningEntityDoesNotMatchStorageForDifferentVersion_strictMode() throws {
+    func testSigningEntityDoesNotMatchStorageForDifferentVersion_strictMode() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -462,8 +429,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // Storage has "J. Smith" as signer for package v2.0.0.
         // The given signer "J. Appleseed" is different so it should fail.
-        XCTAssertThrowsError(
-            try tofu.validate(
+        await XCTAssertAsyncThrowsError(
+            try await tofu.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -486,19 +453,16 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [existingVersion])
     }
 
-    func testSigningEntityDoesNotMatchStorageForDifferentVersion_warnMode() throws {
+    func testSigningEntityDoesNotMatchStorageForDifferentVersion_warnMode() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -538,14 +502,12 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         // Storage has "J. Smith" as signer for package v2.0.0.
         // The given signer "J. Appleseed" is different, but because
         // of .warn mode, no error is thrown.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                observabilityScope: observability.topScope
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity,
+            observabilityScope: observability.topScope
         )
 
         // But there should be a warning
@@ -554,19 +516,16 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, [existingVersion])
     }
 
-    func testNilSigningEntityWhenStorageHasNewerSignedVersions() throws {
+    func testNilSigningEntityWhenStorageHasNewerSignedVersions() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -598,29 +557,24 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         // Storage has versions 1.5.0 and 2.0.0 signed. The given version 1.1.1 is
         // "older" than both, and we allow nil signer in this case, assuming
         // this is before package started being signed.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: .none
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: .none
         )
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, existingVersions)
     }
 
-    func testNilSigningEntityWhenStorageHasOlderSignedVersions_strictMode() throws {
+    func testNilSigningEntityWhenStorageHasOlderSignedVersions_strictMode() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.6.1")
@@ -652,8 +606,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         // Storage has versions 1.5.0 and 2.0.0 signed. The given version 1.6.1 is
         // "newer" than 1.5.0, which we don't allow, because we assume from 1.5.0
         // onwards all versions are signed.
-        XCTAssertThrowsError(
-            try tofu.validate(
+        await XCTAssertAsyncThrowsError(
+            try await tofu.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -676,19 +630,16 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, existingVersions)
     }
 
-    func testNilSigningEntityWhenStorageHasOlderSignedVersions_warnMode() throws {
+    func testNilSigningEntityWhenStorageHasOlderSignedVersions_warnMode() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.6.1")
@@ -723,14 +674,12 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         // "newer" than 1.5.0, which we don't allow, because we assume from 1.5.0
         // onwards all versions are signed. However, because of .warn mode,
         // no error is thrown.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: .none,
-                observabilityScope: observability.topScope
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: .none,
+            observabilityScope: observability.topScope
         )
 
         // But there should be a warning
@@ -739,19 +688,16 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, existingVersions)
     }
 
-    func testNilSigningEntityWhenStorageHasOlderSignedVersionsInDifferentMajorVersion() throws {
+    func testNilSigningEntityWhenStorageHasOlderSignedVersionsInDifferentMajorVersion() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("2.0.0")
@@ -785,29 +731,24 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         // We allow this with the assumption that package signing might not have
         // begun until a later 2.x version, so until we encounter a signed 2.x version,
         // we assume none of them is signed.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: .none
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: .none
         )
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[existingSigningEntity]?.versions, existingVersions)
     }
 
-    func testSigningEntityOfNewerVersionMatchesExpectedSigner() throws {
+    func testSigningEntityOfNewerVersionMatchesExpectedSigner() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("2.0.0")
@@ -839,29 +780,24 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         // Package has expected signer starting from v1.5.0.
         // The given v2.0.0 is newer than v1.5.0, and signer
         // matches the expected signer.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: expectedSigningEntity
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: expectedSigningEntity
         )
 
         // Storage should be updated with v2.0.0 added
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 1)
         XCTAssertEqual(packageSigners.signers[expectedSigningEntity]?.versions, [expectedFromVersion, version])
     }
 
-    func testSigningEntityOfNewerVersionDoesNotMatchExpectedSignerButOlderThanExisting() throws {
+    func testSigningEntityOfNewerVersionDoesNotMatchExpectedSignerButOlderThanExisting() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("2.0.0")
@@ -908,30 +844,25 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         // the given signer was recorded previously for v2.2.0.
         // The given v2.0.0 is before v2.2.0, and we allow the same
         // signer for older versions.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity
         )
 
         // Storage should be updated with v2.0.0 added
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 2)
         XCTAssertEqual(packageSigners.signers[expectedSigningEntity]?.versions, [expectedFromVersion])
         XCTAssertEqual(packageSigners.signers[signingEntity]?.versions, [existingVersion, version])
     }
 
-    func testSigningEntityOfNewerVersionDoesNotMatchExpectedSignerAndNewerThanExisting() throws {
+    func testSigningEntityOfNewerVersionDoesNotMatchExpectedSignerAndNewerThanExisting() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("2.3.0")
@@ -978,8 +909,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         // the given signer was recorded previously for v2.2.0, but
         // the given v2.3.0 is after v2.2.0, which we don't allow
         // because we assume the signer has "stopped" signing at v2.2.0.
-        XCTAssertThrowsError(
-            try tofu.validate(
+        await XCTAssertAsyncThrowsError(
+            try await tofu.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -1002,20 +933,17 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
 
         // Storage should not be updated
-        let packageSigners = try temp_await { callback in
-            signingEntityStorage.get(
-                package: package.underlying,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: callback
-            )
-        }
+        let packageSigners = try await signingEntityStorage.get(
+            package: package.underlying,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
         XCTAssertEqual(packageSigners.signers.count, 2)
         XCTAssertEqual(packageSigners.signers[expectedSigningEntity]?.versions, [expectedFromVersion])
         XCTAssertEqual(packageSigners.signers[signingEntity]?.versions, [existingVersion])
     }
 
-    func testWriteConflictsWithStorage_strictMode() throws {
+    func testWriteConflictsWithStorage_strictMode() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -1035,8 +963,8 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         )
 
         // This triggers a storage write conflict
-        XCTAssertThrowsError(
-            try tofu.validate(
+        await XCTAssertAsyncThrowsError(
+            try await tofu.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -1049,7 +977,7 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
         }
     }
 
-    func testWriteConflictsWithStorage_warnMode() throws {
+    func testWriteConflictsWithStorage_warnMode() async throws {
         let registry = Registry(url: URL("https://packages.example.com"), supportsAvailability: false)
         let package = PackageIdentity.plain("mona.LinkedList").registry!
         let version = Version("1.1.1")
@@ -1072,14 +1000,12 @@ final class PackageSigningEntityTOFUTests: XCTestCase {
 
         // This triggers a storage write conflict, but
         // because of .warn mode, no error is thrown.
-        XCTAssertNoThrow(
-            try tofu.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                observabilityScope: observability.topScope
-            )
+        _ = try await tofu.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity,
+            observabilityScope: observability.topScope
         )
 
         // But there should be a warning
@@ -1096,18 +1022,15 @@ extension PackageSigningEntityTOFU {
         version: Version,
         signingEntity: SigningEntity?,
         observabilityScope: ObservabilityScope? = nil
-    ) throws {
-        try temp_await {
-            self.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                signingEntity: signingEntity,
-                observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    ) async throws {
+        try await self.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            signingEntity: signingEntity,
+            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 }
 

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -26,7 +26,7 @@ import class TSCBasic.InMemoryFileSystem
 import struct TSCUtility.Version
 
 final class RegistryClientTests: XCTestCase {
-    func testGetPackageMetadata() throws {
+    func testGetPackageMetadata() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let releasesURL = URL("\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)")
@@ -87,7 +87,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        let metadata = try registryClient.getPackageMetadata(package: identity)
+        let metadata = try await registryClient.getPackageMetadata(package: identity)
         XCTAssertEqual(metadata.versions, ["1.1.1", "1.0.0"])
         XCTAssertEqual(metadata.alternateLocations!, [
             SourceControlURL("https://github.com/mona/LinkedList"),
@@ -97,7 +97,7 @@ final class RegistryClientTests: XCTestCase {
         ])
     }
 
-    func testGetPackageMetadata_NotFound() throws {
+    func testGetPackageMetadata_NotFound() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let releasesURL = URL("\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)")
@@ -117,7 +117,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try registryClient.getPackageMetadata(package: identity)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.getPackageMetadata(package: identity)) { error in
             guard case RegistryError.failedRetrievingReleases(
                 registry: configuration.defaultRegistry!,
                 package: identity,
@@ -128,7 +128,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetPackageMetadata_ServerError() throws {
+    func testGetPackageMetadata_ServerError() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let releasesURL = URL("\(registryURL)/\(identity.registry!.scope)/\(identity.registry!.name)")
@@ -148,7 +148,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try registryClient.getPackageMetadata(package: identity)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.getPackageMetadata(package: identity)) { error in
             guard case RegistryError
                 .failedRetrievingReleases(
                     registry: configuration.defaultRegistry!,
@@ -164,7 +164,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetPackageMetadata_RegistryNotAvailable() throws {
+    func testGetPackageMetadata_RegistryNotAvailable() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
 
@@ -179,7 +179,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = registry
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try registryClient.getPackageMetadata(package: identity)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.getPackageMetadata(package: identity)) { error in
             guard case RegistryError.registryNotAvailable(registry) = error
             else {
                 return XCTFail("unexpected error: '\(error)'")
@@ -187,7 +187,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetPackageVersionMetadata() throws {
+    func testGetPackageVersionMetadata() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -246,7 +246,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        let metadata = try registryClient.getPackageVersionMetadata(package: identity, version: version)
+        let metadata = try await registryClient.getPackageVersionMetadata(package: identity, version: version)
         XCTAssertEqual(metadata.resources.count, 1)
         XCTAssertEqual(metadata.resources[0].name, "source-archive")
         XCTAssertEqual(metadata.resources[0].type, "application/zip")
@@ -264,7 +264,7 @@ final class RegistryClientTests: XCTestCase {
         ])
     }
 
-    func testGetPackageVersionMetadata_404() throws {
+    func testGetPackageVersionMetadata_404() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -285,8 +285,8 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(
-            try registryClient
+        await XCTAssertAsyncThrowsError(
+            try await registryClient
                 .getPackageVersionMetadata(package: identity, version: version)
         ) { error in
             guard case RegistryError
@@ -302,7 +302,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetPackageVersionMetadata_ServerError() throws {
+    func testGetPackageVersionMetadata_ServerError() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -323,8 +323,8 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(
-            try registryClient
+        await XCTAssertAsyncThrowsError(
+            try await registryClient
                 .getPackageVersionMetadata(package: identity, version: version)
         ) { error in
             guard case RegistryError
@@ -343,7 +343,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetPackageVersionMetadata_RegistryNotAvailable() throws {
+    func testGetPackageVersionMetadata_RegistryNotAvailable() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -359,8 +359,8 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = registry
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(
-            try registryClient
+        await XCTAssertAsyncThrowsError(
+            try await registryClient
                 .getPackageVersionMetadata(package: identity, version: version)
         ) { error in
             guard case RegistryError.registryNotAvailable(registry) = error
@@ -370,7 +370,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testAvailableManifests() throws {
+    func testAvailableManifests() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -475,7 +475,7 @@ final class RegistryClientTests: XCTestCase {
             httpClient: httpClient,
             checksumAlgorithm: checksumAlgorithm
         )
-        let availableManifests = try registryClient.getAvailableManifests(
+        let availableManifests = try await registryClient.getAvailableManifests(
             package: identity,
             version: version
         )
@@ -490,7 +490,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(availableManifests["Package@swift-5.3.swift"]?.content, .none)
     }
 
-    func testAvailableManifests_matchingChecksumInStorage() throws {
+    func testAvailableManifests_matchingChecksumInStorage() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -614,7 +614,7 @@ final class RegistryClientTests: XCTestCase {
             fingerprintCheckingMode: .strict,
             checksumAlgorithm: checksumAlgorithm
         )
-        let availableManifests = try registryClient.getAvailableManifests(
+        let availableManifests = try await registryClient.getAvailableManifests(
             package: identity,
             version: version
         )
@@ -629,7 +629,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(availableManifests["Package@swift-5.3.swift"]?.content, .none)
     }
 
-    func testAvailableManifests_nonMatchingChecksumInStorage_strict() throws {
+    func testAvailableManifests_nonMatchingChecksumInStorage_strict() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -752,8 +752,8 @@ final class RegistryClientTests: XCTestCase {
             checksumAlgorithm: checksumAlgorithm
         )
 
-        XCTAssertThrowsError(
-            try registryClient.getAvailableManifests(
+        await XCTAssertAsyncThrowsError(
+            try await registryClient.getAvailableManifests(
                 package: identity,
                 version: version
             )
@@ -764,7 +764,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testAvailableManifests_nonMatchingChecksumInStorage_warn() throws {
+    func testAvailableManifests_nonMatchingChecksumInStorage_warn() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -890,7 +890,7 @@ final class RegistryClientTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
         // The checksum differs from that in storage, but error is not thrown
         // because fingerprintCheckingMode=.warn
-        let availableManifests = try registryClient.getAvailableManifests(
+        let availableManifests = try await registryClient.getAvailableManifests(
             package: identity,
             version: version,
             observabilityScope: observability.topScope
@@ -911,7 +911,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(availableManifests["Package@swift-5.3.swift"]?.content, .none)
     }
 
-    func testAvailableManifests_404() throws {
+    func testAvailableManifests_404() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -960,7 +960,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try registryClient.getAvailableManifests(package: identity, version: version)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.getAvailableManifests(package: identity, version: version)) { error in
             guard case RegistryError
                 .failedRetrievingManifest(
                     registry: configuration.defaultRegistry!,
@@ -974,7 +974,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testAvailableManifests_ServerError() throws {
+    func testAvailableManifests_ServerError() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1023,7 +1023,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try registryClient.getAvailableManifests(package: identity, version: version)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.getAvailableManifests(package: identity, version: version)) { error in
             guard case RegistryError
                 .failedRetrievingManifest(
                     registry: configuration.defaultRegistry!,
@@ -1038,7 +1038,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testAvailableManifests_RegistryNotAvailable() throws {
+    func testAvailableManifests_RegistryNotAvailable() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1054,7 +1054,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = registry
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try registryClient.getAvailableManifests(package: identity, version: version)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.getAvailableManifests(package: identity, version: version)) { error in
             guard case RegistryError.registryNotAvailable(registry) = error
             else {
                 return XCTFail("unexpected error: '\(error)'")
@@ -1062,7 +1062,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetManifestContent() throws {
+    func testGetManifestContent() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1157,7 +1157,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         do {
-            let manifest = try registryClient.getManifestContent(
+            let manifest = try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: nil
@@ -1167,7 +1167,7 @@ final class RegistryClientTests: XCTestCase {
         }
 
         do {
-            let manifest = try registryClient.getManifestContent(
+            let manifest = try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: .v5_3
@@ -1177,7 +1177,7 @@ final class RegistryClientTests: XCTestCase {
         }
 
         do {
-            let manifest = try registryClient.getManifestContent(
+            let manifest = try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: .v4
@@ -1187,7 +1187,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetManifestContent_optionalContentVersion() throws {
+    func testGetManifestContent_optionalContentVersion() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1282,7 +1282,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         do {
-            let manifest = try registryClient.getManifestContent(
+            let manifest = try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: nil
@@ -1292,7 +1292,7 @@ final class RegistryClientTests: XCTestCase {
         }
 
         do {
-            let manifest = try registryClient.getManifestContent(
+            let manifest = try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: .v5_3
@@ -1302,7 +1302,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetManifestContent_matchingChecksumInStorage() throws {
+    func testGetManifestContent_matchingChecksumInStorage() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1416,7 +1416,7 @@ final class RegistryClientTests: XCTestCase {
         )
 
         do {
-            let manifest = try registryClient.getManifestContent(
+            let manifest = try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: nil
@@ -1426,7 +1426,7 @@ final class RegistryClientTests: XCTestCase {
         }
 
         do {
-            let manifest = try registryClient.getManifestContent(
+            let manifest = try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: .v5_3
@@ -1436,7 +1436,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetManifestContent_nonMatchingChecksumInStorage_strict() throws {
+    func testGetManifestContent_nonMatchingChecksumInStorage_strict() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1545,8 +1545,8 @@ final class RegistryClientTests: XCTestCase {
             checksumAlgorithm: checksumAlgorithm
         )
 
-        XCTAssertThrowsError(
-            try registryClient.getManifestContent(
+        await XCTAssertAsyncThrowsError(
+            try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: nil
@@ -1557,8 +1557,8 @@ final class RegistryClientTests: XCTestCase {
             }
         }
 
-        XCTAssertThrowsError(
-            try registryClient.getManifestContent(
+        await XCTAssertAsyncThrowsError(
+            try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: .v5_3
@@ -1570,7 +1570,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetManifestContent_matchingChecksumInStorage_warn() throws {
+    func testGetManifestContent_matchingChecksumInStorage_warn() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1683,7 +1683,7 @@ final class RegistryClientTests: XCTestCase {
             let observability = ObservabilitySystem.makeForTesting()
             // The checksum differs from that in storage, but error is not thrown
             // because fingerprintCheckingMode=.warn
-            let manifest = try registryClient.getManifestContent(
+            let manifest = try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: nil,
@@ -1703,7 +1703,7 @@ final class RegistryClientTests: XCTestCase {
             let observability = ObservabilitySystem.makeForTesting()
             // The checksum differs from that in storage, but error is not thrown
             // because fingerprintCheckingMode=.warn
-            let manifest = try registryClient.getManifestContent(
+            let manifest = try await registryClient.getManifestContent(
                 package: identity,
                 version: version,
                 customToolsVersion: .v5_3,
@@ -1720,7 +1720,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetManifestContent_404() throws {
+    func testGetManifestContent_404() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1769,8 +1769,8 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(
-            try registryClient
+        await XCTAssertAsyncThrowsError(
+            try await registryClient
                 .getManifestContent(package: identity, version: version, customToolsVersion: nil)
         ) { error in
             guard case RegistryError
@@ -1786,7 +1786,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetManifestContent_ServerError() throws {
+    func testGetManifestContent_ServerError() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1835,8 +1835,8 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(
-            try registryClient
+        await XCTAssertAsyncThrowsError(
+            try await registryClient
                 .getManifestContent(package: identity, version: version, customToolsVersion: nil)
         ) { error in
             guard case RegistryError
@@ -1853,7 +1853,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testGetManifestContent_RegistryNotAvailable() throws {
+    func testGetManifestContent_RegistryNotAvailable() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1869,8 +1869,8 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = registry
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(
-            try registryClient
+        await XCTAssertAsyncThrowsError(
+            try await registryClient
                 .getManifestContent(package: identity, version: version, customToolsVersion: nil)
         ) { error in
             guard case RegistryError
@@ -1881,7 +1881,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testDownloadSourceArchive() throws {
+    func testDownloadSourceArchive() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.registry("mona.LinkedList")
         let version = Version("1.1.1")
@@ -1996,7 +1996,7 @@ final class RegistryClientTests: XCTestCase {
         let fileSystem = InMemoryFileSystem()
         let path = try! AbsolutePath(validating: "/\(identity)-\(version)")
 
-        try registryClient.downloadSourceArchive(
+        try await registryClient.downloadSourceArchive(
             package: identity.underlying,
             version: version,
             fileSystem: fileSystem,
@@ -2017,7 +2017,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(storedMetadata.metadata.scmRepositoryURLs, repositoryURLs)
     }
 
-    func testDownloadSourceArchive_matchingChecksumInStorage() throws {
+    func testDownloadSourceArchive_matchingChecksumInStorage() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -2137,7 +2137,7 @@ final class RegistryClientTests: XCTestCase {
         let fileSystem = InMemoryFileSystem()
         let path = AbsolutePath("/LinkedList-1.1.1")
 
-        try registryClient.downloadSourceArchive(
+        try await registryClient.downloadSourceArchive(
             package: identity,
             version: version,
             fileSystem: fileSystem,
@@ -2148,7 +2148,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(contents.sorted(), [RegistryReleaseMetadataStorage.fileName, "Package.swift"].sorted())
     }
 
-    func testDownloadSourceArchive_nonMatchingChecksumInStorage() throws {
+    func testDownloadSourceArchive_nonMatchingChecksumInStorage() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -2268,8 +2268,8 @@ final class RegistryClientTests: XCTestCase {
         let fileSystem = InMemoryFileSystem()
         let path = AbsolutePath("/LinkedList-1.1.1")
 
-        XCTAssertThrowsError(
-            try registryClient.downloadSourceArchive(
+        await XCTAssertAsyncThrowsError(
+            try await registryClient.downloadSourceArchive(
                 package: identity,
                 version: version,
                 fileSystem: fileSystem,
@@ -2285,7 +2285,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertFalse(fileSystem.exists(path))
     }
 
-    func testDownloadSourceArchive_nonMatchingChecksumInStorage_fingerprintChecking_warn() throws {
+    func testDownloadSourceArchive_nonMatchingChecksumInStorage_fingerprintChecking_warn() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -2408,7 +2408,7 @@ final class RegistryClientTests: XCTestCase {
 
         // The checksum differs from that in storage, but error is not thrown
         // because fingerprintCheckingMode=.warn
-        try registryClient.downloadSourceArchive(
+        try await registryClient.downloadSourceArchive(
             package: identity,
             version: version,
             fileSystem: fileSystem,
@@ -2425,7 +2425,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(contents.sorted(), [RegistryReleaseMetadataStorage.fileName, "Package.swift"].sorted())
     }
 
-    func testDownloadSourceArchive_checksumNotInStorage() throws {
+    func testDownloadSourceArchive_checksumNotInStorage() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -2527,7 +2527,7 @@ final class RegistryClientTests: XCTestCase {
         let fileSystem = InMemoryFileSystem()
         let path = AbsolutePath("/LinkedList-1.1.1")
 
-        try registryClient.downloadSourceArchive(
+        try await registryClient.downloadSourceArchive(
             package: identity,
             version: version,
             fileSystem: fileSystem,
@@ -2538,7 +2538,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(contents.sorted(), [RegistryReleaseMetadataStorage.fileName, "Package.swift"].sorted())
 
         // Expected checksum is not found in storage so the metadata API will be called
-        let fingerprint = try temp_await { callback in
+        let fingerprint = try await safe_async {
             fingerprintStorage.get(
                 package: identity,
                 version: version,
@@ -2547,14 +2547,14 @@ final class RegistryClientTests: XCTestCase {
                 observabilityScope: ObservabilitySystem
                     .NOOP,
                 callbackQueue: .sharedConcurrent,
-                callback: callback
+                callback: $0
             )
         }
         XCTAssertEqual(SourceControlURL(registryURL), fingerprint.origin.url)
         XCTAssertEqual(checksum, fingerprint.value)
     }
 
-    func testDownloadSourceArchive_optionalContentVersion() throws {
+    func testDownloadSourceArchive_optionalContentVersion() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -2656,7 +2656,7 @@ final class RegistryClientTests: XCTestCase {
         let fileSystem = InMemoryFileSystem()
         let path = AbsolutePath("/LinkedList-1.1.1")
 
-        try registryClient.downloadSourceArchive(
+        try await registryClient.downloadSourceArchive(
             package: identity,
             version: version,
             fileSystem: fileSystem,
@@ -2668,7 +2668,7 @@ final class RegistryClientTests: XCTestCase {
         XCTAssertEqual(contents.sorted(), [RegistryReleaseMetadataStorage.fileName, "Package.swift"].sorted())
     }
 
-    func testDownloadSourceArchive_404() throws {
+    func testDownloadSourceArchive_404() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -2730,7 +2730,7 @@ final class RegistryClientTests: XCTestCase {
         let fileSystem = InMemoryFileSystem()
         let path = AbsolutePath("/LinkedList-1.1.1")
 
-        XCTAssertThrowsError(try registryClient.downloadSourceArchive(
+        await XCTAssertAsyncThrowsError(try await registryClient.downloadSourceArchive(
             package: identity,
             version: version,
             fileSystem: fileSystem,
@@ -2749,7 +2749,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testDownloadSourceArchive_ServerError() throws {
+    func testDownloadSourceArchive_ServerError() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -2811,7 +2811,7 @@ final class RegistryClientTests: XCTestCase {
         let fileSystem = InMemoryFileSystem()
         let path = AbsolutePath("/LinkedList-1.1.1")
 
-        XCTAssertThrowsError(try registryClient.downloadSourceArchive(
+        await XCTAssertAsyncThrowsError(try await registryClient.downloadSourceArchive(
             package: identity,
             version: version,
             fileSystem: fileSystem,
@@ -2831,7 +2831,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testDownloadSourceArchive_RegistryNotAvailable() throws {
+    func testDownloadSourceArchive_RegistryNotAvailable() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -2861,7 +2861,7 @@ final class RegistryClientTests: XCTestCase {
         let fileSystem = InMemoryFileSystem()
         let path = AbsolutePath("/LinkedList-1.1.1")
 
-        XCTAssertThrowsError(try registryClient.downloadSourceArchive(
+        await XCTAssertAsyncThrowsError(try await registryClient.downloadSourceArchive(
             package: identity,
             version: version,
             fileSystem: fileSystem,
@@ -2875,7 +2875,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testLookupIdentities() throws {
+    func testLookupIdentities() async throws {
         let registryURL = URL("https://packages.example.com")
         let packageURL = SourceControlURL("https://example.com/mona/LinkedList")
         let identifiersURL = URL("\(registryURL)/identifiers?url=\(packageURL.absoluteString)")
@@ -2915,11 +2915,11 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        let identities = try registryClient.lookupIdentities(scmURL: packageURL)
+        let identities = try await registryClient.lookupIdentities(scmURL: packageURL)
         XCTAssertEqual([PackageIdentity.plain("mona.LinkedList")], identities)
     }
 
-    func testLookupIdentities404() throws {
+    func testLookupIdentities404() async throws {
         let registryURL = URL("https://packages.example.com")
         let packageURL = SourceControlURL("https://example.com/mona/LinkedList")
         let identifiersURL = URL("\(registryURL)/identifiers?url=\(packageURL.absoluteString)")
@@ -2942,11 +2942,11 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        let identities = try registryClient.lookupIdentities(scmURL: packageURL)
+        let identities = try await registryClient.lookupIdentities(scmURL: packageURL)
         XCTAssertEqual([], identities)
     }
 
-    func testLookupIdentities_ServerError() throws {
+    func testLookupIdentities_ServerError() async throws {
         let registryURL = URL("https://packages.example.com")
         let packageURL = SourceControlURL("https://example.com/mona/LinkedList")
         let identifiersURL = URL("\(registryURL)/identifiers?url=\(packageURL.absoluteString)")
@@ -2966,7 +2966,7 @@ final class RegistryClientTests: XCTestCase {
         configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
         let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try registryClient.lookupIdentities(scmURL: packageURL)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.lookupIdentities(scmURL: packageURL)) { error in
             guard case RegistryError
                 .failedIdentityLookup(
                     registry: configuration.defaultRegistry!,
@@ -2980,7 +2980,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testRequestAuthorization_token() throws {
+    func testRequestAuthorization_token() async throws {
         let registryURL = URL("https://packages.example.com")
         let packageURL = SourceControlURL("https://example.com/mona/LinkedList")
         let identifiersURL = URL("\(registryURL)/identifiers?url=\(packageURL.absoluteString)")
@@ -3030,11 +3030,11 @@ final class RegistryClientTests: XCTestCase {
             httpClient: httpClient,
             authorizationProvider: authorizationProvider
         )
-        let identities = try registryClient.lookupIdentities(scmURL: packageURL)
+        let identities = try await registryClient.lookupIdentities(scmURL: packageURL)
         XCTAssertEqual([PackageIdentity.plain("mona.LinkedList")], identities)
     }
 
-    func testRequestAuthorization_basic() throws {
+    func testRequestAuthorization_basic() async throws {
         let registryURL = URL("https://packages.example.com")
         let packageURL = SourceControlURL("https://example.com/mona/LinkedList")
         let identifiersURL = URL("\(registryURL)/identifiers?url=\(packageURL.absoluteString)")
@@ -3088,11 +3088,11 @@ final class RegistryClientTests: XCTestCase {
             httpClient: httpClient,
             authorizationProvider: authorizationProvider
         )
-        let identities = try registryClient.lookupIdentities(scmURL: packageURL)
+        let identities = try await registryClient.lookupIdentities(scmURL: packageURL)
         XCTAssertEqual([PackageIdentity.plain("mona.LinkedList")], identities)
     }
 
-    func testLogin() throws {
+    func testLogin() async throws {
         let registryURL = URL("https://packages.example.com")
         let loginURL = URL("\(registryURL)/login")
 
@@ -3129,10 +3129,10 @@ final class RegistryClientTests: XCTestCase {
             httpClient: httpClient,
             authorizationProvider: authorizationProvider
         )
-        XCTAssertNoThrow(try registryClient.login(loginURL: loginURL))
+        try await registryClient.login(loginURL: loginURL)
     }
 
-    func testLogin_missingCredentials() throws {
+    func testLogin_missingCredentials() async throws {
         let registryURL = URL("https://packages.example.com")
         let loginURL = URL("\(registryURL)/login")
 
@@ -3164,14 +3164,14 @@ final class RegistryClientTests: XCTestCase {
             httpClient: httpClient
         )
 
-        XCTAssertThrowsError(try registryClient.login(loginURL: loginURL)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.login(loginURL: loginURL)) { error in
             guard case RegistryError.loginFailed(_, _) = error else {
                 return XCTFail("Expected RegistryError.unauthorized, got \(error)")
             }
         }
     }
 
-    func testLogin_authenticationMethodNotSupported() throws {
+    func testLogin_authenticationMethodNotSupported() async throws {
         let registryURL = URL("https://packages.example.com")
         let loginURL = URL("\(registryURL)/login")
 
@@ -3209,14 +3209,14 @@ final class RegistryClientTests: XCTestCase {
             authorizationProvider: authorizationProvider
         )
 
-        XCTAssertThrowsError(try registryClient.login(loginURL: loginURL)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.login(loginURL: loginURL)) { error in
             guard case RegistryError.loginFailed = error else {
                 return XCTFail("Expected RegistryError.authenticationMethodNotSupported, got \(error)")
             }
         }
     }
 
-    func testRegistryPublishSync() throws {
+    func testRegistryPublishSync() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -3251,7 +3251,7 @@ final class RegistryClientTests: XCTestCase {
             }
         }
 
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             let archivePath = temporaryDirectory.appending("\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, string: archiveContent)
 
@@ -3266,7 +3266,7 @@ final class RegistryClientTests: XCTestCase {
             configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
             let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-            let result = try registryClient.publish(
+            let result = try await registryClient.publish(
                 registryURL: registryURL,
                 packageIdentity: identity,
                 packageVersion: version,
@@ -3282,7 +3282,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testRegistryPublishAsync() throws {
+    func testRegistryPublishAsync() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -3319,7 +3319,7 @@ final class RegistryClientTests: XCTestCase {
             }
         }
 
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             let archivePath = temporaryDirectory.appending("\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, string: archiveContent)
 
@@ -3334,7 +3334,7 @@ final class RegistryClientTests: XCTestCase {
             configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
             let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-            let result = try registryClient.publish(
+            let result = try await registryClient.publish(
                 registryURL: registryURL,
                 packageIdentity: identity,
                 packageVersion: version,
@@ -3350,7 +3350,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testRegistryPublishWithSignature() throws {
+    func testRegistryPublishWithSignature() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let version = Version("1.1.1")
@@ -3390,7 +3390,7 @@ final class RegistryClientTests: XCTestCase {
             }
         }
 
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             let archivePath = temporaryDirectory.appending(component: "\(identity)-\(version).zip")
             try localFileSystem.writeFileContents(archivePath, string: archiveContent)
 
@@ -3405,7 +3405,7 @@ final class RegistryClientTests: XCTestCase {
             configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
             let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-            let result = try registryClient.publish(
+            let result = try await registryClient.publish(
                 registryURL: registryURL,
                 packageIdentity: identity,
                 packageVersion: version,
@@ -3450,7 +3450,7 @@ final class RegistryClientTests: XCTestCase {
             configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
             let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-            XCTAssertThrowsError(try registryClient.publish(
+            await XCTAssertAsyncThrowsError(try await registryClient.publish(
                 registryURL: registryURL,
                 packageIdentity: identity,
                 packageVersion: version,
@@ -3497,7 +3497,7 @@ final class RegistryClientTests: XCTestCase {
             configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
             let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-            XCTAssertThrowsError(try registryClient.publish(
+            await XCTAssertAsyncThrowsError(try await registryClient.publish(
                 registryURL: registryURL,
                 packageIdentity: identity,
                 packageVersion: version,
@@ -3544,7 +3544,7 @@ final class RegistryClientTests: XCTestCase {
             configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
             let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-            XCTAssertThrowsError(try registryClient.publish(
+            await XCTAssertAsyncThrowsError(try await registryClient.publish(
                 registryURL: registryURL,
                 packageIdentity: identity,
                 packageVersion: version,
@@ -3590,7 +3590,7 @@ final class RegistryClientTests: XCTestCase {
             configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
             let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-            XCTAssertThrowsError(try registryClient.publish(
+            await XCTAssertAsyncThrowsError(try await registryClient.publish(
                 registryURL: registryURL,
                 packageIdentity: identity,
                 packageVersion: version,
@@ -3639,7 +3639,7 @@ final class RegistryClientTests: XCTestCase {
             configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
             let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-            XCTAssertThrowsError(try registryClient.publish(
+            await XCTAssertAsyncThrowsError(try await registryClient.publish(
                 registryURL: registryURL,
                 packageIdentity: identity,
                 packageVersion: version,
@@ -3680,7 +3680,7 @@ final class RegistryClientTests: XCTestCase {
             configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
 
             let registryClient = makeRegistryClient(configuration: configuration, httpClient: httpClient)
-            XCTAssertThrowsError(try registryClient.publish(
+            await XCTAssertAsyncThrowsError(try await registryClient.publish(
                 registryURL: registryURL,
                 packageIdentity: identity,
                 packageVersion: version,
@@ -3698,7 +3698,7 @@ final class RegistryClientTests: XCTestCase {
         }
     }
 
-    func testRegistryAvailability() throws {
+    func testRegistryAvailability() async throws {
         let registryURL = URL("https://packages.example.com")
         let availabilityURL = URL("\(registryURL)/availability")
 
@@ -3722,11 +3722,11 @@ final class RegistryClientTests: XCTestCase {
             httpClient: httpClient
         )
 
-        let status = try registryClient.checkAvailability(registry: registry)
+        let status = try await registryClient.checkAvailability(registry: registry)
         XCTAssertEqual(status, .available)
     }
 
-    func testRegistryAvailability_NotAvailable() throws {
+    func testRegistryAvailability_NotAvailable() async throws {
         let registryURL = URL("https://packages.example.com")
         let availabilityURL = URL("\(registryURL)/availability")
 
@@ -3751,12 +3751,12 @@ final class RegistryClientTests: XCTestCase {
                 httpClient: httpClient
             )
 
-            let status = try registryClient.checkAvailability(registry: registry)
+            let status = try await registryClient.checkAvailability(registry: registry)
             XCTAssertEqual(status, .unavailable)
         }
     }
 
-    func testRegistryAvailability_ServerError() throws {
+    func testRegistryAvailability_ServerError() async throws {
         let registryURL = URL("https://packages.example.com")
         let availabilityURL = URL("\(registryURL)/availability")
 
@@ -3780,11 +3780,11 @@ final class RegistryClientTests: XCTestCase {
             httpClient: httpClient
         )
 
-        let status = try registryClient.checkAvailability(registry: registry)
+        let status = try await registryClient.checkAvailability(registry: registry)
         XCTAssertEqual(status, .error("unknown server error (500)"))
     }
 
-    func testRegistryAvailability_NotSupported() throws {
+    func testRegistryAvailability_NotSupported() async throws {
         let registryURL = URL("https://packages.example.com")
         let availabilityURL = URL("\(registryURL)/availability")
 
@@ -3808,7 +3808,7 @@ final class RegistryClientTests: XCTestCase {
             httpClient: httpClient
         )
 
-        XCTAssertThrowsError(try registryClient.checkAvailability(registry: registry)) { error in
+        await XCTAssertAsyncThrowsError(try await registryClient.checkAvailability(registry: registry)) { error in
             XCTAssertEqual(
                 error as? StringError,
                 StringError("registry \(registry.url) does not support availability checks.")
@@ -3820,57 +3820,57 @@ final class RegistryClientTests: XCTestCase {
 // MARK: - Sugar
 
 extension RegistryClient {
-    fileprivate func getPackageMetadata(package: PackageIdentity) throws -> RegistryClient.PackageMetadata {
-        try temp_await {
-            self.getPackageMetadata(
-                package: package,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    fileprivate func getPackageMetadata(package: PackageIdentity) async throws -> RegistryClient.PackageMetadata {
+        try await self.getPackageMetadata(
+            package: package,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 
     func getPackageVersionMetadata(
         package: PackageIdentity,
         version: Version
-    ) throws -> PackageVersionMetadata {
-        try temp_await {
-            self.getPackageVersionMetadata(
-                package: package,
-                version: version,
-                fileSystem: InMemoryFileSystem(),
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    ) async throws -> PackageVersionMetadata {
+        try await self.getPackageVersionMetadata(
+            package: package,
+            version: version,
+            fileSystem: InMemoryFileSystem(),
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 
     func getPackageVersionMetadata(
         package: PackageIdentity.RegistryIdentity,
         version: Version
     ) throws -> PackageVersionMetadata {
-        try self.getPackageVersionMetadata(
-            package: package.underlying,
-            version: version
-        )
+        // TODO: Finish removing this temp_await
+        // It can't currently be removed because it is passed to
+        // PackageVersionChecksumTOFU which expects a non async method
+        return try temp_await { completion in
+            self.getPackageVersionMetadata(
+                package: package.underlying,
+                version: version,
+                fileSystem: InMemoryFileSystem(),
+                observabilityScope: ObservabilitySystem.NOOP,
+                callbackQueue: .sharedConcurrent,
+                completion: completion
+            )
+        }
     }
 
     fileprivate func getAvailableManifests(
         package: PackageIdentity,
         version: Version,
         observabilityScope: ObservabilityScope = ObservabilitySystem.NOOP
-    ) throws -> [String: (toolsVersion: ToolsVersion, content: String?)] {
-        try temp_await {
-            self.getAvailableManifests(
-                package: package,
-                version: version,
-                observabilityScope: observabilityScope,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    ) async throws -> [String: (toolsVersion: ToolsVersion, content: String?)] {
+        try await self.getAvailableManifests(
+            package: package,
+            version: version,
+            observabilityScope: observabilityScope,
+            callbackQueue: .sharedConcurrent
+        )
     }
 
     fileprivate func getManifestContent(
@@ -3878,17 +3878,14 @@ extension RegistryClient {
         version: Version,
         customToolsVersion: ToolsVersion?,
         observabilityScope: ObservabilityScope = ObservabilitySystem.NOOP
-    ) throws -> String {
-        try temp_await {
-            self.getManifestContent(
-                package: package,
-                version: version,
-                customToolsVersion: customToolsVersion,
-                observabilityScope: observabilityScope,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    ) async throws -> String {
+        try await self.getManifestContent(
+            package: package,
+            version: version,
+            customToolsVersion: customToolsVersion,
+            observabilityScope: observabilityScope,
+            callbackQueue: .sharedConcurrent
+        )
     }
 
     fileprivate func downloadSourceArchive(
@@ -3897,41 +3894,32 @@ extension RegistryClient {
         fileSystem: FileSystem,
         destinationPath: AbsolutePath,
         observabilityScope: ObservabilityScope = ObservabilitySystem.NOOP
-    ) throws {
-        try temp_await {
-            self.downloadSourceArchive(
-                package: package,
-                version: version,
-                destinationPath: destinationPath,
-                progressHandler: .none,
-                fileSystem: fileSystem,
-                observabilityScope: observabilityScope,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    ) async throws {
+        try await self.downloadSourceArchive(
+            package: package,
+            version: version,
+            destinationPath: destinationPath,
+            progressHandler: .none,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope,
+            callbackQueue: .sharedConcurrent
+        )
     }
 
-    fileprivate func lookupIdentities(scmURL: SourceControlURL) throws -> Set<PackageIdentity> {
-        try temp_await {
-            self.lookupIdentities(
-                scmURL: scmURL,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    fileprivate func lookupIdentities(scmURL: SourceControlURL) async throws -> Set<PackageIdentity> {
+        try await self.lookupIdentities(
+            scmURL: scmURL,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 
-    fileprivate func login(loginURL: URL) throws {
-        try temp_await {
-            self.login(
-                loginURL: loginURL,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    fileprivate func login(loginURL: URL) async throws {
+        try await self.login(
+            loginURL: loginURL,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 
     func publish(
@@ -3944,34 +3932,28 @@ extension RegistryClient {
         metadataSignature: [UInt8]?,
         signatureFormat: SignatureFormat?,
         fileSystem: FileSystem
-    ) throws -> RegistryClient.PublishResult {
-        try temp_await {
-            self.publish(
-                registryURL: registryURL,
-                packageIdentity: packageIdentity,
-                packageVersion: packageVersion,
-                packageArchive: packageArchive,
-                packageMetadata: packageMetadata,
-                signature: signature,
-                metadataSignature: metadataSignature,
-                signatureFormat: signatureFormat,
-                fileSystem: fileSystem,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    ) async throws -> RegistryClient.PublishResult {
+        try await self.publish(
+            registryURL: registryURL,
+            packageIdentity: packageIdentity,
+            packageVersion: packageVersion,
+            packageArchive: packageArchive,
+            packageMetadata: packageMetadata,
+            signature: signature,
+            metadataSignature: metadataSignature,
+            signatureFormat: signatureFormat,
+            fileSystem: fileSystem,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 
-    func checkAvailability(registry: Registry) throws -> AvailabilityStatus {
-        try temp_await {
-            self.checkAvailability(
-                registry: registry,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    func checkAvailability(registry: Registry) async throws -> AvailabilityStatus {
+        try await self.checkAvailability(
+            registry: registry,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 }
 

--- a/Tests/PackageRegistryTests/SignatureValidationTests.swift
+++ b/Tests/PackageRegistryTests/SignatureValidationTests.swift
@@ -33,7 +33,7 @@ final class SignatureValidationTests: XCTestCase {
     )
     """
 
-    func testUnsignedPackage_shouldError() throws {
+    func testUnsignedPackage_shouldError() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -82,8 +82,8 @@ final class SignatureValidationTests: XCTestCase {
 
         // Package is not signed. With onUnsigned = .error,
         // an error gets thrown.
-        XCTAssertThrowsError(
-            try signatureValidation.validate(
+        await XCTAssertAsyncThrowsError(
+            try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -97,7 +97,7 @@ final class SignatureValidationTests: XCTestCase {
         }
     }
 
-    func testUnsignedPackage_shouldWarn() throws {
+    func testUnsignedPackage_shouldWarn() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -148,15 +148,13 @@ final class SignatureValidationTests: XCTestCase {
 
         // Package is not signed. With onUnsigned = .warn,
         // no error gets thrown but there should be a warning
-        XCTAssertNoThrow(
-            try signatureValidation.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                content: Data(emptyZipFile.contents),
-                configuration: configuration.signing(for: package, registry: registry),
-                observabilityScope: observability.topScope
-            )
+        _ = try await signatureValidation.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            content: Data(emptyZipFile.contents),
+            configuration: configuration.signing(for: package, registry: registry),
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -165,7 +163,7 @@ final class SignatureValidationTests: XCTestCase {
         }
     }
 
-    func testUnsignedPackage_shouldPrompt() throws {
+    func testUnsignedPackage_shouldPrompt() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -216,8 +214,8 @@ final class SignatureValidationTests: XCTestCase {
 
             // Package is not signed. With onUnsigned = .error,
             // an error gets thrown.
-            XCTAssertThrowsError(
-                try signatureValidation.validate(
+            await XCTAssertAsyncThrowsError(
+                try await signatureValidation.validate(
                     registry: registry,
                     package: package,
                     version: version,
@@ -242,7 +240,7 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Package is not signed, signingEntity should be nil
-            let signingEntity = try signatureValidation.validate(
+            let signingEntity = try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -253,7 +251,7 @@ final class SignatureValidationTests: XCTestCase {
         }
     }
 
-    func testFailedToFetchSignature_shouldError() throws {
+    func testFailedToFetchSignature_shouldError() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -302,8 +300,8 @@ final class SignatureValidationTests: XCTestCase {
         )
 
         // Failed to fetch package metadata / signature
-        XCTAssertThrowsError(
-            try signatureValidation.validate(
+        await XCTAssertAsyncThrowsError(
+            try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -317,7 +315,7 @@ final class SignatureValidationTests: XCTestCase {
         }
     }
 
-    func testUnsignedArchiveAndManifest_shouldPrompt() throws {
+    func testUnsignedArchiveAndManifest_shouldPrompt() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -367,8 +365,8 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Package is not signed. With onUnsigned = .prompt, prompt to continue.
-            XCTAssertThrowsError(
-                try signatureValidation.validate(
+            await XCTAssertAsyncThrowsError(
+                try await signatureValidation.validate(
                     registry: registry,
                     package: package,
                     version: version,
@@ -394,7 +392,7 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Package is not signed, signingEntity should be nil
-            let signingEntity = try signatureValidation.validate(
+            let signingEntity = try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -406,7 +404,7 @@ final class SignatureValidationTests: XCTestCase {
         }
     }
 
-    func testUnsignedArchiveAndManifest_nonPrompt() throws {
+    func testUnsignedArchiveAndManifest_nonPrompt() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -457,16 +455,14 @@ final class SignatureValidationTests: XCTestCase {
 
         // Package is not signed.
         // With the exception of .prompt, we log then continue.
-        XCTAssertNoThrow(
-            try signatureValidation.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                toolsVersion: .none,
-                manifestContent: Self.unsignedManifest,
-                configuration: configuration.signing(for: package, registry: registry),
-                observabilityScope: observability.topScope
-            )
+        _ = try await signatureValidation.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            toolsVersion: .none,
+            manifestContent: Self.unsignedManifest,
+            configuration: configuration.signing(for: package, registry: registry),
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics, problemsOnly: false) { result in
@@ -475,7 +471,7 @@ final class SignatureValidationTests: XCTestCase {
         }
     }
 
-    func testFailedToFetchArchiveSignatureToValidateManifest_diagnostics() throws {
+    func testFailedToFetchArchiveSignatureToValidateManifest_diagnostics() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -519,16 +515,14 @@ final class SignatureValidationTests: XCTestCase {
 
         // Failed to fetch package metadata / signature.
         // This error is not thrown for manifest but there should be diagnostics.
-        XCTAssertNoThrow(
-            try signatureValidation.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                toolsVersion: .none,
-                manifestContent: Self.unsignedManifest,
-                configuration: configuration.signing(for: package, registry: registry),
-                observabilityScope: observability.topScope
-            )
+        _ = try await signatureValidation.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            toolsVersion: .none,
+            manifestContent: Self.unsignedManifest,
+            configuration: configuration.signing(for: package, registry: registry),
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics, problemsOnly: false) { result in
@@ -549,7 +543,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -604,8 +598,8 @@ final class SignatureValidationTests: XCTestCase {
         )
 
         // Archive is signed, but manifest is not signed
-        XCTAssertThrowsError(
-            try signatureValidation.validate(
+        await XCTAssertAsyncThrowsError(
+            try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -629,7 +623,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -694,8 +688,8 @@ final class SignatureValidationTests: XCTestCase {
         )
 
         // Archive is signed, but manifest signature format is bad
-        XCTAssertThrowsError(
-            try signatureValidation.validate(
+        await XCTAssertAsyncThrowsError(
+            try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -718,7 +712,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -778,8 +772,8 @@ final class SignatureValidationTests: XCTestCase {
         )
 
         // Archive is signed, but manifest signature is malformed
-        XCTAssertThrowsError(
-            try signatureValidation.validate(
+        await XCTAssertAsyncThrowsError(
+            try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -804,7 +798,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -832,7 +826,7 @@ final class SignatureValidationTests: XCTestCase {
         var configuration = RegistryConfiguration()
         configuration.defaultRegistry = registry
 
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             // Write test root to trust roots directory
             let trustRootsDirectoryPath = temporaryDirectory.appending(component: "trust-roots")
             try localFileSystem.createDirectory(trustRootsDirectoryPath)
@@ -874,19 +868,17 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Package signature is valid
-            XCTAssertNoThrow(
-                try signatureValidation.validate(
-                    registry: registry,
-                    package: package,
-                    version: version,
-                    content: Data(emptyZipFile.contents),
-                    configuration: configuration.signing(for: package, registry: registry)
-                )
+            _ = try await signatureValidation.validate(
+                registry: registry,
+                package: package,
+                version: version,
+                content: Data(emptyZipFile.contents),
+                configuration: configuration.signing(for: package, registry: registry)
             )
         }
     }
 
-    func testSignedPackage_badSignature() throws {
+    func testSignedPackage_badSignature() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -937,8 +929,8 @@ final class SignatureValidationTests: XCTestCase {
         )
 
         // Package signature can't be parsed so it is invalid
-        XCTAssertThrowsError(
-            try signatureValidation.validate(
+        await XCTAssertAsyncThrowsError(
+            try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -952,7 +944,7 @@ final class SignatureValidationTests: XCTestCase {
         }
     }
 
-    func testSignedPackage_badSignature_skipSignatureValidation() throws {
+    func testSignedPackage_badSignature_skipSignatureValidation() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -997,14 +989,12 @@ final class SignatureValidationTests: XCTestCase {
 
         // Signature is bad, but we are skipping signature
         // validation, so no error is thrown.
-        XCTAssertNoThrow(
-            try signatureValidation.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                content: Data(emptyZipFile.contents),
-                configuration: configuration.signing(for: package, registry: registry)
-            )
+        _ = try await signatureValidation.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            content: Data(emptyZipFile.contents),
+            configuration: configuration.signing(for: package, registry: registry)
         )
     }
 
@@ -1016,7 +1006,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1044,7 +1034,7 @@ final class SignatureValidationTests: XCTestCase {
         var configuration = RegistryConfiguration()
         configuration.defaultRegistry = registry
 
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             // Write test root to trust roots directory
             let trustRootsDirectoryPath = temporaryDirectory.appending(component: "trust-roots")
             try localFileSystem.createDirectory(trustRootsDirectoryPath)
@@ -1086,8 +1076,8 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Package signature doesn't match content so it's invalid
-            XCTAssertThrowsError(
-                try signatureValidation.validate(
+            await XCTAssertAsyncThrowsError(
+                try await signatureValidation.validate(
                     registry: registry,
                     package: package,
                     version: version,
@@ -1110,7 +1100,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1172,8 +1162,8 @@ final class SignatureValidationTests: XCTestCase {
         )
 
         // Test root not trusted; onUntrustedCertificate is set to .error
-        XCTAssertThrowsError(
-            try signatureValidation.validate(
+        await XCTAssertAsyncThrowsError(
+            try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -1195,7 +1185,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1259,8 +1249,8 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Test root not trusted; onUntrustedCertificate is set to .prompt
-            XCTAssertThrowsError(
-                try signatureValidation.validate(
+            await XCTAssertAsyncThrowsError(
+                try await signatureValidation.validate(
                     registry: registry,
                     package: package,
                     version: version,
@@ -1285,7 +1275,7 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Package signer is untrusted, signingEntity should be nil
-            let signingEntity = try signatureValidation.validate(
+            let signingEntity = try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -1304,7 +1294,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1368,15 +1358,13 @@ final class SignatureValidationTests: XCTestCase {
         let observability = ObservabilitySystem.makeForTesting()
 
         // Test root not trusted but onUntrustedCertificate is set to .warn
-        XCTAssertNoThrow(
-            try signatureValidation.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                content: Data(emptyZipFile.contents),
-                configuration: configuration.signing(for: package, registry: registry),
-                observabilityScope: observability.topScope
-            )
+        _ = try await signatureValidation.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            content: Data(emptyZipFile.contents),
+            configuration: configuration.signing(for: package, registry: registry),
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics) { result in
@@ -1393,7 +1381,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1431,7 +1419,7 @@ final class SignatureValidationTests: XCTestCase {
         var configuration = RegistryConfiguration()
         configuration.defaultRegistry = registry
 
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             // Write test root to trust roots directory
             let trustRootsDirectoryPath = temporaryDirectory.appending(component: "trust-roots")
             try localFileSystem.createDirectory(trustRootsDirectoryPath)
@@ -1473,20 +1461,18 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Manifest signature is valid
-            XCTAssertNoThrow(
-                try signatureValidation.validate(
-                    registry: registry,
-                    package: package,
-                    version: version,
-                    toolsVersion: .none,
-                    manifestContent: manifestContent,
-                    configuration: configuration.signing(for: package, registry: registry)
-                )
+            _ = try await signatureValidation.validate(
+                registry: registry,
+                package: package,
+                version: version,
+                toolsVersion: .none,
+                manifestContent: manifestContent,
+                configuration: configuration.signing(for: package, registry: registry)
             )
         }
     }
 
-    func testSignedManifest_badSignature() throws {
+    func testSignedManifest_badSignature() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -1494,7 +1480,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1552,8 +1538,8 @@ final class SignatureValidationTests: XCTestCase {
         )
 
         // Manifest signature can't be parsed so it is invalid
-        XCTAssertThrowsError(
-            try signatureValidation.validate(
+        await XCTAssertAsyncThrowsError(
+            try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -1568,7 +1554,7 @@ final class SignatureValidationTests: XCTestCase {
         }
     }
 
-    func testSignedManifest_badSignature_skipSignatureValidation() throws {
+    func testSignedManifest_badSignature_skipSignatureValidation() async throws {
         let registryURL = URL("https://packages.example.com")
         let identity = PackageIdentity.plain("mona.LinkedList")
         let package = identity.registry!
@@ -1576,7 +1562,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1635,15 +1621,13 @@ final class SignatureValidationTests: XCTestCase {
 
         // Manifest signature is bad, but we are skipping signature
         // validation, so no error is thrown.
-        XCTAssertNoThrow(
-            try signatureValidation.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                toolsVersion: .none,
-                manifestContent: manifestContent,
-                configuration: configuration.signing(for: package, registry: registry)
-            )
+        _ = try await signatureValidation.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            toolsVersion: .none,
+            manifestContent: manifestContent,
+            configuration: configuration.signing(for: package, registry: registry)
         )
     }
 
@@ -1655,7 +1639,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1693,7 +1677,7 @@ final class SignatureValidationTests: XCTestCase {
         var configuration = RegistryConfiguration()
         configuration.defaultRegistry = registry
 
-        try withTemporaryDirectory { temporaryDirectory in
+        try await withTemporaryDirectory { temporaryDirectory in
             // Write test root to trust roots directory
             let trustRootsDirectoryPath = temporaryDirectory.appending(component: "trust-roots")
             try localFileSystem.createDirectory(trustRootsDirectoryPath)
@@ -1735,8 +1719,8 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Manifest signature doesn't match content so it's invalid
-            XCTAssertThrowsError(
-                try signatureValidation.validate(
+            await XCTAssertAsyncThrowsError(
+                try await signatureValidation.validate(
                     registry: registry,
                     package: package,
                     version: version,
@@ -1760,7 +1744,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1834,8 +1818,8 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Test root not trusted; onUntrustedCertificate is set to .prompt
-            XCTAssertThrowsError(
-                try signatureValidation.validate(
+            await XCTAssertAsyncThrowsError(
+                try await signatureValidation.validate(
                     registry: registry,
                     package: package,
                     version: version,
@@ -1861,7 +1845,7 @@ final class SignatureValidationTests: XCTestCase {
             )
 
             // Package signer is not trusted, signingEntity should be nil
-            let signingEntity = try signatureValidation.validate(
+            let signingEntity = try await signatureValidation.validate(
                 registry: registry,
                 package: package,
                 version: version,
@@ -1881,7 +1865,7 @@ final class SignatureValidationTests: XCTestCase {
         let metadataURL = URL("\(registryURL)/\(package.scope)/\(package.name)/\(version)")
         let checksum = "a2ac54cf25fbc1ad0028f03f0aa4b96833b83bb05a14e510892bb27dea4dc812"
 
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = try SwiftSigningIdentity(
             derEncodedCertificate: keyAndCertChain.leafCertificate,
             derEncodedPrivateKey: keyAndCertChain.privateKey,
@@ -1956,16 +1940,14 @@ final class SignatureValidationTests: XCTestCase {
 
         // Test root not trusted.
         // With the exception of .prompt, we log then continue.
-        XCTAssertNoThrow(
-            try signatureValidation.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                toolsVersion: .none,
-                manifestContent: manifestContent,
-                configuration: configuration.signing(for: package, registry: registry),
-                observabilityScope: observability.topScope
-            )
+        _ = try await signatureValidation.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            toolsVersion: .none,
+            manifestContent: manifestContent,
+            configuration: configuration.signing(for: package, registry: registry),
+            observabilityScope: observability.topScope
         )
 
         testDiagnostics(observability.diagnostics, problemsOnly: false) { result in
@@ -1991,23 +1973,19 @@ final class SignatureValidationTests: XCTestCase {
         )
     }
 
-    private func ecSelfSignedTestKeyAndCertChain(callback: (Result<KeyAndCertChain, Error>) -> Void) {
-        do {
-            try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                let privateKey = try localFileSystem.readFileContents(
-                    fixturePath.appending(components: "Certificates", "Test_ec_self_signed_key.p8")
-                ).contents
-                let certificate = try localFileSystem.readFileContents(
-                    fixturePath.appending(components: "Certificates", "Test_ec_self_signed.cer")
-                ).contents
+    private func ecSelfSignedTestKeyAndCertChain() throws -> KeyAndCertChain {
+        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
+            let privateKey = try localFileSystem.readFileContents(
+                fixturePath.appending(components: "Certificates", "Test_ec_self_signed_key.p8")
+            ).contents
+            let certificate = try localFileSystem.readFileContents(
+                fixturePath.appending(components: "Certificates", "Test_ec_self_signed.cer")
+            ).contents
 
-                callback(.success(KeyAndCertChain(
-                    privateKey: privateKey,
-                    certificateChain: [certificate]
-                )))
-            }
-        } catch {
-            callback(.failure(error))
+            return KeyAndCertChain(
+                privateKey: privateKey,
+                certificateChain: [certificate]
+            )
         }
     }
 
@@ -2040,21 +2018,18 @@ extension SignatureValidation {
         content: Data,
         configuration: RegistryConfiguration.Security.Signing,
         observabilityScope: ObservabilityScope? = nil
-    ) throws -> SigningEntity? {
-        try temp_await {
-            self.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                content: content,
-                configuration: configuration,
-                timeout: nil,
-                fileSystem: localFileSystem,
-                observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    ) async throws -> SigningEntity? {
+        try await self.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            content: content,
+            configuration: configuration,
+            timeout: nil,
+            fileSystem: localFileSystem,
+            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 
     fileprivate func validate(
@@ -2065,22 +2040,19 @@ extension SignatureValidation {
         manifestContent: String,
         configuration: RegistryConfiguration.Security.Signing,
         observabilityScope: ObservabilityScope? = nil
-    ) throws -> SigningEntity? {
-        try temp_await {
-            self.validate(
-                registry: registry,
-                package: package,
-                version: version,
-                toolsVersion: toolsVersion,
-                manifestContent: manifestContent,
-                configuration: configuration,
-                timeout: nil,
-                fileSystem: localFileSystem,
-                observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                completion: $0
-            )
-        }
+    ) async throws -> SigningEntity? {
+        try await self.validate(
+            registry: registry,
+            package: package,
+            version: version,
+            toolsVersion: toolsVersion,
+            manifestContent: manifestContent,
+            configuration: configuration,
+            timeout: nil,
+            fileSystem: localFileSystem,
+            observabilityScope: observabilityScope ?? ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 }
 
@@ -2125,15 +2097,12 @@ private struct AcceptingSignatureValidationDelegate: SignatureValidation.Delegat
 }
 
 extension PackageSigningEntityStorage {
-    fileprivate func get(package: PackageIdentity) throws -> PackageSigners {
-        try temp_await {
-            self.get(
-                package: package,
-                observabilityScope: ObservabilitySystem.NOOP,
-                callbackQueue: .sharedConcurrent,
-                callback: $0
-            )
-        }
+    fileprivate func get(package: PackageIdentity) async throws -> PackageSigners {
+        try await self.get(
+            package: package,
+            observabilityScope: ObservabilitySystem.NOOP,
+            callbackQueue: .sharedConcurrent
+        )
     }
 }
 

--- a/Tests/PackageSigningTests/SigningTests.swift
+++ b/Tests/PackageSigningTests/SigningTests.swift
@@ -22,7 +22,7 @@ import XCTest
 
 final class SigningTests: XCTestCase {
     func testCMS1_0_0EndToEnd() async throws {
-        let keyAndCertChain = try temp_await { self.ecTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -66,7 +66,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMSEndToEndWithECSigningIdentity() async throws {
-        let keyAndCertChain = try temp_await { self.ecTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -108,7 +108,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMSEndToEndWithRSASigningIdentity() async throws {
-        let keyAndCertChain = try temp_await { self.rsaTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.rsaTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -150,7 +150,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMSWrongKeyTypeForSignatureAlgorithm() async throws {
-        let keyAndCertChain = try temp_await { self.ecTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -177,7 +177,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMS1_0_0EndToEndWithSelfSignedCertificate() async throws {
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -221,7 +221,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMSEndToEndWithSelfSignedECSigningIdentity() async throws {
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -263,7 +263,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMSEndToEndWithSelfSignedRSASigningIdentity() async throws {
-        let keyAndCertChain = try temp_await { self.rsaSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.rsaSelfSignedTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -322,7 +322,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMSInvalidSignature() async throws {
-        let keyAndCertChain = try temp_await { self.ecTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -359,7 +359,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMSUntrustedCertificate() async throws {
-        let keyAndCertChain = try temp_await { self.ecTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -395,7 +395,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMSCheckCertificateValidityPeriod() async throws {
-        let keyAndCertChain = try temp_await { self.ecTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -589,7 +589,7 @@ final class SigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        let keyAndCertChain = try temp_await { rsaADPKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try rsaADPKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -623,25 +623,21 @@ final class SigningTests: XCTestCase {
             return XCTFail("Expected signature status to be .valid but got \(status)")
         }
 
-        func rsaADPKeyAndCertChain(callback: (Result<KeyAndCertChain, Error>) -> Void) {
-            do {
-                try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                    let privateKey = try readFileContents(
-                        in: fixturePath,
-                        pathComponents: "Certificates", "development_key.p8"
-                    )
-                    let certificate = try readFileContents(
-                        in: fixturePath,
-                        pathComponents: "Certificates", "development.cer"
-                    )
+        func rsaADPKeyAndCertChain() throws -> KeyAndCertChain {
+            try fixture(name: "Signing", createGitRepo: false) { fixturePath in
+                let privateKey = try readFileContents(
+                    in: fixturePath,
+                    pathComponents: "Certificates", "development_key.p8"
+                )
+                let certificate = try readFileContents(
+                    in: fixturePath,
+                    pathComponents: "Certificates", "development.cer"
+                )
 
-                    callback(.success(KeyAndCertChain(
-                        privateKey: privateKey,
-                        certificateChain: [certificate]
-                    )))
-                }
-            } catch {
-                callback(.failure(error))
+                return KeyAndCertChain(
+                    privateKey: privateKey,
+                    certificateChain: [certificate]
+                )
             }
         }
     }
@@ -652,7 +648,7 @@ final class SigningTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
 
-        let keyAndCertChain = try temp_await { ecADPKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try ecADPKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -686,25 +682,21 @@ final class SigningTests: XCTestCase {
             return XCTFail("Expected signature status to be .valid but got \(status)")
         }
 
-        func ecADPKeyAndCertChain(callback: (Result<KeyAndCertChain, Error>) -> Void) {
-            do {
-                try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                    let privateKey = try readFileContents(
-                        in: fixturePath,
-                        pathComponents: "Certificates", "swift_package_key.p8"
-                    )
-                    let certificate = try readFileContents(
-                        in: fixturePath,
-                        pathComponents: "Certificates", "swift_package.cer"
-                    )
+        func ecADPKeyAndCertChain() throws -> KeyAndCertChain {
+            try fixture(name: "Signing", createGitRepo: false) { fixturePath in
+                let privateKey = try readFileContents(
+                    in: fixturePath,
+                    pathComponents: "Certificates", "swift_package_key.p8"
+                )
+                let certificate = try readFileContents(
+                    in: fixturePath,
+                    pathComponents: "Certificates", "swift_package.cer"
+                )
 
-                    callback(.success(KeyAndCertChain(
-                        privateKey: privateKey,
-                        certificateChain: [certificate]
-                    )))
-                }
-            } catch {
-                callback(.failure(error))
+                return KeyAndCertChain(
+                    privateKey: privateKey,
+                    certificateChain: [certificate]
+                )
             }
         }
     }
@@ -880,7 +872,7 @@ final class SigningTests: XCTestCase {
     #endif
 
     func testCMS1_0_0ExtractSigningEntity() async throws {
-        let keyAndCertChain = try temp_await { self.ecTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -919,7 +911,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMS1_0_0ExtractSigningEntityWithSelfSignedCertificate() async throws {
-        let keyAndCertChain = try temp_await { self.ecSelfSignedTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecSelfSignedTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -958,7 +950,7 @@ final class SigningTests: XCTestCase {
     }
 
     func testCMS1_0_0ExtractSigningEntityWithUntrustedCertificate() async throws {
-        let keyAndCertChain = try temp_await { self.ecTestKeyAndCertChain(callback: $0) }
+        let keyAndCertChain = try self.ecTestKeyAndCertChain()
         let signingIdentity = SwiftSigningIdentity(
             certificate: try Certificate(keyAndCertChain.leafCertificate),
             privateKey: try Certificate
@@ -996,107 +988,91 @@ final class SigningTests: XCTestCase {
         }
     }
 
-    private func ecTestKeyAndCertChain(callback: (Result<KeyAndCertChain, Error>) -> Void) {
-        do {
-            try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                let privateKey = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "Test_ec_key.p8"
-                )
-                let certificate = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "Test_ec.cer"
-                )
-                let intermediateCA = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "TestIntermediateCA.cer"
-                )
-                let rootCA = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "TestRootCA.cer"
-                )
+    private func ecTestKeyAndCertChain() throws -> KeyAndCertChain {
+        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
+            let privateKey = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "Test_ec_key.p8"
+            )
+            let certificate = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "Test_ec.cer"
+            )
+            let intermediateCA = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "TestIntermediateCA.cer"
+            )
+            let rootCA = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "TestRootCA.cer"
+            )
 
-                callback(.success(KeyAndCertChain(
-                    privateKey: privateKey,
-                    certificateChain: [certificate, intermediateCA, rootCA]
-                )))
-            }
-        } catch {
-            callback(.failure(error))
+            return KeyAndCertChain(
+                privateKey: privateKey,
+                certificateChain: [certificate, intermediateCA, rootCA]
+            )
         }
     }
 
-    private func ecSelfSignedTestKeyAndCertChain(callback: (Result<KeyAndCertChain, Error>) -> Void) {
-        do {
-            try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                let privateKey = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "Test_ec_self_signed_key.p8"
-                )
-                let certificate = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "Test_ec_self_signed.cer"
-                )
+    private func ecSelfSignedTestKeyAndCertChain() throws -> KeyAndCertChain {
+        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
+            let privateKey = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "Test_ec_self_signed_key.p8"
+            )
+            let certificate = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "Test_ec_self_signed.cer"
+            )
 
-                callback(.success(KeyAndCertChain(
-                    privateKey: privateKey,
-                    certificateChain: [certificate]
-                )))
-            }
-        } catch {
-            callback(.failure(error))
+            return KeyAndCertChain(
+                privateKey: privateKey,
+                certificateChain: [certificate]
+            )
         }
     }
 
-    private func rsaTestKeyAndCertChain(callback: (Result<KeyAndCertChain, Error>) -> Void) {
-        do {
-            try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                let privateKey = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "Test_rsa_key.p8"
-                )
-                let certificate = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "Test_rsa.cer"
-                )
-                let intermediateCA = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "TestIntermediateCA.cer"
-                )
-                let rootCA = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "TestRootCA.cer"
-                )
+    private func rsaTestKeyAndCertChain() throws -> KeyAndCertChain {
+        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
+            let privateKey = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "Test_rsa_key.p8"
+            )
+            let certificate = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "Test_rsa.cer"
+            )
+            let intermediateCA = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "TestIntermediateCA.cer"
+            )
+            let rootCA = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "TestRootCA.cer"
+            )
 
-                callback(.success(KeyAndCertChain(
-                    privateKey: privateKey,
-                    certificateChain: [certificate, intermediateCA, rootCA]
-                )))
-            }
-        } catch {
-            callback(.failure(error))
+            return KeyAndCertChain(
+                privateKey: privateKey,
+                certificateChain: [certificate, intermediateCA, rootCA]
+            )
         }
     }
 
-    private func rsaSelfSignedTestKeyAndCertChain(callback: (Result<KeyAndCertChain, Error>) -> Void) {
-        do {
-            try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                let privateKey = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "Test_rsa_self_signed_key.p8"
-                )
-                let certificate = try readFileContents(
-                    in: fixturePath,
-                    pathComponents: "Certificates", "Test_rsa_self_signed.cer"
-                )
+    private func rsaSelfSignedTestKeyAndCertChain() throws -> KeyAndCertChain {
+        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
+            let privateKey = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "Test_rsa_self_signed_key.p8"
+            )
+            let certificate = try readFileContents(
+                in: fixturePath,
+                pathComponents: "Certificates", "Test_rsa_self_signed.cer"
+            )
 
-                callback(.success(KeyAndCertChain(
-                    privateKey: privateKey,
-                    certificateChain: [certificate]
-                )))
-            }
-        } catch {
-            callback(.failure(error))
+            return KeyAndCertChain(
+                privateKey: privateKey,
+                certificateChain: [certificate]
+            )
         }
     }
 


### PR DESCRIPTION
Move PackageRegistryTests to async/await

### Motivation:

To keep moving things from temp_await to actual await

### Modifications:

Add async alternatives to registry methods
Mark non-async methods noasync to encourage migration

### Result:

All, but one use of temp_await is removed from the tests 
