### PR TITLE
Async package collections tests

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -48,10 +48,12 @@ extension DispatchQueue {
 }
 
 /// Bridges between potentially blocking methods that take a result completion closure and async/await
-public func safe_async<T, ErrorType: Error>(_ body: @Sendable @escaping (@Sendable @escaping (Result<T, ErrorType>) -> Void) -> Void) async throws -> T {
+public func safe_async<T, ErrorType: Error>(
+    _ body: @Sendable @escaping (@Sendable @escaping (Result<T, ErrorType>) -> Void) -> Void
+) async throws -> T {
     try await withCheckedThrowingContinuation { continuation in
-        // It is possible that body make block indefinitely on a lock, sempahore,
-        // or similar then synchrously call the completion handler. For full safety
+        // It is possible that body make block indefinitely on a lock, semaphore,
+        // or similar then synchronously call the completion handler. For full safety
         // it is essential to move the execution off the swift concurrency pool
         DispatchQueue.sharedConcurrent.async {
             body {

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -13,6 +13,7 @@
 import struct Foundation.URL
 import PackageModel
 import SourceControl
+import Basics
 
 // MARK: - Package collection
 
@@ -27,6 +28,7 @@ public protocol PackageCollectionsProtocol {
     /// - Parameters:
     ///   - identifiers: Optional. If specified, only `PackageCollection`s with matching identifiers will be returned.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func listCollections(
         identifiers: Set<PackageCollectionsModel.CollectionIdentifier>?,
         callback: @escaping (Result<[PackageCollectionsModel.Collection], Error>) -> Void
@@ -36,6 +38,7 @@ public protocol PackageCollectionsProtocol {
     ///
     /// - Parameters:
     ///   - callback: The closure to invoke after triggering a refresh for the configured package collections.
+    @available(*, noasync, message: "Use the async alternative")
     func refreshCollections(callback: @escaping (Result<[PackageCollectionsModel.CollectionSource], Error>) -> Void)
 
     /// Refreshes a package collection.
@@ -43,6 +46,7 @@ public protocol PackageCollectionsProtocol {
     /// - Parameters:
     ///   - source: The package collection to be refreshed
     ///   - callback: The closure to invoke with the refreshed `PackageCollection`
+    @available(*, noasync, message: "Use the async alternative")
     func refreshCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
@@ -56,6 +60,7 @@ public protocol PackageCollectionsProtocol {
     ///            By default the new collection is appended to the end (i.e., the least relevant order).
     ///   - trustConfirmationProvider: The closure to invoke when the collection is not signed and user confirmation is required to proceed
     ///   - callback: The closure to invoke with the newly added `PackageCollection`
+    @available(*, noasync, message: "Use the async alternative")
     func addCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         order: Int?,
@@ -68,6 +73,7 @@ public protocol PackageCollectionsProtocol {
     /// - Parameters:
     ///   - source: The package collection's source
     ///   - callback: The closure to invoke with the result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func removeCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         callback: @escaping (Result<Void, Error>) -> Void
@@ -79,6 +85,7 @@ public protocol PackageCollectionsProtocol {
     ///   - source: The source of the `PackageCollection` to be reordered
     ///   - order: The new order that the `PackageCollection` should be positioned after the move
     ///   - callback: The closure to invoke with the result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func moveCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         to order: Int,
@@ -90,6 +97,7 @@ public protocol PackageCollectionsProtocol {
     /// - Parameters:
     ///   - source: The `PackageCollection` source to be updated
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func updateCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
@@ -101,6 +109,7 @@ public protocol PackageCollectionsProtocol {
     /// - Parameters:
     ///   - source: The package collection's source
     ///   - callback: The closure to invoke with the `PackageCollection`
+    @available(*, noasync, message: "Use the async alternative")
     func getCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
@@ -115,6 +124,7 @@ public protocol PackageCollectionsProtocol {
     ///   - identity: The package identity
     ///   - location: The package location (optional for deduplication)
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func getPackageMetadata(
         identity: PackageIdentity,
         location: String?,
@@ -132,6 +142,7 @@ public protocol PackageCollectionsProtocol {
     ///   - collections: Optional. If specified, only look for package in these collections. Data from the most recently
     ///                  processed collection will be used.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func getPackageMetadata(
         identity: PackageIdentity,
         location: String?,
@@ -144,6 +155,7 @@ public protocol PackageCollectionsProtocol {
     /// - Parameters:
     ///   - collections: Optional. If specified, only packages in these collections are included.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func listPackages(
         collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
         callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
@@ -160,6 +172,7 @@ public protocol PackageCollectionsProtocol {
     /// - Parameters:
     ///   - collections: Optional. If specified, only list targets within these collections.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func listTargets(
         collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
         callback: @escaping (Result<PackageCollectionsModel.TargetListResult, Error>) -> Void
@@ -176,6 +189,7 @@ public protocol PackageCollectionsProtocol {
     ///   - query: The search query
     ///   - collections: Optional. If specified, only search within these collections.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func findPackages(
         _ query: String,
         collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
@@ -193,12 +207,165 @@ public protocol PackageCollectionsProtocol {
     ///                 For more flexibility, use the `findPackages` API instead.
     ///   - collections: Optional. If specified, only search within these collections.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func findTargets(
         _ query: String,
         searchType: PackageCollectionsModel.TargetSearchType?,
         collections: Set<PackageCollectionsModel.CollectionIdentifier>?,
         callback: @escaping (Result<PackageCollectionsModel.TargetSearchResult, Error>) -> Void
     )
+}
+
+public extension PackageCollectionsProtocol {
+    func listCollections(
+        identifiers: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> [PackageCollectionsModel.Collection]  {
+        try await safe_async {
+            self.listCollections(identifiers: identifiers, callback: $0)
+        }
+    }
+
+    func refreshCollections() async throws -> [PackageCollectionsModel.CollectionSource] {
+        try await safe_async {
+            self.refreshCollections(callback: $0)
+        }
+    }
+
+    func refreshCollection(
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws -> PackageCollectionsModel.Collection {
+        try await safe_async {
+            self.refreshCollection(
+                source,
+                callback: $0
+            )
+        }
+    }
+
+    func addCollection(
+        _ source: PackageCollectionsModel.CollectionSource,
+        order: Int? = nil,
+        trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)? = nil
+    ) async throws -> PackageCollectionsModel.Collection {
+        try await safe_async {
+            self.addCollection(
+                source,
+                order: order,
+                trustConfirmationProvider:trustConfirmationProvider,
+                callback: $0)
+        }
+    }
+
+    func removeCollection(
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws {
+        try await safe_async {
+            self.removeCollection(
+                source,
+                callback: $0
+            )
+        }
+    }
+
+    func moveCollection(
+        _ source: PackageCollectionsModel.CollectionSource,
+        to order: Int
+    ) async throws {
+        try await safe_async {
+            self.moveCollection(
+                source,
+                to: order,
+                callback: $0
+            )
+        }
+    }
+
+    func updateCollection(
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws -> PackageCollectionsModel.Collection {
+        try await safe_async {
+            self.updateCollection(
+                source,
+                callback: $0
+            )
+        }
+    }
+
+    func getCollection(
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws -> PackageCollectionsModel.Collection {
+        try await safe_async {
+            self.getCollection(
+                source,
+                callback: $0
+            )
+        }
+    }
+
+    func getPackageMetadata(
+        identity: PackageIdentity,
+        location: String? = nil,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.PackageMetadata {
+        try await safe_async {
+            self.getPackageMetadata(
+                identity: identity,
+                location: location,
+                collections: collections,
+                callback: $0
+            )
+        }
+    }
+
+    func listPackages(
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.PackageSearchResult {
+        try await safe_async {
+            self.listPackages(
+                collections: collections,
+                callback: $0
+            )
+        }
+    }
+
+    func listTargets(
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.TargetListResult {
+        try await safe_async {
+            self.listTargets(
+                collections: collections,
+                callback: $0
+            )
+        }
+    }
+
+    func findPackages(
+        _ query: String,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.PackageSearchResult {
+        try await safe_async {
+            self.findPackages(
+                query,
+                collections: collections,
+                callback: $0
+            )
+        }
+    }
+
+    func findTargets(
+        _ query: String,
+        searchType: PackageCollectionsModel.TargetSearchType? = nil,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.TargetSearchResult {
+        try await safe_async {
+            self.findTargets(
+                query,
+                searchType: searchType,
+                collections: collections,
+                callback: $0
+            )
+        }
+    }
 }
 
 public enum PackageCollectionError: Equatable, Error {
@@ -233,6 +400,7 @@ public protocol PackageIndexProtocol {
     ///   - identity: The package identity
     ///   - location: The package location (optional for deduplication)
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func getPackageMetadata(
         identity: PackageIdentity,
         location: String?,
@@ -244,6 +412,7 @@ public protocol PackageIndexProtocol {
     /// - Parameters:
     ///   - query: The search query
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func findPackages(
         _ query: String,
         callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
@@ -255,11 +424,60 @@ public protocol PackageIndexProtocol {
     ///   - offset: Offset of the first item in the result
     ///   - limit: Number of items to return in the result. Implementations might impose a threshold for this.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func listPackages(
         offset: Int,
         limit: Int,
         callback: @escaping (Result<PackageCollectionsModel.PaginatedPackageList, Error>) -> Void
     )
+}
+
+public extension PackageIndexProtocol {
+
+    func getPackageMetadata(
+        identity: PackageIdentity,
+        location: String?
+    ) async throws -> PackageCollectionsModel.PackageMetadata {
+        try await safe_async {
+            self.getPackageMetadata(
+                identity: identity,
+                location: location,
+                callback: $0
+            )
+        }
+    }
+
+    /// Finds and returns packages that match the query.
+    ///
+    /// - Parameters:
+    ///   - query: The search query
+    ///   - callback: The closure to invoke when result becomes available
+    func findPackages(
+        _ query: String
+    ) async throws -> PackageCollectionsModel.PackageSearchResult {
+        try await safe_async {
+            self.findPackages(query, callback: $0)
+        }
+    }
+
+    /// A paginated list of packages in the index.
+    ///
+    /// - Parameters:
+    ///   - offset: Offset of the first item in the result
+    ///   - limit: Number of items to return in the result. Implementations might impose a threshold for this.
+    ///   - callback: The closure to invoke when result becomes available
+    func listPackages(
+        offset: Int,
+        limit: Int
+    ) async throws -> PackageCollectionsModel.PaginatedPackageList {
+        try await safe_async {
+            self.listPackages(
+                offset: offset,
+                limit: limit,
+                callback: $0
+            )
+        }
+    }
 }
 
 public enum PackageIndexError: Equatable, Error {

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -433,7 +433,6 @@ public protocol PackageIndexProtocol {
 }
 
 public extension PackageIndexProtocol {
-
     func getPackageMetadata(
         identity: PackageIdentity,
         location: String?

--- a/Sources/PackageCollections/API.swift
+++ b/Sources/PackageCollections/API.swift
@@ -252,7 +252,8 @@ public extension PackageCollectionsProtocol {
                 source,
                 order: order,
                 trustConfirmationProvider:trustConfirmationProvider,
-                callback: $0)
+                callback: $0
+            )
         }
     }
 

--- a/Sources/PackageCollections/PackageCollections.swift
+++ b/Sources/PackageCollections/PackageCollections.swift
@@ -489,9 +489,11 @@ public struct PackageCollections: PackageCollectionsProtocol, Closable {
 
     // Fetch the collection from the network and store it in local storage
     // This helps avoid network access in normal operations
-    private func refreshCollectionFromSource(source: PackageCollectionsModel.CollectionSource,
-                                             trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)?,
-                                             callback: @escaping (Result<Model.Collection, Error>) -> Void) {
+    private func refreshCollectionFromSource(
+        source: PackageCollectionsModel.CollectionSource,
+        trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)?,
+        callback: @escaping (Result<Model.Collection, Error>) -> Void
+    ) {
         guard let provider = self.collectionProviders[source.type] else {
             return callback(.failure(UnknownProvider(source.type)))
         }

--- a/Sources/PackageCollections/PackageIndexAndCollections.swift
+++ b/Sources/PackageCollections/PackageIndexAndCollections.swift
@@ -254,6 +254,7 @@ public struct PackageIndexAndCollections: Closable {
             )
         }
     }
+
     /// Returns metadata for the package identified by the given `PackageIdentity`, using package index (if configured)
     /// and collections data.
     ///

--- a/Sources/PackageCollections/PackageIndexAndCollections.swift
+++ b/Sources/PackageCollections/PackageIndexAndCollections.swift
@@ -71,20 +71,37 @@ public struct PackageIndexAndCollections: Closable {
     
     // MARK: - Package collection specific APIs
     
+    public func listCollections(
+        identifiers: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> [PackageCollectionsModel.Collection] {
+        try await self.collections.listCollections(identifiers: identifiers)
+    }
+
     /// - SeeAlso: `PackageCollectionsProtocol.listCollections`
+    @available(*, noasync, message: "Use the async alternative")
     public func listCollections(
         identifiers: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
         callback: @escaping (Result<[PackageCollectionsModel.Collection], Error>) -> Void
     ) {
         self.collections.listCollections(identifiers: identifiers, callback: callback)
     }
+    
+    public func refreshCollections() async throws -> [PackageCollectionsModel.CollectionSource] {
+        try await self.collections.refreshCollections()
+    }
 
     /// - SeeAlso: `PackageCollectionsProtocol.refreshCollections`
+    @available(*, noasync, message: "Use the async alternative")
     public func refreshCollections(callback: @escaping (Result<[PackageCollectionsModel.CollectionSource], Error>) -> Void) {
         self.collections.refreshCollections(callback: callback)
     }
 
+    public func refreshCollection(_ source: PackageCollectionsModel.CollectionSource) async throws -> PackageCollectionsModel.Collection {
+        try await self.collections.refreshCollection(source)
+    }
+
     /// - SeeAlso: `PackageCollectionsProtocol.refreshCollection`
+    @available(*, noasync, message: "Use the async alternative")
     public func refreshCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
@@ -92,7 +109,20 @@ public struct PackageIndexAndCollections: Closable {
         self.collections.refreshCollection(source, callback: callback)
     }
 
+    public func addCollection(
+        _ source: PackageCollectionsModel.CollectionSource,
+        order: Int? = nil,
+        trustConfirmationProvider: ((PackageCollectionsModel.Collection, @escaping (Bool) -> Void) -> Void)? = nil
+    ) async throws -> PackageCollectionsModel.Collection {
+        try await self.collections.addCollection(
+            source,
+            order: order,
+            trustConfirmationProvider: trustConfirmationProvider
+        )
+    }
+
     /// - SeeAlso: `PackageCollectionsProtocol.addCollection`
+    @available(*, noasync, message: "Use the async alternative")
     public func addCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         order: Int? = nil,
@@ -101,8 +131,15 @@ public struct PackageIndexAndCollections: Closable {
     ) {
         self.collections.addCollection(source, order: order, trustConfirmationProvider: trustConfirmationProvider, callback: callback)
     }
+    
+    public func removeCollection(
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws {
+        try await self.collections.removeCollection(source)
+    }
 
     /// - SeeAlso: `PackageCollectionsProtocol.removeCollection`
+    @available(*, noasync, message: "Use the async alternative")
     public func removeCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         callback: @escaping (Result<Void, Error>) -> Void
@@ -110,23 +147,44 @@ public struct PackageIndexAndCollections: Closable {
         self.collections.removeCollection(source, callback: callback)
     }
 
+    public func getCollection(
+        _ source: PackageCollectionsModel.CollectionSource
+    ) async throws -> PackageCollectionsModel.Collection {
+        try await self.collections.getCollection(source)
+    }
+
     /// - SeeAlso: `PackageCollectionsProtocol.getCollection`
+    @available(*, noasync, message: "Use the async alternative")
     public func getCollection(
         _ source: PackageCollectionsModel.CollectionSource,
         callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void
     ) {
         self.collections.getCollection(source, callback: callback)
     }
+    
+    public func listPackages(
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.PackageSearchResult {
+        try await self.collections.listPackages(collections: collections)
+    }
 
     /// - SeeAlso: `PackageCollectionsProtocol.listPackages`
+    @available(*, noasync, message: "Use the async alternative")
     public func listPackages(
         collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
         callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void
     ) {
         self.collections.listPackages(collections: collections, callback: callback)
     }
+    
+    public func listTargets(
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.TargetListResult {
+        try await self.collections.listTargets(collections: collections)
+    }
 
     /// - SeeAlso: `PackageCollectionsProtocol.listTargets`
+    @available(*, noasync, message: "Use the async alternative")
     public func listTargets(
         collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil,
         callback: @escaping (Result<PackageCollectionsModel.TargetListResult, Error>) -> Void
@@ -134,7 +192,20 @@ public struct PackageIndexAndCollections: Closable {
         self.collections.listTargets(collections: collections, callback: callback)
     }
     
+    public func findTargets(
+        _ query: String,
+        searchType: PackageCollectionsModel.TargetSearchType? = nil,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.TargetSearchResult {
+        try await self.collections.findTargets(
+            query,
+            searchType: searchType,
+            collections: collections
+        )
+    }
+
     /// - SeeAlso: `PackageCollectionsProtocol.findTargets`
+    @available(*, noasync, message: "Use the async alternative")
     public func findTargets(
         _ query: String,
         searchType: PackageCollectionsModel.TargetSearchType? = nil,
@@ -150,8 +221,16 @@ public struct PackageIndexAndCollections: Closable {
     public func isIndexEnabled() -> Bool {
         self.index.isEnabled
     }
+    
+    public func listPackagesInIndex(
+        offset: Int,
+        limit: Int
+    ) async throws -> PackageCollectionsModel.PaginatedPackageList {
+        try await self.index.listPackages(offset: offset, limit: limit)
+    }
 
     /// - SeeAlso: `PackageIndexProtocol.listPackages`
+    @available(*, noasync, message: "Use the async alternative")
     public func listPackagesInIndex(
         offset: Int,
         limit: Int,
@@ -161,7 +240,20 @@ public struct PackageIndexAndCollections: Closable {
     }
     
     // MARK: - APIs that make use of both package index and collections
-    
+    public func getPackageMetadata(
+        identity: PackageIdentity,
+        location: String? = nil,
+        collections: Set<PackageCollectionsModel.CollectionIdentifier>? = nil
+    ) async throws -> PackageCollectionsModel.PackageMetadata {
+        try await safe_async {
+            self.getPackageMetadata(
+                identity: identity,
+                location: location,
+                collections: collections,
+                callback: $0
+            )
+        }
+    }
     /// Returns metadata for the package identified by the given `PackageIdentity`, using package index (if configured)
     /// and collections data.
     ///
@@ -172,6 +264,7 @@ public struct PackageIndexAndCollections: Closable {
     ///   - location: The package location (optional for deduplication)
     ///   - collections: Optional. If specified, only these collections are used to construct the result.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     public func getPackageMetadata(
         identity: PackageIdentity,
         location: String? = nil,
@@ -231,7 +324,20 @@ public struct PackageIndexAndCollections: Closable {
             }
         }
     }
-    
+
+    public func findPackages(
+        _ query: String,
+        in searchIn: SearchIn = .both(collections: nil)
+    ) async throws -> PackageCollectionsModel.PackageSearchResult {
+        try await safe_async {
+            self.findPackages(
+                query,
+                in: searchIn,
+                callback: $0
+            )
+        }
+    }
+
     /// Finds and returns packages that match the query.
     ///
     /// - Parameters:
@@ -239,6 +345,7 @@ public struct PackageIndexAndCollections: Closable {
     ///   - in: Indicates whether to search in the index only, collections only, or both.
     ///         The optional `Set<CollectionIdentifier>` in some enum cases restricts search within those collections only.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     public func findPackages(
         _ query: String,
         in searchIn: SearchIn = .both(collections: nil),

--- a/Sources/PackageCollections/Providers/PackageCollectionProvider.swift
+++ b/Sources/PackageCollections/Providers/PackageCollectionProvider.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
+
 /// `PackageCollection` provider. For example, package feeds, (future) Package Index.
 protocol PackageCollectionProvider {
     /// Retrieves `PackageCollection` from the specified source.
@@ -17,5 +19,15 @@ protocol PackageCollectionProvider {
     /// - Parameters:
     ///   - source: Where the `PackageCollection` is located
     ///   - callback: The closure to invoke when result becomes available
+    ///
+    @available(*, noasync, message: "Use the async alternative")
     func get(_ source: PackageCollectionsModel.CollectionSource, callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void)
+}
+
+extension PackageCollectionProvider {
+    func get(_ source: Model.CollectionSource) async throws -> Model.Collection {
+        try await safe_async {
+            self.get(source, callback: $0)
+        }
+    }
 }

--- a/Sources/PackageCollections/Storage/PackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsSourcesStorage.swift
@@ -73,7 +73,6 @@ public protocol PackageCollectionsSourcesStorage {
 }
 
 public extension PackageCollectionsSourcesStorage {
-
     func list() async throws -> [PackageCollectionsModel.CollectionSource] {
         try await safe_async {
             self.list(callback: $0)

--- a/Sources/PackageCollections/Storage/PackageCollectionsSourcesStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsSourcesStorage.swift
@@ -10,11 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
+
 public protocol PackageCollectionsSourcesStorage {
     /// Lists all `PackageCollectionSource`s.
     ///
     /// - Parameters:
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func list(callback: @escaping (Result<[PackageCollectionsModel.CollectionSource], Error>) -> Void)
 
     /// Adds the given source.
@@ -24,6 +27,7 @@ public protocol PackageCollectionsSourcesStorage {
     ///   - order: Optional. The order that the source should take after being added.
     ///            By default the new source is appended to the end (i.e., the least relevant order).
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func add(source: PackageCollectionsModel.CollectionSource,
              order: Int?,
              callback: @escaping (Result<Void, Error>) -> Void)
@@ -34,6 +38,7 @@ public protocol PackageCollectionsSourcesStorage {
     ///   - source: The `PackageCollectionSource` to remove
     ///   - profile: The `Profile` to remove source
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func remove(source: PackageCollectionsModel.CollectionSource,
                 callback: @escaping (Result<Void, Error>) -> Void)
 
@@ -43,6 +48,7 @@ public protocol PackageCollectionsSourcesStorage {
     ///   - source: The `PackageCollectionSource` to move
     ///   - order: The order that the source should take.
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func move(source: PackageCollectionsModel.CollectionSource,
               to order: Int,
               callback: @escaping (Result<Void, Error>) -> Void)
@@ -52,6 +58,7 @@ public protocol PackageCollectionsSourcesStorage {
     /// - Parameters:
     ///   - source: The `PackageCollectionSource`
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func exists(source: PackageCollectionsModel.CollectionSource,
                 callback: @escaping (Result<Bool, Error>) -> Void)
 
@@ -60,6 +67,47 @@ public protocol PackageCollectionsSourcesStorage {
     /// - Parameters:
     ///   - source: The `PackageCollectionSource` to update
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func update(source: PackageCollectionsModel.CollectionSource,
                 callback: @escaping (Result<Void, Error>) -> Void)
+}
+
+public extension PackageCollectionsSourcesStorage {
+
+    func list() async throws -> [PackageCollectionsModel.CollectionSource] {
+        try await safe_async {
+            self.list(callback: $0)
+        }
+    }
+
+    func add(source: PackageCollectionsModel.CollectionSource,
+             order: Int? = nil) async throws {
+        try await safe_async {
+            self.add(source: source, order: order, callback: $0)
+        }
+    }
+
+    func remove(source: PackageCollectionsModel.CollectionSource) async throws {
+        try await safe_async {
+            self.remove(source: source, callback: $0)
+        }
+    }
+
+    func move(source: PackageCollectionsModel.CollectionSource, to order: Int) async throws {
+        try await safe_async {
+            self.move(source: source, to:order, callback: $0)
+        }
+    }
+
+    func exists(source: PackageCollectionsModel.CollectionSource) async throws -> Bool {
+        try await safe_async {
+            self.exists(source: source, callback: $0)
+        }
+    }
+
+    func update(source: PackageCollectionsModel.CollectionSource) async throws {
+        try await safe_async {
+            self.update(source: source, callback: $0)
+        }
+    }
 }

--- a/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/PackageCollectionsStorage.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import PackageModel
+import Basics
 
 public protocol PackageCollectionsStorage {
     /// Writes `PackageCollection` to storage.
@@ -18,6 +19,7 @@ public protocol PackageCollectionsStorage {
     /// - Parameters:
     ///   - collection: The `PackageCollection`
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func put(collection: PackageCollectionsModel.Collection,
              callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void)
 
@@ -26,6 +28,7 @@ public protocol PackageCollectionsStorage {
     /// - Parameters:
     ///   - identifier: The identifier of the `PackageCollection`
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func remove(identifier: PackageCollectionsModel.CollectionIdentifier,
                 callback: @escaping (Result<Void, Error>) -> Void)
 
@@ -34,6 +37,7 @@ public protocol PackageCollectionsStorage {
     /// - Parameters:
     ///   - identifier: The identifier of the `PackageCollection`
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func get(identifier: PackageCollectionsModel.CollectionIdentifier,
              callback: @escaping (Result<PackageCollectionsModel.Collection, Error>) -> Void)
 
@@ -42,6 +46,7 @@ public protocol PackageCollectionsStorage {
     /// - Parameters:
     ///   - identifiers: Optional. The identifiers of the `PackageCollection`
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func list(identifiers: [PackageCollectionsModel.CollectionIdentifier]?,
               callback: @escaping (Result<[PackageCollectionsModel.Collection], Error>) -> Void)
 
@@ -51,6 +56,7 @@ public protocol PackageCollectionsStorage {
     ///   - identifiers: Optional. The identifiers of the `PackageCollection`s
     ///   - query: The search query expression
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func searchPackages(identifiers: [PackageCollectionsModel.CollectionIdentifier]?,
                         query: String,
                         callback: @escaping (Result<PackageCollectionsModel.PackageSearchResult, Error>) -> Void)
@@ -74,8 +80,42 @@ public protocol PackageCollectionsStorage {
     ///   - query: The search query expression
     ///   - type: The search type
     ///   - callback: The closure to invoke when result becomes available
+    @available(*, noasync, message: "Use the async alternative")
     func searchTargets(identifiers: [PackageCollectionsModel.CollectionIdentifier]?,
                        query: String,
                        type: PackageCollectionsModel.TargetSearchType,
                        callback: @escaping (Result<PackageCollectionsModel.TargetSearchResult, Error>) -> Void)
+}
+
+public extension PackageCollectionsStorage {
+    func put(collection: PackageCollectionsModel.Collection) async throws -> PackageCollectionsModel.Collection {
+        try await safe_async {
+            self.put(collection: collection, callback: $0)
+        }
+    }
+    func remove(identifier: PackageCollectionsModel.CollectionIdentifier) async throws {
+        try await safe_async {
+            self.remove(identifier: identifier, callback: $0)
+        }
+    }
+    func get(identifier: PackageCollectionsModel.CollectionIdentifier) async throws -> PackageCollectionsModel.Collection {
+        try await safe_async {
+            self.get(identifier: identifier, callback: $0)
+        }
+    }
+    func list(identifiers: [PackageCollectionsModel.CollectionIdentifier]? = nil) async throws -> [PackageCollectionsModel.Collection] {
+        try await safe_async {
+            self.list(identifiers: identifiers, callback: $0)
+        }
+    }
+
+    func searchTargets(
+        identifiers: [PackageCollectionsModel.CollectionIdentifier]? = nil,
+        query: String,
+        type: PackageCollectionsModel.TargetSearchType
+    ) async throws -> PackageCollectionsModel.TargetSearchResult {
+        try await safe_async {
+            self.searchTargets(identifiers: identifiers, query: query, type: type, callback: $0)
+        }
+    }
 }

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -500,7 +500,6 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             }
         }
     }
-    
     func searchTargets(identifiers: [Model.CollectionIdentifier]? = nil,
                        query: String,
                        type: Model.TargetSearchType,
@@ -841,6 +840,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
     internal func populateTargetTrie() async throws {
         try await safe_async { self.populateTargetTrie(callback: $0) }
     }
+
     internal func populateTargetTrie(callback: @escaping (Result<Void, Error>) -> Void = { _ in }) {
         // Check to see if there is any data before submitting task to queue because otherwise it's no-op anyway
         do {

--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -500,7 +500,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             }
         }
     }
-
+    
     func searchTargets(identifiers: [Model.CollectionIdentifier]? = nil,
                        query: String,
                        type: Model.TargetSearchType,
@@ -838,7 +838,9 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             self.useSearchIndices.get() ?? false
         }
     }
-
+    internal func populateTargetTrie() async throws {
+        try await safe_async { self.populateTargetTrie(callback: $0) }
+    }
     internal func populateTargetTrie(callback: @escaping (Result<Void, Error>) -> Void = { _ in }) {
         // Check to see if there is any data before submitting task to queue because otherwise it's no-op anyway
         do {

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -94,48 +94,14 @@ public func testWithTemporaryDirectory(
                 try? localFileSystem.removeFileTree(tmpDirPath)
             }
 
-            // Construct the expected path of the fixture.
-            // FIXME: This seems quite hacky; we should provide some control over where fixtures are found.
-            let fixtureDir = AbsolutePath("../../../Fixtures", relativeTo: #file)
-                .appending(fixtureSubpath)
-
-            // Check that the fixture is really there.
-            guard localFileSystem.isDirectory(fixtureDir) else {
-                XCTFail("No such fixture: \(fixtureDir)", file: file, line: line)
-                throw SwiftPMError.packagePathNotFound
-            }
-
-            // The fixture contains either a checkout or just a Git directory.
-            if localFileSystem.isFile(fixtureDir.appending("Package.swift")) {
-                // It's a single package, so copy the whole directory as-is.
-                let dstDir = tmpDirPath.appending(component: copyName)
-#if os(Windows)
-                try localFileSystem.copy(from: fixtureDir, to: dstDir)
-#else
-                try systemQuietly("cp", "-R", "-H", fixtureDir.pathString, dstDir.pathString)
-#endif
-
-                // Invoke the block, passing it the path of the copied fixture.
-                return try body(dstDir)
-            } else {
-                // Copy each of the package directories and construct a git repo in it.
-                for fileName in try localFileSystem.getDirectoryContents(fixtureDir).sorted() {
-                    let srcDir = fixtureDir.appending(component: fileName)
-                    guard localFileSystem.isDirectory(srcDir) else { continue }
-                    let dstDir = tmpDirPath.appending(component: fileName)
-#if os(Windows)
-                    try localFileSystem.copy(from: srcDir, to: dstDir)
-#else
-                    try systemQuietly("cp", "-R", "-H", srcDir.pathString, dstDir.pathString)
-#endif
-                    if createGitRepo {
-                        initGitRepo(dstDir, tag: "1.2.3", addFile: false)
-                    }
-                }
-
-                // Invoke the block, passing it the path of the copied fixture.
-                return try body(tmpDirPath)
-            }
+            let fixtureDir = try verifyFixtureExists(at: fixtureSubpath, file: file, line: line)
+            let preparedFixture = try setup(
+                fixtureDir: fixtureDir,
+                in: tmpDirPath,
+                copyName: copyName,
+                createGitRepo:createGitRepo
+            )
+            return try body(preparedFixture)
         }
     } catch SwiftPMError.executionFailure(let error, let output, let stderr) {
         print("**** FAILURE EXECUTING SUBPROCESS ****")
@@ -143,6 +109,88 @@ public func testWithTemporaryDirectory(
         print("stderr:", stderr)
         throw error
     }
+}
+@discardableResult public func fixture<T>(
+    name: String,
+    createGitRepo: Bool = true,
+    file: StaticString = #file,
+    line: UInt = #line,
+    body: (AbsolutePath) async throws -> T
+) async throws -> T {
+    do {
+        // Make a suitable test directory name from the fixture subpath.
+        let fixtureSubpath = try RelativePath(validating: name)
+        let copyName = fixtureSubpath.components.joined(separator: "_")
+
+        // Create a temporary directory for the duration of the block.
+        return try await withTemporaryDirectory(prefix: copyName) { tmpDirPath in
+
+            defer {
+                // Unblock and remove the tmp dir on deinit.
+                try? localFileSystem.chmod(.userWritable, path: tmpDirPath, options: [.recursive])
+                try? localFileSystem.removeFileTree(tmpDirPath)
+            }
+
+            let fixtureDir = try verifyFixtureExists(at: fixtureSubpath, file: file, line: line)
+            let preparedFixture = try setup(
+                fixtureDir: fixtureDir,
+                in: tmpDirPath,
+                copyName: copyName,
+                createGitRepo:createGitRepo
+            )
+            return try await body(preparedFixture)
+        }
+    } catch SwiftPMError.executionFailure(let error, let output, let stderr) {
+        print("**** FAILURE EXECUTING SUBPROCESS ****")
+        print("output:", output)
+        print("stderr:", stderr)
+        throw error
+    }
+}
+
+fileprivate func verifyFixtureExists(at fixtureSubpath: RelativePath, file: StaticString = #file, line: UInt = #line) throws -> AbsolutePath {
+    let fixtureDir = AbsolutePath("../../../Fixtures", relativeTo: #file)
+        .appending(fixtureSubpath)
+
+    // Check that the fixture is really there.
+    guard localFileSystem.isDirectory(fixtureDir) else {
+        XCTFail("No such fixture: \(fixtureDir)", file: file, line: line)
+        throw SwiftPMError.packagePathNotFound
+    }
+
+    return fixtureDir
+}
+
+fileprivate func setup(fixtureDir: AbsolutePath, in tmpDirPath: AbsolutePath, copyName: String, createGitRepo: Bool = true) throws -> AbsolutePath {
+
+    func copy(from srcDir: AbsolutePath, to dstDir: AbsolutePath) throws {
+#if os(Windows)
+        try localFileSystem.copy(from: srcDir, to: dstDir)
+#else
+        try systemQuietly("cp", "-R", "-H", srcDir.pathString, dstDir.pathString)
+#endif
+    }
+
+    // The fixture contains either a checkout or just a Git directory.
+    if localFileSystem.isFile(fixtureDir.appending("Package.swift")) {
+        // It's a single package, so copy the whole directory as-is.
+        let dstDir = tmpDirPath.appending(component: copyName)
+        try copy(from: fixtureDir, to: dstDir)
+        // Invoke the block, passing it the path of the copied fixture.
+        return dstDir
+    }
+    // Copy each of the package directories and construct a git repo in it.
+    for fileName in try localFileSystem.getDirectoryContents(fixtureDir).sorted() {
+        let srcDir = fixtureDir.appending(component: fileName)
+        guard localFileSystem.isDirectory(srcDir) else { continue }
+        let dstDir = tmpDirPath.appending(component: fileName)
+
+        try copy(from: srcDir, to: dstDir)
+        if createGitRepo {
+            initGitRepo(dstDir, tag: "1.2.3", addFile: false)
+        }
+    }
+    return tmpDirPath
 }
 
 /// Test-helper function that creates a new Git repository in a directory.  The new repository will contain

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -110,6 +110,7 @@ public func testWithTemporaryDirectory(
         throw error
     }
 }
+
 @discardableResult public func fixture<T>(
     name: String,
     createGitRepo: Bool = true,
@@ -162,7 +163,6 @@ fileprivate func verifyFixtureExists(at fixtureSubpath: RelativePath, file: Stat
 }
 
 fileprivate func setup(fixtureDir: AbsolutePath, in tmpDirPath: AbsolutePath, copyName: String, createGitRepo: Bool = true) throws -> AbsolutePath {
-
     func copy(from srcDir: AbsolutePath, to dstDir: AbsolutePath) throws {
 #if os(Windows)
         try localFileSystem.copy(from: srcDir, to: dstDir)

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -45,13 +45,13 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
         XCTAssertNil(GitHubPackageMetadataProvider.apiURL("bad/Hello-World.git"))
     }
 
-    func testGood() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testGood() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
             let apiURL = URL("https://api.github.com/repos/octocat/Hello-World")
             let releasesURL = URL("https://api.github.com/repos/octocat/Hello-World/releases?per_page=20")
 
-            try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
                 let handler: LegacyHTTPClient.Handler = { request, _, completion in
                     switch (request.method, request.url) {
                     case (.get, apiURL):
@@ -103,7 +103,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
                 let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
                 defer { XCTAssertNoThrow(try provider.close()) }
 
-                let metadata = try provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)
+                let metadata = try await provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)
 
                 XCTAssertEqual(metadata.summary, "This your first repo!")
                 XCTAssertEqual(metadata.versions.count, 2)
@@ -127,8 +127,8 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
         }
     }
 
-    func testRepoNotFound() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testRepoNotFound() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
 
             let handler: LegacyHTTPClient.Handler = { _, _, completion in
@@ -143,18 +143,18 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
             defer { XCTAssertNoThrow(try provider.close()) }
 
-            XCTAssertThrowsError(try provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString), "should throw error") { error in
+            await XCTAssertAsyncThrowsError(try await provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString), "should throw error") { error in
                 XCTAssert(error is NotFoundError, "\(error)")
             }
         }
     }
 
-    func testOthersNotFound() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testOthersNotFound() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
             let apiURL = URL("https://api.github.com/repos/octocat/Hello-World")
 
-            try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
                 let path = fixturePath.appending(components: "GitHub", "metadata.json")
                 let data = try Data(localFileSystem.readFileContents(path).contents)
                 let handler: LegacyHTTPClient.Handler = { request, _, completion in
@@ -176,7 +176,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
                 let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
                 defer { XCTAssertNoThrow(try provider.close()) }
 
-                let metadata = try provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)
+                let metadata = try await provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)
 
                 XCTAssertEqual(metadata.summary, "This your first repo!")
                 XCTAssertEqual(metadata.versions, [])
@@ -187,8 +187,8 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
         }
     }
 
-    func testPermissionDenied() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testPermissionDenied() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
             let apiURL = URL("https://api.github.com/repos/octocat/Hello-World")
 
@@ -204,14 +204,14 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
             defer { XCTAssertNoThrow(try provider.close()) }
 
-            XCTAssertThrowsError(try provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString), "should throw error") { error in
+            await XCTAssertAsyncThrowsError(try await provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString), "should throw error") { error in
                 XCTAssertEqual(error as? GitHubPackageMetadataProviderError, .permissionDenied(apiURL))
             }
         }
     }
 
-    func testInvalidAuthToken() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testInvalidAuthToken() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
             let apiURL = URL("https://api.github.com/repos/octocat/Hello-World")
             let authTokens = [AuthTokenType.github("github.com"): "foo"]
@@ -234,21 +234,21 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
             let provider = GitHubPackageMetadataProvider(configuration: configuration, httpClient: httpClient)
             defer { XCTAssertNoThrow(try provider.close()) }
 
-            XCTAssertThrowsError(try provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString), "should throw error") { error in
+            await XCTAssertAsyncThrowsError(try await provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString), "should throw error") { error in
                 XCTAssertEqual(error as? GitHubPackageMetadataProviderError, .invalidAuthToken(apiURL))
             }
         }
     }
 
-    func testAPILimit() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testAPILimit() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
             let apiURL = URL("https://api.github.com/repos/octocat/Hello-World")
 
             let total = 5
             var remaining = total
 
-            try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+            try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
                 let path = fixturePath.appending(components: "GitHub", "metadata.json")
                 let data = try Data(localFileSystem.readFileContents(path).contents)
                 let handler: LegacyHTTPClient.Handler = { request, _, completion in
@@ -280,20 +280,20 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
                 for index in 0 ... total * 2 {
                     if index >= total {
-                        XCTAssertThrowsError(try provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString), "should throw error") { error in
+                        await XCTAssertAsyncThrowsError(try await provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString), "should throw error") { error in
                             XCTAssertEqual(error as? GitHubPackageMetadataProviderError, .apiLimitsExceeded(apiURL, total))
                         }
                     } else {
-                        XCTAssertNoThrow(try provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString))
+                        _ = try await provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)
                     }
                 }
             }
         }
     }
 
-    func testInvalidURL() throws {
-        try testWithTemporaryDirectory { tmpPath in
-            try fixture(name: "Collections", createGitRepo: false) { _ in
+    func testInvalidURL() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            try await fixture(name: "Collections", createGitRepo: false) { _ in
                 var configuration = GitHubPackageMetadataProvider.Configuration()
                 configuration.cacheDir = tmpPath
                 let provider = GitHubPackageMetadataProvider(configuration: configuration)
@@ -301,16 +301,16 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
                 let url = UUID().uuidString
                 let identity = PackageIdentity(urlString: url)
-                XCTAssertThrowsError(try provider.syncGet(identity: identity, location: url), "should throw error") { error in
+                await XCTAssertAsyncThrowsError(try await provider.syncGet(identity: identity, location: url), "should throw error") { error in
                     XCTAssertEqual(error as? GitHubPackageMetadataProviderError, .invalidSourceControlURL(url))
                 }
             }
         }
     }
 
-    func testInvalidURL2() throws {
-        try testWithTemporaryDirectory { tmpPath in
-            try fixture(name: "Collections", createGitRepo: false) { _ in
+    func testInvalidURL2() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            try await fixture(name: "Collections", createGitRepo: false) { _ in
                 var configuration = GitHubPackageMetadataProvider.Configuration()
                 configuration.cacheDir = tmpPath
                 let provider = GitHubPackageMetadataProvider(configuration: configuration)
@@ -318,14 +318,14 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
 
                 let path = AbsolutePath.root
                 let identity = PackageIdentity(path: path)
-                XCTAssertThrowsError(try provider.syncGet(identity: identity, location: path.pathString), "should throw error") { error in
+                await XCTAssertAsyncThrowsError(try await provider.syncGet(identity: identity, location: path.pathString), "should throw error") { error in
                     XCTAssertEqual(error as? GitHubPackageMetadataProviderError, .invalidSourceControlURL(path.pathString))
                 }
             }
         }
     }
 
-    func testForRealz() throws {
+    func testForRealz() async throws {
         #if ENABLE_GITHUB_NETWORK_TEST
         #else
         try XCTSkipIf(true)
@@ -347,7 +347,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
         defer { XCTAssertNoThrow(try provider.close()) }
 
         for _ in 0 ... 60 {
-            let metadata = try provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)
+            let metadata = try await provider.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)
             XCTAssertNotNil(metadata)
             XCTAssert(metadata.versions.count > 0)
             XCTAssert(metadata.keywords!.count > 0)
@@ -368,8 +368,8 @@ internal extension GitHubPackageMetadataProvider {
 }
 
 private extension GitHubPackageMetadataProvider {
-    func syncGet(identity: PackageIdentity, location: String) throws -> Model.PackageBasicMetadata {
-        try temp_await { callback in
+    func syncGet(identity: PackageIdentity, location: String) async throws -> Model.PackageBasicMetadata {
+        try await safe_async { callback in
             self.get(identity: identity, location: location) { result, _ in callback(result) }
         }
     }

--- a/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
+++ b/Tests/PackageCollectionsTests/JSONPackageCollectionProviderTests.swift
@@ -21,8 +21,8 @@ import SourceControl
 import SPMTestSupport
 
 class JSONPackageCollectionProviderTests: XCTestCase {
-    func testGood() throws {
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+    func testGood() async throws {
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good.json")
             let url = URL("https://www.test.com/collection.json")
             let data: Data = try localFileSystem.readFileContents(path)
@@ -47,7 +47,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             httpClient.configuration.retryStrategy = .none
             let provider = JSONPackageCollectionProvider(httpClient: httpClient)
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
-            let collection = try temp_await { callback in provider.get(source, callback: callback) }
+            let collection = try await provider.get(source)
 
             XCTAssertEqual(collection.name, "Sample Package Collection")
             XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
@@ -87,8 +87,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         }
     }
 
-    func testLocalFile() throws {
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+    func testLocalFile() async throws {
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good.json")
 
             let httpClient = LegacyHTTPClient(handler: { (_, _, _) -> Void in fatalError("should not be called") })
@@ -96,7 +96,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             httpClient.configuration.retryStrategy = .none
             let provider = JSONPackageCollectionProvider(httpClient: httpClient)
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: path.asURL)
-            let collection = try temp_await { callback in provider.get(source, callback: callback) }
+            let collection = try await provider.get(source)
 
             XCTAssertEqual(collection.name, "Sample Package Collection")
             XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
@@ -135,14 +135,14 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         }
     }
 
-    func testInvalidURL() throws {
+    func testInvalidURL() async throws {
         let url = URL("ftp://www.test.com/collection.json")
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
         let httpClient = LegacyHTTPClient(handler: { (_, _, _) -> Void in fatalError("should not be called") })
         httpClient.configuration.circuitBreakerStrategy = .none
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             guard case .invalidSource(let errorMessage) = error as? JSONPackageCollectionProviderError else {
                 return XCTFail("invalid error \(error)")
             }
@@ -150,7 +150,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         })
     }
 
-    func testExceedsDownloadSizeLimitHead() throws {
+    func testExceedsDownloadSizeLimitHead() async throws {
         let maxSize: Int64 = 50
         let url = URL("https://www.test.com/collection.json")
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
@@ -167,12 +167,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
         let configuration = JSONPackageCollectionProvider.Configuration(maximumSizeInBytes: 10)
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             XCTAssertEqual(error as? JSONPackageCollectionProviderError, .responseTooLarge(url, maxSize * 2))
         })
     }
 
-    func testExceedsDownloadSizeLimitGet() throws {
+    func testExceedsDownloadSizeLimitGet() async throws {
         let maxSize: Int64 = 50
         let url = URL("https://www.test.com/collection.json")
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
@@ -196,12 +196,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
         let configuration = JSONPackageCollectionProvider.Configuration(maximumSizeInBytes: 10)
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             XCTAssertEqual(error as? JSONPackageCollectionProviderError, .responseTooLarge(url, maxSize * 2))
         })
     }
 
-    func testNoContentLengthOnGet() throws {
+    func testNoContentLengthOnGet() async throws {
         let url = URL("https://www.test.com/collection.json")
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
 
@@ -216,12 +216,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
         let configuration = JSONPackageCollectionProvider.Configuration(maximumSizeInBytes: 10)
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             XCTAssertEqual(error as? JSONPackageCollectionProviderError, .invalidResponse(url, "Missing Content-Length header"))
         })
     }
 
-    func testExceedsDownloadSizeLimitProgress() throws {
+    func testExceedsDownloadSizeLimitProgress() async throws {
         let maxSize: Int64 = 50
         let url = URL("https://www.test.com/collection.json")
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
@@ -248,12 +248,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
         let configuration = JSONPackageCollectionProvider.Configuration(maximumSizeInBytes: 10)
         let provider = JSONPackageCollectionProvider(configuration: configuration, httpClient: httpClient)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             XCTAssertEqual(error as? HTTPClientError, .responseTooLarge(maxSize * 2))
         })
     }
 
-    func testUnsuccessfulHead_unavailable() throws {
+    func testUnsuccessfulHead_unavailable() async throws {
         let url = URL("https://www.test.com/collection.json")
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
         let statusCode = Int.random(in: 500 ... 550) // Don't use 404 because it leads to a different error message
@@ -268,12 +268,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.circuitBreakerStrategy = .none
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             XCTAssertEqual(error as? JSONPackageCollectionProviderError, .collectionUnavailable(url, statusCode))
         })
     }
 
-    func testUnsuccessfulGet_unavailable() throws {
+    func testUnsuccessfulGet_unavailable() async throws {
         let url = URL("https://www.test.com/collection.json")
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
         let statusCode = Int.random(in: 500 ... 550) // Don't use 404 because it leads to a different error message
@@ -294,12 +294,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.circuitBreakerStrategy = .none
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             XCTAssertEqual(error as? JSONPackageCollectionProviderError, .collectionUnavailable(url, statusCode))
         })
     }
 
-    func testUnsuccessfulHead_notFound() throws {
+    func testUnsuccessfulHead_notFound() async throws {
         let url = URL("https://www.test.com/collection.json")
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
 
@@ -313,12 +313,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.circuitBreakerStrategy = .none
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             XCTAssertEqual(error as? JSONPackageCollectionProviderError, .collectionNotFound(url))
         })
     }
 
-    func testUnsuccessfulGet_notFound() throws {
+    func testUnsuccessfulGet_notFound() async throws {
         let url = URL("https://www.test.com/collection.json")
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
 
@@ -338,12 +338,12 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.circuitBreakerStrategy = .none
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             XCTAssertEqual(error as? JSONPackageCollectionProviderError, .collectionNotFound(url))
         })
     }
 
-    func testBadJSON() throws {
+    func testBadJSON() async throws {
         let url = URL("https://www.test.com/collection.json")
         let data = Data("blah".utf8)
 
@@ -366,15 +366,15 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
         let provider = JSONPackageCollectionProvider(httpClient: httpClient)
         let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
-        XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
             XCTAssertEqual(error as? JSONPackageCollectionProviderError, .invalidJSON(url))
         })
     }
 
-    func testSignedGood() throws {
+    func testSignedGood() async throws {
         try skipIfSignatureCheckNotSupported()
 
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL("https://www.test.com/collection.json")
             let data: Data = try localFileSystem.readFileContents(path)
@@ -402,7 +402,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             let signatureValidator = MockCollectionSignatureValidator(["Sample Package Collection"])
             let provider = JSONPackageCollectionProvider(httpClient: httpClient, signatureValidator: signatureValidator)
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
-            let collection = try temp_await { callback in provider.get(source, callback: callback) }
+            let collection = try await provider.get(source)
 
             XCTAssertEqual(collection.name, "Sample Package Collection")
             XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
@@ -446,8 +446,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         }
     }
 
-    func testSigned_skipSignatureCheck() throws {
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+    func testSigned_skipSignatureCheck() async throws {
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL("https://www.test.com/collection.json")
             let data: Data = try localFileSystem.readFileContents(path)
@@ -475,7 +475,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             let provider = JSONPackageCollectionProvider(httpClient: httpClient, signatureValidator: signatureValidator)
             // Skip signature check
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: url, skipSignatureCheck: true)
-            let collection = try temp_await { callback in provider.get(source, callback: callback) }
+            let collection = try await provider.get(source)
 
             XCTAssertEqual(collection.name, "Sample Package Collection")
             XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
@@ -515,10 +515,10 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         }
     }
 
-    func testSigned_noTrustedRootCertsConfigured() throws {
+    func testSigned_noTrustedRootCertsConfigured() async throws {
         try skipIfSignatureCheckNotSupported()
 
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL("https://www.test.com/collection.json")
             let data: Data = try localFileSystem.readFileContents(path)
@@ -546,7 +546,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             let provider = JSONPackageCollectionProvider(httpClient: httpClient, signatureValidator: signatureValidator)
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
 
-            XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+            await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
                 switch error {
                 case PackageCollectionError.cannotVerifySignature:
                     break
@@ -557,10 +557,10 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         }
     }
 
-    func testSignedBad() throws {
+    func testSignedBad() async throws {
         try skipIfSignatureCheckNotSupported()
 
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL("https://www.test.com/collection.json")
             let data: Data = try localFileSystem.readFileContents(path)
@@ -589,7 +589,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             let provider = JSONPackageCollectionProvider(httpClient: httpClient, signatureValidator: signatureValidator)
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
 
-            XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+            await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
                 switch error {
                 case PackageCollectionError.invalidSignature:
                     break
@@ -600,10 +600,10 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         }
     }
 
-    func testSignedLocalFile() throws {
+    func testSignedLocalFile() async throws {
         try skipIfSignatureCheckNotSupported()
 
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good_signed.json")
 
             let httpClient = LegacyHTTPClient(handler: { (_, _, _) -> Void in fatalError("should not be called") })
@@ -615,7 +615,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
 
             let provider = JSONPackageCollectionProvider(httpClient: httpClient, signatureValidator: signatureValidator)
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: path.asURL)
-            let collection = try temp_await { callback in provider.get(source, callback: callback) }
+            let collection = try await provider.get(source)
 
             XCTAssertEqual(collection.name, "Sample Package Collection")
             XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
@@ -654,8 +654,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         }
     }
 
-    func testRequiredSigningGood() throws {
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+    func testRequiredSigningGood() async throws {
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL("https://www.test.com/collection.json")
             let data: Data = try localFileSystem.readFileContents(path)
@@ -688,7 +688,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             let provider = JSONPackageCollectionProvider(httpClient: httpClient, signatureValidator: signatureValidator,
                                                          sourceCertPolicy: sourceCertPolicy)
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
-            let collection = try temp_await { callback in provider.get(source, callback: callback) }
+            let collection = try await provider.get(source)
 
             XCTAssertEqual(collection.name, "Sample Package Collection")
             XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
@@ -728,8 +728,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         }
     }
 
-    func testRequiredSigningMultiplePoliciesGood() throws {
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+    func testRequiredSigningMultiplePoliciesGood() async throws {
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good_signed.json")
             let url = URL("https://www.test.com/collection.json")
             let data: Data = try localFileSystem.readFileContents(path)
@@ -767,7 +767,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
             let provider = JSONPackageCollectionProvider(httpClient: httpClient, signatureValidator: signatureValidator,
                                                          sourceCertPolicy: sourceCertPolicy)
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
-            let collection = try temp_await { callback in provider.get(source, callback: callback) }
+            let collection = try await provider.get(source)
 
             XCTAssertEqual(collection.name, "Sample Package Collection")
             XCTAssertEqual(collection.overview, "This is a sample package collection listing made-up packages.")
@@ -807,8 +807,8 @@ class JSONPackageCollectionProviderTests: XCTestCase {
         }
     }
 
-    func testMissingRequiredSignature() throws {
-        try fixture(name: "Collections", createGitRepo: false) { fixturePath in
+    func testMissingRequiredSignature() async throws {
+        try await fixture(name: "Collections", createGitRepo: false) { fixturePath in
             let path = fixturePath.appending(components: "JSON", "good.json")
             let url = URL("https://www.test.com/collection.json")
             let data: Data = try localFileSystem.readFileContents(path)
@@ -842,7 +842,7 @@ class JSONPackageCollectionProviderTests: XCTestCase {
                                                          sourceCertPolicy: sourceCertPolicy)
             let source = PackageCollectionsModel.CollectionSource(type: .json, url: url)
 
-            XCTAssertThrowsError(try temp_await { callback in provider.get(source, callback: callback) }, "expected error", { error in
+            await XCTAssertAsyncThrowsError(try await provider.get(source), "expected error", { error in
                 switch error {
                 case PackageCollectionError.missingSignature:
                     break

--- a/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsSourcesStorageTest.swift
@@ -18,24 +18,24 @@ import XCTest
 import class TSCBasic.InMemoryFileSystem
 
 final class PackageCollectionsSourcesStorageTest: XCTestCase {
-    func testHappyCase() throws {
+    func testHappyCase() async throws {
         let mockFileSystem = InMemoryFileSystem()
         let storage = FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem)
 
-        try assertHappyCase(storage: storage)
+        try await assertHappyCase(storage: storage)
 
         let buffer = try mockFileSystem.readFileContents(storage.path)
         XCTAssertNotEqual(buffer.count, 0, "expected file to be written")
         print(buffer)
     }
 
-    func testRealFile() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testRealFile() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let fileSystem = localFileSystem
             let path = tmpPath.appending("test.json")
             let storage = FilePackageCollectionsSourcesStorage(fileSystem: fileSystem, path: path)
 
-            try assertHappyCase(storage: storage)
+            try await assertHappyCase(storage: storage)
 
             let buffer = try fileSystem.readFileContents(storage.path)
             XCTAssertNotEqual(buffer.count, 0, "expected file to be written")
@@ -43,78 +43,78 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
         }
     }
 
-    func assertHappyCase(storage: PackageCollectionsSourcesStorage) throws {
+    func assertHappyCase(storage: PackageCollectionsSourcesStorage) async throws {
         let sources = makeMockSources()
 
-        try sources.forEach { source in
-            _ = try temp_await { callback in storage.add(source: source, order: nil, callback: callback) }
+        for source in sources {
+            _ = try await storage.add(source: source, order: nil)
         }
 
         do {
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            let list = try await storage.list()
             XCTAssertEqual(list.count, sources.count, "sources should match")
         }
 
         let remove = sources.enumerated().filter { index, _ in index % 2 == 0 }.map { $1 }
-        try remove.forEach { source in
-            _ = try temp_await { callback in storage.remove(source: source, callback: callback) }
+        for source in remove {
+            _ = try await storage.remove(source: source)
         }
 
         do {
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            let list = try await storage.list()
             XCTAssertEqual(list.count, sources.count - remove.count, "sources should match")
         }
 
         let remaining = sources.filter { !remove.contains($0) }
-        try sources.forEach { source in
-            XCTAssertEqual(try temp_await { callback in storage.exists(source: source, callback: callback) }, remaining.contains(source))
+        for source in sources {
+            try await XCTAssertAsyncTrue(try await storage.exists(source: source) == remaining.contains(source))
         }
 
         do {
-            _ = try temp_await { callback in storage.move(source: remaining.last!, to: 0, callback: callback) }
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            _ = try await storage.move(source: remaining.last!, to: 0)
+            let list = try await storage.list()
             XCTAssertEqual(list.count, remaining.count, "sources should match")
             XCTAssertEqual(list.first, remaining.last, "item should match")
         }
 
         do {
-            _ = try temp_await { callback in storage.move(source: remaining.last!, to: remaining.count - 1, callback: callback) }
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            _ = try await storage.move(source: remaining.last!, to: remaining.count - 1)
+            let list = try await storage.list()
             XCTAssertEqual(list.count, remaining.count, "sources should match")
             XCTAssertEqual(list.last, remaining.last, "item should match")
         }
 
         do {
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            let list = try await storage.list()
             var source = list.first!
             source.isTrusted = !(source.isTrusted ?? false)
-            _ = try temp_await { callback in storage.update(source: source, callback: callback) }
-            let listAfter = try temp_await { callback in storage.list(callback: callback) }
+            _ = try await storage.update(source: source)
+            let listAfter = try await storage.list()
             XCTAssertEqual(source.isTrusted, listAfter.first!.isTrusted, "isTrusted should match")
         }
 
         do {
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            let list = try await storage.list()
             var source = list.first!
             source.skipSignatureCheck = !source.skipSignatureCheck
-            _ = try temp_await { callback in storage.update(source: source, callback: callback) }
-            let listAfter = try temp_await { callback in storage.list(callback: callback) }
+            _ = try await storage.update(source: source)
+            let listAfter = try await storage.list()
             XCTAssertEqual(source.skipSignatureCheck, listAfter.first!.skipSignatureCheck, "skipSignatureCheck should match")
         }
     }
 
-    func testFileDeleted() throws {
+    func testFileDeleted() async throws {
         let mockFileSystem = InMemoryFileSystem()
         let storage = FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem)
 
         let sources = makeMockSources()
 
-        try sources.forEach { source in
-            _ = try temp_await { callback in storage.add(source: source, order: nil, callback: callback) }
+        for source in sources {
+            _ = try await storage.add(source: source, order: nil)
         }
 
         do {
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            let list = try await storage.list()
             XCTAssertEqual(list.count, sources.count, "collections should match")
         }
 
@@ -122,23 +122,23 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
         XCTAssertFalse(mockFileSystem.exists(storage.path), "expected file to be deleted")
 
         do {
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            let list = try await storage.list()
             XCTAssertEqual(list.count, 0, "collections should match")
         }
     }
 
-    func testFileEmpty() throws {
+    func testFileEmpty() async throws {
         let mockFileSystem = InMemoryFileSystem()
         let storage = FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem)
 
         let sources = makeMockSources()
 
-        try sources.forEach { source in
-            _ = try temp_await { callback in storage.add(source: source, order: nil, callback: callback) }
+        for source in sources {
+            _ = try await storage.add(source: source, order: nil)
         }
 
         do {
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            let list = try await storage.list()
             XCTAssertEqual(list.count, sources.count, "collections should match")
         }
 
@@ -147,22 +147,22 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
         XCTAssertEqual(buffer.count, 0, "expected file to be empty")
 
         do {
-            let list = try temp_await { callback in storage.list(callback: callback) }
+            let list = try await storage.list()
             XCTAssertEqual(list.count, 0, "collections should match")
         }
     }
 
-    func testFileCorrupt() throws {
+    func testFileCorrupt() async throws {
         let mockFileSystem = InMemoryFileSystem()
         let storage = FilePackageCollectionsSourcesStorage(fileSystem: mockFileSystem)
 
         let sources = makeMockSources()
 
-        try sources.forEach { source in
-            _ = try temp_await { callback in storage.add(source: source, order: nil, callback: callback) }
+        for source in sources {
+            _ = try await storage.add(source: source, order: nil)
         }
 
-        let list = try temp_await { callback in storage.list(callback: callback) }
+        let list = try await storage.list()
         XCTAssertEqual(list.count, sources.count, "collections should match")
 
         try mockFileSystem.writeFileContents(storage.path, string: "{")
@@ -171,7 +171,7 @@ final class PackageCollectionsSourcesStorageTest: XCTestCase {
         XCTAssertNotEqual(buffer.count, 0, "expected file to be written")
         print(buffer)
 
-        XCTAssertThrowsError(try temp_await { callback in storage.list(callback: callback) }, "expected an error", { error in
+        await XCTAssertAsyncThrowsError(try await storage.list(), "expected an error", { error in
             XCTAssert(error is DecodingError, "expected error to match")
         })
     }

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -17,47 +17,47 @@ import tsan_utils
 import XCTest
 
 class PackageCollectionsStorageTests: XCTestCase {
-    func testHappyCase() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testHappyCase() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 
             let mockSources = makeMockSources()
-            try mockSources.forEach { source in
-                XCTAssertThrowsError(try temp_await { callback in storage.get(identifier: .init(from: source), callback: callback) }, "expected error", { error in
+            for source in mockSources {
+                await XCTAssertAsyncThrowsError(try await storage.get(identifier: .init(from: source)), "expected error", { error in
                     XCTAssert(error is NotFoundError, "Expected NotFoundError")
                 })
             }
 
             let mockCollections = makeMockCollections(count: 50)
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in storage.put(collection: collection, callback: callback) }
+            for collection in mockCollections {
+                _ = try await storage.put(collection: collection)
             }
 
-            try mockCollections.forEach { collection in
-                let retVal = try temp_await { callback in storage.get(identifier: collection.identifier, callback: callback) }
+            for collection in mockCollections {
+                let retVal = try await storage.get(identifier: collection.identifier)
                 XCTAssertEqual(retVal.identifier, collection.identifier)
             }
 
             do {
-                let list = try temp_await { callback in storage.list(callback: callback) }
+                let list = try await storage.list()
                 XCTAssertEqual(list.count, mockCollections.count)
             }
 
             do {
                 let count = Int.random(in: 1 ..< mockCollections.count)
-                let list = try temp_await { callback in storage.list(identifiers: mockCollections.prefix(count).map { $0.identifier }, callback: callback) }
+                let list = try await storage.list(identifiers: mockCollections.prefix(count).map { $0.identifier })
                 XCTAssertEqual(list.count, count)
             }
 
             do {
-                _ = try temp_await { callback in storage.remove(identifier: mockCollections.first!.identifier, callback: callback) }
-                let list = try temp_await { callback in storage.list(callback: callback) }
+                _ = try await storage.remove(identifier: mockCollections.first!.identifier)
+                let list = try await storage.list()
                 XCTAssertEqual(list.count, mockCollections.count - 1)
             }
 
-            XCTAssertThrowsError(try temp_await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }, "expected error", { error in
+            await XCTAssertAsyncThrowsError(try await storage.get(identifier: mockCollections.first!.identifier), "expected error", { error in
                 XCTAssert(error is NotFoundError, "Expected NotFoundError")
             })
 
@@ -69,24 +69,24 @@ class PackageCollectionsStorageTests: XCTestCase {
         }
     }
 
-    func testFileDeleted() throws {
+    func testFileDeleted() async throws {
 #if os(Windows)
         try XCTSkipIf(true, "open files cannot be deleted on Windows")
 #endif
         try XCTSkipIf(is_tsan_enabled())
 
-        try testWithTemporaryDirectory { tmpPath in
+        try await testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 
             let mockCollections = makeMockCollections(count: 3)
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in storage.put(collection: collection, callback: callback) }
+            for collection in mockCollections {
+                _ = try await storage.put(collection: collection)
             }
 
-            try mockCollections.forEach { collection in
-                let retVal = try temp_await { callback in storage.get(identifier: collection.identifier, callback: callback) }
+            for collection in mockCollections {
+                let retVal = try await storage.get(identifier: collection.identifier)
                 XCTAssertEqual(retVal.identifier, collection.identifier)
             }
 
@@ -99,36 +99,36 @@ class PackageCollectionsStorageTests: XCTestCase {
             try storage.fileSystem.removeFileTree(storagePath)
             storage.resetCache()
 
-            XCTAssertThrowsError(try temp_await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }, "expected error", { error in
+            await XCTAssertAsyncThrowsError(try await storage.get(identifier: mockCollections.first!.identifier), "expected error", { error in
                 XCTAssert(error is NotFoundError, "Expected NotFoundError")
             })
 
-            XCTAssertNoThrow(try temp_await { callback in storage.put(collection: mockCollections.first!, callback: callback) })
-            let retVal = try temp_await { callback in storage.get(identifier: mockCollections.first!.identifier, callback: callback) }
+            _ = try await storage.put(collection: mockCollections.first!)
+            let retVal = try await storage.get(identifier: mockCollections.first!.identifier)
             XCTAssertEqual(retVal.identifier, mockCollections.first!.identifier)
 
             XCTAssertTrue(storage.fileSystem.exists(storagePath), "expected file to exist at \(storagePath)")
         }
     }
 
-    func testFileCorrupt() throws {
+    func testFileCorrupt() async throws {
 #if os(Windows)
         try XCTSkipIf(true, "open files cannot be deleted on Windows")
 #endif
         try XCTSkipIf(is_tsan_enabled())
 
-        try testWithTemporaryDirectory { tmpPath in
+        try await testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 
             let mockCollections = makeMockCollections(count: 3)
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in storage.put(collection: collection, callback: callback) }
+            for collection in mockCollections {
+                _ = try await storage.put(collection: collection)
             }
 
-            try mockCollections.forEach { collection in
-                let retVal = try temp_await { callback in storage.get(identifier: collection.identifier, callback: callback) }
+            for collection in mockCollections {
+                let retVal = try await storage.get(identifier: collection.identifier)
                 XCTAssertEqual(retVal.identifier, collection.identifier)
             }
 
@@ -143,17 +143,17 @@ class PackageCollectionsStorageTests: XCTestCase {
 
             let storage2 = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage2.close()) }
-            XCTAssertThrowsError(try temp_await { callback in storage2.get(identifier: mockCollections.first!.identifier, callback: callback) }, "expected error", { error in
+            await XCTAssertAsyncThrowsError(try await storage2.get(identifier: mockCollections.first!.identifier), "expected error", { error in
                 XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
             })
 
-            XCTAssertThrowsError(try temp_await { callback in storage2.put(collection: mockCollections.first!, callback: callback) }, "expected error", { error in
+            await XCTAssertAsyncThrowsError(try await storage2.put(collection: mockCollections.first!), "expected error", { error in
                 XCTAssert("\(error)".contains("is not a database"), "Expected file is not a database error")
             })
         }
     }
 
-    func testListLessThanBatch() throws {
+    func testListLessThanBatch() async throws {
         var configuration = SQLitePackageCollectionsStorage.Configuration()
         configuration.batchSize = 10
         let storage = SQLitePackageCollectionsStorage(location: .memory, configuration: configuration)
@@ -161,15 +161,15 @@ class PackageCollectionsStorageTests: XCTestCase {
 
         let count = configuration.batchSize / 2
         let mockCollections = makeMockCollections(count: count)
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in storage.put(collection: collection, callback: callback) }
+        for collection in mockCollections {
+            _ = try await storage.put(collection: collection)
         }
 
-        let list = try temp_await { callback in storage.list(callback: callback) }
+        let list = try await storage.list()
         XCTAssertEqual(list.count, mockCollections.count)
     }
 
-    func testListNonBatching() throws {
+    func testListNonBatching() async throws {
         var configuration = SQLitePackageCollectionsStorage.Configuration()
         configuration.batchSize = 10
         let storage = SQLitePackageCollectionsStorage(location: .memory, configuration: configuration)
@@ -177,15 +177,15 @@ class PackageCollectionsStorageTests: XCTestCase {
 
         let count = Int(Double(configuration.batchSize) * 2.5)
         let mockCollections = makeMockCollections(count: count)
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in storage.put(collection: collection, callback: callback) }
+        for collection in mockCollections {
+            _ = try await storage.put(collection: collection)
         }
 
-        let list = try temp_await { callback in storage.list(callback: callback) }
+        let list = try await storage.list()
         XCTAssertEqual(list.count, mockCollections.count)
     }
 
-    func testListBatching() throws {
+    func testListBatching() async throws {
         var configuration = SQLitePackageCollectionsStorage.Configuration()
         configuration.batchSize = 10
         let storage = SQLitePackageCollectionsStorage(location: .memory, configuration: configuration)
@@ -193,46 +193,46 @@ class PackageCollectionsStorageTests: XCTestCase {
 
         let count = Int(Double(configuration.batchSize) * 2.5)
         let mockCollections = makeMockCollections(count: count)
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in storage.put(collection: collection, callback: callback) }
+        for collection in mockCollections {
+            _ = try await storage.put(collection: collection)
         }
 
-        let list = try temp_await { callback in storage.list(identifiers: mockCollections.map { $0.identifier }, callback: callback) }
+        let list = try await storage.list(identifiers: mockCollections.map { $0.identifier })
         XCTAssertEqual(list.count, mockCollections.count)
     }
 
-    func testPutUpdates() throws {
+    func testPutUpdates() async throws {
         let storage = SQLitePackageCollectionsStorage(location: .memory)
         defer { XCTAssertNoThrow(try storage.close()) }
 
         let mockCollections = makeMockCollections(count: 3)
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in storage.put(collection: collection, callback: callback) }
+        for collection in mockCollections {
+            _ = try await storage.put(collection: collection)
         }
 
-        let list = try temp_await { callback in storage.list(identifiers: mockCollections.map { $0.identifier }, callback: callback) }
+        let list = try await storage.list(identifiers: mockCollections.map { $0.identifier })
         XCTAssertEqual(list.count, mockCollections.count)
 
-        _ = try temp_await { callback in storage.put(collection: mockCollections.last!, callback: callback) }
+        _ = try await storage.put(collection: mockCollections.last!)
         XCTAssertEqual(list.count, mockCollections.count)
     }
 
-    func testPopulateTargetTrie() throws {
-        try testWithTemporaryDirectory { tmpPath in
+    func testPopulateTargetTrie() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
             let path = tmpPath.appending("test.db")
             let storage = SQLitePackageCollectionsStorage(path: path)
             defer { XCTAssertNoThrow(try storage.close()) }
 
             let mockCollections = makeMockCollections(count: 3)
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in storage.put(collection: collection, callback: callback) }
+            for collection in mockCollections {
+                _ = try await storage.put(collection: collection)
             }
 
             let version = mockCollections.last!.packages.last!.versions.last!
             let targetName = version.defaultManifest!.targets.last!.name
 
             do {
-                let searchResult = try temp_await { callback in storage.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
+                let searchResult = try await storage.searchTargets(query: targetName, type: .exactMatch)
                 XCTAssert(searchResult.items.count > 0, "should get results")
             }
 
@@ -243,9 +243,9 @@ class PackageCollectionsStorageTests: XCTestCase {
 
             // populateTargetTrie is called in `.init`; call it again explicitly so we know when it's finished
             do {
-                try temp_await { callback in storage2.populateTargetTrie(callback: callback) }
+                try await storage2.populateTargetTrie()
 
-                let searchResult = try temp_await { callback in storage2.searchTargets(query: targetName, type: .exactMatch, callback: callback) }
+                let searchResult = try await storage2.searchTargets(query: targetName, type: .exactMatch)
                 XCTAssert(searchResult.items.count > 0, "should get results")
             } catch {
                 // It's possible that some platforms don't have support FTS

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import XCTest
+import SPMTestSupport
 
 import Basics
 @testable import PackageCollections
@@ -21,7 +22,7 @@ import SourceControl
 import struct TSCUtility.Version
 
 final class PackageCollectionsTests: XCTestCase {
-    func testUpdateAuthTokens() throws {
+    func testUpdateAuthTokens() async throws {
         let authTokens = ThreadSafeKeyValueStore<AuthTokenType, String>()
         let configuration = PackageCollections.Configuration(authTokens: { authTokens.get() })
 
@@ -56,7 +57,7 @@ final class PackageCollectionsTests: XCTestCase {
         }
     }
 
-    func testBasicRegistration() throws {
+    func testBasicRegistration() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -69,21 +70,21 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in packageCollections.addCollection(collection.source, order: nil, callback: callback) }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, order: nil)
         }
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list, mockCollections, "list count should match")
         }
     }
 
-    func testAddDuplicates() throws {
+    func testAddDuplicates() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -97,21 +98,21 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
-        _ = try temp_await { callback in packageCollections.addCollection(mockCollection.source, order: nil, callback: callback) }
-        _ = try temp_await { callback in packageCollections.addCollection(mockCollection.source, order: nil, callback: callback) }
-        _ = try temp_await { callback in packageCollections.addCollection(mockCollection.source, order: nil, callback: callback) }
+        _ = try await packageCollections.addCollection(mockCollection.source, order: nil)
+        _ = try await packageCollections.addCollection(mockCollection.source, order: nil)
+        _ = try await packageCollections.addCollection(mockCollection.source, order: nil)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 1, "list count should match")
         }
     }
 
-    func testAddUnsigned() throws {
+    func testAddUnsigned() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -125,36 +126,35 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         // User trusted
-        _ = try temp_await { callback in packageCollections.addCollection(mockCollections[0].source, order: nil, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        _ = try await packageCollections.addCollection(mockCollections[0].source, order: nil, trustConfirmationProvider: { _, cb in cb(true) })
         // User untrusted
-        XCTAssertThrowsError(
-            try temp_await { callback in
-                packageCollections.addCollection(mockCollections[1].source, order: nil, trustConfirmationProvider: { _, cb in cb(false) }, callback: callback)
-            }) { error in
+        await XCTAssertAsyncThrowsError(
+            try await packageCollections.addCollection(mockCollections[1].source, order: nil, trustConfirmationProvider: { _, cb in cb(false) })
+            ) { error in
             guard case PackageCollectionError.untrusted = error else {
                 return XCTFail("Expected PackageCollectionError.untrusted")
             }
         }
         // User preference unknown
-        XCTAssertThrowsError(
-            try temp_await { callback in packageCollections.addCollection(mockCollections[2].source, order: nil, trustConfirmationProvider: nil, callback: callback) }) { error in
+        await XCTAssertAsyncThrowsError(
+            try await packageCollections.addCollection(mockCollections[2].source, order: nil, trustConfirmationProvider: nil)) { error in
             guard case PackageCollectionError.trustConfirmationRequired = error else {
                 return XCTFail("Expected PackageCollectionError.trustConfirmationRequired")
             }
         }
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 1, "list count should match")
         }
     }
 
-    func testInvalidCollectionNotAdded() throws {
+    func testInvalidCollectionNotAdded() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -170,29 +170,28 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
 
-            let sources = try temp_await { callback in storage.sources.list(callback: callback) }
+            let sources = try await storage.sources.list()
             XCTAssertEqual(sources.count, 0, "sources should be empty")
         }
 
         // add fails because collection is not found
-        guard case .failure(let error) = temp_await({ callback in packageCollections.addCollection(mockCollection.source, order: nil, callback: callback) }),
-            error is NotFoundError else {
-            return XCTFail("expected error")
+        await XCTAssertAsyncThrowsError(try await packageCollections.addCollection(mockCollection.source, order: nil)) { error in
+            XCTAssert(error is NotFoundError)
         }
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list count should match")
 
-            let sources = try temp_await { callback in storage.sources.list(callback: callback) }
+            let sources = try await storage.sources.list()
             XCTAssertEqual(sources.count, 0, "sources should be empty")
         }
     }
 
-    func testCollectionPendingTrustConfirmIsKeptOnAdd() throws {
+    func testCollectionPendingTrustConfirmIsKeptOnAdd() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -208,29 +207,28 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
 
-            let sources = try temp_await { callback in storage.sources.list(callback: callback) }
+            let sources = try await storage.sources.list()
             XCTAssertEqual(sources.count, 0, "sources should be empty")
         }
 
         // add fails because collection requires trust confirmation
-        guard case .failure(let error) = temp_await({ callback in packageCollections.addCollection(mockCollection.source, order: nil, callback: callback) }),
-            case PackageCollectionError.trustConfirmationRequired = error else {
-            return XCTFail("expected error")
+        await XCTAssertAsyncThrowsError(try await packageCollections.addCollection(mockCollection.source, order: nil)) { error in
+            XCTAssert(error as? PackageCollectionError == PackageCollectionError.trustConfirmationRequired)
         }
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list count should match")
 
-            let sources = try temp_await { callback in storage.sources.list(callback: callback) }
+            let sources = try await storage.sources.list()
             XCTAssertEqual(sources.count, 1, "sources should match")
         }
     }
 
-    func testCollectionWithInvalidSignatureNotAdded() throws {
+    func testCollectionWithInvalidSignatureNotAdded() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -246,29 +244,28 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
 
-            let sources = try temp_await { callback in storage.sources.list(callback: callback) }
+            let sources = try await storage.sources.list()
             XCTAssertEqual(sources.count, 0, "sources should be empty")
         }
 
         // add fails because collection's signature is invalid
-        guard case .failure(let error) = temp_await({ callback in packageCollections.addCollection(mockCollection.source, order: nil, callback: callback) }),
-            case PackageCollectionError.invalidSignature = error else {
-            return XCTFail("expected PackageCollectionError.invalidSignature")
+        await XCTAssertAsyncThrowsError(try await packageCollections.addCollection(mockCollection.source, order: nil)) { error in
+            XCTAssert((error as? PackageCollectionError) == PackageCollectionError.invalidSignature)
         }
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list count should match")
 
-            let sources = try temp_await { callback in storage.sources.list(callback: callback) }
+            let sources = try await storage.sources.list()
             XCTAssertEqual(sources.count, 0, "sources should be empty")
         }
     }
 
-    func testDelete() throws {
+    func testDelete() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -281,45 +278,45 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in packageCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await packageCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list, mockCollections, "list count should match")
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.removeCollection(mockCollections.first!.source, callback: callback) }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            try await packageCollections.removeCollection(mockCollections.first!.source)
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count - 1, "list count should match")
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.removeCollection(mockCollections.first!.source, callback: callback) }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            try await packageCollections.removeCollection(mockCollections.first!.source)
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count - 1, "list count should match")
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.removeCollection(mockCollections[mockCollections.count - 1].source, callback: callback) }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            try await packageCollections.removeCollection(mockCollections[mockCollections.count - 1].source)
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count - 2, "list count should match")
         }
 
         do {
             let unknownSource = makeMockSources(count: 1).first!
-            _ = try temp_await { callback in packageCollections.removeCollection(unknownSource, callback: callback) }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            try await packageCollections.removeCollection(unknownSource)
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count - 2, "list should be empty")
         }
     }
 
-    func testDeleteFromBothStorages() throws {
+    func testDeleteFromBothStorages() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -333,28 +330,28 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
-        _ = try temp_await { callback in packageCollections.addCollection(mockCollection.source, order: nil, callback: callback) }
+        _ = try await packageCollections.addCollection(mockCollection.source, order: nil)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 1, "list count should match")
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.removeCollection(mockCollection.source, callback: callback) }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            try await packageCollections.removeCollection(mockCollection.source)
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list count should match")
 
             // check if exists in storage
-            XCTAssertThrowsError(try temp_await { callback in storage.collections.get(identifier: mockCollection.identifier, callback: callback) }, "expected error")
+            await XCTAssertAsyncThrowsError(try await storage.collections.get(identifier: mockCollection.identifier), "expected error")
         }
     }
 
-    func testOrdering() throws {
+    func testOrdering() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -367,18 +364,18 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[0].source, order: 0, callback: callback) }
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[1].source, order: 1, callback: callback) }
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[2].source, order: 2, callback: callback) }
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[3].source, order: Int.min, callback: callback) }
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[4].source, order: Int.max, callback: callback) }
+            _ = try await packageCollections.addCollection(mockCollections[0].source, order: 0)
+            _ = try await packageCollections.addCollection(mockCollections[1].source, order: 1)
+            _ = try await packageCollections.addCollection(mockCollections[2].source, order: 2)
+            _ = try await packageCollections.addCollection(mockCollections[3].source, order: Int.min)
+            _ = try await packageCollections.addCollection(mockCollections[4].source, order: Int.max)
 
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 5, "list count should match")
 
             let expectedOrder = [
@@ -398,12 +395,12 @@ final class PackageCollectionsTests: XCTestCase {
         // bump the order
 
         do {
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[5].source, order: 2, callback: callback) }
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[6].source, order: 2, callback: callback) }
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[7].source, order: 0, callback: callback) }
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[8].source, order: -1, callback: callback) }
+            _ = try await packageCollections.addCollection(mockCollections[5].source, order: 2)
+            _ = try await packageCollections.addCollection(mockCollections[6].source, order: 2)
+            _ = try await packageCollections.addCollection(mockCollections[7].source, order: 0)
+            _ = try await packageCollections.addCollection(mockCollections[8].source, order: -1)
 
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 9, "list count should match")
 
             let expectedOrder = [
@@ -425,7 +422,7 @@ final class PackageCollectionsTests: XCTestCase {
         }
     }
 
-    func testReorder() throws {
+    func testReorder() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -438,16 +435,16 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[0].source, order: 0, callback: callback) }
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[1].source, order: 1, callback: callback) }
-            _ = try temp_await { callback in packageCollections.addCollection(mockCollections[2].source, order: 2, callback: callback) }
+            _ = try await packageCollections.addCollection(mockCollections[0].source, order: 0)
+            _ = try await packageCollections.addCollection(mockCollections[1].source, order: 1)
+            _ = try await packageCollections.addCollection(mockCollections[2].source, order: 2)
 
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 3, "list count should match")
 
             let expectedOrder = [
@@ -463,8 +460,8 @@ final class PackageCollectionsTests: XCTestCase {
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.moveCollection(mockCollections[2].source, to: -1, callback: callback) }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            try await packageCollections.moveCollection(mockCollections[2].source, to: -1)
+            let list = try await packageCollections.listCollections()
 
             let expectedOrder = [
                 mockCollections[0].identifier: 0,
@@ -479,8 +476,8 @@ final class PackageCollectionsTests: XCTestCase {
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.moveCollection(mockCollections[2].source, to: Int.max, callback: callback) }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            try await packageCollections.moveCollection(mockCollections[2].source, to: Int.max)
+            let list = try await packageCollections.listCollections()
 
             let expectedOrder = [
                 mockCollections[0].identifier: 0,
@@ -495,8 +492,8 @@ final class PackageCollectionsTests: XCTestCase {
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.moveCollection(mockCollections[2].source, to: 0, callback: callback) }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            try await packageCollections.moveCollection(mockCollections[2].source, to: 0)
+            let list = try await packageCollections.listCollections()
 
             let expectedOrder = [
                 mockCollections[0].identifier: 1,
@@ -511,8 +508,8 @@ final class PackageCollectionsTests: XCTestCase {
         }
 
         do {
-            _ = try temp_await { callback in packageCollections.moveCollection(mockCollections[2].source, to: 1, callback: callback) }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            try await packageCollections.moveCollection(mockCollections[2].source, to: 1)
+            let list = try await packageCollections.listCollections()
 
             let expectedOrder = [
                 mockCollections[0].identifier: 0,
@@ -527,7 +524,7 @@ final class PackageCollectionsTests: XCTestCase {
         }
     }
 
-    func testUpdateTrust() throws {
+    func testUpdateTrust() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -541,15 +538,15 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         // User preference unknown - collection not saved to storage
-        _ = try? temp_await { callback in packageCollections.addCollection(mockCollections.first!.source, order: nil, trustConfirmationProvider: nil, callback: callback) }
+        _ = try await packageCollections.addCollection(mockCollections.first!.source, order: nil, trustConfirmationProvider: nil)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
@@ -557,28 +554,28 @@ final class PackageCollectionsTests: XCTestCase {
 
         // Update to trust the source. It will trigger a collection refresh which will save collection to storage.
         source.isTrusted = true
-        _ = try temp_await { callback in packageCollections.updateCollection(source, callback: callback) }
+        _ = try await packageCollections.updateCollection(source)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 1, "list count should match")
         }
 
         // Update to untrust the source. It will trigger a collection refresh which will remove collection from storage.
         source.isTrusted = false
-        XCTAssertThrowsError(try temp_await { callback in packageCollections.updateCollection(source, callback: callback) }) { error in
+        await XCTAssertAsyncThrowsError(try await packageCollections.updateCollection(source)) { error in
             guard case PackageCollectionError.untrusted = error else {
                 return XCTFail("Expected PackageCollectionError.untrusted")
             }
         }
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
     }
 
-    func testList() throws {
+    func testList() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -592,15 +589,15 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([mockPackage.identity: mockMetadata])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) })
         }
 
-        let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+        let list = try await packageCollections.listCollections()
         XCTAssertEqual(list.count, mockCollections.count, "list count should match")
     }
 
-    func testListSubset() throws {
+    func testListSubset() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -614,16 +611,16 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([mockPackage.identity: mockMetadata])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) })
         }
 
         let expectedCollections = Set([mockCollections.first!.identifier, mockCollections.last!.identifier])
-        let list = try temp_await { callback in packageCollections.listCollections(identifiers: expectedCollections, callback: callback) }
+        let list = try await packageCollections.listCollections(identifiers: expectedCollections)
         XCTAssertEqual(list.count, expectedCollections.count, "list count should match")
     }
 
-    func testListPerformance() throws {
+    func testListPerformance() async throws {
         #if ENABLE_COLLECTION_PERF_TESTS
         #else
         try XCTSkipIf(true)
@@ -642,23 +639,18 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([mockPackage.identity: mockMetadata])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        let sync = DispatchGroup()
-        mockCollections.forEach { collection in
-            sync.enter()
-            packageCollections.addCollection(collection.source, order: nil) { _ in
-                sync.leave()
-            }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, order: nil)
         }
-        sync.wait()
 
         let start = Date()
-        let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+        let list = try await packageCollections.listCollections()
         XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         let delta = Date().timeIntervalSince(start)
         XCTAssert(delta < 1.0, "should list quickly, took \(delta)")
     }
 
-    func testPackageSearch() throws {
+    func testPackageSearch() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -732,67 +724,67 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([:])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) })
         }
 
         do {
             // search by package name
-            let searchResult = try temp_await { callback in packageCollections.findPackages(mockManifest.packageName, callback: callback) }
+            let searchResult = try await packageCollections.findPackages(mockManifest.packageName)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "list count should match")
         }
 
         do {
             // search by package description/summary
-            let searchResult = try temp_await { callback in packageCollections.findPackages(mockPackage.summary!, callback: callback) }
+            let searchResult = try await packageCollections.findPackages(mockPackage.summary!)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "list count should match")
         }
 
         do {
             // search by package keywords
-            let searchResult = try temp_await { callback in packageCollections.findPackages(mockPackage.keywords!.first!, callback: callback) }
+            let searchResult = try await packageCollections.findPackages(mockPackage.keywords!.first!)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "list count should match")
         }
 
         do {
             // search by package repository url
-            let searchResult = try temp_await { callback in packageCollections.findPackages(mockPackage.location, callback: callback) }
+            let searchResult = try await packageCollections.findPackages(mockPackage.location)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
         }
 
         do {
             // search by package identity
-            let searchResult = try temp_await { callback in packageCollections.findPackages(mockPackage.identity.description, callback: callback) }
+            let searchResult = try await packageCollections.findPackages(mockPackage.identity.description)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
         }
 
         do {
             // search by product name
-            let searchResult = try temp_await { callback in packageCollections.findPackages(mockProducts.first!.name, callback: callback) }
+            let searchResult = try await packageCollections.findPackages(mockProducts.first!.name)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "list count should match")
         }
 
         do {
             // search by target name
-            let searchResult = try temp_await { callback in packageCollections.findPackages(mockTargets.first!.name, callback: callback) }
+            let searchResult = try await packageCollections.findPackages(mockTargets.first!.name)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
         }
 
         do {
             // empty search
-            let searchResult = try temp_await { callback in packageCollections.findPackages(UUID().uuidString, callback: callback) }
+            let searchResult = try await packageCollections.findPackages(UUID().uuidString)
             XCTAssertEqual(searchResult.items.count, 0, "list count should match")
         }
     }
 
-    func testPackageSearchPerformance() throws {
+    func testPackageSearchPerformance() async throws {
         #if ENABLE_COLLECTION_PERF_TESTS
         #else
         try XCTSkipIf(true)
@@ -809,25 +801,20 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([:])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        let sync = DispatchGroup()
-        mockCollections.forEach { collection in
-            sync.enter()
-            packageCollections.addCollection(collection.source, order: nil) { _ in
-                sync.leave()
-            }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, order: nil)
         }
-        sync.wait()
 
         // search by package name
         let start = Date()
         let repoName = mockCollections.last!.packages.last!.identity.description
-        let searchResult = try temp_await { callback in packageCollections.findPackages(repoName, callback: callback) }
+        let searchResult = try await packageCollections.findPackages(repoName)
         XCTAssert(searchResult.items.count > 0, "should get results")
         let delta = Date().timeIntervalSince(start)
         XCTAssert(delta < 1.0, "should search quickly, took \(delta)")
     }
 
-    func testTargetsSearch() throws {
+    func testTargetsSearch() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -901,13 +888,13 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([:])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) })
         }
 
         do {
             // search by exact target name
-            let searchResult = try temp_await { callback in packageCollections.findTargets(mockTargets.first!.name, searchType: .exactMatch, callback: callback) }
+            let searchResult = try await packageCollections.findTargets(mockTargets.first!.name, searchType: .exactMatch)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.packages.map { $0.identity }, [mockPackage.identity], "packages should match")
             XCTAssertEqual(searchResult.items.first?.packages.flatMap { $0.collections }.sorted(), expectedCollectionsIdentifiers, "collections should match")
@@ -915,7 +902,7 @@ final class PackageCollectionsTests: XCTestCase {
 
         do {
             // search by prefix target name
-            let searchResult = try temp_await { callback in packageCollections.findTargets(String(mockTargets.first!.name.prefix(mockTargets.first!.name.count - 1)), searchType: .prefix, callback: callback) }
+            let searchResult = try await packageCollections.findTargets(String(mockTargets.first!.name.prefix(mockTargets.first!.name.count - 1)), searchType: .prefix)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.packages.map { $0.identity }, [mockPackage.identity], "packages should match")
             XCTAssertEqual(searchResult.items.first?.packages.flatMap { $0.collections }.sorted(), expectedCollectionsIdentifiers, "collections should match")
@@ -923,12 +910,12 @@ final class PackageCollectionsTests: XCTestCase {
 
         do {
             // empty search
-            let searchResult = try temp_await { callback in packageCollections.findTargets(UUID().uuidString, searchType: .exactMatch, callback: callback) }
+            let searchResult = try await packageCollections.findTargets(UUID().uuidString, searchType: .exactMatch)
             XCTAssertEqual(searchResult.items.count, 0, "list count should match")
         }
     }
 
-    func testTargetsSearchPerformance() throws {
+    func testTargetsSearchPerformance() async throws {
         #if ENABLE_COLLECTION_PERF_TESTS
         #else
         try XCTSkipIf(true)
@@ -945,25 +932,20 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([:])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        let sync = DispatchGroup()
-        mockCollections.forEach { collection in
-            sync.enter()
-            packageCollections.addCollection(collection.source, order: nil) { _ in
-                sync.leave()
-            }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, order: nil)
         }
-        sync.wait()
 
         // search by target name
         let start = Date()
         let targetName = mockCollections.last!.packages.last!.versions.last!.defaultManifest!.targets.last!.name
-        let searchResult = try temp_await { callback in packageCollections.findTargets(targetName, searchType: .exactMatch, callback: callback) }
+        let searchResult = try await packageCollections.findTargets(targetName, searchType: .exactMatch)
         XCTAssert(searchResult.items.count > 0, "should get results")
         let delta = Date().timeIntervalSince(start)
         XCTAssert(delta < 1.0, "should search quickly, took \(delta)")
     }
 
-    func testHappyRefresh() throws {
+    func testHappyRefresh() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -975,17 +957,17 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([:])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        try mockCollections.forEach { collection in
+        for collection in mockCollections {
             // save directly to storage to circumvent refresh on add
-            _ = try temp_await { callback in storage.sources.add(source: collection.source, order: nil, callback: callback) }
+            try await storage.sources.add(source: collection.source, order: nil)
         }
-        _ = try temp_await { callback in packageCollections.refreshCollections(callback: callback) }
+        _ = try await packageCollections.refreshCollections()
 
-        let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+        let list = try await packageCollections.listCollections()
         XCTAssertEqual(list.count, mockCollections.count, "list count should match")
     }
 
-    func testBrokenRefresh() throws {
+    func testBrokenRefresh() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         struct BrokenProvider: PackageCollectionProvider {
@@ -1030,20 +1012,20 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([:])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        XCTAssertThrowsError(try temp_await { callback in packageCollections.addCollection(brokenSources.first!, order: nil, callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await packageCollections.addCollection(brokenSources.first!), "expected error") { error in
             XCTAssertEqual(error as? MyError, expectedError, "expected error to match")
-        })
+        }
 
         // save directly to storage to circumvent refresh on add
-        try goodSources.forEach { source in
-            _ = try temp_await { callback in storage.sources.add(source: source, order: nil, callback: callback) }
+        for source in goodSources {
+            try await storage.sources.add(source: source, order: nil)
         }
-        try brokenSources.forEach { source in
-            _ = try temp_await { callback in storage.sources.add(source: source, order: nil, callback: callback) }
+        for source in brokenSources {
+            try await storage.sources.add(source: source, order: nil)
         }
-        _ = try temp_await { callback in storage.sources.add(source: .init(type: .json, url: "https://feed-\(UUID().uuidString)"), order: nil, callback: callback) }
+        try await storage.sources.add(source: .init(type: .json, url: "https://feed-\(UUID().uuidString)"), order: nil)
 
-        XCTAssertThrowsError(try temp_await { callback in packageCollections.refreshCollections(callback: callback) }, "expected error", { error in
+        await XCTAssertAsyncThrowsError(try await packageCollections.refreshCollections(), "expected error") { error in
             if let error = error as? MultipleErrors {
                 XCTAssertEqual(error.errors.count, brokenSources.count, "expected error to match")
                 error.errors.forEach { error in
@@ -1052,14 +1034,14 @@ final class PackageCollectionsTests: XCTestCase {
             } else {
                 XCTFail("expected error to match")
             }
-        })
+        }
 
         // test isolation - broken feeds does not impact good ones
-        let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+        let list = try await packageCollections.listCollections()
         XCTAssertEqual(list.count, goodSources.count + 1, "list count should match")
     }
 
-    func testRefreshOne() throws {
+    func testRefreshOne() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1071,17 +1053,17 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([:])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        try mockCollections.forEach { collection in
+        for collection in mockCollections {
             // save directly to storage to circumvent refresh on add
-            _ = try temp_await { callback in storage.sources.add(source: collection.source, order: nil, callback: callback) }
+            try await storage.sources.add(source: collection.source, order: nil)
         }
-        _ = try temp_await { callback in packageCollections.refreshCollection(mockCollections.first!.source, callback: callback) }
+        _ = try await packageCollections.refreshCollection(mockCollections.first!.source)
 
-        let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+        let list = try await packageCollections.listCollections()
         XCTAssertEqual(list.count, mockCollections.count, "list count should match")
     }
 
-    func testRefreshOneTrustedUnsigned() throws {
+    func testRefreshOneTrustedUnsigned() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1094,14 +1076,14 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         // User trusted
-        let collection = try temp_await { callback in packageCollections.addCollection(mockCollections[0].source, order: nil, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        let collection = try await packageCollections.addCollection(mockCollections[0].source, order: nil, trustConfirmationProvider: { _, cb in cb(true) })
         XCTAssertEqual(true, collection.source.isTrusted) // isTrusted is nil-able
 
         // `isTrusted` should be true so refreshCollection should succeed
-        XCTAssertNoThrow(try temp_await { callback in packageCollections.refreshCollection(collection.source, callback: callback) })
+        _ = try await packageCollections.refreshCollection(collection.source)
     }
 
-    func testRefreshOneNotFound() throws {
+    func testRefreshOneNotFound() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1114,12 +1096,12 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         // Don't add collection so it's not found in the config
-        XCTAssertThrowsError(try temp_await { callback in packageCollections.refreshCollection(mockCollections[0].source, callback: callback) }, "expected error") { error in
+        await XCTAssertAsyncThrowsError(try await packageCollections.refreshCollection(mockCollections[0].source), "expected error") { error in
             XCTAssert(error is NotFoundError)
         }
     }
 
-    func testListTargets() throws {
+    func testListTargets() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1132,19 +1114,19 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in packageCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await packageCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
-        let targetsList = try temp_await { callback in packageCollections.listTargets(callback: callback) }
+        let targetsList = try await packageCollections.listTargets()
         let expectedTargets = Set(mockCollections.flatMap { $0.packages.flatMap { $0.versions.flatMap { $0.defaultManifest!.targets.map { $0.name } } } })
         XCTAssertEqual(Set(targetsList.map { $0.target.name }), expectedTargets, "targets should match")
 
@@ -1157,7 +1139,7 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertEqual(targetsCollectionsList, expectedCollections, "collections should match")
     }
 
-    func testFetchMetadataHappy() throws {
+    func testFetchMetadataHappy() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1172,19 +1154,19 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in packageCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await packageCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
-        let metadata = try temp_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
+        let metadata = try await packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location)
 
         let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.identity }.contains(mockPackage.identity) }.map { $0.identifier })
         XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
@@ -1195,7 +1177,7 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertNil(metadata.provider, "provider should be nil")
     }
 
-    func testFetchMetadataInOrder() throws {
+    func testFetchMetadataInOrder() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1209,19 +1191,19 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in packageCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await packageCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
-        let metadata = try temp_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
+        let metadata = try await packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location)
 
         let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.identity }.contains(mockPackage.identity) }.map { $0.identifier })
         XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
@@ -1233,7 +1215,7 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertNil(metadata.provider, "provider should be nil")
     }
 
-    func testFetchMetadataInCollections() throws {
+    func testFetchMetadataInCollections() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1247,20 +1229,20 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in packageCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await packageCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
         let collectionIdentifiers: Set<Model.CollectionIdentifier> = [mockCollections.last!.identifier]
-        let metadata = try temp_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, collections: collectionIdentifiers, callback: callback) }
+        let metadata = try await packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, collections: collectionIdentifiers)
         XCTAssertEqual(Set(metadata.collections), collectionIdentifiers, "collections should match")
 
         let expectedMetadata = PackageCollections.mergedPackageMetadata(package: mockPackage, basicMetadata: nil)
@@ -1270,7 +1252,7 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertNil(metadata.provider, "provider should be nil")
     }
 
-    func testMergedPackageMetadata() throws {
+    func testMergedPackageMetadata() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let packageId = UUID().uuidString
@@ -1363,7 +1345,7 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertEqual(metadata.languages, mockMetadata.languages, "languages should match")
     }
 
-    func testFetchMetadataNotFoundInCollections() throws {
+    func testFetchMetadataNotFoundInCollections() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1377,16 +1359,16 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
-        XCTAssertThrowsError(try temp_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }, "expected error") { error in
+        await XCTAssertAsyncThrowsError(try await packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location), "expected error") { error in
             XCTAssert(error is NotFoundError)
         }
     }
 
-    func testFetchMetadataNotFoundByProvider() throws {
+    func testFetchMetadataNotFoundByProvider() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1400,19 +1382,19 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in packageCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await packageCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
-        let metadata = try temp_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
+        let metadata = try await packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location)
 
         let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.identity }.contains(mockPackage.identity) }.map { $0.identifier })
         XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
@@ -1424,7 +1406,7 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertNil(metadata.provider, "provider should be nil")
     }
 
-    func testFetchMetadataProviderError() throws {
+    func testFetchMetadataProviderError() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         struct BrokenMetadataProvider: PackageMetadataProvider {
@@ -1452,20 +1434,20 @@ final class PackageCollectionsTests: XCTestCase {
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
         do {
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in packageCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await packageCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in packageCollections.listCollections(callback: callback) }
+            let list = try await packageCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
         // Despite metadata provider error we should still get back data from storage
-        let metadata = try temp_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
+        let metadata = try await packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location)
         let expectedMetadata = PackageCollections.mergedPackageMetadata(package: mockPackage, basicMetadata: nil)
         XCTAssertEqual(metadata.package, expectedMetadata, "package should match")
 
@@ -1473,7 +1455,7 @@ final class PackageCollectionsTests: XCTestCase {
         XCTAssertNil(metadata.provider, "provider should be nil")
     }
 
-    func testFetchMetadataPerformance() throws {
+    func testFetchMetadataPerformance() async throws {
         #if ENABLE_COLLECTION_PERF_TESTS
         #else
         try XCTSkipIf(true)
@@ -1492,23 +1474,18 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([mockPackage.identity: mockMetadata])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        let sync = DispatchGroup()
-        mockCollections.forEach { collection in
-            sync.enter()
-            packageCollections.addCollection(collection.source, order: nil) { _ in
-                sync.leave()
-            }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, order: nil)
         }
-        sync.wait()
 
         let start = Date()
-        let metadata = try temp_await { callback in packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
+        let metadata = try await packageCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location)
         XCTAssertNotNil(metadata)
         let delta = Date().timeIntervalSince(start)
         XCTAssert(delta < 1.0, "should fetch quickly, took \(delta)")
     }
 
-    func testListPackages() throws {
+    func testListPackages() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let configuration = PackageCollections.Configuration()
@@ -1580,8 +1557,8 @@ final class PackageCollectionsTests: XCTestCase {
         let metadataProvider = MockMetadataProvider([:])
         let packageCollections = PackageCollections(configuration: configuration, storage: storage, collectionProviders: collectionProviders, metadataProvider: metadataProvider)
 
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        for collection in mockCollections {
+            _ = try await packageCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) })
         }
 
         do {
@@ -1589,7 +1566,7 @@ final class PackageCollectionsTests: XCTestCase {
             let expectedPackages = Set(mockCollections.flatMap { $0.packages.map { $0.identity } } + [mockPackage.identity])
             let expectedCollections = Set([mockCollection.identifier, mockCollection2.identifier])
 
-            let searchResult = try temp_await { callback in packageCollections.listPackages(collections: fetchCollections, callback: callback) }
+            let searchResult = try await packageCollections.listPackages(collections: fetchCollections)
             XCTAssertEqual(searchResult.items.count, expectedPackages.count, "list count should match")
             XCTAssertEqual(Set(searchResult.items.map { $0.package.identity }), expectedPackages, "items should match")
             XCTAssertEqual(Set(searchResult.items.first(where: { $0.package.identity == mockPackage.identity })?.collections ?? []), expectedCollections, "collections should match")
@@ -1601,7 +1578,7 @@ final class PackageCollectionsTests: XCTestCase {
             let expectedPackages = Set(mockCollections[0].packages.map { $0.identity } + [mockPackage.identity])
             let expectedCollections = Set([mockCollection.identifier, mockCollection2.identifier])
 
-            let searchResult = try temp_await { callback in packageCollections.listPackages(collections: fetchCollections, callback: callback) }
+            let searchResult = try await packageCollections.listPackages(collections: fetchCollections)
             XCTAssertEqual(searchResult.items.count, expectedPackages.count, "list count should match")
             XCTAssertEqual(Set(searchResult.items.map { $0.package.identity }), expectedPackages, "items should match")
             XCTAssertEqual(Set(searchResult.items.first(where: { $0.package.identity == mockPackage.identity })?.collections ?? []), expectedCollections, "collections should match")

--- a/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsTests.swift
@@ -543,7 +543,7 @@ final class PackageCollectionsTests: XCTestCase {
         }
 
         // User preference unknown - collection not saved to storage
-        _ = try await packageCollections.addCollection(mockCollections.first!.source, order: nil, trustConfirmationProvider: nil)
+        _ = try? await packageCollections.addCollection(mockCollections.first!.source, order: nil, trustConfirmationProvider: nil)
 
         do {
             let list = try await packageCollections.listCollections()

--- a/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexAndCollectionsTests.swift
@@ -20,7 +20,7 @@ import XCTest
 import struct TSCUtility.Version
 
 class PackageIndexAndCollectionsTests: XCTestCase {
-    func testCollectionAddRemoveGetList() throws {
+    func testCollectionAddRemoveGetList() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
@@ -33,31 +33,31 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
 
         do {
-            let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+            let list = try await indexAndCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in indexAndCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await indexAndCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+            let list = try await indexAndCollections.listCollections()
             XCTAssertEqual(list, mockCollections, "list count should match")
         }
         
         do {
-            let collection = try temp_await { callback in indexAndCollections.getCollection(mockCollections.first!.source, callback: callback) }
+            let collection = try await indexAndCollections.getCollection(mockCollections.first!.source)
             XCTAssertEqual(collection, mockCollections.first, "collection should match")
         }
         
         do {
-            _ = try temp_await { callback in indexAndCollections.removeCollection(mockCollections.first!.source, callback: callback) }
-            let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+            try await indexAndCollections.removeCollection(mockCollections.first!.source)
+            let list = try await indexAndCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count - 1, "list count should match")
         }
     }
     
-    func testRefreshCollections() throws {
+    func testRefreshCollections() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
@@ -69,17 +69,17 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         let indexAndCollections = PackageIndexAndCollections(index: packageIndex, collections: packageCollections, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
 
-        try mockCollections.forEach { collection in
+        for collection in mockCollections {
             // save directly to storage to circumvent refresh on add
-            _ = try temp_await { callback in storage.sources.add(source: collection.source, order: nil, callback: callback) }
+            try await storage.sources.add(source: collection.source, order: nil)
         }
-        _ = try temp_await { callback in indexAndCollections.refreshCollections(callback: callback) }
+        _ = try await indexAndCollections.refreshCollections()
 
-        let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+        let list = try await indexAndCollections.listCollections()
         XCTAssertEqual(list.count, mockCollections.count, "list count should match")
     }
     
-    func testRefreshCollection() throws {
+    func testRefreshCollection() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
@@ -91,17 +91,17 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         let indexAndCollections = PackageIndexAndCollections(index: packageIndex, collections: packageCollections, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
 
-        try mockCollections.forEach { collection in
+        for collection in mockCollections {
             // save directly to storage to circumvent refresh on add
-            _ = try temp_await { callback in storage.sources.add(source: collection.source, order: nil, callback: callback) }
+            try await storage.sources.add(source: collection.source, order: nil)
         }
-        _ = try temp_await { callback in indexAndCollections.refreshCollection(mockCollections.first!.source, callback: callback) }
+        _ = try await indexAndCollections.refreshCollection(mockCollections.first!.source)
 
-        let collection = try temp_await { callback in indexAndCollections.getCollection(mockCollections.first!.source, callback: callback) }
+        let collection = try await indexAndCollections.getCollection(mockCollections.first!.source)
         XCTAssertEqual(collection, mockCollections.first, "collection should match")
     }
 
-    func testListPackages() throws {
+    func testListPackages() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
@@ -174,8 +174,8 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         let indexAndCollections = PackageIndexAndCollections(index: packageIndex, collections: packageCollections, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
 
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in indexAndCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        for collection in mockCollections {
+            _ = try await indexAndCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) })
         }
 
         do {
@@ -183,7 +183,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
             let expectedPackages = Set(mockCollections.flatMap { $0.packages.map { $0.identity } } + [mockPackage.identity])
             let expectedCollections = Set([mockCollection.identifier, mockCollection2.identifier])
 
-            let searchResult = try temp_await { callback in indexAndCollections.listPackages(collections: fetchCollections, callback: callback) }
+            let searchResult = try await indexAndCollections.listPackages(collections: fetchCollections)
             XCTAssertEqual(searchResult.items.count, expectedPackages.count, "list count should match")
             XCTAssertEqual(Set(searchResult.items.map { $0.package.identity }), expectedPackages, "items should match")
             XCTAssertEqual(Set(searchResult.items.first(where: { $0.package.identity == mockPackage.identity })?.collections ?? []), expectedCollections, "collections should match")
@@ -195,14 +195,14 @@ class PackageIndexAndCollectionsTests: XCTestCase {
             let expectedPackages = Set(mockCollections[0].packages.map { $0.identity } + [mockPackage.identity])
             let expectedCollections = Set([mockCollection.identifier, mockCollection2.identifier])
 
-            let searchResult = try temp_await { callback in indexAndCollections.listPackages(collections: fetchCollections, callback: callback) }
+            let searchResult = try await indexAndCollections.listPackages(collections: fetchCollections)
             XCTAssertEqual(searchResult.items.count, expectedPackages.count, "list count should match")
             XCTAssertEqual(Set(searchResult.items.map { $0.package.identity }), expectedPackages, "items should match")
             XCTAssertEqual(Set(searchResult.items.first(where: { $0.package.identity == mockPackage.identity })?.collections ?? []), expectedCollections, "collections should match")
         }
     }
 
-    func testListTargets() throws {
+    func testListTargets() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
@@ -215,19 +215,19 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
 
         do {
-            let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+            let list = try await indexAndCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in indexAndCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await indexAndCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+            let list = try await indexAndCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
 
-        let targetsList = try temp_await { callback in indexAndCollections.listTargets(callback: callback) }
+        let targetsList = try await indexAndCollections.listTargets()
         let expectedTargets = Set(mockCollections.flatMap { $0.packages.flatMap { $0.versions.flatMap { $0.defaultManifest!.targets.map { $0.name } } } })
         XCTAssertEqual(Set(targetsList.map { $0.target.name }), expectedTargets, "targets should match")
 
@@ -240,7 +240,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         XCTAssertEqual(targetsCollectionsList, expectedCollections, "collections should match")
     }
     
-    func testFindTargets() throws {
+    func testFindTargets() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
 
         let storage = makeMockStorage()
@@ -315,13 +315,13 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         let indexAndCollections = PackageIndexAndCollections(index: packageIndex, collections: packageCollections, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
 
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in indexAndCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        for collection in mockCollections {
+            _ = try await indexAndCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) })
         }
 
         do {
             // search by exact target name
-            let searchResult = try temp_await { callback in indexAndCollections.findTargets(mockTargets.first!.name, searchType: .exactMatch, callback: callback) }
+            let searchResult = try await indexAndCollections.findTargets(mockTargets.first!.name, searchType: .exactMatch)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.packages.map { $0.identity }, [mockPackage.identity], "packages should match")
             XCTAssertEqual(searchResult.items.first?.packages.flatMap { $0.collections }.sorted(), expectedCollectionsIdentifiers, "collections should match")
@@ -329,7 +329,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
 
         do {
             // search by prefix target name
-            let searchResult = try temp_await { callback in indexAndCollections.findTargets(String(mockTargets.first!.name.prefix(mockTargets.first!.name.count - 1)), searchType: .prefix, callback: callback) }
+            let searchResult = try await indexAndCollections.findTargets(String(mockTargets.first!.name.prefix(mockTargets.first!.name.count - 1)), searchType: .prefix)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.packages.map { $0.identity }, [mockPackage.identity], "packages should match")
             XCTAssertEqual(searchResult.items.first?.packages.flatMap { $0.collections }.sorted(), expectedCollectionsIdentifiers, "collections should match")
@@ -337,12 +337,12 @@ class PackageIndexAndCollectionsTests: XCTestCase {
 
         do {
             // empty search
-            let searchResult = try temp_await { callback in indexAndCollections.findTargets(UUID().uuidString, searchType: .exactMatch, callback: callback) }
+            let searchResult = try await indexAndCollections.findTargets(UUID().uuidString, searchType: .exactMatch)
             XCTAssertEqual(searchResult.items.count, 0, "list count should match")
         }
     }
         
-    func testListPackagesInIndex() throws {
+    func testListPackagesInIndex() async throws {
         let storage = makeMockStorage()
         defer { XCTAssertNoThrow(try storage.close()) }
         let packageCollections = makePackageCollections(mockCollections: [], storage: storage)
@@ -354,11 +354,11 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         let indexAndCollections = PackageIndexAndCollections(index: packageIndex, collections: packageCollections, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
 
-        let result = try temp_await { callback in indexAndCollections.listPackagesInIndex(offset: 1, limit: 5, callback: callback) }
+        let result = try await indexAndCollections.listPackagesInIndex(offset: 1, limit: 5)
         XCTAssertFalse(result.items.isEmpty)
     }
     
-    func testGetPackageMetadata() throws {
+    func testGetPackageMetadata() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
@@ -374,19 +374,19 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
         
         do {
-            let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+            let list = try await indexAndCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in indexAndCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await indexAndCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+            let list = try await indexAndCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
         
-        let metadata = try temp_await { callback in indexAndCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
+        let metadata = try await indexAndCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location)
         
         let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.identity }.contains(mockPackage.identity) }.map { $0.identifier })
         XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
@@ -397,7 +397,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         XCTAssertEqual(metadata.provider?.name, "package index")
     }
     
-    func testGetPackageMetadata_brokenIndex() throws {
+    func testGetPackageMetadata_brokenIndex() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
@@ -413,20 +413,20 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
         
         do {
-            let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+            let list = try await indexAndCollections.listCollections()
             XCTAssertEqual(list.count, 0, "list should be empty")
         }
 
         do {
-            try mockCollections.forEach { collection in
-                _ = try temp_await { callback in indexAndCollections.addCollection(collection.source, order: nil, callback: callback) }
+            for collection in mockCollections {
+                _ = try await indexAndCollections.addCollection(collection.source, order: nil)
             }
-            let list = try temp_await { callback in indexAndCollections.listCollections(callback: callback) }
+            let list = try await indexAndCollections.listCollections()
             XCTAssertEqual(list.count, mockCollections.count, "list count should match")
         }
         
-        let metadata = try temp_await { callback in indexAndCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }
-        
+        let metadata = try await indexAndCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location)
+
         let expectedCollections = Set(mockCollections.filter { $0.packages.map { $0.identity }.contains(mockPackage.identity) }.map { $0.identifier })
         XCTAssertEqual(Set(metadata.collections), expectedCollections, "collections should match")
         
@@ -437,7 +437,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         XCTAssertNil(metadata.provider)
     }
     
-    func testGetPackageMetadata_indexAndCollectionError() throws {
+    func testGetPackageMetadata_indexAndCollectionError() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
@@ -450,7 +450,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         
         let mockPackage = makeMockPackage(id: "test-package")
         // Package not found in collections; index is broken
-        XCTAssertThrowsError(try temp_await { callback in indexAndCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location, callback: callback) }) { error in
+        await XCTAssertAsyncThrowsError(try await indexAndCollections.getPackageMetadata(identity: mockPackage.identity, location: mockPackage.location)) { error in
             // Index error is returned
             guard let _ = error as? BrokenPackageIndex.TerribleThing else {
                 return XCTFail("Expected BrokenPackageIndex.TerribleThing")
@@ -458,7 +458,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         }
     }
     
-    func testFindPackages() throws {
+    func testFindPackages() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
@@ -532,13 +532,13 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         let indexAndCollections = PackageIndexAndCollections(index: packageIndex, collections: packageCollections, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
         
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in indexAndCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        for collection in mockCollections {
+            _ = try await indexAndCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) })
         }
         
         // both index and collections
         do {
-            let searchResult = try temp_await { callback in indexAndCollections.findPackages(mockPackage.identity.description, in: .both(collections: nil), callback: callback) }
+            let searchResult = try await indexAndCollections.findPackages(mockPackage.identity.description, in: .both(collections: nil))
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
             XCTAssertEqual(searchResult.items.first?.indexes, [packageIndex.url], "indexes should match")
@@ -546,7 +546,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         
         // index only
         do {
-            let searchResult = try temp_await { callback in indexAndCollections.findPackages(mockPackage.identity.description, in: .index, callback: callback) }
+            let searchResult = try await indexAndCollections.findPackages(mockPackage.identity.description, in: .index)
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertTrue(searchResult.items.first?.collections.isEmpty ?? true, "collections should match")
             XCTAssertEqual(searchResult.items.first?.indexes, [packageIndex.url], "indexes should match")
@@ -554,14 +554,14 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         
         // collections only
         do {
-            let searchResult = try temp_await { callback in indexAndCollections.findPackages(mockPackage.identity.description, in: .collections(nil), callback: callback) }
+            let searchResult = try await indexAndCollections.findPackages(mockPackage.identity.description, in: .collections(nil))
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
             XCTAssertTrue(searchResult.items.first?.indexes.isEmpty ?? true, "indexes should match")
         }
     }
     
-    func testFindPackages_brokenIndex() throws {
+    func testFindPackages_brokenIndex() async throws {
         try PackageCollectionsTests_skipIfUnsupportedPlatform()
         
         let storage = makeMockStorage()
@@ -635,13 +635,13 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         let indexAndCollections = PackageIndexAndCollections(index: packageIndex, collections: packageCollections, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try indexAndCollections.close()) }
         
-        try mockCollections.forEach { collection in
-            _ = try temp_await { callback in indexAndCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) }, callback: callback) }
+        for collection in mockCollections {
+            _ = try await indexAndCollections.addCollection(collection.source, trustConfirmationProvider: { _, cb in cb(true) })
         }
         
         // both index and collections
         do {
-            let searchResult = try temp_await { callback in indexAndCollections.findPackages(mockPackage.identity.description, in: .both(collections: nil), callback: callback) }
+            let searchResult = try await indexAndCollections.findPackages(mockPackage.identity.description, in: .both(collections: nil))
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
             // Results come from collections since index is broken
@@ -650,7 +650,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         
         // index only
         do {
-            XCTAssertThrowsError(try temp_await { callback in indexAndCollections.findPackages(mockPackage.identity.description, in: .index, callback: callback) }) { error in
+            await XCTAssertAsyncThrowsError(try await indexAndCollections.findPackages(mockPackage.identity.description, in: .index)) { error in
                 guard error is BrokenPackageIndex.TerribleThing else {
                     return XCTFail("invalid error \(error)")
                 }
@@ -659,7 +659,7 @@ class PackageIndexAndCollectionsTests: XCTestCase {
         
         // collections only
         do {
-            let searchResult = try temp_await { callback in indexAndCollections.findPackages(mockPackage.identity.description, in: .collections(nil), callback: callback) }
+            let searchResult = try await indexAndCollections.findPackages(mockPackage.identity.description, in: .collections(nil))
             XCTAssertEqual(searchResult.items.count, 1, "list count should match")
             XCTAssertEqual(searchResult.items.first?.collections.sorted(), expectedCollectionsIdentifiers, "collections should match")
             // Not searching in index so should not be impacted by its error

--- a/Tests/PackageCollectionsTests/PackageIndexTests.swift
+++ b/Tests/PackageCollectionsTests/PackageIndexTests.swift
@@ -18,7 +18,7 @@ import SPMTestSupport
 import XCTest
 
 class PackageIndexTests: XCTestCase {
-    func testGetPackageMetadata() throws {
+    func testGetPackageMetadata() async throws {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, disableCache: true)
         configuration.enabled = true
@@ -45,13 +45,13 @@ class PackageIndexTests: XCTestCase {
         let index = PackageIndex(configuration: configuration, customHTTPClient: httpClient, callbackQueue: .sharedConcurrent, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try index.close()) }
         
-        let metadata = try temp_await { callback in index.getPackageMetadata(identity: .init(url: repoURL), location: repoURL.absoluteString, callback: callback) }
+        let metadata = try await index.getPackageMetadata(identity: .init(url: repoURL), location: repoURL.absoluteString)
         XCTAssertEqual(metadata.package.identity, package.identity)
         XCTAssert(metadata.collections.isEmpty)
         XCTAssertNotNil(metadata.provider)
     }
     
-    func testGetPackageMetadata_featureDisabled() {
+    func testGetPackageMetadata_featureDisabled() async {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, disableCache: true)
         configuration.enabled = false
@@ -60,12 +60,12 @@ class PackageIndexTests: XCTestCase {
         defer { XCTAssertNoThrow(try index.close()) }
         
         let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
-        XCTAssertThrowsError(try temp_await { callback in index.getPackageMetadata(identity: .init(url: repoURL), location: repoURL.absoluteString, callback: callback) }) { error in
+        await XCTAssertAsyncThrowsError(try await index.getPackageMetadata(identity: .init(url: repoURL), location: repoURL.absoluteString)) { error in
             XCTAssertEqual(error as? PackageIndexError, .featureDisabled)
         }
     }
     
-    func testGetPackageMetadata_notConfigured() {
+    func testGetPackageMetadata_notConfigured() async {
         var configuration = PackageIndexConfiguration(url: nil, disableCache: true)
         configuration.enabled = true
                 
@@ -73,12 +73,12 @@ class PackageIndexTests: XCTestCase {
         defer { XCTAssertNoThrow(try index.close()) }
         
         let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
-        XCTAssertThrowsError(try temp_await { callback in index.getPackageMetadata(identity: .init(url: repoURL), location: repoURL.absoluteString, callback: callback) }) { error in
+        await XCTAssertAsyncThrowsError(try await index.getPackageMetadata(identity: .init(url: repoURL), location: repoURL.absoluteString)) { error in
             XCTAssertEqual(error as? PackageIndexError, .notConfigured)
         }
     }
     
-    func testFindPackages() throws {
+    func testFindPackages() async throws {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, searchResultMaxItemsCount: 10, disableCache: true)
         configuration.enabled = true
@@ -106,7 +106,7 @@ class PackageIndexTests: XCTestCase {
         let index = PackageIndex(configuration: configuration, customHTTPClient: httpClient, callbackQueue: .sharedConcurrent, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try index.close()) }
         
-        let result = try temp_await { callback in index.findPackages(query, callback: callback) }
+        let result = try await index.findPackages(query)
         XCTAssertEqual(result.items.count, packages.count)
         for (i, item) in result.items.enumerated() {
             XCTAssertEqual(item.package.identity, packages[i].identity)
@@ -115,7 +115,7 @@ class PackageIndexTests: XCTestCase {
         }
     }
     
-    func testFindPackages_resultsLimit() throws {
+    func testFindPackages_resultsLimit() async throws {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, searchResultMaxItemsCount: 3, disableCache: true)
         configuration.enabled = true
@@ -144,7 +144,7 @@ class PackageIndexTests: XCTestCase {
         let index = PackageIndex(configuration: configuration, customHTTPClient: httpClient, callbackQueue: .sharedConcurrent, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try index.close()) }
         
-        let result = try temp_await { callback in index.findPackages(query, callback: callback) }
+        let result = try await index.findPackages(query)
         XCTAssertEqual(result.items.count, configuration.searchResultMaxItemsCount)
         for (i, item) in result.items.enumerated() {
             XCTAssertEqual(item.package.identity, packages[i].identity)
@@ -153,7 +153,7 @@ class PackageIndexTests: XCTestCase {
         }
     }
     
-    func testFindPackages_featureDisabled() {
+    func testFindPackages_featureDisabled() async {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, disableCache: true)
         configuration.enabled = false
@@ -161,24 +161,24 @@ class PackageIndexTests: XCTestCase {
         let index = PackageIndex(configuration: configuration, callbackQueue: .sharedConcurrent, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try index.close()) }
         
-        XCTAssertThrowsError(try temp_await { callback in index.findPackages("foobar", callback: callback) }) { error in
+        await XCTAssertAsyncThrowsError(try await index.findPackages("foobar")) { error in
             XCTAssertEqual(error as? PackageIndexError, .featureDisabled)
         }
     }
     
-    func testFindPackages_notConfigured() {
+    func testFindPackages_notConfigured() async {
         var configuration = PackageIndexConfiguration(url: nil, disableCache: true)
         configuration.enabled = true
                 
         let index = PackageIndex(configuration: configuration, callbackQueue: .sharedConcurrent, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try index.close()) }
         
-        XCTAssertThrowsError(try temp_await { callback in index.findPackages("foobar", callback: callback) }) { error in
+        await XCTAssertAsyncThrowsError(try await index.findPackages("foobar")) { error in
             XCTAssertEqual(error as? PackageIndexError, .notConfigured)
         }
     }
     
-    func testListPackages() throws {
+    func testListPackages() async throws {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, disableCache: true)
         configuration.enabled = true
@@ -209,14 +209,14 @@ class PackageIndexTests: XCTestCase {
         let index = PackageIndex(configuration: configuration, customHTTPClient: httpClient, callbackQueue: .sharedConcurrent, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try index.close()) }
         
-        let result = try temp_await { callback in index.listPackages(offset: offset, limit: limit, callback: callback) }
+        let result = try await index.listPackages(offset: offset, limit: limit)
         XCTAssertEqual(result.items.count, packages.count)
         XCTAssertEqual(result.offset, offset)
         XCTAssertEqual(result.limit, limit)
         XCTAssertEqual(result.total, total)
     }
     
-    func testListPackages_featureDisabled() {
+    func testListPackages_featureDisabled() async {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, disableCache: true)
         configuration.enabled = false
@@ -224,24 +224,24 @@ class PackageIndexTests: XCTestCase {
         let index = PackageIndex(configuration: configuration, callbackQueue: .sharedConcurrent, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try index.close()) }
         
-        XCTAssertThrowsError(try temp_await { callback in index.listPackages(offset: 0, limit: 10, callback: callback) }) { error in
+        await XCTAssertAsyncThrowsError(try await index.listPackages(offset: 0, limit: 10)) { error in
             XCTAssertEqual(error as? PackageIndexError, .featureDisabled)
         }
     }
     
-    func testListPackages_notConfigured() {
+    func testListPackages_notConfigured() async {
         var configuration = PackageIndexConfiguration(url: nil, disableCache: true)
         configuration.enabled = true
                 
         let index = PackageIndex(configuration: configuration, callbackQueue: .sharedConcurrent, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try index.close()) }
         
-        XCTAssertThrowsError(try temp_await { callback in index.listPackages(offset: 0, limit: 10, callback: callback) }) { error in
+        await XCTAssertAsyncThrowsError(try await index.listPackages(offset: 0, limit: 10)) { error in
             XCTAssertEqual(error as? PackageIndexError, .notConfigured)
         }
     }
     
-    func testAsPackageMetadataProvider() throws {
+    func testAsPackageMetadataProvider() async throws {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, disableCache: true)
         configuration.enabled = true
@@ -268,11 +268,11 @@ class PackageIndexTests: XCTestCase {
         let index = PackageIndex(configuration: configuration, customHTTPClient: httpClient, callbackQueue: .sharedConcurrent, observabilityScope: ObservabilitySystem.NOOP)
         defer { XCTAssertNoThrow(try index.close()) }
         
-        let metadata = try index.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)
+        let metadata = try await index.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)
         XCTAssertEqual(metadata.summary, package.summary)
     }
     
-    func testAsGetPackageMetadataProvider_featureDisabled() {
+    func testAsGetPackageMetadataProvider_featureDisabled() async {
         let url = URL("https://package-index.test")
         var configuration = PackageIndexConfiguration(url: url, disableCache: true)
         configuration.enabled = false
@@ -281,12 +281,12 @@ class PackageIndexTests: XCTestCase {
         defer { XCTAssertNoThrow(try index.close()) }
         
         let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
-        XCTAssertThrowsError(try index.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)) { error in
+        await XCTAssertAsyncThrowsError(try await index.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)) { error in
             XCTAssertEqual(error as? PackageIndexError, .featureDisabled)
         }
     }
     
-    func testAsGetPackageMetadataProvider_notConfigured() {
+    func testAsGetPackageMetadataProvider_notConfigured() async {
         var configuration = PackageIndexConfiguration(url: nil, disableCache: true)
         configuration.enabled = true
                 
@@ -294,15 +294,15 @@ class PackageIndexTests: XCTestCase {
         defer { XCTAssertNoThrow(try index.close()) }
         
         let repoURL = SourceControlURL("https://github.com/octocat/Hello-World.git")
-        XCTAssertThrowsError(try index.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)) { error in
+        await XCTAssertAsyncThrowsError(try await index.syncGet(identity: .init(url: repoURL), location: repoURL.absoluteString)) { error in
             XCTAssertEqual(error as? PackageIndexError, .notConfigured)
         }
     }
 }
 
 private extension PackageIndex {
-    func syncGet(identity: PackageIdentity, location: String) throws -> Model.PackageBasicMetadata {
-        try temp_await { callback in
+    func syncGet(identity: PackageIdentity, location: String) async throws -> Model.PackageBasicMetadata {
+        try await safe_async { callback in
             self.get(identity: identity, location: location) { result, _ in callback(result) }
         }
     }


### PR DESCRIPTION
Adopt proper async/await for PackageCollectionsTests 

### Motivation:

Move more of the testing to be async/await native to make it easier to migrate to async/await in the core libraries

### Modifications:

1 commit that adds an async fixture variant
1 commit that replaces a lot of temp_await

### Result:

Less than 100 uses of temp_await in the repo
