### PR TITLE
Revert "Avoid use of `temp_await` in `PackageRegistryToolTests.swift`"

### DIFF
--- a/Sources/Basics/Archiver/Archiver.swift
+++ b/Sources/Basics/Archiver/Archiver.swift
@@ -56,11 +56,6 @@ public protocol Archiver {
 }
 
 extension Archiver {
-    /// Asynchronously extracts the contents of an archive to a destination folder.
-    ///
-    /// - Parameters:
-    ///   - archivePath: The `AbsolutePath` to the archive to extract.
-    ///   - destinationPath: The `AbsolutePath` to the directory to extract to.
     public func extract(
         from archivePath: AbsolutePath,
         to destinationPath: AbsolutePath
@@ -84,32 +79,6 @@ extension Archiver {
     ) async throws -> Bool {
         try await safe_async {
             self.validate(path: path, completion: $0)
-        }
-    }    
-
-    /// Asynchronously compresses the contents of a directory to a destination archive.
-    ///
-    /// - Parameters:
-    ///   - directory: The `AbsolutePath` to the archive to extract.
-    ///   - destinationPath: The `AbsolutePath` to the directory to extract to.
-    public func compress(
-        directory: AbsolutePath,
-        to destinationPath: AbsolutePath
-    ) async throws {
-        try await withCheckedThrowingContinuation {
-            self.compress(directory: directory, to: destinationPath, completion: $0.resume(with:))
-        }
-    }
-
-    /// Asynchronously validates if a file is an archive.
-    ///
-    /// - Parameters:
-    ///   - path: The `AbsolutePath` to the archive to validate.
-    public func validate(
-        path: AbsolutePath
-    ) async throws -> Bool {
-        try await withCheckedThrowingContinuation {
-            self.validate(path: path, completion: $0.resume(with:))
         }
     }
 }


### PR DESCRIPTION
Reverts apple/swift-package-manager#7015