### PR TITLE
Fix error handling for dump symbol graph

### DIFF
--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -69,12 +69,22 @@ struct DumpSymbolGraph: SwiftCommand {
         let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.targets }.filter{ $0.type == .library }
         for target in targets {
             print("-- Emitting symbol graph for", target.name)
-            try symbolGraphExtractor.extractSymbolGraph(
+            let result = try symbolGraphExtractor.extractSymbolGraph(
                 target: target,
                 buildPlan: buildPlan,
+                outputRedirection: .collect(redirectStderr: true),
                 outputDirectory: symbolGraphDirectory,
                 verboseOutput: swiftTool.logLevel <= .info
             )
+
+            if result.exitStatus != .terminated(code: 0) {
+                switch result.output {
+                case .success(let value):
+                    swiftTool.observabilityScope.emit(error: "Failed to emit symbol graph for '\(target.c99name)': \(String(decoding: value, as: UTF8.self))")
+                case .failure(let error):
+                    swiftTool.observabilityScope.emit(error: "Internal error while emitting symbol graph for '\(target.c99name)': \(error)")
+                }
+            }
         }
 
         print("Files written to", symbolGraphDirectory.pathString)

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -23,6 +23,7 @@ import DriverSupport
 #endif
 
 import class TSCBasic.Process
+import struct TSCBasic.ProcessResult
 
 /// A wrapper for swift-symbolgraph-extract tool.
 public struct SymbolGraphExtract {
@@ -56,7 +57,7 @@ public struct SymbolGraphExtract {
         outputRedirection: TSCBasic.Process.OutputRedirection = .none,
         outputDirectory: AbsolutePath,
         verboseOutput: Bool
-    ) throws {
+    ) throws -> ProcessResult {
         let buildParameters = buildPlan.buildParameters
         try self.fileSystem.createDirectory(outputDirectory, recursive: true)
 
@@ -101,6 +102,6 @@ public struct SymbolGraphExtract {
             outputRedirection: outputRedirection
         )
         try process.launch()
-        try process.waitUntilExit()
+        return try process.waitUntilExit()
     }
 }


### PR DESCRIPTION
We were ignoring exit codes and output here, making the corresponding tests impossible to debug (and probably also making the command hard to use).