### PR TITLE
Pass `-disable-sandbox` to Swift compiler if requested

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -545,6 +545,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             additionalFileRules: additionalFileRules,
             buildToolPluginInvocationResults: buildToolPluginInvocationResults,
             prebuildCommandResults: prebuildCommandResults,
+            disableSandbox: self.pluginConfiguration?.disableSandbox ?? false,
             fileSystem: self.fileSystem,
             observabilityScope: self.observabilityScope
         )

--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -28,6 +28,7 @@ extension BuildPlan {
     static func makeDerivedTestTargets(
         _ buildParameters: BuildParameters,
         _ graph: PackageGraph,
+        _ disableSandbox: Bool,
         _ fileSystem: FileSystem,
         _ observabilityScope: ObservabilityScope
     ) throws -> [(product: ResolvedProduct, discoveryTargetBuildDescription: SwiftTargetBuildDescription?, entryPointTargetBuildDescription: SwiftTargetBuildDescription)] {
@@ -95,6 +96,7 @@ extension BuildPlan {
                     toolsVersion: toolsVersion,
                     buildParameters: buildParameters,
                     testTargetRole: .discovery,
+                    disableSandbox: disableSandbox,
                     fileSystem: fileSystem,
                     observabilityScope: observabilityScope
                 )
@@ -132,6 +134,7 @@ extension BuildPlan {
                     toolsVersion: toolsVersion,
                     buildParameters: buildParameters,
                     testTargetRole: .entryPoint(isSynthesized: true),
+                    disableSandbox: disableSandbox,
                     fileSystem: fileSystem,
                     observabilityScope: observabilityScope
                 )
@@ -174,6 +177,7 @@ extension BuildPlan {
                             toolsVersion: toolsVersion,
                             buildParameters: buildParameters,
                             testTargetRole: .entryPoint(isSynthesized: false),
+                            disableSandbox: disableSandbox,
                             fileSystem: fileSystem,
                             observabilityScope: observabilityScope
                         )
@@ -195,6 +199,7 @@ extension BuildPlan {
                         toolsVersion: toolsVersion,
                         buildParameters: buildParameters,
                         testTargetRole: .entryPoint(isSynthesized: false),
+                        disableSandbox: disableSandbox,
                         fileSystem: fileSystem,
                         observabilityScope: observabilityScope
                     )

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -235,6 +235,9 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// Cache for  tools information.
     var externalExecutablesCache = [BinaryTarget: [ExecutableInfo]]()
 
+    /// Whether to disable sandboxing (e.g. for macros).
+    private let disableSandbox: Bool
+
     /// The filesystem to operate on.
     let fileSystem: any FileSystem
 
@@ -271,6 +274,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         additionalFileRules: [FileRuleDescription] = [],
         buildToolPluginInvocationResults: [ResolvedTarget: [BuildToolPluginInvocationResult]] = [:],
         prebuildCommandResults: [ResolvedTarget: [PrebuildCommandResult]] = [:],
+        disableSandbox: Bool = false,
         fileSystem: any FileSystem,
         observabilityScope: ObservabilityScope
     ) throws {
@@ -279,6 +283,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         self.graph = graph
         self.buildToolPluginInvocationResults = buildToolPluginInvocationResults
         self.prebuildCommandResults = prebuildCommandResults
+        self.disableSandbox = disableSandbox
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope.makeChildScope(description: "Build Plan")
 
@@ -377,6 +382,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     prebuildCommandResults: prebuildCommandResults[target] ?? [],
                     requiredMacroProducts: requiredMacroProducts,
                     shouldGenerateTestObservation: generateTestObservation,
+                    disableSandbox: self.disableSandbox,
                     fileSystem: fileSystem,
                     observabilityScope: observabilityScope)
                 )
@@ -423,6 +429,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
             let derivedTestTargets = try Self.makeDerivedTestTargets(
                 productsBuildParameters,
                 graph,
+                self.disableSandbox,
                 self.fileSystem,
                 self.observabilityScope
             )


### PR DESCRIPTION
The Swift compiler supports disabling sandboxing for macros now, so we should opt-in to that if the selected toolchain supports it and the user has disabled sandboxing. We warn if macros are being used and disabling sandboxing was requested but isn't available.

rdar://118851130
