### PR TITLE
wip: add an API of plugins to retrieve authentication information

### DIFF
--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -322,6 +322,20 @@ final class PluginDelegate: PluginInvocationDelegate {
         }
     }
 
+    func authorizationInfoRequest(
+        for url: URL,
+        completion: @escaping (Result<PluginInvocationAuthorizationInfoResult?, Error>) -> Void
+    ) {
+        // Get the authorization info from the authorization provider
+        DispatchQueue.sharedConcurrent.async {
+            completion(Result {
+                try self.swiftTool.getAuthorizationProvider()?.authentication(for: url).map {
+                    .init(username: $0, password: $1)
+                }
+            })
+        }
+    }
+
     private func createSymbolGraphForPlugin(
         forTarget targetName: String,
         options: PluginInvocationSymbolGraphOptions

--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -246,6 +246,27 @@ public struct PackageManager {
         /// The directory that contains the symbol graph files for the target.
         public var directoryPath: Path
     }
+
+    /// Return authorization information for the URL.
+    // FIXME: add a hashing key
+    public func getAuthorizationInfo(
+        for url: String
+    ) throws -> AuthorizationInfo? {
+        // Ask the plugin host for authorization information, and wait for a response.
+        // FIXME: We'll want to make this asynchronous when there is back deployment support for it.
+        return try sendMessageAndWaitForReply(.authorizationInfoRequest(url: url)) {
+            guard case .authorizationInfoResponse(let result) = $0 else { return nil }
+            return result.map{ .init($0) }
+        }
+    }
+
+    /// Represents  authorization information
+    public struct AuthorizationInfo {
+        /// The username
+        public var username: String
+        /// The password
+        public var password: String
+    }
 }
 
 fileprivate extension PackageManager {
@@ -438,5 +459,12 @@ fileprivate extension PluginToHostMessage.SymbolGraphOptions.AccessLevel {
 fileprivate extension PackageManager.SymbolGraphResult {
     init(_ result: HostToPluginMessage.SymbolGraphResult) {
         self.directoryPath = .init(result.directoryPath)
+    }
+}
+
+fileprivate extension PackageManager.AuthorizationInfo {
+    init(_ result: HostToPluginMessage.AuthorizationInfo) {
+        self.username = result.username
+        self.password = result.password
     }
 }

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -246,7 +246,14 @@ enum HostToPluginMessage: Codable {
         struct SymbolGraphResult: Codable {
             var directoryPath: String
         }
-    
+
+    /// A response to a request for authorization info
+    case authorizationInfoResponse(result: AuthorizationInfo?)
+        struct AuthorizationInfo: Codable {
+            var username: String
+            var password: String
+        }
+
     /// A response of an error while trying to complete a request.
     case errorResponse(error: String)
 }
@@ -324,4 +331,7 @@ enum PluginToHostMessage: Codable {
             var includeSPI: Bool
             var emitExtensionBlocks: Bool
         }
+
+    /// the plugin requesting authorization information
+    case authorizationInfoRequest(url: String)
 }


### PR DESCRIPTION
motivation: some plugins need authentication information, having an API to retrieve it from SwiftPM is helpful to abstract different authentication providers

changes: 
* create a new API for plugins to request authentication information from SwiftPM
* implement the IPC encoding/decoding for the API 


TODO:
[] tests
[] encrypt IPC so that auth info cannot be man-in-the-middle
[] add plugin privilege to signal a plugin would access auth information 


rdar://116226961