### PR TITLE
Keep separate build parameters for host and target

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -216,7 +216,7 @@ public final class ClangTargetBuildDescription {
 
         var args = [String]()
         // Only enable ARC on macOS.
-        if buildParameters.targetTriple.isDarwin() {
+        if self.buildParameters.triple.isDarwin() {
             args += ["-fobjc-arc"]
         }
         args += try buildParameters.targetTripleArgs(for: target)
@@ -225,32 +225,33 @@ public final class ClangTargetBuildDescription {
         args += activeCompilationConditions
         args += ["-fblocks"]
 
+        let buildTriple = self.buildParameters.triple
         // Enable index store, if appropriate.
         //
         // This feature is not widely available in OSS clang. So, we only enable
         // index store for Apple's clang or if explicitly asked to.
         if ProcessEnv.vars.keys.contains("SWIFTPM_ENABLE_CLANG_INDEX_STORE") {
-            args += buildParameters.indexStoreArguments(for: target)
-        } else if buildParameters.targetTriple.isDarwin(),
-                  (try? buildParameters.toolchain._isClangCompilerVendorApple()) == true
+            args += self.buildParameters.indexStoreArguments(for: target)
+        } else if buildTriple.isDarwin(),
+                  (try? self.buildParameters.toolchain._isClangCompilerVendorApple()) == true
         {
-            args += buildParameters.indexStoreArguments(for: target)
+            args += self.buildParameters.indexStoreArguments(for: target)
         }
 
         // Enable Clang module flags, if appropriate.
         let enableModules: Bool
+        let triple = self.buildParameters.triple
         if toolsVersion < .v5_8 {
             // For version < 5.8, we enable them except in these cases:
             // 1. on Darwin when compiling for C++, because C++ modules are disabled on Apple-built Clang releases
             // 2. on Windows when compiling for any language, because of issues with the Windows SDK
             // 3. on Android when compiling for any language, because of issues with the Android SDK
-            enableModules = !(buildParameters.targetTriple.isDarwin() && isCXX) && !buildParameters.targetTriple
-                .isWindows() && !buildParameters.targetTriple.isAndroid()
+            enableModules = !(triple.isDarwin() && isCXX) && !triple.isWindows() && !triple.isAndroid()
         } else {
             // For version >= 5.8, we disable them when compiling for C++ regardless of platforms, see:
             // https://github.com/llvm/llvm-project/issues/55980 for clang frontend crash when module
             // enabled for C++ on c++17 standard and above.
-            enableModules = !isCXX && !buildParameters.targetTriple.isWindows() && !buildParameters.targetTriple.isAndroid()
+            enableModules = !isCXX && !triple.isWindows() && !triple.isAndroid()
         }
 
         if enableModules {

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -110,15 +110,16 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             return []
         }
 
+        let triple = self.buildParameters.triple
         switch self.buildParameters.configuration {
         case .debug:
             return []
         case .release:
-            if self.buildParameters.targetTriple.isApple() {
+            if triple.isApple() {
                 return ["-Xlinker", "-dead_strip"]
-            } else if self.buildParameters.targetTriple.isWindows() {
+            } else if triple.isWindows() {
                 return ["-Xlinker", "/OPT:REF"]
-            } else if self.buildParameters.targetTriple.arch == .wasm32 {
+            } else if triple.arch == .wasm32 {
                 // FIXME: wasm-ld strips data segments referenced through __start/__stop symbols
                 // during GC, and it removes Swift metadata sections like swift5_protocols
                 // We should add support of SHF_GNU_RETAIN-like flag for __attribute__((retain))
@@ -136,7 +137,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     /// The arguments to the librarian to create a static library.
     public func archiveArguments() throws -> [String] {
         let librarian = self.buildParameters.toolchain.librarianPath.pathString
-        let triple = self.buildParameters.targetTriple
+        let triple = self.buildParameters.triple
         if triple.isWindows(), librarian.hasSuffix("link") || librarian.hasSuffix("link.exe") {
             return try [librarian, "/LIB", "/OUT:\(binaryPath.pathString)", "@\(self.linkFileListPath.pathString)"]
         }
@@ -187,6 +188,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         }
 
         var isLinkingStaticStdlib = false
+        let triple = self.buildParameters.triple
         switch derivedProductType {
         case .macro:
             throw InternalError("macro not supported") // should never be reached
@@ -206,7 +208,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             args += self.deadStripArguments
         case .library(.dynamic):
             args += ["-emit-library"]
-            if self.buildParameters.targetTriple.isDarwin() {
+            if triple.isDarwin() {
                 let relativePath = try "@rpath/\(buildParameters.binaryRelativePath(for: self.product).pathString)"
                 args += ["-Xlinker", "-install_name", "-Xlinker", relativePath]
             }
@@ -215,9 +217,9 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             // Link the Swift stdlib statically, if requested.
             // TODO: unify this logic with SwiftTargetBuildDescription.stdlibArguments
             if self.buildParameters.linkingParameters.shouldLinkStaticSwiftStdlib {
-                if self.buildParameters.targetTriple.isDarwin() {
+                if triple.isDarwin() {
                     self.observabilityScope.emit(.swiftBackDeployError)
-                } else if self.buildParameters.targetTriple.isSupportingStaticStdlib {
+                } else if triple.isSupportingStaticStdlib {
                     args += ["-static-stdlib"]
                     isLinkingStaticStdlib = true
                 }
@@ -260,9 +262,9 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         // Set rpath such that dynamic libraries are looked up
         // adjacent to the product, unless overridden.
         if !self.buildParameters.linkingParameters.shouldDisableLocalRpath {
-            if self.buildParameters.targetTriple.isLinux() {
+            if triple.isLinux() {
                 args += ["-Xlinker", "-rpath=$ORIGIN"]
-            } else if self.buildParameters.targetTriple.isDarwin() {
+            } else if triple.isDarwin() {
                 let rpath = self.product.type == .test ? "@loader_path/../../../" : "@loader_path"
                 args += ["-Xlinker", "-rpath", "-Xlinker", rpath]
             }
@@ -283,7 +285,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
             // When deploying to macOS prior to macOS 12, add an rpath to the
             // back-deployed concurrency libraries.
-            if useStdlibRpath, self.buildParameters.targetTriple.isMacOSX {
+            if useStdlibRpath, triple.isMacOSX {
                 let macOSSupportedPlatform = self.package.platforms.getDerived(for: .macOS, usingXCTest: product.isLinkingXCTest)
                 if macOSSupportedPlatform.version.major < 12 {
                     let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
@@ -351,7 +353,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         flags += libraries.map { "-l" + $0 }
 
         // Linked frameworks.
-        if self.buildParameters.targetTriple.supportsFrameworks {
+        if self.buildParameters.triple.supportsFrameworks {
             let frameworks = OrderedSet(self.staticTargets.reduce([]) {
                 $0 + self.buildParameters.createScope(for: $1).evaluate(.LINK_FRAMEWORKS)
             })

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -105,11 +105,10 @@ public final class SwiftTargetBuildDescription {
 
     /// The path to the swiftmodule file after compilation.
     var moduleOutputPath: AbsolutePath {
+        let triple = buildParameters.triple
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
-        let allowLinkingAgainstExecutables = (
-            self.buildParameters.triple.isDarwin() ||
-            self.buildParameters.triple.isLinux() ||
-            self.buildParameters.triple.isWindows()) && self.toolsVersion >= .v5_5
+        let allowLinkingAgainstExecutables = (triple.isDarwin() || triple.isLinux() || triple.isWindows()) &&
+            self.toolsVersion >= .v5_5
         let dirPath = (target.type == .executable && !allowLinkingAgainstExecutables) ? self.tempsPath : self
             .buildParameters.buildPath
         return dirPath.appending(component: self.target.c99name + ".swiftmodule")

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -106,8 +106,10 @@ public final class SwiftTargetBuildDescription {
     /// The path to the swiftmodule file after compilation.
     var moduleOutputPath: AbsolutePath {
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
-        let allowLinkingAgainstExecutables = (buildParameters.targetTriple.isDarwin() || self.buildParameters.targetTriple
-            .isLinux() || self.buildParameters.targetTriple.isWindows()) && self.toolsVersion >= .v5_5
+        let allowLinkingAgainstExecutables = (
+            self.buildParameters.triple.isDarwin() ||
+            self.buildParameters.triple.isLinux() ||
+            self.buildParameters.triple.isWindows()) && self.toolsVersion >= .v5_5
         let dirPath = (target.type == .executable && !allowLinkingAgainstExecutables) ? self.tempsPath : self
             .buildParameters.buildPath
         return dirPath.appending(component: self.target.c99name + ".swiftmodule")
@@ -317,7 +319,7 @@ public final class SwiftTargetBuildDescription {
             return
         }
 
-        guard buildParameters.targetTriple.isDarwin(), buildParameters.testingParameters.experimentalTestOutput else {
+        guard self.buildParameters.triple.isDarwin(), self.buildParameters.testingParameters.experimentalTestOutput else {
             return
         }
 
@@ -361,7 +363,7 @@ public final class SwiftTargetBuildDescription {
         guard let bundlePath else { return }
 
         let mainPathSubstitution: String
-        if self.buildParameters.targetTriple.isWASI() {
+        if self.buildParameters.triple.isWASI() {
             // We prefer compile-time evaluation of the bundle path here for WASI. There's no benefit in evaluating this
             // at runtime, especially as `Bundle` support in WASI Foundation is partial. We expect all resource paths to
             // evaluate to `/\(resourceBundleName)/\(resourcePath)`, which allows us to pass this path to JS APIs like
@@ -646,7 +648,7 @@ public final class SwiftTargetBuildDescription {
 
     /// Returns true if ObjC compatibility header should be emitted.
     private var shouldEmitObjCCompatibilityHeader: Bool {
-        self.buildParameters.targetTriple.isDarwin() && self.target.type == .library
+        self.buildParameters.triple.isDarwin() && self.target.type == .library
     }
 
     func writeOutputFileMap() throws -> AbsolutePath {
@@ -849,7 +851,7 @@ public final class SwiftTargetBuildDescription {
         var arguments: [String] = []
 
         let isLinkingStaticStdlib = self.buildParameters.linkingParameters.shouldLinkStaticSwiftStdlib
-            && self.buildParameters.targetTriple.isSupportingStaticStdlib
+            && self.buildParameters.triple.isSupportingStaticStdlib
         if isLinkingStaticStdlib {
             arguments += ["-static-stdlib"]
         }

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import struct SPMBuildCore.BuildParameters
 import class PackageGraph.ResolvedTarget
 import struct PackageModel.Resource
 import struct SPMBuildCore.BuildToolPluginInvocationResult
@@ -89,6 +90,15 @@ public enum TargetBuildDescription {
             return target.buildToolPluginInvocationResults
         case .clang(let target):
             return target.buildToolPluginInvocationResults
+        }
+    }
+
+    var buildParameters: BuildParameters {
+        switch self {
+        case .swift(let swiftTargetBuildDescription):
+            swiftTargetBuildDescription.buildParameters
+        case .clang(let clangTargetBuildDescription):
+            clangTargetBuildDescription.buildParameters
         }
     }
 }

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -96,9 +96,9 @@ public enum TargetBuildDescription {
     var buildParameters: BuildParameters {
         switch self {
         case .swift(let swiftTargetBuildDescription):
-            swiftTargetBuildDescription.buildParameters
+            return swiftTargetBuildDescription.buildParameters
         case .clang(let clangTargetBuildDescription):
-            clangTargetBuildDescription.buildParameters
+            return clangTargetBuildDescription.buildParameters
         }
     }
 }

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
@@ -15,7 +15,7 @@ import struct LLBuildManifest.Node
 
 extension LLBuildManifestBuilder {
     func createProductCommand(_ buildProduct: ProductBuildDescription) throws {
-        let cmdName = try buildProduct.product.getCommandName(config: self.buildConfig)
+        let cmdName = try buildProduct.product.getCommandName(config: buildProduct.buildParameters.buildConfig)
 
         // Add dependency on Info.plist generation on Darwin platforms.
         let testInputs: [AbsolutePath]
@@ -34,7 +34,7 @@ extension LLBuildManifestBuilder {
         }
 
         // Create a phony node to represent the entire target.
-        let targetName = try buildProduct.product.getLLBuildTargetName(config: self.buildConfig)
+        let targetName = try buildProduct.product.getLLBuildTargetName(config: buildProduct.buildParameters.buildConfig)
         let output: Node = .virtual(targetName)
 
         let finalProductNode: Node
@@ -60,7 +60,7 @@ extension LLBuildManifestBuilder {
             let linkedBinaryPath = try buildProduct.binaryPath
             if case .executable = buildProduct.product.type,
                buildProduct.buildParameters.triple.isMacOSX,
-               buildParameters.debuggingParameters.shouldEnableDebuggingEntitlement {
+               buildProduct.buildParameters.debuggingParameters.shouldEnableDebuggingEntitlement {
                 shouldCodeSign = true
                 linkedBinaryNode = try .file(buildProduct.binaryPath, isMutated: true)
             } else {
@@ -85,7 +85,7 @@ extension LLBuildManifestBuilder {
                     outputPath: plistPath
                 )
 
-                let cmdName = try buildProduct.product.getCommandName(config: self.buildConfig)
+                let cmdName = try buildProduct.product.getCommandName(config: buildProduct.buildParameters.buildConfig)
                 let codeSigningOutput = Node.virtual(targetName + "-CodeSigning")
                 try self.manifest.addShellCmd(
                     name: "\(cmdName)-entitlements",

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
@@ -20,7 +20,7 @@ extension LLBuildManifestBuilder {
         // Add dependency on Info.plist generation on Darwin platforms.
         let testInputs: [AbsolutePath]
         if buildProduct.product.type == .test
-            && buildProduct.buildParameters.targetTriple.isDarwin()
+            && buildProduct.buildParameters.triple.isDarwin()
             && buildProduct.buildParameters.testingParameters.experimentalTestOutput {
             let testBundleInfoPlistPath = try buildProduct.binaryPath.parentDirectory.parentDirectory.appending(component: "Info.plist")
             testInputs = [testBundleInfoPlistPath]
@@ -59,7 +59,7 @@ extension LLBuildManifestBuilder {
             let linkedBinaryNode: Node
             let linkedBinaryPath = try buildProduct.binaryPath
             if case .executable = buildProduct.product.type,
-               buildParameters.targetTriple.isMacOSX,
+               buildProduct.buildParameters.triple.isMacOSX,
                buildParameters.debuggingParameters.shouldEnableDebuggingEntitlement {
                 shouldCodeSign = true
                 linkedBinaryNode = try .file(buildProduct.binaryPath, isMutated: true)

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
@@ -45,7 +45,7 @@ extension LLBuildManifestBuilder {
             outputs.append(output)
         }
 
-        let cmdName = target.target.getLLBuildResourcesCmdName(config: self.buildConfig)
+        let cmdName = target.target.getLLBuildResourcesCmdName(config: target.buildParameters.buildConfig)
         self.manifest.addPhonyCmd(name: cmdName, inputs: outputs, outputs: [.virtual(cmdName)])
 
         return .virtual(cmdName)

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -45,7 +45,7 @@ extension LLBuildManifestBuilder {
         let moduleNode = Node.file(target.moduleOutputPath)
         let cmdOutputs = objectNodes + [moduleNode]
 
-        if self.buildParameters.driverParameters.useIntegratedSwiftDriver {
+        if target.buildParameters.driverParameters.useIntegratedSwiftDriver {
             try self.addSwiftCmdsViaIntegratedDriver(
                 target,
                 inputs: inputs,
@@ -68,7 +68,7 @@ extension LLBuildManifestBuilder {
         // jobs needed to build this Swift target.
         var commandLine = try target.emitCommandLine()
         commandLine.append("-driver-use-frontend-path")
-        commandLine.append(self.buildParameters.toolchain.swiftCompilerPath.pathString)
+        commandLine.append(target.buildParameters.toolchain.swiftCompilerPath.pathString)
         // FIXME: At some point SwiftPM should provide its own executor for
         // running jobs/launching processes during planning
         let resolver = try ArgsResolver(fileSystem: target.fileSystem)
@@ -132,7 +132,7 @@ extension LLBuildManifestBuilder {
             // common intermediate dependency modules, such dependencies can lead
             // to cycles in the resulting manifest.
             var manifestNodeInputs: [Node] = []
-            if self.buildParameters.driverParameters.useExplicitModuleBuild && !isMainModule(job) {
+            if targetDescription.buildParameters.driverParameters.useExplicitModuleBuild && !isMainModule(job) {
                 manifestNodeInputs = jobInputs
             } else {
                 manifestNodeInputs = (inputs + jobInputs).uniqued()
@@ -276,7 +276,7 @@ extension LLBuildManifestBuilder {
         var dependencyModuleDetailsMap: SwiftDriver.ExternalTargetModuleDetailsMap = [:]
         // Collect paths for target dependencies of this target (direct and transitive)
         try self.collectTargetDependencyModuleDetails(
-            for: targetDescription.target,
+            for: .swift(targetDescription),
             dependencyModuleDetailsMap: &dependencyModuleDetailsMap
         )
 
@@ -284,7 +284,7 @@ extension LLBuildManifestBuilder {
         // jobs needed to build this Swift target.
         var commandLine = try targetDescription.emitCommandLine()
         commandLine.append("-driver-use-frontend-path")
-        commandLine.append(self.buildParameters.toolchain.swiftCompilerPath.pathString)
+        commandLine.append(targetDescription.buildParameters.toolchain.swiftCompilerPath.pathString)
         commandLine.append("-experimental-explicit-module-build")
         let resolver = try ArgsResolver(fileSystem: self.fileSystem)
         let executor = SPMSwiftDriverExecutor(
@@ -316,10 +316,10 @@ extension LLBuildManifestBuilder {
     /// dependency,
     /// in the form of a path to a .swiftmodule file and the dependency's InterModuleDependencyGraph.
     private func collectTargetDependencyModuleDetails(
-        for target: ResolvedTarget,
+        for targetDescription: TargetBuildDescription,
         dependencyModuleDetailsMap: inout SwiftDriver.ExternalTargetModuleDetailsMap
     ) throws {
-        for dependency in target.dependencies(satisfying: self.buildEnvironment) {
+        for dependency in targetDescription.target.dependencies(satisfying: targetDescription.buildParameters.buildEnvironment) {
             switch dependency {
             case .product:
                 // Product dependencies are broken down into the targets that make them up.
@@ -327,18 +327,24 @@ extension LLBuildManifestBuilder {
                     throw InternalError("unknown dependency product for \(dependency)")
                 }
                 for dependencyProductTarget in dependencyProduct.targets {
+                    guard let dependencyTargetDescription = self.plan.targetMap[dependencyProductTarget] else {
+                        throw InternalError("unknown dependency target for \(dependencyProductTarget)")
+                    }
                     try self.addTargetDependencyInfo(
-                        for: dependencyProductTarget,
+                        for: dependencyTargetDescription,
                         dependencyModuleDetailsMap: &dependencyModuleDetailsMap
                     )
                 }
             case .target:
                 // Product dependencies are broken down into the targets that make them up.
-                guard let dependencyTarget = dependency.target else {
+                guard
+                    let dependencyTarget = dependency.target,
+                    let dependencyTargetDescription = self.plan.targetMap[dependencyTarget]
+                else {
                     throw InternalError("unknown dependency target for \(dependency)")
                 }
                 try self.addTargetDependencyInfo(
-                    for: dependencyTarget,
+                    for: dependencyTargetDescription,
                     dependencyModuleDetailsMap: &dependencyModuleDetailsMap
                 )
             }
@@ -346,19 +352,19 @@ extension LLBuildManifestBuilder {
     }
 
     private func addTargetDependencyInfo(
-        for target: ResolvedTarget,
+        for targetDescription: TargetBuildDescription,
         dependencyModuleDetailsMap: inout SwiftDriver.ExternalTargetModuleDetailsMap
     ) throws {
-        guard case .swift(let dependencySwiftTargetDescription) = self.plan.targetMap[target] else {
+        guard case .swift(let dependencySwiftTargetDescription) = targetDescription else {
             return
         }
-        dependencyModuleDetailsMap[ModuleDependencyId.swiftPlaceholder(target.c99name)] =
+        dependencyModuleDetailsMap[ModuleDependencyId.swiftPlaceholder(targetDescription.target.c99name)] =
             SwiftDriver.ExternalTargetModuleDetails(
                 path: TSCAbsolutePath(dependencySwiftTargetDescription.moduleOutputPath),
                 isFramework: false
             )
         try self.collectTargetDependencyModuleDetails(
-            for: target,
+            for: targetDescription,
             dependencyModuleDetailsMap: &dependencyModuleDetailsMap
         )
     }
@@ -369,7 +375,7 @@ extension LLBuildManifestBuilder {
         cmdOutputs: [Node]
     ) throws {
         let isLibrary = target.target.type == .library || target.target.type == .test
-        let cmdName = target.target.getCommandName(config: self.buildConfig)
+        let cmdName = target.target.getCommandName(config: target.buildParameters.buildConfig)
 
         self.manifest.addWriteSourcesFileListCommand(sources: target.sources, sourcesFileListPath: target.sourcesFileListPath)
         self.manifest.addSwiftCmd(
@@ -443,7 +449,7 @@ extension LLBuildManifestBuilder {
             }
         }
 
-        for dependency in target.target.dependencies(satisfying: self.buildEnvironment) {
+        for dependency in target.target.dependencies(satisfying: target.buildParameters.buildEnvironment) {
             switch dependency {
             case .target(let target, _):
                 try addStaticTargetInputs(target)
@@ -470,7 +476,7 @@ extension LLBuildManifestBuilder {
         }
 
         for binaryPath in target.libraryBinaryPaths {
-            let path = self.destinationPath(forBinaryAt: binaryPath)
+            let path = target.buildParameters.destinationPath(forBinaryAt: binaryPath)
             if self.fileSystem.isDirectory(binaryPath) {
                 inputs.append(directory: path)
             } else {
@@ -482,7 +488,7 @@ extension LLBuildManifestBuilder {
 
         // Depend on any required macro product's output.
         try target.requiredMacroProducts.forEach { macro in
-            try inputs.append(.virtual(macro.getLLBuildTargetName(config: buildConfig)))
+            try inputs.append(.virtual(macro.getLLBuildTargetName(config: target.buildParameters.buildConfig)))
         }
 
         return inputs
@@ -491,7 +497,7 @@ extension LLBuildManifestBuilder {
     /// Adds a top-level phony command that builds the entire target.
     private func addTargetCmd(_ target: SwiftTargetBuildDescription, cmdOutputs: [Node]) {
         // Create a phony node to represent the entire target.
-        let targetName = target.target.getLLBuildTargetName(config: self.buildConfig)
+        let targetName = target.target.getLLBuildTargetName(config: target.buildParameters.buildConfig)
         let targetOutput: Node = .virtual(targetName)
 
         self.manifest.addNode(targetOutput, toTarget: targetName)
@@ -500,7 +506,7 @@ extension LLBuildManifestBuilder {
             inputs: cmdOutputs,
             outputs: [targetOutput]
         )
-        if self.plan.graph.isInRootPackages(target.target, satisfying: self.buildEnvironment) {
+        if self.plan.graph.isInRootPackages(target.target, satisfying: target.buildParameters.buildEnvironment) {
             if !target.isTestTarget {
                 self.addNode(targetOutput, toTarget: .main)
             }
@@ -510,13 +516,13 @@ extension LLBuildManifestBuilder {
 
     private func addModuleWrapCmd(_ target: SwiftTargetBuildDescription) throws {
         // Add commands to perform the module wrapping Swift modules when debugging strategy is `modulewrap`.
-        guard self.buildParameters.debuggingStrategy == .modulewrap else { return }
+        guard target.buildParameters.debuggingStrategy == .modulewrap else { return }
         var moduleWrapArgs = [
             target.buildParameters.toolchain.swiftCompilerPath.pathString,
             "-modulewrap", target.moduleOutputPath.pathString,
             "-o", target.wrappedModuleOutputPath.pathString,
         ]
-        moduleWrapArgs += try self.buildParameters.targetTripleArgs(for: target.target)
+        moduleWrapArgs += try target.buildParameters.targetTripleArgs(for: target.target)
         self.manifest.addShellCmd(
             name: target.wrappedModuleOutputPath.pathString,
             description: "Wrapping AST for \(target.target.name) for debugging",

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -365,7 +365,6 @@ extension BuildParameters {
     }
 
     var buildConfig: String { self.configuration.dirname }
-
 }
 
 extension Sequence where Element: Hashable {

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -65,12 +65,6 @@ public class LLBuildManifestBuilder {
 
     public internal(set) var manifest: LLBuildManifest = .init()
 
-    @available(*, deprecated, message: "use `productsBuildParameters` or `toolsBuildParameters` on `self.plan` instead")
-    var buildParameters: BuildParameters { self.plan.buildParameters }
-
-    @available(*, deprecated, message: "use `productsBuildParameters` or `toolsBuildParameters` on `self.plan` instead")
-    var buildEnvironment: BuildEnvironment { self.buildParameters.buildEnvironment }
-
     /// Mapping from Swift compiler path to Swift get version files.
     var swiftGetVersionFiles = [AbsolutePath: AbsolutePath]()
 

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -85,9 +85,9 @@ public class LLBuildManifestBuilder {
         self.observabilityScope = observabilityScope
     }
 
-    // MARK: - Generate Manifest
+    // MARK: - Generate Build Manifest
 
-    /// Generate manifest at the given path.
+    /// Generate build manifest at the given path.
     @discardableResult
     public func generateManifest(at path: AbsolutePath) throws -> LLBuildManifest {
         self.swiftGetVersionFiles.removeAll()

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -94,7 +94,7 @@ public class LLBuildManifestBuilder {
 
         addPackageStructureCommand()
         addBinaryDependencyCommands()
-        if self.plan.productsBuildParameters.driverParameters.useExplicitModuleBuild {
+        if self.plan.destinationBuildParameters.driverParameters.useExplicitModuleBuild {
             // Explicit module builds use the integrated driver directly and
             // require that every target's build jobs specify its dependencies explicitly to plan
             // its build.
@@ -113,7 +113,7 @@ public class LLBuildManifestBuilder {
             }
         }
 
-        if self.plan.productsBuildParameters.testingParameters.library == .xctest {
+        if self.plan.destinationBuildParameters.testingParameters.library == .xctest {
             try self.addTestDiscoveryGenerationCommand()
         }
         try self.addTestEntryPointGenerationCommand()
@@ -271,7 +271,7 @@ extension LLBuildManifestBuilder {
             let outputs = testEntryPointTarget.target.sources.paths
 
             let mainFileName = TestEntryPointTool.mainFileName(
-                for: self.plan.productsBuildParameters.testingParameters.library
+                for: self.plan.destinationBuildParameters.testingParameters.library
             )
             guard let mainOutput = (outputs.first { $0.basename == mainFileName }) else {
                 throw InternalError("main output (\(mainFileName)) not found")

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -42,8 +42,15 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     /// The delegate used by the build system.
     public weak var delegate: SPMBuildCore.BuildSystemDelegate?
 
-    /// The build parameters.
-    public let buildParameters: BuildParameters
+    /// Build parameters for products
+    @available(*, deprecated, renamed: "productsBuildParameters")
+    public var buildParameters: BuildParameters { self.productsBuildParameters }
+
+    /// Build parameters for products.
+    let productsBuildParameters: BuildParameters
+
+    /// Build parameters for build tools: plugins and macros.
+    let toolsBuildParameters: BuildParameters
 
     /// The closure for loading the package graph.
     let packageGraphLoader: () throws -> PackageGraph
@@ -102,7 +109,8 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     private let pkgConfigDirectories: [AbsolutePath]
 
     public init(
-        buildParameters: BuildParameters,
+        productsBuildParameters: BuildParameters,
+        toolsBuildParameters: BuildParameters,
         cacheBuildManifest: Bool,
         packageGraphLoader: @escaping () throws -> PackageGraph,
         pluginConfiguration: PluginConfiguration? = .none,
@@ -114,10 +122,14 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         observabilityScope: ObservabilityScope
     ) {
         /// Checks if stdout stream is tty.
-        var buildParameters = buildParameters
-        buildParameters.outputParameters.isColorized = outputStream.isTTY
+        var productsBuildParameters = productsBuildParameters
+        productsBuildParameters.outputParameters.isColorized = outputStream.isTTY
 
-        self.buildParameters = buildParameters
+        var toolsBuildParameters = toolsBuildParameters
+        toolsBuildParameters.outputParameters.isColorized = outputStream.isTTY
+
+        self.productsBuildParameters = productsBuildParameters
+        self.toolsBuildParameters = toolsBuildParameters
         self.cacheBuildManifest = cacheBuildManifest
         self.packageGraphLoader = packageGraphLoader
         self.additionalFileRules = additionalFileRules
@@ -147,7 +159,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                     if try self.buildPackageStructure() {
                         // confirm the step above created the build description as expected
                         // we trust it to update the build description when needed
-                        let buildDescriptionPath = self.buildParameters.buildDescriptionPath
+                        let buildDescriptionPath = self.productsBuildParameters.buildDescriptionPath
                         guard self.fileSystem.exists(buildDescriptionPath) else {
                             throw InternalError("could not find build descriptor at \(buildDescriptionPath)")
                         }
@@ -184,7 +196,11 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             return
         }
         // Ensure the compiler supports the import-scan operation
-        guard DriverSupport.checkSupportedFrontendFlags(flags: ["import-prescan"], toolchain: self.buildParameters.toolchain, fileSystem: localFileSystem) else {
+        guard DriverSupport.checkSupportedFrontendFlags(
+            flags: ["import-prescan"],
+            toolchain: self.productsBuildParameters.toolchain,
+            fileSystem: localFileSystem
+        ) else {
             return
         }
 
@@ -240,7 +256,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
     /// Perform a build using the given build description and subset.
     public func build(subset: BuildSubset) throws {
-        guard !buildParameters.shouldSkipBuilding else {
+        guard !self.productsBuildParameters.shouldSkipBuilding else {
             return
         }
 
@@ -266,7 +282,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         }
 
         // delegate is only available after createBuildSystem is called
-        self.buildSystemDelegate?.buildStart(configuration: self.buildParameters.configuration)
+        self.buildSystemDelegate?.buildStart(configuration: self.productsBuildParameters.configuration)
 
         // Perform the build.
         let llbuildTarget = try computeLLBuildTargetName(for: subset)
@@ -279,8 +295,8 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         guard success else { throw Diagnostics.fatalError }
 
         // Create backwards-compatibility symlink to old build path.
-        let oldBuildPath = buildParameters.dataPath.parentDirectory.appending(
-            component: buildParameters.configuration.dirname
+        let oldBuildPath = productsBuildParameters.dataPath.parentDirectory.appending(
+            component: productsBuildParameters.configuration.dirname
         )
         if self.fileSystem.exists(oldBuildPath) {
             do { try self.fileSystem.removeFileTree(oldBuildPath) }
@@ -294,7 +310,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         }
 
         do {
-            try self.fileSystem.createSymbolicLink(oldBuildPath, pointingAt: buildParameters.buildPath, relative: true)
+            try self.fileSystem.createSymbolicLink(oldBuildPath, pointingAt: productsBuildParameters.buildPath, relative: true)
         } catch {
             self.observabilityScope.emit(
                 warning: "unable to create symbolic link at \(oldBuildPath)",
@@ -411,8 +427,8 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             let graph = try getPackageGraph()
             if let result = subset.llbuildTargetName(
                 for: graph,
-                   config: buildParameters.configuration.dirname,
-                   observabilityScope: self.observabilityScope
+                config: productsBuildParameters.configuration.dirname,
+                observabilityScope: self.observabilityScope
             ) {
                 return result
             }
@@ -428,9 +444,10 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         let buildToolPluginInvocationResults: [ResolvedTarget: [BuildToolPluginInvocationResult]]
         let prebuildCommandResults: [ResolvedTarget: [PrebuildCommandResult]]
         // Invoke any build tool plugins in the graph to generate prebuild commands and build commands.
-        if let pluginConfiguration, !self.buildParameters.shouldSkipBuilding {
-            let buildOperationForPluginDependencies = try BuildOperation(
-                buildParameters: self.buildParameters.forTriple(self.buildParameters.hostTriple),
+        if let pluginConfiguration, !self.productsBuildParameters.shouldSkipBuilding {
+            let buildOperationForPluginDependencies = BuildOperation(
+                productsBuildParameters: self.productsBuildParameters,
+                toolsBuildParameters: self.toolsBuildParameters,
                 cacheBuildManifest: false,
                 packageGraphLoader: { return graph },
                 additionalFileRules: self.additionalFileRules,
@@ -442,11 +459,11 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             )
             buildToolPluginInvocationResults = try graph.invokeBuildToolPlugins(
                 outputDir: pluginConfiguration.workDirectory.appending("outputs"),
-                builtToolsDir: self.buildParameters.buildPath,
-                buildEnvironment: self.buildParameters.buildEnvironment,
-                toolSearchDirectories: [self.buildParameters.toolchain.swiftCompilerPath.parentDirectory],
+                builtToolsDir: self.toolsBuildParameters.buildPath,
+                buildEnvironment: self.toolsBuildParameters.buildEnvironment,
+                toolSearchDirectories: [self.toolsBuildParameters.toolchain.swiftCompilerPath.parentDirectory],
                 pkgConfigDirectories: self.pkgConfigDirectories,
-                sdkRootPath: self.buildParameters.toolchain.sdkRootPath,
+                sdkRootPath: self.toolsBuildParameters.toolchain.sdkRootPath,
                 pluginScriptRunner: pluginConfiguration.scriptRunner,
                 observabilityScope: self.observabilityScope,
                 fileSystem: self.fileSystem
@@ -526,7 +543,8 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
         // Create the build plan based, on the graph and any information from plugins.
         let plan = try BuildPlan(
-            buildParameters: buildParameters,
+            productsBuildParameters: self.productsBuildParameters,
+            toolsBuildParameters: self.toolsBuildParameters,
             graph: graph,
             additionalFileRules: additionalFileRules,
             buildToolPluginInvocationResults: buildToolPluginInvocationResults,
@@ -567,7 +585,8 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             : NinjaProgressAnimation(stream: self.outputStream)
 
         let buildExecutionContext = BuildExecutionContext(
-            buildParameters,
+            productsBuildParameters: self.productsBuildParameters,
+            toolsBuildParameters: self.toolsBuildParameters,
             buildDescription: buildDescription,
             fileSystem: self.fileSystem,
             observabilityScope: self.observabilityScope,
@@ -587,12 +606,12 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         )
         self.buildSystemDelegate = buildSystemDelegate
 
-        let databasePath = buildParameters.dataPath.appending("build.db").pathString
+        let databasePath = self.productsBuildParameters.dataPath.appending("build.db").pathString
         let buildSystem = SPMLLBuild.BuildSystem(
-            buildFile: buildParameters.llbuildManifest.pathString,
+            buildFile: self.productsBuildParameters.llbuildManifest.pathString,
             databaseFile: databasePath,
             delegate: buildSystemDelegate,
-            schedulerLanes: buildParameters.workers
+            schedulerLanes: self.productsBuildParameters.workers
         )
 
         // TODO: this seems fragile, perhaps we replace commandFailureHandler by adding relevant calls in the delegates chain
@@ -709,7 +728,7 @@ extension BuildDescription {
     static func create(with plan: BuildPlan, disableSandboxForPluginCommands: Bool, fileSystem: Basics.FileSystem, observabilityScope: ObservabilityScope) throws -> (BuildDescription, LLBuildManifest) {
         // Generate the llbuild manifest.
         let llbuild = LLBuildManifestBuilder(plan, disableSandboxForPluginCommands: disableSandboxForPluginCommands, fileSystem: fileSystem, observabilityScope: observabilityScope)
-        let buildManifest = try llbuild.generateManifest(at: plan.buildParameters.llbuildManifest)
+        let buildManifest = try llbuild.generateManifest(at: plan.productsBuildParameters.llbuildManifest)
 
         let swiftCommands = llbuild.manifest.getCmdToolMap(kind: SwiftCompilerTool.self)
         let swiftFrontendCommands = llbuild.manifest.getCmdToolMap(kind: SwiftFrontendTool.self)
@@ -730,10 +749,10 @@ extension BuildDescription {
             pluginDescriptions: plan.pluginDescriptions
         )
         try fileSystem.createDirectory(
-            plan.buildParameters.buildDescriptionPath.parentDirectory,
+            plan.productsBuildParameters.buildDescriptionPath.parentDirectory,
             recursive: true
         )
-        try buildDescription.write(fileSystem: fileSystem, path: plan.buildParameters.buildDescriptionPath)
+        try buildDescription.write(fileSystem: fileSystem, path: plan.productsBuildParameters.buildDescriptionPath)
         return (buildDescription, buildManifest)
     }
 }

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -412,7 +412,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     }
 
     /// Compute the llbuild target name using the given subset.
-    func computeLLBuildTargetName(for subset: BuildSubset) throws -> String {
+    private func computeLLBuildTargetName(for subset: BuildSubset) throws -> String {
         switch subset {
         case .allExcludingTests:
             return LLBuildManifestBuilder.TargetKind.main.targetName
@@ -423,7 +423,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             let graph = try getPackageGraph()
             if let result = subset.llbuildTargetName(
                 for: graph,
-                config: productsBuildParameters.configuration.dirname,
+                config: self.productsBuildParameters.configuration.dirname,
                 observabilityScope: self.observabilityScope
             ) {
                 return result

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -42,10 +42,6 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     /// The delegate used by the build system.
     public weak var delegate: SPMBuildCore.BuildSystemDelegate?
 
-    /// Build parameters for products
-    @available(*, deprecated, renamed: "productsBuildParameters")
-    public var buildParameters: BuildParameters { self.productsBuildParameters }
-
     /// Build parameters for products.
     let productsBuildParameters: BuildParameters
 

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -721,7 +721,12 @@ extension BuildOperation {
 }
 
 extension BuildDescription {
-    static func create(with plan: BuildPlan, disableSandboxForPluginCommands: Bool, fileSystem: Basics.FileSystem, observabilityScope: ObservabilityScope) throws -> (BuildDescription, LLBuildManifest) {
+    static func create(
+        with plan: BuildPlan,
+        disableSandboxForPluginCommands: Bool,
+        fileSystem: Basics.FileSystem,
+        observabilityScope: ObservabilityScope
+    ) throws -> (BuildDescription, LLBuildManifest) {
         // Generate the llbuild manifest.
         let llbuild = LLBuildManifestBuilder(plan, disableSandboxForPluginCommands: disableSandboxForPluginCommands, fileSystem: fileSystem, observabilityScope: observabilityScope)
         let buildManifest = try llbuild.generateManifest(at: plan.productsBuildParameters.llbuildManifest)

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -729,7 +729,7 @@ extension BuildDescription {
     ) throws -> (BuildDescription, LLBuildManifest) {
         // Generate the llbuild manifest.
         let llbuild = LLBuildManifestBuilder(plan, disableSandboxForPluginCommands: disableSandboxForPluginCommands, fileSystem: fileSystem, observabilityScope: observabilityScope)
-        let buildManifest = try llbuild.generateManifest(at: plan.productsBuildParameters.llbuildManifest)
+        let buildManifest = try llbuild.generateManifest(at: plan.destinationBuildParameters.llbuildManifest)
 
         let swiftCommands = llbuild.manifest.getCmdToolMap(kind: SwiftCompilerTool.self)
         let swiftFrontendCommands = llbuild.manifest.getCmdToolMap(kind: SwiftFrontendTool.self)
@@ -750,10 +750,10 @@ extension BuildDescription {
             pluginDescriptions: plan.pluginDescriptions
         )
         try fileSystem.createDirectory(
-            plan.productsBuildParameters.buildDescriptionPath.parentDirectory,
+            plan.destinationBuildParameters.buildDescriptionPath.parentDirectory,
             recursive: true
         )
-        try buildDescription.write(fileSystem: fileSystem, path: plan.productsBuildParameters.buildDescriptionPath)
+        try buildDescription.write(fileSystem: fileSystem, path: plan.destinationBuildParameters.buildDescriptionPath)
         return (buildDescription, buildManifest)
     }
 }

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -494,7 +494,7 @@ public final class BuildExecutionContext {
                 // library is currently installed as `libIndexStore.dll` rather than
                 // `IndexStore.dll`.  In the future, this may require a fallback
                 // search, preferring `IndexStore.dll` over `libIndexStore.dll`.
-                let indexStoreLib = buildParameters.toolchain.swiftCompilerPath
+                let indexStoreLib = toolsBuildParameters.toolchain.swiftCompilerPath
                     .parentDirectory
                     .appending("libIndexStore.dll")
                 #else

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -371,7 +371,7 @@ public struct BuildDescription: Codable {
         self.testEntryPointCommands = testEntryPointCommands
         self.copyCommands = copyCommands
         self.writeCommands = writeCommands
-        self.explicitTargetDependencyImportCheckingMode = plan.productsBuildParameters.driverParameters
+        self.explicitTargetDependencyImportCheckingMode = plan.destinationBuildParameters.driverParameters
             .explicitTargetDependencyImportCheckingMode
         self.targetDependencyMap = try plan.targets.reduce(into: [TargetName: [TargetName]]()) { partial, targetBuildDescription in
             let deps = try targetBuildDescription.target.recursiveDependencies(

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -435,10 +435,6 @@ public protocol BuildErrorAdviceProvider {
 /// The context available during build execution.
 public final class BuildExecutionContext {
     /// Build parameters for products.
-    @available(*, deprecated, message: "use either `productsBuildParameters` or `toolsBuildParameters`")
-    var buildParameters: BuildParameters { self.productsBuildParameters }
-
-    /// Build parameters for products.
     let productsBuildParameters: BuildParameters
 
     /// Build parameters for build tools.

--- a/Sources/Build/BuildPlan/BuildPlan+Clang.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Clang.swift
@@ -18,7 +18,9 @@ import class PackageModel.SystemLibraryTarget
 extension BuildPlan {
     /// Plan a Clang target.
     func plan(clangTarget: ClangTargetBuildDescription) throws {
-        for case .target(let dependency, _) in try clangTarget.target.recursiveDependencies(satisfying: buildEnvironment) {
+        let dependencies = try clangTarget.target.recursiveDependencies(satisfying: clangTarget.buildEnvironment)
+
+        for case .target(let dependency, _) in dependencies {
             switch dependency.underlyingTarget {
             case is SwiftTarget:
                 if case let .swift(dependencyTargetDescription)? = targetMap[dependency] {
@@ -42,7 +44,7 @@ extension BuildPlan {
                 clangTarget.additionalFlags += try pkgConfig(for: target).cFlags
             case let target as BinaryTarget:
                 if case .xcframework = target.kind {
-                    let libraries = try self.parseXCFramework(for: target)
+                    let libraries = try self.parseXCFramework(for: target, triple: clangTarget.buildParameters.triple)
                     for library in libraries {
                         library.headersPaths.forEach {
                             clangTarget.additionalFlags += ["-I", $0.pathString]

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -241,8 +241,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// ObservabilityScope with which to emit diagnostics
     let observabilityScope: ObservabilityScope
 
-    /// Create a build plan with a package graph and same build parameters for products and tools. Provided for
-    /// testing purposes only.
+    @available(*, deprecated, renamed: "init(productsBuildParameters:toolsBuildParameters:graph:)")
     public convenience init(
         buildParameters: BuildParameters,
         graph: PackageGraph,

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -187,26 +187,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// Build parameters used for tools.
     public let toolsBuildParameters: BuildParameters
 
-    /// Parameters used for building this target.
-    func buildParameters(for target: ResolvedTarget) -> BuildParameters {
-        switch target.buildTriple {
-        case .buildTools:
-            return self.toolsBuildParameters
-        case .buildProducts:
-            return self.productsBuildParameters
-        }
-    }
-
-    /// Parameters used for building this product.
-    func buildParameters(for product: ResolvedProduct) -> BuildParameters {
-        switch product.buildTriple {
-        case .buildTools:
-            return self.toolsBuildParameters
-        case .buildProducts:
-            return self.productsBuildParameters
-        }
-    }
-
     /// Triple for which this target is compiled.
     private func buildTriple(for target: ResolvedTarget) -> Basics.Triple {
         self.buildParameters(for: target).triple
@@ -272,7 +252,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
 
     /// Create a build plan with a package graph and same build parameters for products and tools. Provided for
     /// testing purposes only.
-    convenience init(
+    public convenience init(
         buildParameters: BuildParameters,
         graph: PackageGraph,
         additionalFileRules: [FileRuleDescription] = [],

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -178,9 +178,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
     }
 
-    @available(*, deprecated, message: "use either `productsBuildParameters` or `toolsBuildParameters`")
-    public var buildParameters: BuildParameters { self.productsBuildParameters }
-
     /// Build parameters used for products.
     public let productsBuildParameters: BuildParameters
 
@@ -195,12 +192,6 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// Triple for which this product is compiled.
     private func buildTriple(for product: ResolvedProduct) -> Basics.Triple {
         self.buildParameters(for: product).triple
-    }
-
-    /// The build environment.
-    @available(*, deprecated, message: "Use `buildParameters(for:)` to get build parameters instead")
-    var buildEnvironment: BuildEnvironment {
-        self.buildParameters.buildEnvironment
     }
 
     /// The package graph.

--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -13,7 +13,7 @@
 import SPMBuildCore
 
 public func generateTestObservationCode(buildParameters: BuildParameters) -> String {
-    guard buildParameters.targetTriple.supportsTestSummary else {
+    guard buildParameters.triple.supportsTestSummary else {
         return ""
     }
 

--- a/Sources/Commands/PackageTools/APIDiff.swift
+++ b/Sources/Commands/PackageTools/APIDiff.swift
@@ -98,7 +98,7 @@ struct APIDiff: SwiftCommand {
         let baselineDumper = try APIDigesterBaselineDumper(
             baselineRevision: baselineRevision,
             packageRoot: swiftTool.getPackageRoot(),
-            productsBuildParameters: try buildSystem.buildPlan.productsBuildParameters,
+            productsBuildParameters: try buildSystem.buildPlan.destinationBuildParameters,
             toolsBuildParameters: try buildSystem.buildPlan.toolsBuildParameters,
             apiDigesterTool: apiDigesterTool,
             observabilityScope: swiftTool.observabilityScope
@@ -114,7 +114,7 @@ struct APIDiff: SwiftCommand {
 
         let results = ThreadSafeArrayStore<SwiftAPIDigester.ComparisonResult>()
         let group = DispatchGroup()
-        let semaphore = DispatchSemaphore(value: Int(try buildSystem.buildPlan.productsBuildParameters.workers))
+        let semaphore = DispatchSemaphore(value: Int(try buildSystem.buildPlan.destinationBuildParameters.workers))
         var skippedModules: Set<String> = []
 
         for module in modulesToDiff {

--- a/Sources/Commands/PackageTools/APIDiff.swift
+++ b/Sources/Commands/PackageTools/APIDiff.swift
@@ -98,7 +98,8 @@ struct APIDiff: SwiftCommand {
         let baselineDumper = try APIDigesterBaselineDumper(
             baselineRevision: baselineRevision,
             packageRoot: swiftTool.getPackageRoot(),
-            buildParameters: try buildSystem.buildPlan.buildParameters,
+            productsBuildParameters: try buildSystem.buildPlan.productsBuildParameters,
+            toolsBuildParameters: try buildSystem.buildPlan.toolsBuildParameters,
             apiDigesterTool: apiDigesterTool,
             observabilityScope: swiftTool.observabilityScope
         )
@@ -113,7 +114,7 @@ struct APIDiff: SwiftCommand {
 
         let results = ThreadSafeArrayStore<SwiftAPIDigester.ComparisonResult>()
         let group = DispatchGroup()
-        let semaphore = DispatchSemaphore(value: Int(try buildSystem.buildPlan.buildParameters.workers))
+        let semaphore = DispatchSemaphore(value: Int(try buildSystem.buildPlan.productsBuildParameters.workers))
         var skippedModules: Set<String> = []
 
         for module in modulesToDiff {

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -65,7 +65,7 @@ struct DumpSymbolGraph: SwiftCommand {
 
         // Run the tool once for every library and executable target in the root package.
         let buildPlan = try buildSystem.buildPlan
-        let symbolGraphDirectory = buildPlan.productsBuildParameters.dataPath.appending("symbolgraph")
+        let symbolGraphDirectory = buildPlan.destinationBuildParameters.dataPath.appending("symbolgraph")
         let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.targets }.filter{ $0.type == .library }
         for target in targets {
             print("-- Emitting symbol graph for", target.name)

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -65,7 +65,7 @@ struct DumpSymbolGraph: SwiftCommand {
 
         // Run the tool once for every library and executable target in the root package.
         let buildPlan = try buildSystem.buildPlan
-        let symbolGraphDirectory = buildPlan.buildParameters.dataPath.appending("symbolgraph")
+        let symbolGraphDirectory = buildPlan.productsBuildParameters.dataPath.appending("symbolgraph")
         let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.targets }.filter{ $0.type == .library }
         for target in targets {
             print("-- Emitting symbol graph for", target.name)

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -140,7 +140,7 @@ struct DumpPIF: SwiftCommand {
     func run(_ swiftTool: SwiftTool) throws {
         let graph = try swiftTool.loadPackageGraph()
         let pif = try PIFBuilder.generatePIF(
-            buildParameters: swiftTool.buildParameters(),
+            buildParameters: swiftTool.productsBuildParameters,
             packageGraph: graph,
             fileSystem: swiftTool.fileSystem,
             observabilityScope: swiftTool.observabilityScope,

--- a/Sources/Commands/PackageTools/InstalledPackages.swift
+++ b/Sources/Commands/PackageTools/InstalledPackages.swift
@@ -83,7 +83,7 @@ extension SwiftPackageTool {
             try tool.createBuildSystem(explicitProduct: productToInstall.name)
                 .build(subset: .product(productToInstall.name))
 
-            let binPath = try tool.buildParameters().buildPath.appending(component: productToInstall.name)
+            let binPath = try tool.productsBuildParameters.buildPath.appending(component: productToInstall.name)
             let finalBinPath = swiftpmBinDir.appending(component: binPath.basename)
             try tool.fileSystem.copy(from: binPath, to: finalBinPath)
 

--- a/Sources/Commands/PackageTools/PluginCommand.swift
+++ b/Sources/Commands/PackageTools/PluginCommand.swift
@@ -259,8 +259,7 @@ struct PluginCommand: SwiftCommand {
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
         let buildSystem = try swiftTool.createBuildSystem(
             explicitBuildSystem: .native,
-            cacheBuildManifest: false,
-            customBuildParameters: buildParameters
+            cacheBuildManifest: false
         )
         let accessibleTools = try plugin.processAccessibleTools(
             packageGraph: packageGraph,

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -95,7 +95,7 @@ struct SnippetCard: Card {
         print("Building '\(snippet.path)'\n")
         let buildSystem = try swiftTool.createBuildSystem(explicitProduct: snippet.name)
         try buildSystem.build(subset: .product(snippet.name))
-        let executablePath = try swiftTool.buildParameters().buildPath.appending(component: snippet.name)
+        let executablePath = try swiftTool.productsBuildParameters.buildPath.appending(component: snippet.name)
         if let exampleTarget = try buildSystem.getPackageGraph().allTargets.first(where: { $0.name == snippet.name }) {
             try ProcessEnv.chdir(exampleTarget.sources.paths[0].parentDirectory)
         }

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -134,7 +134,7 @@ public struct SwiftBuildTool: SwiftCommand {
             shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib,
             // command result output goes on stdout
             // ie "swift build" should output to stdout
-            customOutputStream: TSCBasic.stdoutStream
+            outputStream: TSCBasic.stdoutStream
         )
         do {
             try buildSystem.build(subset: subset)

--- a/Sources/Commands/SwiftBuildTool.swift
+++ b/Sources/Commands/SwiftBuildTool.swift
@@ -109,7 +109,7 @@ public struct SwiftBuildTool: SwiftCommand {
 
     public func run(_ swiftTool: SwiftTool) throws {
         if options.shouldPrintBinPath {
-            return try print(swiftTool.buildParameters().buildPath.description)
+            return try print(swiftTool.productsBuildParameters.buildPath.description)
         }
 
         if options.printManifestGraphviz {

--- a/Sources/Commands/SwiftRunTool.swift
+++ b/Sources/Commands/SwiftRunTool.swift
@@ -125,15 +125,13 @@ public struct SwiftRunTool: SwiftCommand {
                     explicitProduct: self.options.executable
                 )
             }
-            let buildParameters = try swiftTool.buildParameters()
 
             // Construct the build operation.
             // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the REPL. rdar://86112934
             let buildSystem = try swiftTool.createBuildSystem(
                 explicitBuildSystem: .native,
                 cacheBuildManifest: false,
-                customBuildParameters: buildParameters,
-                customPackageGraphLoader: graphLoader
+                packageGraphLoader: graphLoader
             )
 
             // Perform build.
@@ -159,7 +157,7 @@ public struct SwiftRunTool: SwiftCommand {
                     try buildSystem.build(subset: .product(productName))
                 }
 
-                let executablePath = try swiftTool.buildParameters().buildPath.appending(component: productName)
+                let executablePath = try swiftTool.productsBuildParameters.buildPath.appending(component: productName)
 
                 // Make sure we are running from the original working directory.
                 let cwd: AbsolutePath? = swiftTool.fileSystem.currentWorkingDirectory
@@ -201,7 +199,7 @@ public struct SwiftRunTool: SwiftCommand {
                     try buildSystem.build(subset: .product(productName))
                 }
 
-                let executablePath = try swiftTool.buildParameters().buildPath.appending(component: productName)
+                let executablePath = try swiftTool.productsBuildParameters.buildPath.appending(component: productName)
                 try self.run(
                     fileSystem: swiftTool.fileSystem,
                     executablePath: executablePath,

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -217,7 +217,7 @@ public struct SwiftTestTool: SwiftCommand {
         let buildParameters = try swiftTool.buildParametersForTest(options: self.options, library: .xctest)
 
         // Remove test output from prior runs and validate priors.
-        if self.options.enableExperimentalTestOutput && buildParameters.targetTriple.supportsTestSummary {
+        if self.options.enableExperimentalTestOutput && buildParameters.triple.supportsTestSummary {
             _ = try? localFileSystem.removeFileTree(buildParameters.testOutputPath)
         }
 
@@ -573,7 +573,7 @@ extension SwiftTestTool {
 
         func run(_ swiftTool: SwiftTool) throws {
             try SwiftTestTool.handleTestOutput(
-                buildParameters: try swiftTool.buildParameters(),
+                buildParameters: try swiftTool.productsBuildParameters,
                 packagePath: localFileSystem.currentWorkingDirectory ?? .root // by definition runs in the current working directory
             )
         }
@@ -1201,7 +1201,10 @@ final class XUnitGenerator {
 }
 
 extension SwiftTool {
-    func buildParametersForTest(options: TestToolOptions, library: BuildParameters.Testing.Library) throws -> BuildParameters {
+    func buildParametersForTest(
+        options: TestToolOptions,
+        library: BuildParameters.Testing.Library
+    ) throws -> BuildParameters {
         var result = try self.buildParametersForTest(
             enableCodeCoverage: options.enableCodeCoverage,
             enableTestability: options.enableTestableImports,
@@ -1269,7 +1272,7 @@ private extension Basics.Diagnostic {
 ///
 /// - Returns: The paths to the build test products.
 private func buildTestsIfNeeded(swiftTool: SwiftTool, buildParameters: BuildParameters, testProduct: String?) throws -> [BuiltTestProduct] {
-    let buildSystem = try swiftTool.createBuildSystem(customBuildParameters: buildParameters)
+    let buildSystem = try swiftTool.createBuildSystem(productsBuildParameters: buildParameters)
 
     let subset = testProduct.map(BuildSubset.product) ?? .allIncludingTests
     try buildSystem.build(subset: subset)

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -39,8 +39,11 @@ struct APIDigesterBaselineDumper {
     /// The root package path.
     let packageRoot: AbsolutePath
 
-    /// The input build parameters.
-    let inputBuildParameters: BuildParameters
+    /// Parameters used when building end products.
+    let productsBuildParameters: BuildParameters
+
+    /// Parameters used when building tools (plugins and macros).
+    let toolsBuildParameters: BuildParameters
 
     /// The API digester tool.
     let apiDigesterTool: SwiftAPIDigester
@@ -51,13 +54,15 @@ struct APIDigesterBaselineDumper {
     init(
         baselineRevision: Revision,
         packageRoot: AbsolutePath,
-        buildParameters: BuildParameters,
+        productsBuildParameters: BuildParameters,
+        toolsBuildParameters: BuildParameters,
         apiDigesterTool: SwiftAPIDigester,
         observabilityScope: ObservabilityScope
     ) {
         self.baselineRevision = baselineRevision
         self.packageRoot = packageRoot
-        self.inputBuildParameters = buildParameters
+        self.productsBuildParameters = productsBuildParameters
+        self.toolsBuildParameters = toolsBuildParameters
         self.apiDigesterTool = apiDigesterTool
         self.observabilityScope = observabilityScope
     }
@@ -71,7 +76,7 @@ struct APIDigesterBaselineDumper {
         swiftTool: SwiftTool
     ) throws -> AbsolutePath {
         var modulesToDiff = modulesToDiff
-        let apiDiffDir = inputBuildParameters.apiDiff
+        let apiDiffDir = productsBuildParameters.apiDiff
         let baselineDir = (baselineDir ?? apiDiffDir).appending(component: baselineRevision.identifier)
         let baselinePath: (String)->AbsolutePath = { module in
             baselineDir.appending(component: module + ".json")
@@ -127,23 +132,24 @@ struct APIDigesterBaselineDumper {
         }
 
         // Update the data path input build parameters so it's built in the sandbox.
-        var buildParameters = inputBuildParameters
-        buildParameters.dataPath = workspace.location.scratchDirectory
+        var productsBuildParameters = productsBuildParameters
+        productsBuildParameters.dataPath = workspace.location.scratchDirectory
 
         // Build the baseline module.
         // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the APIDigester. rdar://86112934
         let buildSystem = try swiftTool.createBuildSystem(
             explicitBuildSystem: .native,
             cacheBuildManifest: false,
-            customBuildParameters: buildParameters,
-            customPackageGraphLoader: { graph }
+            productsBuildParameters: productsBuildParameters,
+            toolsBuildParameters: toolsBuildParameters,
+            packageGraphLoader: { graph }
         )
         try buildSystem.build()
 
         // Dump the SDK JSON.
         try swiftTool.fileSystem.createDirectory(baselineDir, recursive: true)
         let group = DispatchGroup()
-        let semaphore = DispatchSemaphore(value: Int(buildParameters.workers))
+        let semaphore = DispatchSemaphore(value: Int(productsBuildParameters.workers))
         let errors = ThreadSafeArrayStore<Swift.Error>()
         for module in modulesToDiff {
             semaphore.wait()

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -71,7 +71,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         parameters: PluginInvocationBuildParameters
     ) throws -> PluginInvocationBuildResult {
         // Configure the build parameters.
-        var buildParameters = try self.swiftTool.buildParameters()
+        var buildParameters = try self.swiftTool.toolsBuildParameters
         switch parameters.configuration {
         case .debug:
             buildParameters.configuration = .debug
@@ -171,7 +171,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Build the tests. Ideally we should only build those that match the subset, but we don't have a way to know
         // which ones they are until we've built them and can examine the binaries.
         let toolchain = try swiftTool.getTargetToolchain()
-        var buildParameters = try swiftTool.buildParameters()
+        var buildParameters = try swiftTool.toolsBuildParameters
         buildParameters.testingParameters.enableTestability = true
         buildParameters.testingParameters.enableCodeCoverage = parameters.enableCodeCoverage
         let buildSystem = try swiftTool.createBuildSystem(customBuildParameters: buildParameters)

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -71,7 +71,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         parameters: PluginInvocationBuildParameters
     ) throws -> PluginInvocationBuildResult {
         // Configure the build parameters.
-        var buildParameters = try self.swiftTool.toolsBuildParameters
+        var buildParameters = try self.swiftTool.productsBuildParameters
         switch parameters.configuration {
         case .debug:
             buildParameters.configuration = .debug
@@ -113,9 +113,9 @@ final class PluginDelegate: PluginInvocationDelegate {
             explicitBuildSystem: .native,
             explicitProduct: explicitProduct,
             cacheBuildManifest: false,
-            customBuildParameters: buildParameters,
-            customOutputStream: outputStream,
-            customLogLevel: logLevel
+            productsBuildParameters: buildParameters,
+            outputStream: outputStream,
+            logLevel: logLevel
         )
 
         // Run the build. This doesn't return until the build is complete.
@@ -170,23 +170,23 @@ final class PluginDelegate: PluginInvocationDelegate {
     ) throws -> PluginInvocationTestResult {
         // Build the tests. Ideally we should only build those that match the subset, but we don't have a way to know
         // which ones they are until we've built them and can examine the binaries.
-        let toolchain = try swiftTool.getTargetToolchain()
-        var buildParameters = try swiftTool.toolsBuildParameters
-        buildParameters.testingParameters.enableTestability = true
-        buildParameters.testingParameters.enableCodeCoverage = parameters.enableCodeCoverage
-        let buildSystem = try swiftTool.createBuildSystem(customBuildParameters: buildParameters)
+        let toolchain = try swiftTool.getHostToolchain()
+        var toolsBuildParameters = try swiftTool.toolsBuildParameters
+        toolsBuildParameters.testingParameters.enableTestability = true
+        toolsBuildParameters.testingParameters.enableCodeCoverage = parameters.enableCodeCoverage
+        let buildSystem = try swiftTool.createBuildSystem(toolsBuildParameters: toolsBuildParameters)
         try buildSystem.build(subset: .allIncludingTests)
 
         // Clean out the code coverage directory that may contain stale `profraw` files from a previous run of
         // the code coverage tool.
         if parameters.enableCodeCoverage {
-            try swiftTool.fileSystem.removeFileTree(buildParameters.codeCovPath)
+            try swiftTool.fileSystem.removeFileTree(toolsBuildParameters.codeCovPath)
         }
 
         // Construct the environment we'll pass down to the tests.
         let testEnvironment = try TestingSupport.constructTestEnvironment(
             toolchain: toolchain,
-            buildParameters: buildParameters,
+            buildParameters: toolsBuildParameters,
             sanitizers: swiftTool.options.build.sanitizers
         )
 
@@ -271,12 +271,12 @@ final class PluginDelegate: PluginInvocationDelegate {
         let codeCoverageDataFile: AbsolutePath?
         if parameters.enableCodeCoverage {
             // Use `llvm-prof` to merge all the `.profraw` files into a single `.profdata` file.
-            let mergedCovFile = buildParameters.codeCovDataFile
-            let codeCovFileNames = try swiftTool.fileSystem.getDirectoryContents(buildParameters.codeCovPath)
+            let mergedCovFile = toolsBuildParameters.codeCovDataFile
+            let codeCovFileNames = try swiftTool.fileSystem.getDirectoryContents(toolsBuildParameters.codeCovPath)
             var llvmProfCommand = [try toolchain.getLLVMProf().pathString]
             llvmProfCommand += ["merge", "-sparse"]
             for fileName in codeCovFileNames where fileName.hasSuffix(".profraw") {
-                let filePath = buildParameters.codeCovPath.appending(component: fileName)
+                let filePath = toolsBuildParameters.codeCovPath.appending(component: fileName)
                 llvmProfCommand.append(filePath.pathString)
             }
             llvmProfCommand += ["-o", mergedCovFile.pathString]
@@ -291,8 +291,8 @@ final class PluginDelegate: PluginInvocationDelegate {
             }
             // We get the output on stdout, and have to write it to a JSON ourselves.
             let jsonOutput = try TSCBasic.Process.checkNonZeroExit(arguments: llvmCovCommand)
-            let jsonCovFile = buildParameters.codeCovDataFile.parentDirectory.appending(
-                component: buildParameters.codeCovDataFile.basenameWithoutExt + ".json"
+            let jsonCovFile = toolsBuildParameters.codeCovDataFile.parentDirectory.appending(
+                component: toolsBuildParameters.codeCovDataFile.basenameWithoutExt + ".json"
             )
             try swiftTool.fileSystem.writeFileContents(jsonCovFile, string: jsonOutput)
 
@@ -369,7 +369,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         guard let package = packageGraph.package(for: target) else {
             throw StringError("could not determine the package for target “\(target.name)”")
         }
-        let outputDir = try buildSystem.buildPlan.buildParameters.dataPath.appending(
+        let outputDir = try buildSystem.buildPlan.toolsBuildParameters.dataPath.appending(
             components: "extracted-symbols",
             package.identity.description,
             target.name

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -50,7 +50,9 @@ public struct SymbolGraphExtract {
         case json(pretty: Bool)
     }
     
-    /// Creates a symbol graph for `target` in `outputDirectory` using the build information from `buildPlan`. The `outputDirection` determines how the output from the tool subprocess is handled, and `verbosity` specifies how much console output to ask the tool to emit.
+    /// Creates a symbol graph for `target` in `outputDirectory` using the build information from `buildPlan`.
+    /// The `outputDirection` determines how the output from the tool subprocess is handled, and `verbosity` specifies
+    /// how much console output to ask the tool to emit.
     public func extractSymbolGraph(
         target: ResolvedTarget,
         buildPlan: BuildPlan,
@@ -58,7 +60,7 @@ public struct SymbolGraphExtract {
         outputDirectory: AbsolutePath,
         verboseOutput: Bool
     ) throws -> ProcessResult {
-        let buildParameters = buildPlan.buildParameters
+        let buildParameters = buildPlan.buildParameters(for: target)
         try self.fileSystem.createDirectory(outputDirectory, recursive: true)
 
         // Construct arguments for extracting symbols for a single target.

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -211,7 +211,7 @@ extension SwiftTool {
         experimentalTestOutput: Bool = false,
         library: BuildParameters.Testing.Library
     ) throws -> BuildParameters {
-        var parameters = try self.buildParameters()
+        var parameters = try self.productsBuildParameters
 
         var explicitlyEnabledDiscovery = false
         var explicitlySpecifiedPath: AbsolutePath?
@@ -224,7 +224,7 @@ extension SwiftTool {
         }
         parameters.testingParameters = .init(
             configuration: parameters.configuration,
-            targetTriple: parameters.targetTriple,
+            targetTriple: parameters.triple,
             forceTestDiscovery: explicitlyEnabledDiscovery,
             testEntryPointPath: explicitlySpecifiedPath,
             library: library

--- a/Sources/Commands/Utilities/XCTEvents.swift
+++ b/Sources/Commands/Utilities/XCTEvents.swift
@@ -237,12 +237,12 @@ extension TestErrorInfo {
 extension TestIssue {
     init(_ issue: XCTIssue) {
         self.init(
-            type: .init(productsBuildParameters: issue.type),
+            type: .init(destinationBuildParameters: issue.type),
             compactDescription: issue.compactDescription,
             detailedDescription: issue.detailedDescription,
-            associatedError: issue.associatedError.map { .init(productsBuildParameters: $0) },
-            sourceCodeContext: .init(productsBuildParameters: issue.sourceCodeContext),
-            attachments: issue.attachments.map { .init(productsBuildParameters: $0) }
+            associatedError: issue.associatedError.map { .init(destinationBuildParameters: $0) },
+            sourceCodeContext: .init(destinationBuildParameters: issue.sourceCodeContext),
+            attachments: issue.attachments.map { .init(destinationBuildParameters: $0) }
         )
     }
 }
@@ -275,8 +275,8 @@ extension TestLocation {
 extension TestSourceCodeContext {
     init(_ context: XCTSourceCodeContext) {
         self.init(
-            callStack: context.callStack.map { .init(productsBuildParameters: $0) },
-            location: context.location.map { .init(productsBuildParameters: $0) }
+            callStack: context.callStack.map { .init(destinationBuildParameters: $0) },
+            location: context.location.map { .init(destinationBuildParameters: $0) }
         )
     }
 }
@@ -285,8 +285,8 @@ extension TestSourceCodeFrame {
     init(_ frame: XCTSourceCodeFrame) {
         self.init(
             address: frame.address,
-            symbolInfo: (try? frame.symbolInfo()).map { .init(productsBuildParameters: $0) },
-            symbolicationError: frame.symbolicationError.map { .init(productsBuildParameters: $0) }
+            symbolInfo: (try? frame.symbolInfo()).map { .init(destinationBuildParameters: $0) },
+            symbolicationError: frame.symbolicationError.map { .init(destinationBuildParameters: $0) }
         )
     }
 }
@@ -296,7 +296,7 @@ extension TestSourceCodeSymbolInfo {
         self.init(
             imageName: symbolInfo.imageName,
             symbolName: symbolInfo.symbolName,
-            location: symbolInfo.location.map { .init(productsBuildParameters: $0) }
+            location: symbolInfo.location.map { .init(destinationBuildParameters: $0) }
         )
     }
 }

--- a/Sources/Commands/Utilities/XCTEvents.swift
+++ b/Sources/Commands/Utilities/XCTEvents.swift
@@ -237,12 +237,12 @@ extension TestErrorInfo {
 extension TestIssue {
     init(_ issue: XCTIssue) {
         self.init(
-            type: .init(issue.type),
+            type: .init(productsBuildParameters: issue.type),
             compactDescription: issue.compactDescription,
             detailedDescription: issue.detailedDescription,
-            associatedError: issue.associatedError.map { .init($0) },
-            sourceCodeContext: .init(issue.sourceCodeContext),
-            attachments: issue.attachments.map { .init($0) }
+            associatedError: issue.associatedError.map { .init(productsBuildParameters: $0) },
+            sourceCodeContext: .init(productsBuildParameters: issue.sourceCodeContext),
+            attachments: issue.attachments.map { .init(productsBuildParameters: $0) }
         )
     }
 }
@@ -275,8 +275,8 @@ extension TestLocation {
 extension TestSourceCodeContext {
     init(_ context: XCTSourceCodeContext) {
         self.init(
-            callStack: context.callStack.map { .init($0) },
-            location: context.location.map { .init($0) }
+            callStack: context.callStack.map { .init(productsBuildParameters: $0) },
+            location: context.location.map { .init(productsBuildParameters: $0) }
         )
     }
 }
@@ -285,8 +285,8 @@ extension TestSourceCodeFrame {
     init(_ frame: XCTSourceCodeFrame) {
         self.init(
             address: frame.address,
-            symbolInfo: (try? frame.symbolInfo()).map { .init($0) },
-            symbolicationError: frame.symbolicationError.map { .init($0) }
+            symbolInfo: (try? frame.symbolInfo()).map { .init(productsBuildParameters: $0) },
+            symbolicationError: frame.symbolicationError.map { .init(productsBuildParameters: $0) }
         )
     }
 }
@@ -296,7 +296,7 @@ extension TestSourceCodeSymbolInfo {
         self.init(
             imageName: symbolInfo.imageName,
             symbolName: symbolInfo.symbolName,
-            location: symbolInfo.location.map { .init($0) }
+            location: symbolInfo.location.map { .init(productsBuildParameters: $0) }
         )
     }
 }

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -613,7 +613,7 @@ public final class SwiftTool {
             return false
         }
 
-        let buildParameters = try self.buildParameters()
+        let buildParameters = try self.productsBuildParameters
         let haveBuildManifestAndDescription =
             self.fileSystem.exists(buildParameters.llbuildManifest) &&
             self.fileSystem.exists(buildParameters.buildDescriptionPath)
@@ -659,11 +659,11 @@ public final class SwiftTool {
             kind: explicitBuildSystem ?? options.build.buildSystem,
             explicitProduct: explicitProduct,
             cacheBuildManifest: cacheBuildManifest,
-            customBuildParameters: customBuildParameters,
-            customPackageGraphLoader: customPackageGraphLoader,
-            customOutputStream: customOutputStream,
-            customLogLevel: customLogLevel,
-            customObservabilityScope: customObservabilityScope
+            productsBuildParameters: customBuildParameters,
+            packageGraphLoader: customPackageGraphLoader,
+            outputStream: customOutputStream,
+            logLevel: customLogLevel,
+            observabilityScope: customObservabilityScope
         )
 
         // register the build system with the cancellation handler
@@ -677,14 +677,13 @@ public final class SwiftTool {
     """
 
     private func _buildParams(toolchain: UserToolchain) throws -> BuildParameters {
-        let hostTriple = try self.getHostToolchain().targetTriple
-        let targetTriple = toolchain.targetTriple
+        let triple = toolchain.targetTriple
 
         let dataPath = self.scratchDirectory.appending(
-            component: targetTriple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
+            component: triple.platformBuildPathComponent(buildSystem: options.build.buildSystem)
         )
 
-        if options.build.getTaskAllowEntitlement != nil && !targetTriple.isMacOSX {
+        if options.build.getTaskAllowEntitlement != nil && !triple.isMacOSX {
             observabilityScope.emit(warning: Self.entitlementsMacOSWarning)
         }
 
@@ -692,8 +691,7 @@ public final class SwiftTool {
             dataPath: dataPath,
             configuration: options.build.configuration,
             toolchain: toolchain,
-            hostTriple: hostTriple,
-            targetTriple: targetTriple,
+            triple: triple,
             flags: options.build.buildFlags,
             pkgConfigDirectories: options.locations.pkgConfigDirectories,
             architectures: options.build.architectures,
@@ -703,7 +701,7 @@ public final class SwiftTool {
             isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
             debuggingParameters: .init(
                 debugInfoFormat: options.build.debugInfoFormat.buildParameter,
-                targetTriple: targetTriple,
+                triple: triple,
                 shouldEnableDebuggingEntitlement:
                     options.build.getTaskAllowEntitlement ?? (options.build.configuration == .debug),
                 omitFramePointers: options.build.omitFramePointers
@@ -729,7 +727,7 @@ public final class SwiftTool {
             ),
             testingParameters: .init(
                 configuration: options.build.configuration,
-                targetTriple: targetTriple,
+                targetTriple: triple,
                 forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
                 testEntryPointPath: options.build.testEntryPointPath
             )
@@ -737,28 +735,37 @@ public final class SwiftTool {
     }
 
     /// Return the build parameters for the host toolchain.
-    public func hostBuildParameters() throws -> BuildParameters {
-        return try _hostBuildParameters.get()
+    public var toolsBuildParameters: BuildParameters {
+        get throws {
+            try _toolsBuildParameters.get()
+        }
     }
 
-    private lazy var _hostBuildParameters: Result<BuildParameters, Swift.Error> = {
-        return Result(catching: {
+    private lazy var _toolsBuildParameters: Result<BuildParameters, Swift.Error> = {
+        Result(catching: {
             try _buildParams(toolchain: self.getHostToolchain())
         })
     }()
 
-    /// Return the build parameters.
-    public func buildParameters() throws -> BuildParameters {
-        return try _buildParameters.get()
+    public var productsBuildParameters: BuildParameters {
+        get throws {
+            try _productsBuildParameters.get()
+        }
     }
 
-    private lazy var _buildParameters: Result<BuildParameters, Swift.Error> = {
+    /// Return the build parameters.
+    @available(*, deprecated, renamed: "productsBuildParameters")
+    public func buildParameters() throws -> BuildParameters {
+        try _productsBuildParameters.get()
+    }
+
+    private lazy var _productsBuildParameters: Result<BuildParameters, Swift.Error> = {
         return Result(catching: {
             try _buildParams(toolchain: self.getTargetToolchain())
         })
     }()
 
-    /// Lazily compute the target toolchain.
+    /// Lazily compute the target toolchain.z
     private lazy var _targetToolchain: Result<UserToolchain, Swift.Error> = {
         var swiftSDK: SwiftSDK
         let hostSwiftSDK: SwiftSDK

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -755,14 +755,8 @@ public final class SwiftTool {
         }
     }
 
-    /// Return the build parameters.
-    @available(*, deprecated, renamed: "productsBuildParameters")
-    public func buildParameters() throws -> BuildParameters {
-        try _productsBuildParameters.get()
-    }
-
     private lazy var _productsBuildParameters: Result<BuildParameters, Swift.Error> = {
-        return Result(catching: {
+        Result(catching: {
             try _buildParams(toolchain: self.getTargetToolchain())
         })
     }()

--- a/Sources/PackageGraph/BuildTriple.swift
+++ b/Sources/PackageGraph/BuildTriple.swift
@@ -15,8 +15,8 @@
 /// > system "targets" and can lead to confusion in this context.
 public enum BuildTriple {
     /// Triple for which build tools are compiled (the host triple).
-    case buildTools
+    case tools
 
-    /// Triple for which build products are compiled (the target triple).
-    case buildProducts
+    /// Triple of the destination platform for which end products are compiled (the target triple).
+    case destination
 }

--- a/Sources/PackageGraph/BuildTriple.swift
+++ b/Sources/PackageGraph/BuildTriple.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Triple for which code should be compiled for.
+/// > Note: We're not using "host" and "target" triple terminology in this enum, as that clashes with build
+/// > system "targets" and can lead to confusion in this context.
+public enum BuildTriple {
+    /// Triple for which build tools are compiled (the host triple).
+    case buildTools
+
+    /// Triple for which build products are compiled (the target triple).
+    case buildProducts
+}

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_library(PackageGraph
   BoundVersion.swift
+  BuildTriple.swift
   DependencyMirrors.swift
   Diagnostics.swift
   GraphLoadingNode.swift

--- a/Sources/PackageGraph/Resolution/ResolvedProduct.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedProduct.swift
@@ -85,7 +85,7 @@ public final class ResolvedProduct {
             )
         }
         
-        self.buildTriple = .buildProducts
+        self.buildTriple = .destination
     }
 
     /// True if this product contains Swift targets.

--- a/Sources/PackageGraph/Resolution/ResolvedProduct.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedProduct.swift
@@ -39,6 +39,9 @@ public final class ResolvedProduct {
     /// The list of platforms that are supported by this product.
     public let platforms: SupportedPlatforms
 
+    /// Triple for which this resolved product should be compiled for.
+    public let buildTriple: BuildTriple
+
     /// The main executable target of product.
     ///
     /// Note: This property is only valid for executable products.
@@ -81,6 +84,8 @@ public final class ResolvedProduct {
                 platforms: platforms
             )
         }
+        
+        self.buildTriple = .buildProducts
     }
 
     /// True if this product contains Swift targets.

--- a/Sources/PackageGraph/Resolution/ResolvedTarget.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedTarget.swift
@@ -155,7 +155,7 @@ public final class ResolvedTarget {
         self.dependencies = dependencies
         self.defaultLocalization = defaultLocalization
         self.platforms = platforms
-        self.buildTriple = .buildProducts
+        self.buildTriple = .destination
     }
 }
 

--- a/Sources/PackageGraph/Resolution/ResolvedTarget.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedTarget.swift
@@ -141,6 +141,9 @@ public final class ResolvedTarget {
     /// The list of platforms that are supported by this target.
     public let platforms: SupportedPlatforms
 
+    /// Triple for which this resolved target should be compiled for.
+    public let buildTriple: BuildTriple
+
     /// Create a resolved target instance.
     public init(
         target: Target,
@@ -152,6 +155,7 @@ public final class ResolvedTarget {
         self.dependencies = dependencies
         self.defaultLocalization = defaultLocalization
         self.platforms = platforms
+        self.buildTriple = .buildProducts
     }
 }
 

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
@@ -17,7 +17,7 @@ extension BuildParameters {
     public struct Debugging: Encodable {
         public init(
             debugInfoFormat: DebugInfoFormat = .dwarf,
-            targetTriple: Triple,
+            triple: Triple,
             shouldEnableDebuggingEntitlement: Bool,
             omitFramePointers: Bool?
         ) {
@@ -25,13 +25,13 @@ extension BuildParameters {
 
             // Per rdar://112065568 for backtraces to work on macOS a special entitlement needs to be granted on the final
             // executable.
-            self.shouldEnableDebuggingEntitlement = targetTriple.isMacOSX && shouldEnableDebuggingEntitlement
+            self.shouldEnableDebuggingEntitlement = triple.isMacOSX && shouldEnableDebuggingEntitlement
             // rdar://117578677: frame-pointer to support backtraces
             // this can be removed once the backtracer uses DWARF instead of frame pointers
             if let omitFramePointers {
                 // if set, we respect user's preference
                 self.omitFramePointers = omitFramePointers
-            } else if targetTriple.isLinux() {
+            } else if triple.isLinux() {
                 // on Linux we preserve frame pointers by default
                 self.omitFramePointers = false
             } else {
@@ -67,7 +67,7 @@ extension BuildParameters {
             return nil
         }
 
-        if targetTriple.isApple() {
+        if self.triple.isApple() {
             return .swiftAST
         }
         return .modulewrap

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -36,14 +36,6 @@ public struct BuildParameters: Encodable {
     public var toolchain: Toolchain { _toolchain.toolchain }
     private let _toolchain: _Toolchain
 
-    /// Host triple.
-    @available(*, deprecated, message: "use separate `BuildParameters` values to distinguish between host and target")
-    public var hostTriple: Triple { self.triple }
-
-    /// Target triple.
-    @available(*, deprecated, message: "use separate `BuildParameters` values to distinguish between host and target")
-    public var targetTriple: Triple { self.triple }
-
     /// The triple for which the code is built using these build parameters.
     public var triple: Triple
 

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -188,32 +188,6 @@ public struct BuildParameters: Encodable {
         self.testingParameters = testingParameters ?? .init(configuration: configuration, targetTriple: triple)
     }
 
-    @available(*, deprecated, message: "Use build parameters value separately created at a higher value instead")
-    public func forTriple(_ targetTriple: Triple) throws -> BuildParameters {
-        var hostSDK = try SwiftSDK.hostSwiftSDK()
-        hostSDK.targetTriple = targetTriple
-
-        return try .init(
-            dataPath: self.dataPath.parentDirectory.appending(components: ["plugins", "tools"]),
-            configuration: self.configuration,
-            toolchain: try UserToolchain(swiftSDK: hostSDK),
-            triple: nil,
-            flags: BuildFlags(),
-            pkgConfigDirectories: self.pkgConfigDirectories,
-            architectures: nil,
-            workers: self.workers,
-            shouldCreateDylibForDynamicProducts: self.shouldCreateDylibForDynamicProducts,
-            sanitizers: self.sanitizers,
-            indexStoreMode: self.indexStoreMode,
-            isXcodeBuildSystemEnabled: self.isXcodeBuildSystemEnabled,
-            shouldSkipBuilding: self.shouldSkipBuilding,
-            driverParameters: self.driverParameters,
-            linkingParameters: self.linkingParameters,
-            outputParameters: self.outputParameters,
-            testingParameters: self.testingParameters
-        )
-    }
-
     /// The path to the build directory (inside the data directory).
     public var buildPath: AbsolutePath {
         if isXcodeBuildSystemEnabled {

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -37,10 +37,15 @@ public struct BuildParameters: Encodable {
     private let _toolchain: _Toolchain
 
     /// Host triple.
-    public var hostTriple: Triple
+    @available(*, deprecated, message: "use separate `BuildParameters` values to distinguish between host and target")
+    public var hostTriple: Triple { self.triple }
 
     /// Target triple.
-    public var targetTriple: Triple
+    @available(*, deprecated, message: "use separate `BuildParameters` values to distinguish between host and target")
+    public var targetTriple: Triple { self.triple }
+
+    /// The triple for which the code is built using these build parameters.
+    public var triple: Triple
 
     /// Extra build flags.
     public var flags: BuildFlags
@@ -71,8 +76,8 @@ public struct BuildParameters: Encodable {
 
     /// The current platform we're building for.
     var currentPlatform: PackageModel.Platform {
-        if self.targetTriple.isDarwin() {
-            switch self.targetTriple.darwinPlatform {
+        if self.triple.isDarwin() {
+            switch self.triple.darwinPlatform {
             case .iOS(.catalyst):
                 return .macCatalyst
             case .iOS(.device), .iOS(.simulator):
@@ -84,13 +89,13 @@ public struct BuildParameters: Encodable {
             case .macOS, nil:
                 return .macOS
             }
-        } else if self.targetTriple.isAndroid() {
+        } else if self.triple.isAndroid() {
             return .android
-        } else if self.targetTriple.isWASI() {
+        } else if self.triple.isWASI() {
             return .wasi
-        } else if self.targetTriple.isWindows() {
+        } else if self.triple.isWindows() {
             return .windows
-        } else if self.targetTriple.isOpenBSD() {
+        } else if self.triple.isOpenBSD() {
             return .openbsd
         } else {
             return .linux
@@ -121,8 +126,7 @@ public struct BuildParameters: Encodable {
         dataPath: AbsolutePath,
         configuration: BuildConfiguration,
         toolchain: Toolchain,
-        hostTriple: Triple? = nil,
-        targetTriple: Triple? = nil,
+        triple: Triple? = nil,
         flags: BuildFlags,
         pkgConfigDirectories: [AbsolutePath] = [],
         architectures: [String]? = nil,
@@ -138,9 +142,9 @@ public struct BuildParameters: Encodable {
         outputParameters: Output = .init(),
         testingParameters: Testing? = nil
     ) throws {
-        let targetTriple = try targetTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
+        let triple = try triple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
         self.debuggingParameters = debuggingParameters ?? .init(
-            targetTriple: targetTriple,
+            triple: triple,
             shouldEnableDebuggingEntitlement: configuration == .debug,
             omitFramePointers: nil
         )
@@ -148,21 +152,20 @@ public struct BuildParameters: Encodable {
         self.dataPath = dataPath
         self.configuration = configuration
         self._toolchain = _Toolchain(toolchain: toolchain)
-        self.hostTriple = try hostTriple ?? .getHostTriple(usingSwiftCompiler: toolchain.swiftCompilerPath)
-        self.targetTriple = targetTriple
+        self.triple = triple
         switch self.debuggingParameters.debugInfoFormat {
         case .dwarf:
             var flags = flags
             // DWARF requires lld as link.exe expects CodeView debug info.
-            self.flags = flags.merging(targetTriple.isWindows() ? BuildFlags(
+            self.flags = flags.merging(triple.isWindows() ? BuildFlags(
                 cCompilerFlags: ["-gdwarf"],
                 cxxCompilerFlags: ["-gdwarf"],
                 swiftCompilerFlags: ["-g", "-use-ld=lld"],
                 linkerFlags: ["-debug:dwarf"]
             ) : BuildFlags(cCompilerFlags: ["-g"], cxxCompilerFlags: ["-g"], swiftCompilerFlags: ["-g"]))
         case .codeview:
-            if !targetTriple.isWindows() {
-                throw StringError("CodeView debug information is currently not supported on \(targetTriple.osName)")
+            if !triple.isWindows() {
+                throw StringError("CodeView debug information is currently not supported on \(triple.osName)")
             }
             var flags = flags
             self.flags = flags.merging(BuildFlags(
@@ -190,9 +193,10 @@ public struct BuildParameters: Encodable {
         self.driverParameters = driverParameters
         self.linkingParameters = linkingParameters
         self.outputParameters = outputParameters
-        self.testingParameters = testingParameters ?? .init(configuration: configuration, targetTriple: targetTriple)
+        self.testingParameters = testingParameters ?? .init(configuration: configuration, targetTriple: triple)
     }
 
+    @available(*, deprecated, message: "Use build parameters value separately created at a higher value instead")
     public func forTriple(_ targetTriple: Triple) throws -> BuildParameters {
         var hostSDK = try SwiftSDK.hostSwiftSDK()
         hostSDK.targetTriple = targetTriple
@@ -201,8 +205,7 @@ public struct BuildParameters: Encodable {
             dataPath: self.dataPath.parentDirectory.appending(components: ["plugins", "tools"]),
             configuration: self.configuration,
             toolchain: try UserToolchain(swiftSDK: hostSDK),
-            hostTriple: self.hostTriple,
-            targetTriple: targetTriple,
+            triple: nil,
             flags: BuildFlags(),
             pkgConfigDirectories: self.pkgConfigDirectories,
             architectures: nil,
@@ -245,14 +248,19 @@ public struct BuildParameters: Encodable {
     }
 
     public var llbuildManifest: AbsolutePath {
+        // FIXME: this path isn't specific to `BuildParameters` due to its use of `..`
+        // FIXME: it should be calculated in a different place
         return dataPath.appending(components: "..", configuration.dirname + ".yaml")
     }
 
     public var pifManifest: AbsolutePath {
+        // FIXME: this path isn't specific to `BuildParameters` due to its use of `..`
+        // FIXME: it should be calculated in a different place
         return dataPath.appending(components: "..", "manifest.pif")
     }
 
     public var buildDescriptionPath: AbsolutePath {
+        // FIXME: this path isn't specific to `BuildParameters`, should be moved one directory level higher
         return buildPath.appending(components: "description.json")
     }
 
@@ -266,30 +274,30 @@ public struct BuildParameters: Encodable {
 
     /// Returns the path to the dynamic library of a product for the current build parameters.
     func potentialDynamicLibraryPath(for product: ResolvedProduct) throws -> RelativePath {
-        try RelativePath(validating: "\(targetTriple.dynamicLibraryPrefix)\(product.name)\(targetTriple.dynamicLibraryExtension)")
+        try RelativePath(validating: "\(self.triple.dynamicLibraryPrefix)\(product.name)\(self.triple.dynamicLibraryExtension)")
     }
 
     /// Returns the path to the binary of a product for the current build parameters, relative to the build directory.
     public func binaryRelativePath(for product: ResolvedProduct) throws -> RelativePath {
-        let potentialExecutablePath = try RelativePath(validating: "\(product.name)\(targetTriple.executableExtension)")
+        let potentialExecutablePath = try RelativePath(validating: "\(product.name)\(self.triple.executableExtension)")
 
         switch product.type {
         case .executable, .snippet:
             return potentialExecutablePath
         case .library(.static):
-            return try RelativePath(validating: "lib\(product.name)\(targetTriple.staticLibraryExtension)")
+            return try RelativePath(validating: "lib\(product.name)\(self.triple.staticLibraryExtension)")
         case .library(.dynamic):
             return try potentialDynamicLibraryPath(for: product)
         case .library(.automatic), .plugin:
             fatalError()
         case .test:
-            guard !targetTriple.isWASI() else {
+            guard !self.triple.isWASI() else {
                 return try RelativePath(validating: "\(product.name).wasm")
             }
             switch testingParameters.library {
             case .xctest:
                 let base = "\(product.name).xctest"
-                if targetTriple.isDarwin() {
+                if self.triple.isDarwin() {
                     return try RelativePath(validating: "\(base)/Contents/MacOS/\(product.name)")
                 } else {
                     return try RelativePath(validating: base)

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -36,6 +36,9 @@ public struct BuildParameters: Encodable {
     public var toolchain: Toolchain { _toolchain.toolchain }
     private let _toolchain: _Toolchain
 
+    @available(*, deprecated, renamed: "triple", message: "Use separate `BuildParameters` values for host and target.")
+    public var targetTriple: Triple { self.triple }
+
     /// The triple for which the code is built using these build parameters.
     public var triple: Triple
 

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -74,17 +74,44 @@ extension ProductBuildDescription {
     /// The path to the product binary produced.
     public var binaryPath: AbsolutePath {
         get throws {
-            return try buildParameters.binaryPath(for: product)
+            return try self.buildParameters.binaryPath(for: product)
         }
     }
 }
 
 public protocol BuildPlan {
-    var buildParameters: BuildParameters { get }
+    /// Parameters used when building end products.
+    var productsBuildParameters: BuildParameters { get }
+
+    /// Parameters used when building tools (macros and plugins).
+    var toolsBuildParameters: BuildParameters { get }
+
     var buildProducts: AnySequence<ProductBuildDescription> { get }
 
     func createAPIToolCommonArgs(includeLibrarySearchPaths: Bool) throws -> [String]
     func createREPLArguments() throws -> [String]
+}
+
+extension BuildPlan {
+    /// Parameters used for building this target.
+    public func buildParameters(for target: ResolvedTarget) -> BuildParameters {
+        switch target.buildTriple {
+        case .buildTools:
+            return self.toolsBuildParameters
+        case .buildProducts:
+            return self.productsBuildParameters
+        }
+    }
+
+    /// Parameters used for building this product.
+    public func buildParameters(for product: ResolvedProduct) -> BuildParameters {
+        switch product.buildTriple {
+        case .buildTools:
+            return self.toolsBuildParameters
+        case .buildProducts:
+            return self.productsBuildParameters
+        }
+    }
 }
 
 public protocol BuildSystemFactory {

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -80,8 +80,8 @@ extension ProductBuildDescription {
 }
 
 public protocol BuildPlan {
-    /// Parameters used when building end products.
-    var productsBuildParameters: BuildParameters { get }
+    /// Parameters used when building end products for the destination platform.
+    var destinationBuildParameters: BuildParameters { get }
 
     /// Parameters used when building tools (macros and plugins).
     var toolsBuildParameters: BuildParameters { get }
@@ -93,23 +93,23 @@ public protocol BuildPlan {
 }
 
 extension BuildPlan {
-    /// Parameters used for building this target.
+    /// Parameters used for building a given target.
     public func buildParameters(for target: ResolvedTarget) -> BuildParameters {
         switch target.buildTriple {
-        case .buildTools:
+        case .tools:
             return self.toolsBuildParameters
-        case .buildProducts:
-            return self.productsBuildParameters
+        case .destination:
+            return self.destinationBuildParameters
         }
     }
 
-    /// Parameters used for building this product.
+    /// Parameters used for building a given product.
     public func buildParameters(for product: ResolvedProduct) -> BuildParameters {
         switch product.buildTriple {
-        case .buildTools:
+        case .tools:
             return self.toolsBuildParameters
-        case .buildProducts:
-            return self.productsBuildParameters
+        case .destination:
+            return self.destinationBuildParameters
         }
     }
 }

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -91,11 +91,12 @@ public protocol BuildSystemFactory {
     func makeBuildSystem(
         explicitProduct: String?,
         cacheBuildManifest: Bool,
-        customBuildParameters: BuildParameters?,
-        customPackageGraphLoader: (() throws -> PackageGraph)?,
-        customOutputStream: OutputByteStream?,
-        customLogLevel: Diagnostic.Severity?,
-        customObservabilityScope: ObservabilityScope?
+        productsBuildParameters: BuildParameters?,
+        toolsBuildParameters: BuildParameters?,
+        packageGraphLoader: (() throws -> PackageGraph)?,
+        outputStream: OutputByteStream?,
+        logLevel: Diagnostic.Severity?,
+        observabilityScope: ObservabilityScope?
     ) throws -> any BuildSystem
 }
 
@@ -116,11 +117,12 @@ public struct BuildSystemProvider {
         kind: Kind,
         explicitProduct: String? = .none,
         cacheBuildManifest: Bool = true,
-        customBuildParameters: BuildParameters? = .none,
-        customPackageGraphLoader: (() throws -> PackageGraph)? = .none,
-        customOutputStream: OutputByteStream? = .none,
-        customLogLevel: Diagnostic.Severity? = .none,
-        customObservabilityScope: ObservabilityScope? = .none
+        productsBuildParameters: BuildParameters? = .none,
+        toolsBuildParameters: BuildParameters? = .none,
+        packageGraphLoader: (() throws -> PackageGraph)? = .none,
+        outputStream: OutputByteStream? = .none,
+        logLevel: Diagnostic.Severity? = .none,
+        observabilityScope: ObservabilityScope? = .none
     ) throws -> any BuildSystem {
         guard let buildSystemFactory = self.providers[kind] else {
             throw Errors.buildSystemProviderNotRegistered(kind: kind)
@@ -128,11 +130,12 @@ public struct BuildSystemProvider {
         return try buildSystemFactory.makeBuildSystem(
             explicitProduct: explicitProduct,
             cacheBuildManifest: cacheBuildManifest,
-            customBuildParameters: customBuildParameters,
-            customPackageGraphLoader: customPackageGraphLoader,
-            customOutputStream: customOutputStream,
-            customLogLevel: customLogLevel,
-            customObservabilityScope: customObservabilityScope
+            productsBuildParameters: productsBuildParameters,
+            toolsBuildParameters: toolsBuildParameters,
+            packageGraphLoader: packageGraphLoader,
+            outputStream: outputStream,
+            logLevel: logLevel,
+            observabilityScope: observabilityScope
         )
     }
 }

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -190,7 +190,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             platform: "macosx",
             sdk: "macosx",
             sdkVariant: nil,
-            targetArchitecture: buildParameters.targetTriple.archName,
+            targetArchitecture: buildParameters.triple.archName,
             supportedArchitectures: [],
             disableOnlyActiveArch: true
         )

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -281,8 +281,7 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
                 dataPath: dataPath,
                 configuration: configuration,
                 toolchain: self.targetToolchain,
-                hostTriple: self.hostToolchain.targetTriple,
-                targetTriple: self.targetToolchain.targetTriple,
+                triple: self.hostToolchain.targetTriple,
                 flags: buildFlags,
                 architectures: architectures,
                 isXcodeBuildSystemEnabled: buildSystem == .xcode,
@@ -308,7 +307,9 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
             switch buildSystem {
             case .native:
                 return BuildOperation(
-                    buildParameters: buildParameters,
+                    // when building `swift-bootstrap`, host and target build parameters are the same
+                    productsBuildParameters: buildParameters,
+                    toolsBuildParameters: buildParameters,
                     cacheBuildManifest: false,
                     packageGraphLoader: packageGraphLoader,
                     additionalFileRules: [],

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -33,6 +33,29 @@ extension Build.BuildPlan {
         let buildConfigurationComponent = buildParameters.buildEnvironment.configuration == .release ? "release" : "debug"
         return buildParameters.dataPath.appending(components: buildConfigurationComponent)
     }
+
+    /// Create a build plan with a package graph and same build parameters for products and tools. Provided for
+    /// testing purposes only.
+    convenience init(
+        buildParameters: BuildParameters,
+        graph: PackageGraph,
+        additionalFileRules: [FileRuleDescription] = [],
+        buildToolPluginInvocationResults: [ResolvedTarget: [BuildToolPluginInvocationResult]] = [:],
+        prebuildCommandResults: [ResolvedTarget: [PrebuildCommandResult]] = [:],
+        fileSystem: any FileSystem,
+        observabilityScope: ObservabilityScope
+    ) throws {
+        try self.init(
+            productsBuildParameters: buildParameters,
+            toolsBuildParameters: buildParameters,
+            graph: graph,
+            additionalFileRules: additionalFileRules,
+            buildToolPluginInvocationResults: buildToolPluginInvocationResults,
+            prebuildCommandResults: prebuildCommandResults,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope
+        )
+    }
 }
 
 final class BuildPlanTests: XCTestCase {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -713,7 +713,7 @@ final class BuildPlanTests: XCTestCase {
         ]
       #elseif os(Windows)
         let linkArguments = [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -725,7 +725,7 @@ final class BuildPlanTests: XCTestCase {
         ]
       #else
         let linkArguments = [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1304,7 +1304,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -1316,7 +1316,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1486,7 +1486,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -1498,7 +1498,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-lstdc++",
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
@@ -1628,7 +1628,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -1639,7 +1639,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1865,7 +1865,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "PkgPackageTests.xctest").pathString,
             "-module-name", "PkgPackageTests",
@@ -1876,7 +1876,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
-            result.plan.buildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "PkgPackageTests.xctest").pathString,
             "-module-name", "PkgPackageTests",

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3740,7 +3740,7 @@ final class BuildPlanTests: XCTestCase {
             var copy = extraBuildParameters
             copy.linkingParameters.shouldLinkStaticSwiftStdlib = true
             // pick a triple with support for static linking
-            copy.targetTriple = .x86_64Linux
+            copy.triple = .x86_64Linux
             return copy
         }()
         let staticResult = try BuildPlanResult(plan: BuildPlan(

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -29,7 +29,7 @@ import enum TSCUtility.Diagnostics
 
 extension Build.BuildPlan {
     var productsBuildPath: AbsolutePath {
-        let buildParameters = self.productsBuildParameters
+        let buildParameters = self.destinationBuildParameters
         let buildConfigurationComponent = buildParameters.buildEnvironment.configuration == .release ? "release" : "debug"
         return buildParameters.dataPath.appending(components: buildConfigurationComponent)
     }
@@ -698,7 +698,7 @@ final class BuildPlanTests: XCTestCase {
 
       #if os(macOS)
         let linkArguments = [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -713,7 +713,7 @@ final class BuildPlanTests: XCTestCase {
         ]
       #elseif os(Windows)
         let linkArguments = [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -725,7 +725,7 @@ final class BuildPlanTests: XCTestCase {
         ]
       #else
         let linkArguments = [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -916,7 +916,7 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             )
 
-            let buildPath = plan.productsBuildParameters.dataPath.appending(components: "release")
+            let buildPath = plan.destinationBuildParameters.dataPath.appending(components: "release")
 
             let result = try BuildPlanResult(plan: plan)
             let buildProduct = try result.buildProduct(for: "exe")
@@ -1054,14 +1054,14 @@ final class BuildPlanTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(1)
 
-        let buildPath = result.plan.productsBuildParameters.dataPath.appending(components: "release")
+        let buildPath = result.plan.destinationBuildParameters.dataPath.appending(components: "release")
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
         XCTAssertMatch(exe, ["-swift-version", "4", "-O", .equal(j), "-DSWIFT_PACKAGE", "-module-cache-path", "\(buildPath.appending(components: "ModuleCache"))", .anySequence, "-g"])
 
       #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1075,7 +1075,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -1087,7 +1087,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1131,14 +1131,14 @@ final class BuildPlanTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(1)
 
-        let buildPath = result.plan.productsBuildParameters.dataPath.appending(components: "release")
+        let buildPath = result.plan.destinationBuildParameters.dataPath.appending(components: "release")
 
         let exe = try result.target(for: "exe").swiftTarget().compileArguments()
         XCTAssertMatch(exe, ["-swift-version", "4", "-O", .equal(j), "-DSWIFT_PACKAGE", "-module-cache-path", "\(buildPath.appending(components: "ModuleCache"))", .anySequence, "-g"])
 
       #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1151,7 +1151,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -1162,7 +1162,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1226,7 +1226,7 @@ final class BuildPlanTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(3)
 
-        let buildPath = result.plan.productsBuildParameters.dataPath.appending(components: "debug")
+        let buildPath = result.plan.destinationBuildParameters.dataPath.appending(components: "debug")
 
         let ext = try result.target(for: "extlib").clangTarget()
         var args: [String] = []
@@ -1291,7 +1291,7 @@ final class BuildPlanTests: XCTestCase {
 
       #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1304,7 +1304,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -1316,7 +1316,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1472,7 +1472,7 @@ final class BuildPlanTests: XCTestCase {
 
       #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-lc++",
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
@@ -1486,7 +1486,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -1498,7 +1498,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-lstdc++",
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
@@ -1614,7 +1614,7 @@ final class BuildPlanTests: XCTestCase {
 
       #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1628,7 +1628,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -1639,7 +1639,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -1850,7 +1850,7 @@ final class BuildPlanTests: XCTestCase {
             rpathsForBackdeployment = []
         }
         XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "PkgPackageTests.xctest", "Contents", "MacOS", "PkgPackageTests").pathString,
             "-module-name", "PkgPackageTests",
@@ -1865,7 +1865,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "PkgPackageTests.xctest").pathString,
             "-module-name", "PkgPackageTests",
@@ -1876,7 +1876,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "PkgPackageTests.xctest").pathString,
             "-module-name", "PkgPackageTests",
@@ -1930,7 +1930,7 @@ final class BuildPlanTests: XCTestCase {
 
       #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -2271,7 +2271,7 @@ final class BuildPlanTests: XCTestCase {
 
       #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -2285,7 +2285,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -2296,7 +2296,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -2411,7 +2411,7 @@ final class BuildPlanTests: XCTestCase {
 
       #if os(macOS)
         XCTAssertEqual(fooLinkArgs, [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "Foo").pathString,
             "-module-name", "Foo",
@@ -2426,7 +2426,7 @@ final class BuildPlanTests: XCTestCase {
         ])
 
         XCTAssertEqual(barLinkArgs, [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "libBar-Baz.dylib").pathString,
             "-module-name", "Bar_Baz",
@@ -2441,7 +2441,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #elseif os(Windows)
         XCTAssertEqual(fooLinkArgs, [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "Foo.exe").pathString,
             "-module-name", "Foo",
@@ -2453,7 +2453,7 @@ final class BuildPlanTests: XCTestCase {
         ])
 
         XCTAssertEqual(barLinkArgs, [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "Bar-Baz.dll").pathString,
             "-module-name", "Bar_Baz",
@@ -2464,7 +2464,7 @@ final class BuildPlanTests: XCTestCase {
         ])
       #else
         XCTAssertEqual(fooLinkArgs, [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "Foo").pathString,
             "-module-name", "Foo",
@@ -2477,7 +2477,7 @@ final class BuildPlanTests: XCTestCase {
         ])
 
         XCTAssertEqual(barLinkArgs, [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "libBar-Baz.so").pathString,
             "-module-name", "Bar_Baz",
@@ -2545,7 +2545,7 @@ final class BuildPlanTests: XCTestCase {
 
         #if os(macOS)
             let linkArguments = [
-                result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+                result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
                 "-L", buildPath.pathString,
                 "-o", buildPath.appending(components: "liblib.dylib").pathString,
                 "-module-name", "lib",
@@ -2560,7 +2560,7 @@ final class BuildPlanTests: XCTestCase {
             ]
         #elseif os(Windows)
             let linkArguments = [
-                result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+                result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
                 "-L", buildPath.pathString,
                 "-o", buildPath.appending(components: "lib.dll").pathString,
                 "-module-name", "lib",
@@ -2571,7 +2571,7 @@ final class BuildPlanTests: XCTestCase {
             ]
         #else
             let linkArguments = [
-                result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+                result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
                 "-L", buildPath.pathString,
                 "-o", buildPath.appending(components: "liblib.so").pathString,
                 "-module-name", "lib",
@@ -2624,7 +2624,7 @@ final class BuildPlanTests: XCTestCase {
         result.checkProductsCount(2)
         result.checkTargetsCount(2)
         
-        let triple = result.plan.productsBuildParameters.triple
+        let triple = result.plan.destinationBuildParameters.triple
         let buildPath = result.plan.productsBuildPath
 
         let exe = try result.target(for: "exe").clangTarget()
@@ -2679,7 +2679,7 @@ final class BuildPlanTests: XCTestCase {
 
     #if os(macOS)
         XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-lc++",
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "liblib.dylib").pathString,
@@ -2694,7 +2694,7 @@ final class BuildPlanTests: XCTestCase {
         ])
 
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -2707,7 +2707,7 @@ final class BuildPlanTests: XCTestCase {
         ])
     #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "lib.dll").pathString,
             "-module-name", "lib",
@@ -2719,7 +2719,7 @@ final class BuildPlanTests: XCTestCase {
         ])
 
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -2731,7 +2731,7 @@ final class BuildPlanTests: XCTestCase {
         ])
     #else
         XCTAssertEqual(try result.buildProduct(for: "lib").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-lstdc++",
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "liblib.so").pathString,
@@ -2745,7 +2745,7 @@ final class BuildPlanTests: XCTestCase {
         ])
 
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -3111,7 +3111,7 @@ final class BuildPlanTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
 
-        let buildPath = result.plan.productsBuildParameters.dataPath.appending(components: "debug")
+        let buildPath = result.plan.destinationBuildParameters.dataPath.appending(components: "debug")
 
         let lib = try result.target(for: "lib").clangTarget()
         let args = [
@@ -3140,7 +3140,7 @@ final class BuildPlanTests: XCTestCase {
         ])
 
         XCTAssertEqual(try result.buildProduct(for: "exe").linkArguments(), [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe", "-emit-executable",
@@ -3224,7 +3224,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(
             try appBuildDescription.linkArguments(),
             [
-                result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+                result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
                 "-L", buildPath.pathString,
                 "-o", buildPath.appending(components: "app.wasm").pathString,
                 "-module-name", "app", "-static-stdlib", "-emit-executable",
@@ -3241,7 +3241,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(
             try testBuildDescription.linkArguments(),
             [
-                result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+                result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
                 "-L", buildPath.pathString,
                 "-o", buildPath.appending(components: "PkgPackageTests.wasm").pathString,
                 "-module-name", "PkgPackageTests",
@@ -3336,7 +3336,7 @@ final class BuildPlanTests: XCTestCase {
             ))
 
             let lib = try result.target(for: "lib").clangTarget()
-            let path = StringPattern.equal(result.plan.productsBuildParameters.indexStore.pathString)
+            let path = StringPattern.equal(result.plan.destinationBuildParameters.indexStore.pathString)
 
             #if os(macOS)
             XCTAssertMatch(try lib.basicArguments(isCXX: false), [.anySequence, "-index-store-path", path, .anySequence])
@@ -4532,7 +4532,7 @@ final class BuildPlanTests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let dynamicLibraryExtension = plan.productsBuildParameters.triple.dynamicLibraryExtension
+        let dynamicLibraryExtension = plan.destinationBuildParameters.triple.dynamicLibraryExtension
 #if os(Windows)
         let dynamicLibraryPrefix = ""
 #else
@@ -4649,7 +4649,7 @@ final class BuildPlanTests: XCTestCase {
                 inputs: ["\(buildPath.appending(components: "exe.build", "exe.swiftmodule").escapedPathString)"]
                 outputs: ["\(buildPath.appending(components: "exe.build", "exe.swiftmodule.o").escapedPathString)"]
                 description: "Wrapping AST for exe for debugging"
-                args: ["\(result.plan.productsBuildParameters.toolchain.swiftCompilerPath.escapedPathString)","-modulewrap","\(buildPath.appending(components: "exe.build", "exe.swiftmodule").escapedPathString)","-o","\(buildPath.appending(components: "exe.build", "exe.swiftmodule.o").escapedPathString)","-target","x86_64-unknown-linux-gnu"]
+                args: ["\(result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.escapedPathString)","-modulewrap","\(buildPath.appending(components: "exe.build", "exe.swiftmodule").escapedPathString)","-o","\(buildPath.appending(components: "exe.build", "exe.swiftmodule.o").escapedPathString)","-target","x86_64-unknown-linux-gnu"]
             """))
         XCTAssertMatch(contents, .contains("""
               "\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)":
@@ -4657,7 +4657,7 @@ final class BuildPlanTests: XCTestCase {
                 inputs: ["\(buildPath.appending(components: "lib.swiftmodule").escapedPathString)"]
                 outputs: ["\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)"]
                 description: "Wrapping AST for lib for debugging"
-                args: ["\(result.plan.productsBuildParameters.toolchain.swiftCompilerPath.escapedPathString)","-modulewrap","\(buildPath.appending(components: "lib.swiftmodule").escapedPathString)","-o","\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)","-target","x86_64-unknown-linux-gnu"]
+                args: ["\(result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.escapedPathString)","-modulewrap","\(buildPath.appending(components: "lib.swiftmodule").escapedPathString)","-o","\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)","-target","x86_64-unknown-linux-gnu"]
             """))
     }
 
@@ -4702,23 +4702,23 @@ final class BuildPlanTests: XCTestCase {
 
             let contents: String = try fs.readFileContents(yaml)
 
-            if result.plan.productsBuildParameters.triple.isWindows() {
+            if result.plan.destinationBuildParameters.triple.isWindows() {
                 XCTAssertMatch(contents, .contains("""
                   "C.rary-debug.a":
                     tool: shell
                     inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString)","\(buildPath.appending(components: "rary.build", "rary.swiftmodule.o").escapedPathString)","\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
                     outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
                     description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
-                    args: ["\(result.plan.productsBuildParameters.toolchain.librarianPath.escapedPathString)","/LIB","/OUT:\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
+                    args: ["\(result.plan.destinationBuildParameters.toolchain.librarianPath.escapedPathString)","/LIB","/OUT:\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
                 """))
-            } else if result.plan.productsBuildParameters.triple.isDarwin() {
+            } else if result.plan.destinationBuildParameters.triple.isDarwin() {
                 XCTAssertMatch(contents, .contains("""
                   "C.rary-debug.a":
                     tool: shell
                     inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString)","\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
                     outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
                     description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
-                    args: ["\(result.plan.productsBuildParameters.toolchain.librarianPath.escapedPathString)","-static","-o","\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
+                    args: ["\(result.plan.destinationBuildParameters.toolchain.librarianPath.escapedPathString)","-static","-o","\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
                 """))
             } else {    // assume `llvm-ar` is the librarian
                 XCTAssertMatch(contents, .contains("""
@@ -4727,7 +4727,7 @@ final class BuildPlanTests: XCTestCase {
                     inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString)","\(buildPath.appending(components: "rary.build", "rary.swiftmodule.o").escapedPathString)","\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
                     outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
                     description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
-                    args: ["\(result.plan.productsBuildParameters.toolchain.librarianPath.escapedPathString)","crs","\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
+                    args: ["\(result.plan.destinationBuildParameters.toolchain.librarianPath.escapedPathString)","crs","\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
                 """))
             }
         }
@@ -5497,7 +5497,7 @@ final class BuildPlanTests: XCTestCase {
 
       #if os(macOS)
         let linkArguments = [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",
@@ -5511,7 +5511,7 @@ final class BuildPlanTests: XCTestCase {
         ]
       #elseif os(Windows)
         let linkArguments = [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe.exe").pathString,
             "-module-name", "exe",
@@ -5522,7 +5522,7 @@ final class BuildPlanTests: XCTestCase {
         ]
       #else
         let linkArguments = [
-            result.plan.productsBuildParameters.toolchain.swiftCompilerPath.pathString,
+            result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-L", buildPath.pathString,
             "-o", buildPath.appending(components: "exe").pathString,
             "-module-name", "exe",

--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -50,7 +50,8 @@ final class LLBuildManifestBuilderTests: XCTestCase {
             configuration: .release
         ))
         var plan = try BuildPlan(
-            buildParameters: buildParameters,
+            productsBuildParameters: buildParameters,
+            toolsBuildParameters: buildParameters,
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -84,7 +85,8 @@ final class LLBuildManifestBuilderTests: XCTestCase {
             configuration: .debug
         ))
         plan = try BuildPlan(
-            buildParameters: buildParameters,
+            productsBuildParameters: buildParameters,
+            toolsBuildParameters: buildParameters,
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -137,7 +139,8 @@ final class LLBuildManifestBuilderTests: XCTestCase {
             configuration: .release
         ))
         plan = try BuildPlan(
-            buildParameters: buildParameters,
+            productsBuildParameters: buildParameters,
+            toolsBuildParameters: buildParameters,
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -161,7 +164,8 @@ final class LLBuildManifestBuilderTests: XCTestCase {
             configuration: .debug
         ))
         plan = try BuildPlan(
-            buildParameters: buildParameters,
+            productsBuildParameters: buildParameters,
+            toolsBuildParameters: buildParameters,
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope

--- a/Tests/BuildTests/MockBuildTestHelper.swift
+++ b/Tests/BuildTests/MockBuildTestHelper.swift
@@ -85,14 +85,13 @@ func mockBuildParameters(
         dataPath: buildPath,
         configuration: config,
         toolchain: toolchain,
-        hostTriple: hostTriple,
-        targetTriple: targetTriple,
+        triple: targetTriple,
         flags: flags,
         pkgConfigDirectories: [],
         workers: 3,
         indexStoreMode: indexStoreMode,
         debuggingParameters: .init(
-            targetTriple: targetTriple,
+            triple: targetTriple,
             shouldEnableDebuggingEntitlement: config == .debug,
             omitFramePointers: omitFramePointers
         ),

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -255,7 +255,8 @@ final class SwiftToolTests: CommandsTestCase {
         let explicitDwarfOptions = try GlobalOptions.parse(["--triple", "x86_64-unknown-windows-msvc", "-debug-info-format", "dwarf"])
         let explicitDwarf = try SwiftTool.createSwiftToolForTest(options: explicitDwarfOptions)
         plan = try BuildPlan(
-            buildParameters: explicitDwarf.buildParameters(),
+            productsBuildParameters: explicitDwarf.productsBuildParameters,
+            toolsBuildParameters: explicitDwarf.toolsBuildParameters,
             graph: graph,
             fileSystem: fs,
             observabilityScope: observer.topScope
@@ -269,7 +270,7 @@ final class SwiftToolTests: CommandsTestCase {
         let explicitCodeView = try SwiftTool.createSwiftToolForTest(options: explicitCodeViewOptions)
 
         plan = try BuildPlan(
-            buildParameters: explicitCodeView.buildParameters(),
+            buildParameters: explicitCodeView.productsBuildParameters,
             graph: graph,
             fileSystem: fs,
             observabilityScope: observer.topScope
@@ -283,7 +284,7 @@ final class SwiftToolTests: CommandsTestCase {
         let unsupportedCodeViewOptions = try GlobalOptions.parse(["--triple", "x86_64-unknown-linux-gnu", "-debug-info-format", "codeview"])
         let unsupportedCodeView = try SwiftTool.createSwiftToolForTest(options: unsupportedCodeViewOptions)
 
-        XCTAssertThrowsError(try unsupportedCodeView.buildParameters()) {
+        XCTAssertThrowsError(try unsupportedCodeView.productsBuildParameters) {
             XCTAssertEqual($0 as? StringError, StringError("CodeView debug information is currently not supported on linux"))
         }
 
@@ -291,7 +292,8 @@ final class SwiftToolTests: CommandsTestCase {
         let implicitDwarfOptions = try GlobalOptions.parse(["--triple", "x86_64-unknown-windows-msvc"])
         let implicitDwarf = try SwiftTool.createSwiftToolForTest(options: implicitDwarfOptions)
         plan = try BuildPlan(
-            buildParameters: implicitDwarf.buildParameters(),
+            productsBuildParameters: implicitDwarf.productsBuildParameters,
+            toolsBuildParameters: implicitDwarf.toolsBuildParameters,
             graph: graph,
             fileSystem: fs,
             observabilityScope: observer.topScope
@@ -303,7 +305,8 @@ final class SwiftToolTests: CommandsTestCase {
         let explicitNoDebugInfoOptions = try GlobalOptions.parse(["--triple", "x86_64-unknown-windows-msvc", "-debug-info-format", "none"])
         let explicitNoDebugInfo = try SwiftTool.createSwiftToolForTest(options: explicitNoDebugInfoOptions)
         plan = try BuildPlan(
-            buildParameters: explicitNoDebugInfo.buildParameters(),
+            productsBuildParameters: explicitNoDebugInfo.productsBuildParameters,
+            toolsBuildParameters: explicitNoDebugInfo.toolsBuildParameters,
             graph: graph,
             fileSystem: fs,
             observabilityScope: observer.topScope

--- a/Tests/CommandsTests/SwiftToolTests.swift
+++ b/Tests/CommandsTests/SwiftToolTests.swift
@@ -270,7 +270,8 @@ final class SwiftToolTests: CommandsTestCase {
         let explicitCodeView = try SwiftTool.createSwiftToolForTest(options: explicitCodeViewOptions)
 
         plan = try BuildPlan(
-            buildParameters: explicitCodeView.productsBuildParameters,
+            productsBuildParameters: explicitCodeView.productsBuildParameters,
+            toolsBuildParameters: explicitCodeView.productsBuildParameters,
             graph: graph,
             fileSystem: fs,
             observabilityScope: observer.topScope


### PR DESCRIPTION
Unblocks support for macros in cross-compilation implemented in https://github.com/apple/swift-package-manager/pull/7118.

### Motivation:

So far we used a single `BuildParameters` value for the whole build graph, which explicitly mentioned both host and target triples, but assumed you can use the same toolchain for both, which is not true. Additionally, it would assume that all other build parameters can be shared between the host and target, like debug info format, build configuration, sanitizers etc. That's not true either, one would use CodeView for build tools on Windows when cross-compiling products with DWARF for Linux, or build macros in release mode for performance while cross-compiling code that uses debug build configuration.

### Modifications:

Removed `hostTriple` and `targetTriple` from `BuildParameters`, keeping only a single `triple` property of `Triple` type in it. In `SwiftTool` and `BuildPlan` we'll use two separate `destinationBuildParameters` and `toolsBuildParameters` instead. The latter will pick one of the two `BuildParameters` values for specific target and product build descriptions.

### Result:

We can compile build tools for the host, while cross-compiling end products for the target, in the same build graph. This also removes one of big roadblocks in folding build tool and package plugins into the build graph, instead of building and invoking them separately outside of the build graph.
