### PR TITLE
Skip unknown XCBuild message types

### DIFF
--- a/Sources/XCBuildSupport/XCBuildDelegate.swift
+++ b/Sources/XCBuildSupport/XCBuildDelegate.swift
@@ -127,7 +127,7 @@ extension XCBuildDelegate: XCBuildOutputParserDelegate {
                     self.buildSystem.delegate?.buildSystem(self.buildSystem, didFinishWithResult: true)
                 }
             }
-        case .buildStarted, .preparationComplete, .targetUpToDate, .targetStarted, .targetComplete, .taskUpToDate:
+        case .buildStarted, .preparationComplete, .targetUpToDate, .targetStarted, .targetComplete, .taskUpToDate, .unknown:
             break
         }
     }

--- a/Sources/XCBuildSupport/XCBuildMessage.swift
+++ b/Sources/XCBuildSupport/XCBuildMessage.swift
@@ -122,6 +122,7 @@ public enum XCBuildMessage {
     case taskOutput(TaskOutputInfo)
     case taskComplete(TaskCompleteInfo)
     case targetDiagnostic(TargetDiagnosticInfo)
+    case unknown
 }
 
 extension XCBuildMessage.BuildDiagnosticInfo: Codable, Equatable, Sendable {}
@@ -285,7 +286,7 @@ extension XCBuildMessage: Codable, Equatable, Sendable {
         case "targetDiagnostic":
             self = try .targetDiagnostic(TargetDiagnosticInfo(from: decoder))
         default:
-            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "invalid kind \(kind)")
+            self = .unknown
         }
     }
 
@@ -335,6 +336,9 @@ extension XCBuildMessage: Codable, Equatable, Sendable {
         case let .targetDiagnostic(info):
             try container.encode("targetDiagnostic", forKey: .kind)
             try info.encode(to: encoder)
+        case .unknown:
+            assertionFailure()
+            break
         }
     }
 }


### PR DESCRIPTION
We want this to be extensible, and so we shouldn't fail when encountering an unknown/future message type.

rdar://118856310