### PR TITLE
Remove dependency on swift-system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ endif()
 add_compile_options(-DUSE_IMPL_ONLY_IMPORTS)
 
 if(FIND_PM_DEPS)
-  find_package(SwiftSystem CONFIG REQUIRED)
   find_package(TSC CONFIG REQUIRED)
 
   find_package(LLBuild CONFIG)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,14 +186,7 @@ Clone the following repositories beside the SwiftPM directory:
    $> git clone https://github.com/apple/swift-driver
    ```
 
-6. [swift-system] and check out tag with the [latest version](https://github.com/apple/swift-system/tags).
-
-    For example, if the latest tag is 1.0.0:
-    ```sh
-    $> git clone https://github.com/apple/swift-system --branch 1.0.0
-    ```
-
-7. [swift-collections] and check out tag with the [latest version](https://github.com/apple/swift-collections/tags).
+6. [swift-collections] and check out tag with the [latest version](https://github.com/apple/swift-collections/tags).
 
     For example, if the latest tag is 1.0.1:
     ```sh
@@ -221,7 +214,6 @@ Clone the following repositories beside the SwiftPM directory:
 [swift-collections]: https://github.com/apple/swift-collections
 [swift-driver]: https://github.com/apple/swift-driver
 [swift-llbuild]: https://github.com/apple/swift-llbuild
-[swift-system]: https://github.com/apple/swift-system
 [swift-tools-support-core]: https://github.com/apple/swift-tools-support-core
 [swift-crypto]: https://github.com/apple/swift-crypto
 [swift-asn1]: https://github.com/apple/swift-asn1

--- a/Package.swift
+++ b/Package.swift
@@ -159,7 +159,6 @@ let package = Package(
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-                .product(name: "SystemPackage", package: "swift-system"),
             ],
             exclude: ["CMakeLists.txt", "Vendor/README.md"]
         ),
@@ -738,7 +737,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.2")),
         .package(url: "https://github.com/apple/swift-driver.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "3.0.0")),
-        .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "1.0.1")),
     ]
@@ -748,7 +746,6 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-argument-parser"),
         .package(path: "../swift-driver"),
         .package(path: "../swift-crypto"),
-        .package(path: "../swift-system"),
         .package(path: "../swift-collections"),
         .package(path: "../swift-certificates"),
     ]

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -64,7 +64,6 @@ add_library(Basics
 target_link_libraries(Basics PUBLIC
   SwiftCollections::DequeModule
   SwiftCollections::OrderedCollections
-  SwiftSystem::SystemPackage
   TSCBasic
   TSCUtility)
 target_link_libraries(Basics PRIVATE

--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -13,7 +13,6 @@
 import struct Foundation.Data
 import class Foundation.FileManager
 import struct Foundation.UUID
-import SystemPackage
 
 import struct TSCBasic.ByteString
 import struct TSCBasic.FileInfo

--- a/Utilities/Docker/docker-compose.yaml
+++ b/Utilities/Docker/docker-compose.yaml
@@ -39,7 +39,6 @@ services:
       - ../../../swift-crypto:/code/swift-crypto:z
       - ../../../swift-driver:/code/swift-driver:z
       - ../../../swift-llbuild:/code/llbuild:z
-      - ../../../swift-system:/code/swift-system:z
       - ../../../swift-collections:/code/swift-collections:z
       - ../../../swift-asn1:/code/swift-asn1:z
       - ../../../swift-certificates:/code/swift-certificates:z

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -194,7 +194,6 @@ def parse_global_args(args):
     args.source_dirs["swift-argument-parser"] = os.path.join(args.project_root, "..", "swift-argument-parser")
     args.source_dirs["swift-crypto"]          = os.path.join(args.project_root, "..", "swift-crypto")
     args.source_dirs["swift-driver"]          = os.path.join(args.project_root, "..", "swift-driver")
-    args.source_dirs["swift-system"]          = os.path.join(args.project_root, "..", "swift-system")
     args.source_dirs["swift-collections"]     = os.path.join(args.project_root, "..", "swift-collections")
     args.source_dirs["swift-certificates"]    = os.path.join(args.project_root, "..", "swift-certificates")
     args.source_dirs["swift-asn1"]            = os.path.join(args.project_root, "..", "swift-asn1")
@@ -320,19 +319,14 @@ def build(args):
         if not "llbuild" in args.build_dirs:
             build_llbuild(args)
 
-        # tsc depends on swift-system so they must be built first.
-        build_dependency(args, "swift-system")
         # swift-driver depends on tsc, swift-argument-parser, and yams so they must be built first.
-        tsc_cmake_flags = [
-            "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
-        ]
+        tsc_cmake_flags = []
         build_dependency(args, "tsc", tsc_cmake_flags)
         build_dependency(args, "swift-argument-parser", ["-DBUILD_TESTING=NO", "-DBUILD_EXAMPLES=NO"])
         build_dependency(args, "yams", [], [get_foundation_cmake_arg(args)] if args.foundation_build_dir else [])
 
         swift_driver_cmake_flags = [
             get_llbuild_cmake_arg(args),
-            "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
             "-DTSC_DIR=" + os.path.join(args.build_dirs["tsc"], "cmake/modules"),
             "-DYams_DIR=" + os.path.join(args.build_dirs["yams"], "cmake/modules"),
             "-DArgumentParser_DIR=" + os.path.join(args.build_dirs["swift-argument-parser"], "cmake/modules"),
@@ -589,7 +583,6 @@ def build_swiftpm_with_cmake(args):
         "-DTSC_DIR="               + os.path.join(args.build_dirs["tsc"],                   "cmake/modules"),
         "-DArgumentParser_DIR="    + os.path.join(args.build_dirs["swift-argument-parser"], "cmake/modules"),
         "-DSwiftDriver_DIR="       + os.path.join(args.build_dirs["swift-driver"],          "cmake/modules"),
-        "-DSwiftSystem_DIR="       + os.path.join(args.build_dirs["swift-system"],          "cmake/modules"),
         "-DSwiftCollections_DIR="  + os.path.join(args.build_dirs["swift-collections"],     "cmake/modules"),
         "-DSwiftCrypto_DIR="       + os.path.join(args.build_dirs["swift-crypto"],          "cmake/modules"),
         "-DSwiftASN1_DIR="         + os.path.join(args.build_dirs["swift-asn1"],            "cmake/modules"),
@@ -610,7 +603,6 @@ def build_swiftpm_with_cmake(args):
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-argument-parser"], "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-crypto"],          "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-driver"],          "lib"))
-        add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-system"],          "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-collections"],     "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-asn1"],            "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-certificates"],    "lib"))
@@ -744,7 +736,6 @@ def get_swiftpm_env_cmd(args):
             os.path.join(args.build_dirs["swift-argument-parser"], "lib"),
             os.path.join(args.build_dirs["swift-crypto"],          "lib"),
             os.path.join(args.build_dirs["swift-driver"],          "lib"),
-            os.path.join(args.build_dirs["swift-system"],          "lib"),
             os.path.join(args.build_dirs["swift-collections"],     "lib"),
             os.path.join(args.build_dirs["swift-asn1"],            "lib"),
             os.path.join(args.build_dirs["swift-certificates"],    "lib"),


### PR DESCRIPTION
This dependency is unused and just unnecessarily complicates things.