### PR TITLE
add 5.9 release notes

### DIFF
--- a/Documentation/ReleaseNotes/5.9.md
+++ b/Documentation/ReleaseNotes/5.9.md
@@ -1,0 +1,17 @@
+# SwiftPM 5.9 Release Notes
+
+## Cross compilation
+
+SwiftPM now supports cross compilation based on the Swift SDK bundle format. While the feature is still considered experimental, we invite users to try it out and provide feedback.
+
+## Package registry
+
+SwiftPM can now publish to a registry following the specification defined in SE-0391, as well as support signed packages, which may be required by a registry. Trust-on-first-use (TOFU) validation checks can now use signing identities in addition to fingerprints, and are enforced for source archives as well as package manifests.
+
+## Other improvments
+
+The CompilerPluginSupport module enables defining macro targets. Macro targets allow authoring and distributing custom Swift macros as APIs in a library.
+
+Packages can use the new package access modifier, allowing access of symbols in another target / module within the same package without making them public. SwiftPM automatically sets the new compiler configuration to ensure this feature works out-of-the-box for packages.
+  
+The allowNetworkConnections(scope:reason:) setting gives a command plugin permissions to access the network. Permissions can be scoped to Unix domain sockets as well as local or remote IP connections, with an option to limit by port. For non-interactive use cases, the --allow-network-connections command-line flag allows network connections for a particular scope.

--- a/Documentation/ReleaseNotes/5.9.md
+++ b/Documentation/ReleaseNotes/5.9.md
@@ -18,7 +18,7 @@ struct PackageResources {
 }
 ```
 
-## Other improvments
+## Other improvements
 
 The `CompilerPluginSupport` module enables defining macro targets. Macro targets allow authoring and distributing custom Swift macros as APIs in a library.
 

--- a/Documentation/ReleaseNotes/5.9.md
+++ b/Documentation/ReleaseNotes/5.9.md
@@ -8,10 +8,24 @@ SwiftPM now supports cross compilation based on the Swift SDK bundle format. Whi
 
 SwiftPM can now publish to a registry following the specification defined in SE-0391, as well as support signed packages, which may be required by a registry. Trust-on-first-use (TOFU) validation checks can now use signing identities in addition to fingerprints, and are enforced for source archives as well as package manifests.
 
+## Embedded resources
+
+Basic support for a new `.embedInCode` resource rule which allows embedding the contents of the resource into the executable code by generating a byte array
+
+```
+struct PackageResources {
+  static let best_txt: [UInt8] = [104,101,108,108,111,32,119,111,114,108,100,10]
+}
+```
+
 ## Other improvments
 
-The CompilerPluginSupport module enables defining macro targets. Macro targets allow authoring and distributing custom Swift macros as APIs in a library.
+The `CompilerPluginSupport` module enables defining macro targets. Macro targets allow authoring and distributing custom Swift macros as APIs in a library.
 
-Packages can use the new package access modifier, allowing access of symbols in another target / module within the same package without making them public. SwiftPM automatically sets the new compiler configuration to ensure this feature works out-of-the-box for packages.
+Packages can use the new `package` access modifier, allowing access of symbols in another target / module within the same package without making them public. SwiftPM automatically sets the new compiler configuration to ensure this feature works out-of-the-box for packages.
   
-The allowNetworkConnections(scope:reason:) setting gives a command plugin permissions to access the network. Permissions can be scoped to Unix domain sockets as well as local or remote IP connections, with an option to limit by port. For non-interactive use cases, the --allow-network-connections command-line flag allows network connections for a particular scope.
+The `allowNetworkConnections(scope:reason:)` setting gives a command plugin permissions to access the network. Permissions can be scoped to Unix domain sockets as well as local or remote IP connections, with an option to limit by port. For non-interactive use cases, the `--allow-network-connections` command-line flag allows network connections for a particular scope.
+
+When a package contains a single target, sources may be distributed anywhere within the `./Sources` directory. If sources are placed in a subdirectory under `./Sources/<target>`, or there is more than one target, the existing expectation for sources apply
+
+Build tool plugins can be used with C-family targets


### PR DESCRIPTION
motivation: make sure 5.9 release notes are published

changes:
Document key 5.9 features per https://www.swift.org/blog/swift-5.9-released and https://github.com/apple/swift-package-manager/blob/main/CHANGELOG.md
