### PR TITLE
A fix for incorrectly overriding environment variables rdar://118814900

### DIFF
--- a/Sources/SPMTestSupport/SwiftPMProduct.swift
+++ b/Sources/SPMTestSupport/SwiftPMProduct.swift
@@ -101,9 +101,10 @@ extension SwiftPM {
         env: [String: String]? = nil
     ) throws -> ProcessResult {
         var environment = ProcessInfo.processInfo.environment
-        for (key, value) in env ?? [:] {
-            environment[key] = value
-        }
+#if !os(Windows)
+        environment["SDKROOT"] = nil
+#endif
+
 #if Xcode
         // Unset these variables which causes issues when running tests via Xcode.
         environment["XCTestConfigurationFilePath"] = nil
@@ -114,13 +115,14 @@ extension SwiftPM {
         // FIXME: We use this private environment variable hack to be able to
         // create special conditions in swift-build for swiftpm tests.
         environment["SWIFTPM_TESTS_MODULECACHE"] = xctestBinaryPath.parentDirectory.pathString
-#if !os(Windows)
-        environment["SDKROOT"] = nil
-#endif
         
         // Unset the internal env variable that allows skipping certain tests.
         environment["_SWIFTPM_SKIP_TESTS_LIST"] = nil
         
+        for (key, value) in env ?? [:] {
+            environment[key] = value
+        }
+
         var completeArgs = [xctestBinaryPath.pathString]
         if let packagePath = packagePath {
             completeArgs += ["--package-path", packagePath.pathString]


### PR DESCRIPTION
A fix for incorrectly overriding environment variables rdar://118814900

### Motivation:

In SwiftPMProduct.swift, the environment variables are overridden irrespective of the "env" variables provided.

### Modifications:

Move the code snippet that fills the environment variable array to an appropriate place

### Result:

Environment variables are correctly populated 
