### PR TITLE
[NFC] Remove unused `fileSystem` from `GraphLoadingNode`

### DIFF
--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -20,7 +20,6 @@ import PackageModel
 ///
 /// - SeeAlso: ``DependencyResolutionNode``
 public struct GraphLoadingNode: Equatable, Hashable {
-
     /// The package identity.
     public let identity: PackageIdentity
 
@@ -30,29 +29,15 @@ public struct GraphLoadingNode: Equatable, Hashable {
     /// The product filter applied to the package.
     public let productFilter: ProductFilter
 
-    /// The file system to use for loading the given package.
-    public let fileSystem: FileSystem
-
-    public init(identity: PackageIdentity, manifest: Manifest, productFilter: ProductFilter, fileSystem: FileSystem) {
+    public init(identity: PackageIdentity, manifest: Manifest, productFilter: ProductFilter) {
         self.identity = identity
         self.manifest = manifest
         self.productFilter = productFilter
-        self.fileSystem = fileSystem
     }
 
     /// Returns the dependencies required by this node.
     internal var requiredDependencies: [PackageDependency] {
         return self.manifest.dependenciesRequired(for: self.productFilter)
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(identity)
-        hasher.combine(manifest)
-        hasher.combine(productFilter)
-    }
-
-    public static func == (lhs: GraphLoadingNode, rhs: GraphLoadingNode) -> Bool {
-        return lhs.identity == rhs.identity && lhs.manifest == rhs.manifest && lhs.productFilter == rhs.productFilter
     }
 }
 

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -46,10 +46,14 @@ extension PackageGraph {
         root.manifests.forEach {
             manifestMap[$0.key] = ($0.value, fileSystem)
         }
-        let successors: (GraphLoadingNode) -> [GraphLoadingNode] = { node in
-            node.requiredDependencies.compactMap{ dependency in
-                return manifestMap[dependency.identity].map { (manifest, fileSystem) in
-                    GraphLoadingNode(identity: dependency.identity, manifest: manifest, productFilter: dependency.productFilter, fileSystem: fileSystem)
+        func nodeSuccessorsProvider(node: GraphLoadingNode) -> [GraphLoadingNode] {
+            node.requiredDependencies.compactMap { dependency in
+                manifestMap[dependency.identity].map { (manifest, fileSystem) in
+                    GraphLoadingNode(
+                        identity: dependency.identity,
+                        manifest: manifest,
+                        productFilter: dependency.productFilter
+                    )
                 }
             }
         }
@@ -59,11 +63,15 @@ extension PackageGraph {
             manifestMap[$0.identity]?.manifest
         })
         let rootManifestNodes = root.packages.map { identity, package in
-            GraphLoadingNode(identity: identity, manifest: package.manifest, productFilter: .everything, fileSystem: fileSystem)
+            GraphLoadingNode(identity: identity, manifest: package.manifest, productFilter: .everything)
         }
-        let rootDependencyNodes = root.dependencies.lazy.compactMap { (dependency: PackageDependency) -> GraphLoadingNode? in
+        let rootDependencyNodes = root.dependencies.lazy.compactMap { dependency in
             manifestMap[dependency.identity].map {
-                GraphLoadingNode(identity: dependency.identity, manifest: $0.manifest, productFilter: dependency.productFilter, fileSystem: $0.fs)
+                GraphLoadingNode(
+                    identity: dependency.identity,
+                    manifest: $0.manifest,
+                    productFilter: dependency.productFilter
+                )
             }
         }
         let inputManifests = rootManifestNodes + rootDependencyNodes
@@ -72,13 +80,13 @@ extension PackageGraph {
         var allNodes: [GraphLoadingNode]
 
         // Detect cycles in manifest dependencies.
-        if let cycle = findCycle(inputManifests, successors: successors) {
+        if let cycle = findCycle(inputManifests, successors: nodeSuccessorsProvider) {
             observabilityScope.emit(PackageGraphError.cycleDetected(cycle))
             // Break the cycle so we can build a partial package graph.
             allNodes = inputManifests.filter({ $0.manifest != cycle.cycle[0] })
         } else {
-            // Sort all manifests toplogically.
-            allNodes = try topologicalSort(inputManifests, successors: successors)
+            // Sort all manifests topologically.
+            allNodes = try topologicalSort(inputManifests, successors: nodeSuccessorsProvider)
         }
 
         var flattenedManifests: [PackageIdentity: GraphLoadingNode] = [:]
@@ -87,8 +95,7 @@ extension PackageGraph {
                 let merged = GraphLoadingNode(
                     identity: node.identity,
                     manifest: node.manifest,
-                    productFilter: existing.productFilter.union(node.productFilter),
-                    fileSystem: node.fileSystem
+                    productFilter: existing.productFilter.union(node.productFilter)
                 )
                 flattenedManifests[node.identity] = merged
             } else {
@@ -123,7 +130,7 @@ extension PackageGraph {
                     shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
                     testEntryPointPath: testEntryPointPath,
                     createREPLProduct: manifest.packageKind.isRoot ? createREPLProduct : false,
-                    fileSystem: node.fileSystem,
+                    fileSystem: fileSystem,
                     observabilityScope: nodeObservabilityScope
                 )
                 let package = try builder.construct()

--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -181,8 +181,7 @@ extension Workspace {
                 let node = GraphLoadingNode(
                     identity: identity,
                     manifest: package.manifest,
-                    productFilter: .everything,
-                    fileSystem: workspace.fileSystem
+                    productFilter: .everything
                 )
                 return node
             } + root.dependencies.compactMap { dependency in
@@ -192,8 +191,7 @@ extension Workspace {
                     GraphLoadingNode(
                         identity: dependency.identity,
                         manifest: manifest,
-                        productFilter: dependency.productFilter,
-                        fileSystem: workspace.fileSystem
+                        productFilter: dependency.productFilter
                     )
                 }
             }
@@ -247,8 +245,7 @@ extension Workspace {
                         GraphLoadingNode(
                             identity: dependency.identity,
                             manifest: manifest,
-                            productFilter: dependency.productFilter,
-                            fileSystem: workspace.fileSystem
+                            productFilter: dependency.productFilter
                         )
                     }
                 }


### PR DESCRIPTION
### Motivation:

`GraphLoadingNode`s in the same graph always use same file system instance, there's no need to store references to it in each node.

### Modifications:

Removed `fileSystem` property on `GraphLoadingNode`, as it also simplifies `Equatable` and `Hashable` implementations on this type.

### Result:

`GraphLoadingNode` is now a true value type, with no need to define `Equatable` and `Hashable` manually on it.
