### PR TITLE
Fix dump symbol graph target list

### DIFF
--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -66,7 +66,7 @@ struct DumpSymbolGraph: SwiftCommand {
         // Run the tool once for every library and executable target in the root package.
         let buildPlan = try buildSystem.buildPlan
         let symbolGraphDirectory = buildPlan.buildParameters.dataPath.appending("symbolgraph")
-        let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.targets }.filter{ $0.type == .library || $0.type == .executable }
+        let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.targets }.filter{ $0.type == .library }
         for target in targets {
             print("-- Emitting symbol graph for", target.name)
             try symbolGraphExtractor.extractSymbolGraph(


### PR DESCRIPTION
We only build a module for executable targets in very limited cases (when a test target depends on it), so we can't generally expect them to be available for dumping their symbol graph.