### PR TITLE
🍒[cxx-interop] Make test discovery compatible with C++ interop

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -535,6 +535,25 @@ public final class SwiftTargetBuildDescription {
             args += ["-color-diagnostics"]
         }
 
+        // If this is a generated test discovery target, it might import a test
+        // target that is built with C++ interop enabled. In that case, the test
+        // discovery target must enable C++ interop as well
+        switch testTargetRole {
+        case .discovery:
+            for dependency in try self.target.recursiveTargetDependencies() {
+                let dependencyScope = self.buildParameters.createScope(for: dependency)
+                let dependencySwiftFlags = dependencyScope.evaluate(.OTHER_SWIFT_FLAGS)
+                if let interopModeFlag = dependencySwiftFlags.first(where: { $0.hasPrefix("-cxx-interoperability-mode=") }) {
+                    args += [interopModeFlag]
+                    break
+                }
+            }
+            if let cxxStandard = self.package.manifest.cxxLanguageStandard {
+                args += ["-Xcc", "-std=\(cxxStandard)"]
+            }
+        default: break
+        }
+
         // Add arguments from declared build settings.
         args += try self.buildSettingsFlags()
 


### PR DESCRIPTION
### Motivation:

If a Swift module is built with C++ interop enabled, all of its dependencies must also be built with C++ interop enabled.

Swift packages that use test discovery get a synthesized "PackageDiscoveredTests" target which is built by SwiftPM when someone runs `swift test` command. This module is currently always built without C++ interop, which is causing issues for projects that rely on it. ### Modifications:

This patch makes sure that the `-cxx-interoperability-mode=` command line flag gets propagated to the test discovery target.

### Result:

Packages that use both C++ interop and test discovery can now be built successfully by SwiftPM.

rdar://117078320 / resolves https://github.com/apple/swift-package-manager/issues/6990

Original PR: https://github.com/apple/swift-package-manager/pull/7165

(cherry picked from commit d2eb0ca06353d84da396e43e8f88943f2bb515a5)
