### PR TITLE
Rename the swift-testing entry point.

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -219,13 +219,13 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
             stream.send(
                 #"""
                 #if canImport(Testing)
-                @_spi(SwiftPackageManagerSupport) import Testing
+                import Testing
                 #endif
 
                 @main struct Runner {
                     static func main() async {
                 #if canImport(Testing)
-                        await Testing.swiftPMEntryPoint() as Never
+                        await Testing.__swiftPMEntryPoint() as Never
                 #endif
                     }
                 }


### PR DESCRIPTION
This PR renames the entry point function used by SwiftPM to call into swift-testing such that it does not need to be SPI. By marking it SPI, we unintentionally made it very difficult to use with a toolchain that does not include private module information.

swift-testing will continue to export the old symbol name as used by SwiftPM until this change has firmly landed in toolchains, after which we will remove the old function.

See: https://github.com/apple/swift-testing/pull/141