### PR TITLE
Adopt `async`/`await` in more tests

### DIFF
--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -24,6 +24,46 @@ public enum PluginAction {
 }
 
 extension PluginTarget {
+    public func invoke(
+        action: PluginAction,
+        buildEnvironment: BuildEnvironment,
+        scriptRunner: PluginScriptRunner,
+        workingDirectory: AbsolutePath,
+        outputDirectory: AbsolutePath,
+        toolSearchDirectories: [AbsolutePath],
+        accessibleTools: [String: (path: AbsolutePath, triples: [String]?)],
+        writableDirectories: [AbsolutePath],
+        readOnlyDirectories: [AbsolutePath],
+        allowNetworkConnections: [SandboxNetworkPermission],
+        pkgConfigDirectories: [AbsolutePath],
+        sdkRootPath: AbsolutePath?,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        delegate: PluginInvocationDelegate
+    ) async throws -> Bool {
+        try await safe_async {
+            self.invoke(
+                action: action,
+                buildEnvironment: buildEnvironment,
+                scriptRunner: scriptRunner,
+                workingDirectory: workingDirectory,
+                outputDirectory: outputDirectory,
+                toolSearchDirectories: toolSearchDirectories,
+                accessibleTools: accessibleTools,
+                writableDirectories: writableDirectories,
+                readOnlyDirectories: readOnlyDirectories,
+                allowNetworkConnections: allowNetworkConnections,
+                pkgConfigDirectories: pkgConfigDirectories,
+                sdkRootPath: sdkRootPath,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                callbackQueue: callbackQueue,
+                delegate: delegate,
+                completion: $0
+            )
+        }
+    }
     /// Invokes the plugin by compiling its source code (if needed) and then running it as a subprocess. The specified
     /// plugin action determines which entry point is called in the subprocess, and the package and the tool mapping
     /// determine the context that is available to the plugin.
@@ -47,6 +87,7 @@ extension PluginTarget {
     ///   - fileSystem: The file system to which all of the paths refers.
     ///
     /// - Returns: A PluginInvocationResult that contains the results of invoking the plugin.
+    @available(*, noasync, message: "Use the async alternative")
     public func invoke(
         action: PluginAction,
         buildEnvironment: BuildEnvironment,

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -48,22 +48,23 @@ public func testWithTemporaryDirectory(
     )
 }
 
-public func testWithTemporaryDirectory(
+@discardableResult
+public func testWithTemporaryDirectory<Result>(
     function: StaticString = #function,
-    body: (AbsolutePath) async throws -> Void
-) async throws {
+    body: (AbsolutePath) async throws -> Result
+) async throws -> Result {
     let cleanedFunction = function.description
         .replacingOccurrences(of: "(", with: "")
         .replacingOccurrences(of: ")", with: "")
         .replacingOccurrences(of: ".", with: "")
         .replacingOccurrences(of: ":", with: "_")
-    try await withTemporaryDirectory(prefix: "spm-tests-\(cleanedFunction)") { tmpDirPath in
+    return try await withTemporaryDirectory(prefix: "spm-tests-\(cleanedFunction)") { tmpDirPath in
         defer {
             // Unblock and remove the tmp dir on deinit.
             try? localFileSystem.chmod(.userWritable, path: tmpDirPath, options: [.recursive])
             try? localFileSystem.removeFileTree(tmpDirPath)
         }
-        try await body(tmpDirPath)
+        return try await body(tmpDirPath)
     }
 }
 

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -92,6 +92,27 @@ public class RepositoryManager: Cancellable {
         self.concurrencySemaphore = DispatchSemaphore(value: maxConcurrentOperations)
     }
 
+    public func lookup(
+        package: PackageIdentity,
+        repository: RepositorySpecifier,
+        updateStrategy: RepositoryUpdateStrategy,
+        observabilityScope: ObservabilityScope,
+        delegateQueue: DispatchQueue,
+        callbackQueue: DispatchQueue
+    ) async throws -> RepositoryHandle {
+        try await safe_async {
+            self.lookup(
+                package: package,
+                repository: repository,
+                updateStrategy: updateStrategy,
+                observabilityScope: observabilityScope,
+                delegateQueue: delegateQueue,
+                callbackQueue: callbackQueue,
+                completion: $0
+            )
+        }
+    }
+
     /// Get a handle to a repository.
     ///
     /// This will initiate a clone of the repository automatically, if necessary.
@@ -107,6 +128,7 @@ public class RepositoryManager: Cancellable {
     ///   - delegateQueue: Dispatch queue for delegate events
     ///   - callbackQueue: Dispatch queue for callbacks
     ///   - completion: The completion block that should be called after lookup finishes.
+    @available(*, noasync, message: "Use the async alternative")
     public func lookup(
         package: PackageIdentity,
         repository: RepositorySpecifier,

--- a/Tests/CommandsTests/PackageRegistryToolTests.swift
+++ b/Tests/CommandsTests/PackageRegistryToolTests.swift
@@ -643,7 +643,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
 
             // Validate signatures
             var verifierConfiguration = VerifierConfiguration()
-            verifierConfiguration.trustedRoots = try temp_await { self.testRoots(callback: $0) }
+            verifierConfiguration.trustedRoots = try testRoots()
 
             // archive signature
             let archivePath = workingDirectory.appending("\(packageIdentity)-\(version).zip")
@@ -753,7 +753,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
 
             // Validate signatures
             var verifierConfiguration = VerifierConfiguration()
-            verifierConfiguration.trustedRoots = try temp_await { self.testRoots(callback: $0) }
+            verifierConfiguration.trustedRoots = try testRoots()
 
             // archive signature
             let archivePath = workingDirectory.appending("\(packageIdentity)-\(version).zip")
@@ -860,7 +860,7 @@ final class PackageRegistryToolTests: CommandsTestCase {
 
             // Validate signatures
             var verifierConfiguration = VerifierConfiguration()
-            verifierConfiguration.trustedRoots = try temp_await { self.testRoots(callback: $0) }
+            verifierConfiguration.trustedRoots = try testRoots()
 
             // archive signature
             let archivePath = workingDirectory.appending("\(packageIdentity)-\(version).zip")
@@ -920,15 +920,11 @@ final class PackageRegistryToolTests: CommandsTestCase {
         XCTAssertEqual(try SwiftPackageRegistryTool.Login.loginURL(from: registryURL, loginAPIPath: "/secret-sign-in").absoluteString, "https://packages.example.com:8081/secret-sign-in")
     }
 
-    private func testRoots(callback: (Result<[[UInt8]], Error>) -> Void) {
-        do {
-            try fixture(name: "Signing", createGitRepo: false) { fixturePath in
-                let rootCA = try localFileSystem
-                    .readFileContents(fixturePath.appending(components: "Certificates", "TestRootCA.cer")).contents
-                callback(.success([rootCA]))
-            }
-        } catch {
-            callback(.failure(error))
+    private func testRoots() throws -> [[UInt8]] {
+        try fixture(name: "Signing", createGitRepo: false) { fixturePath in
+            let rootCA = try localFileSystem
+                .readFileContents(fixturePath.appending(components: "Certificates", "TestRootCA.cer")).contents
+            return [rootCA]
         }
     }
 

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -2903,11 +2903,11 @@ final class PackageToolTests: CommandsTestCase {
         }
     }
 
-    func testSinglePluginTarget() throws {
+    func testSinglePluginTarget() async throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
-        try testWithTemporaryDirectory { tmpPath in
+        try await testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
@@ -2956,13 +2956,10 @@ final class PackageToolTests: CommandsTestCase {
 
             // Load the root manifest.
             let rootInput = PackageGraphRootInput(packages: [packageDir], dependencies: [])
-            let rootManifests = try temp_await {
-                workspace.loadRootManifests(
-                    packages: rootInput.packages,
-                    observabilityScope: observability.topScope,
-                    completion: $0
-                )
-            }
+            let rootManifests = try await workspace.loadRootManifests(
+                packages: rootInput.packages,
+                observabilityScope: observability.topScope
+            )
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -168,14 +168,14 @@ class PluginTests: XCTestCase {
         }
     }
     
-    func testCommandPluginInvocation() throws {
+    func testCommandPluginInvocation() async throws {
         try XCTSkipIf(true, "test is disabled because it isn't stable, see rdar://117870608")
 
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
         // FIXME: This test is getting quite long — we should add some support functionality for creating synthetic plugin tests and factor this out into separate tests.
-        try testWithTemporaryDirectory { tmpPath in
+        try await testWithTemporaryDirectory { tmpPath in
             // Create a sample package with a library target and a plugin. It depends on a sample package.
             let packageDir = tmpPath.appending(components: "MyPackage")
             let manifestFile = packageDir.appending("Package.swift")
@@ -366,13 +366,10 @@ class PluginTests: XCTestCase {
             
             // Load the root manifest.
             let rootInput = PackageGraphRootInput(packages: [packageDir], dependencies: [])
-            let rootManifests = try temp_await {
-                workspace.loadRootManifests(
-                    packages: rootInput.packages,
-                    observabilityScope: observability.topScope,
-                    completion: $0
-                )
-            }
+            let rootManifests = try await workspace.loadRootManifests(
+                packages: rootInput.packages,
+                observabilityScope: observability.topScope
+            )
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
@@ -434,7 +431,7 @@ class PluginTests: XCTestCase {
                 line: UInt = #line,
                 expectFailure: Bool = false,
                 diagnosticsChecker: (DiagnosticsTestResult) throws -> Void
-            ) {
+            ) async {
                 // Find the named plugin.
                 let plugins = package.targets.compactMap{ $0.underlyingTarget as? PluginTarget }
                 guard let plugin = plugins.first(where: { $0.name == pluginName }) else {
@@ -462,7 +459,7 @@ class PluginTests: XCTestCase {
                     )
 
                     let toolSearchDirectories = [try UserToolchain.default.swiftCompilerPath.parentDirectory]
-                    let success = try temp_await { plugin.invoke(
+                    let success = try await safe_async { plugin.invoke(
                         action: .performCommand(package: package, arguments: arguments),
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         scriptRunner: scriptRunner,
@@ -479,7 +476,8 @@ class PluginTests: XCTestCase {
                         observabilityScope: observability.topScope,
                         callbackQueue: delegateQueue,
                         delegate: delegate,
-                        completion: $0) }
+                        completion: $0)
+                    }
                     if expectFailure {
                         XCTAssertFalse(success, "expected command to fail, but it succeeded", file: file, line: line)
                     }
@@ -499,19 +497,19 @@ class PluginTests: XCTestCase {
             }
 
             // Invoke the command plugin that prints out various things it was given, and check them.
-            testCommand(package: package, plugin: "PluginPrintingInfo", targets: ["MyLibrary"], arguments: ["veni", "vidi", "vici"]) { output in
+            await testCommand(package: package, plugin: "PluginPrintingInfo", targets: ["MyLibrary"], arguments: ["veni", "vidi", "vici"]) { output in
                 output.check(diagnostic: .equal("Root package is MyPackage."), severity: .info)
                 output.check(diagnostic: .and(.prefix("Found the swiftc tool"), .suffix(".")), severity: .info)
             }
 
             // Invoke the command plugin that throws an unhandled error at the top level.
-            testCommand(package: package, plugin: "PluginFailingWithError", targets: [], arguments: [], expectFailure: true) { output in
+            await testCommand(package: package, plugin: "PluginFailingWithError", targets: [], arguments: [], expectFailure: true) { output in
                 output.check(diagnostic: .equal("This text should appear before the uncaught thrown error."), severity: .info)
                 output.check(diagnostic: .equal("This is the uncaught thrown error."), severity: .error)
 
             }
             // Invoke the command plugin that exits with code 1 without returning an error.
-            testCommand(package: package, plugin: "PluginFailingWithoutError", targets: [], arguments: [], expectFailure: true) { output in
+            await testCommand(package: package, plugin: "PluginFailingWithoutError", targets: [], arguments: [], expectFailure: true) { output in
                 output.check(diagnostic: .equal("This text should appear before we exit."), severity: .info)
                 output.check(diagnostic: .equal("Plugin ended with exit code 1"), severity: .error)
             }
@@ -534,10 +532,10 @@ class PluginTests: XCTestCase {
         }
     }
 
-    func testPluginUsageDoesntAffectTestTargetMappings() throws {
+    func testPluginUsageDoesntAffectTestTargetMappings() async throws {
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
-        try fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { packageDir in
+        try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { packageDir in
             // Load a workspace from the package.
             let observability = ObservabilitySystem.makeForTesting()
             let workspace = try Workspace(
@@ -549,13 +547,10 @@ class PluginTests: XCTestCase {
 
             // Load the root manifest.
             let rootInput = PackageGraphRootInput(packages: [packageDir], dependencies: [])
-            let rootManifests = try temp_await {
-                workspace.loadRootManifests(
-                    packages: rootInput.packages,
-                    observabilityScope: observability.topScope,
-                    completion: $0
-                )
-            }
+            let rootManifests = try await workspace.loadRootManifests(
+                packages: rootInput.packages,
+                observabilityScope: observability.topScope
+            )
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
@@ -570,11 +565,11 @@ class PluginTests: XCTestCase {
         }
     }
 
-    func testCommandPluginCancellation() throws {
+    func testCommandPluginCancellation() async throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
         
-        try testWithTemporaryDirectory { tmpPath in
+        try await testWithTemporaryDirectory { (tmpPath: AbsolutePath) -> Void in
             // Create a sample package with a couple of plugins a other targets and products.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
@@ -646,13 +641,10 @@ class PluginTests: XCTestCase {
             
             // Load the root manifest.
             let rootInput = PackageGraphRootInput(packages: [packageDir], dependencies: [])
-            let rootManifests = try temp_await {
-                workspace.loadRootManifests(
-                    packages: rootInput.packages,
-                    observabilityScope: observability.topScope,
-                    completion: $0
-                )
-            }
+            let rootManifests = try await workspace.loadRootManifests(
+                packages: rootInput.packages,
+                observabilityScope: observability.topScope
+            )
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
@@ -732,64 +724,81 @@ class PluginTests: XCTestCase {
                 toolchain: try UserToolchain.default
             )
             let delegate = PluginDelegate(delegateQueue: delegateQueue)
-            let sync = DispatchSemaphore(value: 0)
-            plugin.invoke(
-                action: .performCommand(package: package, arguments: []),
-                buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
-                scriptRunner: scriptRunner,
-                workingDirectory: package.path,
-                outputDirectory: pluginDir.appending("output"),
-                toolSearchDirectories: [try UserToolchain.default.swiftCompilerPath.parentDirectory],
-                accessibleTools: [:],
-                writableDirectories: [pluginDir.appending("output")],
-                readOnlyDirectories: [package.path],
-                allowNetworkConnections: [],
-                pkgConfigDirectories: [],
-                sdkRootPath: try UserToolchain.default.sdkRootPath,
-                fileSystem: localFileSystem,
-                observabilityScope: observability.topScope,
-                callbackQueue: delegateQueue,
-                delegate: delegate,
-                completion: { _ in
-                    sync.signal()
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    // TODO: have invoke natively support task cancelation instead
+                    try await withTaskCancellationHandler {
+                        _ = try await plugin.invoke(
+                            action: .performCommand(package: package, arguments: []),
+                            buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
+                            scriptRunner: scriptRunner,
+                            workingDirectory: package.path,
+                            outputDirectory: pluginDir.appending("output"),
+                            toolSearchDirectories: [try UserToolchain.default.swiftCompilerPath.parentDirectory],
+                            accessibleTools: [:],
+                            writableDirectories: [pluginDir.appending("output")],
+                            readOnlyDirectories: [package.path],
+                            allowNetworkConnections: [],
+                            pkgConfigDirectories: [],
+                            sdkRootPath: try UserToolchain.default.sdkRootPath,
+                            fileSystem: localFileSystem,
+                            observabilityScope: observability.topScope,
+                            callbackQueue: delegateQueue,
+                            delegate: delegate
+                        )
+                    } onCancel: {
+                        do {
+                            try scriptRunner.cancel(deadline: .now() + .seconds(5))
+                        } catch {
+                            XCTFail("Cancelling script runner should not fail: \(error)")
+                        }
+                    }
                 }
-            )
-            
-            // Wait for three seconds.
-            let result = sync.wait(timeout: .now() + 3)
-            XCTAssertEqual(result, .timedOut, "expected the plugin to time out")
-            
-            // At this point we should have parsed out the process identifier. But it's possible we don't always — this is being investigated in rdar://88792829.
-            var pid: Int? = .none
-            delegateQueue.sync {
-                pid = delegate.parsedProcessIdentifier
+                group.addTask {
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64(DispatchTimeInterval.seconds(3).nanoseconds()!))
+                    } catch {
+                        XCTFail("The plugin should not finish within 3 seconds")
+                    }
+                }
+
+                try await group.next()
+
+
+                // At this point we should have parsed out the process identifier. But it's possible we don't always — this is being investigated in rdar://88792829.
+                var pid: Int? = .none
+                delegateQueue.sync {
+                    pid = delegate.parsedProcessIdentifier
+                }
+                guard let pid else {
+                    throw XCTSkip("skipping test because no pid was received from the plugin; being investigated as rdar://88792829\n\(delegate.diagnostics.description)")
+                }
+
+                // Check that it's running (we do this by asking for its priority — this only works on some platforms).
+                #if os(macOS)
+                errno = 0
+                getpriority(Int32(PRIO_PROCESS), UInt32(pid))
+                XCTAssertEqual(errno, 0, "unexpectedly got errno \(errno) when trying to check process \(pid)")
+                #endif
+
+                // Ask the plugin running to cancel all plugins.
+                group.cancelAll()
+
+                // Check that it's no longer running (we do this by asking for its priority — this only works on some platforms).
+                #if os(macOS)
+                errno = 0
+                getpriority(Int32(PRIO_PROCESS), UInt32(pid))
+                XCTAssertEqual(errno, ESRCH, "unexpectedly got errno \(errno) when trying to check process \(pid)")
+                #endif
             }
-            guard let pid else {
-                throw XCTSkip("skipping test because no pid was received from the plugin; being investigated as rdar://88792829\n\(delegate.diagnostics.description)")
-            }
-            
-            // Check that it's running (we do this by asking for its priority — this only works on some platforms).
-            #if os(macOS)
-            errno = 0
-            getpriority(Int32(PRIO_PROCESS), UInt32(pid))
-            XCTAssertEqual(errno, 0, "unexpectedly got errno \(errno) when trying to check process \(pid)")
-            #endif
-            
-            // Ask the plugin running to cancel all plugins.
-            try scriptRunner.cancel(deadline: .now() + .seconds(5))
-            
-            // Check that it's no longer running (we do this by asking for its priority — this only works on some platforms).
-            #if os(macOS)
-            errno = 0
-            getpriority(Int32(PRIO_PROCESS), UInt32(pid))
-            XCTAssertEqual(errno, ESRCH, "unexpectedly got errno \(errno) when trying to check process \(pid)")
-            #endif
+
+
         }
     }
 
-    func testUnusedPluginProductWarnings() throws {
+    func testUnusedPluginProductWarnings() async throws {
         // Test the warnings we get around unused plugin products in package dependencies.
-        try testWithTemporaryDirectory { tmpPath in
+        try await testWithTemporaryDirectory { tmpPath in
             // Create a sample package that uses three packages that vend plugins.
             let packageDir = tmpPath.appending(components: "MyPackage")
             try localFileSystem.createDirectory(packageDir, recursive: true)
@@ -942,13 +951,10 @@ class PluginTests: XCTestCase {
 
             // Load the root manifest.
             let rootInput = PackageGraphRootInput(packages: [packageDir], dependencies: [])
-            let rootManifests = try temp_await {
-                workspace.loadRootManifests(
-                    packages: rootInput.packages,
-                    observabilityScope: observability.topScope,
-                    completion: $0
-                )
-            }
+            let rootManifests = try await workspace.loadRootManifests(
+                packages: rootInput.packages,
+                observabilityScope: observability.topScope
+            )
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -602,8 +602,8 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     }
 
     // run this with TSAN/ASAN to detect concurrency issues
-    func testConcurrencyWithWarmup() throws {
-        try testWithTemporaryDirectory { path in
+    func testConcurrencyWithWarmup() async throws {
+        try await testWithTemporaryDirectory { path in
             let total = 1000
             let manifestPath = path.appending(components: "pkg", "Package.swift")
             try localFileSystem.createDirectory(manifestPath.parentDirectory)
@@ -630,63 +630,53 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 
             // warm up caches
             delegate.prepare()
-            let manifest = try temp_await {
-                manifestLoader.load(
-                    manifestPath: manifestPath,
-                    manifestToolsVersion: .v4_2,
-                    packageIdentity: .plain("Trivial"),
-                    packageKind: .fileSystem(manifestPath.parentDirectory),
-                    packageLocation: manifestPath.pathString,
-                    packageVersion: nil,
-                    identityResolver: identityResolver,
-                    dependencyMapper: dependencyMapper,
-                    fileSystem: localFileSystem,
-                    observabilityScope: observability.topScope,
-                    delegateQueue: .sharedConcurrent,
-                    callbackQueue: .sharedConcurrent,
-                    completion: $0
-                )
-            }
+            let manifest = try await manifestLoader.load(
+                manifestPath: manifestPath,
+                manifestToolsVersion: .v4_2,
+                packageIdentity: .plain("Trivial"),
+                packageKind: .fileSystem(manifestPath.parentDirectory),
+                packageLocation: manifestPath.pathString,
+                packageVersion: nil,
+                identityResolver: identityResolver,
+                dependencyMapper: dependencyMapper,
+                fileSystem: localFileSystem,
+                observabilityScope: observability.topScope,
+                delegateQueue: .sharedConcurrent,
+                callbackQueue: .sharedConcurrent
+            )
 
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssertEqual(manifest.displayName, "Trivial")
             XCTAssertEqual(manifest.targets[0].name, "foo")
 
-            let sync = DispatchGroup()
-            for _ in 0 ..< total {
-                sync.enter()
-                delegate.prepare(expectParsing: false)
-                manifestLoader.load(
-                    manifestPath: manifestPath,
-                    manifestToolsVersion: .v4_2,
-                    packageIdentity: .plain("Trivial"),
-                    packageKind: .fileSystem(manifestPath.parentDirectory),
-                    packageLocation: manifestPath.pathString,
-                    packageVersion: nil,
-                    identityResolver: identityResolver,
-                    dependencyMapper: dependencyMapper,
-                    fileSystem: localFileSystem,
-                    observabilityScope: observability.topScope,
-                    delegateQueue: .sharedConcurrent,
-                    callbackQueue: .sharedConcurrent
-                ) { result in
-                    defer {
-                        sync.leave()
-                    }
-
-                    switch result {
-                    case .failure(let error):
-                        XCTFail("\(error)")
-                    case .success(let manifest):
-                        XCTAssertNoDiagnostics(observability.diagnostics)
-                        XCTAssertEqual(manifest.displayName, "Trivial")
-                        XCTAssertEqual(manifest.targets[0].name, "foo")
+            await withTaskGroup(of:Void.self) { group in
+                for _ in 0 ..< total {
+                    delegate.prepare(expectParsing: false)
+                    group.addTask {
+                        do {
+                            let manifest = try await manifestLoader.load(
+                                manifestPath: manifestPath,
+                                manifestToolsVersion: .v4_2,
+                                packageIdentity: .plain("Trivial"),
+                                packageKind: .fileSystem(manifestPath.parentDirectory),
+                                packageLocation: manifestPath.pathString,
+                                packageVersion: nil,
+                                identityResolver: identityResolver,
+                                dependencyMapper: dependencyMapper,
+                                fileSystem: localFileSystem,
+                                observabilityScope: observability.topScope,
+                                delegateQueue: .sharedConcurrent,
+                                callbackQueue: .sharedConcurrent
+                            )
+                            XCTAssertNoDiagnostics(observability.diagnostics)
+                            XCTAssertEqual(manifest.displayName, "Trivial")
+                            XCTAssertEqual(manifest.targets[0].name, "foo")
+                        } catch {
+                            XCTFail("\(error)")
+                        }
                     }
                 }
-            }
-
-            if case .timedOut = sync.wait(timeout: .now() + 30) {
-                XCTFail("timeout")
+                await group.waitForAll()
             }
 
             XCTAssertEqual(try delegate.loaded(timeout: .now() + 1).count, total+1)
@@ -696,7 +686,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
     }
 
     // run this with TSAN/ASAN to detect concurrency issues
-    func testConcurrencyNoWarmUp() throws {
+    func testConcurrencyNoWarmUp() async throws {
 #if os(Windows)
         // FIXME: does this actually trigger only on Windows or are other
         // platforms just getting lucky?  I'm feeling lucky.
@@ -704,7 +694,7 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
 #else
         try XCTSkipIfCI()
 
-        try testWithTemporaryDirectory { path in
+        try await testWithTemporaryDirectory { path in
             let total = 100
             let observability = ObservabilitySystem.makeForTesting()
             let delegate = ManifestTestDelegate()
@@ -712,60 +702,52 @@ class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             let identityResolver = DefaultIdentityResolver()
             let dependencyMapper = DefaultDependencyMapper(identityResolver: identityResolver)
 
-            let sync = DispatchGroup()
-            for _ in 0 ..< total {
-                let random = Int.random(in: 0 ... total / 4)
-                let manifestPath = path.appending(components: "pkg-\(random)", "Package.swift")
-                if !localFileSystem.exists(manifestPath) {
-                    try localFileSystem.createDirectory(manifestPath.parentDirectory)
-                    try localFileSystem.writeFileContents(
-                        manifestPath,
-                        string: """
-                        import PackageDescription
-                        let package = Package(
-                            name: "Trivial-\(random)",
-                            targets: [
-                                .target(
-                                    name: "foo-\(random)",
-                                    dependencies: []),
-                            ]
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for _ in 0 ..< total {
+                    let random = Int.random(in: 0 ... total / 4)
+                    let manifestPath = path.appending(components: "pkg-\(random)", "Package.swift")
+                    if !localFileSystem.exists(manifestPath) {
+                        try localFileSystem.createDirectory(manifestPath.parentDirectory)
+                        try localFileSystem.writeFileContents(
+                            manifestPath,
+                            string: """
+                            import PackageDescription
+                            let package = Package(
+                                name: "Trivial-\(random)",
+                                targets: [
+                                    .target(
+                                        name: "foo-\(random)",
+                                        dependencies: []),
+                                ]
+                            )
+                            """
                         )
-                        """
-                    )
-                }
-
-                sync.enter()
-                delegate.prepare()
-                manifestLoader.load(
-                    manifestPath: manifestPath,
-                    manifestToolsVersion: .v4_2,
-                    packageIdentity: .plain("Trivial-\(random)"),
-                    packageKind: .fileSystem(manifestPath.parentDirectory),
-                    packageLocation: manifestPath.pathString,
-                    packageVersion: nil,
-                    identityResolver: identityResolver,
-                    dependencyMapper: dependencyMapper,
-                    fileSystem: localFileSystem,
-                    observabilityScope: observability.topScope,
-                    delegateQueue: .sharedConcurrent,
-                    callbackQueue: .sharedConcurrent
-                ) { result in
-                    defer {
-                        sync.leave()
                     }
-
-                    switch result {
-                    case .failure(let error):
-                        XCTFail("\(error)")
-                    case .success(let manifest):
-                        XCTAssertEqual(manifest.displayName, "Trivial-\(random)")
-                        XCTAssertEqual(manifest.targets[0].name, "foo-\(random)")
+                    group.addTask {
+                        do {
+                            delegate.prepare()
+                            let manifest = try await manifestLoader.load(
+                                manifestPath: manifestPath,
+                                manifestToolsVersion: .v4_2,
+                                packageIdentity: .plain("Trivial-\(random)"),
+                                packageKind: .fileSystem(manifestPath.parentDirectory),
+                                packageLocation: manifestPath.pathString,
+                                packageVersion: nil,
+                                identityResolver: identityResolver,
+                                dependencyMapper: dependencyMapper,
+                                fileSystem: localFileSystem,
+                                observabilityScope: observability.topScope,
+                                delegateQueue: .sharedConcurrent,
+                                callbackQueue: .sharedConcurrent
+                            )
+                            XCTAssertEqual(manifest.displayName, "Trivial-\(random)")
+                            XCTAssertEqual(manifest.targets[0].name, "foo-\(random)")
+                        } catch {
+                            XCTFail("\(error)")
+                        }
                     }
                 }
-            }
-
-            if case .timedOut = sync.wait(timeout: .now() + 60) {
-                XCTFail("timeout")
+                try await group.waitForAll()
             }
 
             XCTAssertEqual(try delegate.loaded(timeout: .now() + 1).count, total)

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -20,11 +20,11 @@ import class TSCBasic.InMemoryFileSystem
 import enum TSCBasic.ProcessEnv
 
 class RepositoryManagerTests: XCTestCase {
-    func testBasics() throws {
+    func testBasics() async throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 
-        try testWithTemporaryDirectory { path in
+        try await testWithTemporaryDirectory { path in
             let provider = DummyRepositoryProvider(fileSystem: fs)
             let delegate = DummyRepositoryManagerDelegate()
 
@@ -43,7 +43,7 @@ class RepositoryManagerTests: XCTestCase {
 
             do {
                 delegate.prepare(fetchExpected: true, updateExpected: false)
-                let handle = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+                let handle = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
                 XCTAssertNoDiagnostics(observability.diagnostics)
 
                 prevHandle = handle
@@ -69,7 +69,7 @@ class RepositoryManagerTests: XCTestCase {
 
             do {
                 delegate.prepare(fetchExpected: true, updateExpected: false)
-                XCTAssertThrowsError(try manager.lookup(repository: badDummyRepo, observabilityScope: observability.topScope)) { error in
+                await XCTAssertAsyncThrowsError(try await manager.lookup(repository: badDummyRepo, observabilityScope: observability.topScope)) { error in
                     XCTAssertEqual(error as? DummyError, DummyError.invalidRepository)
                 }
 
@@ -85,7 +85,7 @@ class RepositoryManagerTests: XCTestCase {
 
             do {
                 delegate.prepare(fetchExpected: false, updateExpected: true)
-                let handle = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+                let handle = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
                 XCTAssertNoDiagnostics(observability.diagnostics)
                 XCTAssertEqual(handle.repository, dummyRepo)
                 XCTAssertEqual(handle.repository, prevHandle?.repository)
@@ -111,7 +111,7 @@ class RepositoryManagerTests: XCTestCase {
 
                 // We should get a new handle now because we deleted the existing repository.
                 delegate.prepare(fetchExpected: true, updateExpected: false)
-                let handle = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+                let handle = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
                 XCTAssertNoDiagnostics(observability.diagnostics)
                 XCTAssertEqual(handle.repository, dummyRepo)
 
@@ -125,11 +125,11 @@ class RepositoryManagerTests: XCTestCase {
         }
     }
 
-    func testCache() throws {
+    func testCache() async throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 
-        try fixture(name: "DependencyResolution/External/Simple") { (fixturePath: AbsolutePath) in
+        try await fixture(name: "DependencyResolution/External/Simple") { (fixturePath: AbsolutePath) in
             let cachePath = fixturePath.appending("cache")
             let repositoriesPath = fixturePath.appending("repositories")
             let repo = RepositorySpecifier(path: fixturePath.appending("Foo"))
@@ -148,7 +148,7 @@ class RepositoryManagerTests: XCTestCase {
 
             // fetch packages and populate cache
             delegate.prepare(fetchExpected: true, updateExpected: false)
-            _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
             try XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
@@ -163,7 +163,7 @@ class RepositoryManagerTests: XCTestCase {
 
             // fetch packages from the cache
             delegate.prepare(fetchExpected: true, updateExpected: false)
-            _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
             try delegate.wait(timeout: .now() + 2)
@@ -178,7 +178,7 @@ class RepositoryManagerTests: XCTestCase {
 
             // fetch packages and populate cache
             delegate.prepare(fetchExpected: true, updateExpected: false)
-            _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
             try XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
@@ -190,7 +190,7 @@ class RepositoryManagerTests: XCTestCase {
 
             // update packages from the cache
             delegate.prepare(fetchExpected: false, updateExpected: true)
-            _ = try manager.lookup(repository: repo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: repo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try delegate.wait(timeout: .now() + 2)
             try XCTAssertEqual(delegate.willUpdate[0].storagePath(), repo.storagePath())
@@ -198,11 +198,11 @@ class RepositoryManagerTests: XCTestCase {
         }
     }
 
-    func testReset() throws {
+    func testReset() async throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 
-        try testWithTemporaryDirectory { path in
+        try await testWithTemporaryDirectory { path in
             let repos = path.appending("repo")
             let provider = DummyRepositoryProvider(fileSystem: fs)
             let delegate = DummyRepositoryManagerDelegate()
@@ -218,10 +218,10 @@ class RepositoryManagerTests: XCTestCase {
             let dummyRepo = RepositorySpecifier(path: "/dummy")
 
             delegate.prepare(fetchExpected: true, updateExpected: false)
-            _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             delegate.prepare(fetchExpected: false, updateExpected: true)
-            _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch.count, 1)
@@ -234,7 +234,7 @@ class RepositoryManagerTests: XCTestCase {
             try fs.createDirectory(repos, recursive: true)
 
             delegate.prepare(fetchExpected: true, updateExpected: false)
-            _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch.count, 2)
@@ -243,11 +243,11 @@ class RepositoryManagerTests: XCTestCase {
     }
 
     /// Check that the manager is persistent.
-    func testPersistence() throws {
+    func testPersistence() async throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 
-        try testWithTemporaryDirectory { path in
+        try await testWithTemporaryDirectory { path in
             let provider = DummyRepositoryProvider(fileSystem: fs)
             let dummyRepo = RepositorySpecifier(path: "/dummy")
 
@@ -262,7 +262,7 @@ class RepositoryManagerTests: XCTestCase {
                 )
 
                 delegate.prepare(fetchExpected: true, updateExpected: false)
-                _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+                _ = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
                 XCTAssertNoDiagnostics(observability.diagnostics)
                 try delegate.wait(timeout: .now() + 2)
                 XCTAssertEqual(delegate.willFetch.map { $0.repository }, [dummyRepo])
@@ -283,7 +283,7 @@ class RepositoryManagerTests: XCTestCase {
                 )
 
                 delegate.prepare(fetchExpected: true, updateExpected: false)
-                _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+                _ = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
                 XCTAssertNoDiagnostics(observability.diagnostics)
                 // This time fetch shouldn't be called.
                 try delegate.wait(timeout: .now() + 2)
@@ -312,7 +312,7 @@ class RepositoryManagerTests: XCTestCase {
                 let dummyRepo = RepositorySpecifier(path: "/dummy")
 
                 delegate.prepare(fetchExpected: true, updateExpected: false)
-                _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+                _ = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
                 XCTAssertNoDiagnostics(observability.diagnostics)
                 try delegate.wait(timeout: .now() + 2)
                 XCTAssertEqual(delegate.willFetch.map { $0.repository }, [dummyRepo])
@@ -335,11 +335,11 @@ class RepositoryManagerTests: XCTestCase {
         }
     }
 
-    func testConcurrency() throws {
+    func testConcurrency() async throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 
-        try testWithTemporaryDirectory { path in
+        try await testWithTemporaryDirectory { path in
             let provider = DummyRepositoryProvider(fileSystem: fs)
             let delegate = DummyRepositoryManagerDelegate()
             let manager = RepositoryManager(
@@ -350,27 +350,23 @@ class RepositoryManagerTests: XCTestCase {
             )
             let dummyRepo = RepositorySpecifier(path: "/dummy")
 
-            let group = DispatchGroup()
-            let results = ThreadSafeKeyValueStore<Int, Result<RepositoryManager.RepositoryHandle, Error>>()
+            let results = ThreadSafeKeyValueStore<Int, RepositoryManager.RepositoryHandle>()
             let concurrency = 10000
-            for index in 0 ..< concurrency {
-                group.enter()
-                delegate.prepare(fetchExpected: index == 0, updateExpected: index > 0)
-                manager.lookup(
-                    package: .init(url: SourceControlURL(dummyRepo.url)),
-                    repository: dummyRepo,
-                    updateStrategy: .always,
-                    observabilityScope: observability.topScope,
-                    delegateQueue: .sharedConcurrent,
-                    callbackQueue: .sharedConcurrent
-                ) { result in
-                    results[index] = result
-                    group.leave()
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for index in 0 ..< concurrency {
+                    group.addTask {
+                        delegate.prepare(fetchExpected: index == 0, updateExpected: index > 0)
+                        results[index] = try await manager.lookup(
+                            package: .init(url: SourceControlURL(dummyRepo.url)),
+                            repository: dummyRepo,
+                            updateStrategy: .always,
+                            observabilityScope: observability.topScope,
+                            delegateQueue: .sharedConcurrent,
+                            callbackQueue: .sharedConcurrent
+                        )
+                    }
                 }
-            }
-
-            if case .timedOut = group.wait(timeout: .now() + 60) {
-                return XCTFail("timeout")
+                try await group.waitForAll()
             }
 
             XCTAssertNoDiagnostics(observability.diagnostics)
@@ -383,16 +379,16 @@ class RepositoryManagerTests: XCTestCase {
 
             XCTAssertEqual(results.count, concurrency)
             for index in 0 ..< concurrency {
-                XCTAssertEqual(try results[index]?.get().repository, dummyRepo)
+                XCTAssertEqual(results[index]?.repository, dummyRepo)
             }
         }
     }
 
-    func testSkipUpdate() throws {
+    func testSkipUpdate() async throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 
-        try testWithTemporaryDirectory { path in
+        try await testWithTemporaryDirectory { path in
             let repos = path.appending("repo")
             let provider = DummyRepositoryProvider(fileSystem: fs)
             let delegate = DummyRepositoryManagerDelegate()
@@ -408,7 +404,7 @@ class RepositoryManagerTests: XCTestCase {
             let dummyRepo = RepositorySpecifier(path: "/dummy")
 
             delegate.prepare(fetchExpected: true, updateExpected: false)
-            _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch.count, 1)
@@ -417,10 +413,10 @@ class RepositoryManagerTests: XCTestCase {
             XCTAssertEqual(delegate.didUpdate.count, 0)
 
             delegate.prepare(fetchExpected: false, updateExpected: true)
-            _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             delegate.prepare(fetchExpected: false, updateExpected: true)
-            _ = try manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch.count, 1)
@@ -429,7 +425,7 @@ class RepositoryManagerTests: XCTestCase {
             XCTAssertEqual(delegate.didUpdate.count, 2)
 
             delegate.prepare(fetchExpected: false, updateExpected: false)
-            _ = try manager.lookup(repository: dummyRepo, updateStrategy: .never, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: dummyRepo, updateStrategy: .never, observabilityScope: observability.topScope)
             XCTAssertNoDiagnostics(observability.diagnostics)
             try delegate.wait(timeout: .now() + 2)
             XCTAssertEqual(delegate.willFetch.count, 1)
@@ -571,11 +567,11 @@ class RepositoryManagerTests: XCTestCase {
         }
     }
 
-    func testInvalidRepositoryOnDisk() throws {
+    func testInvalidRepositoryOnDisk() async throws {
         let fileSystem = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
 
-        try testWithTemporaryDirectory { path in
+        try await testWithTemporaryDirectory { path in
             let repositoriesDirectory = path.appending("repositories")
             try fileSystem.createDirectory(repositoriesDirectory, recursive: true)
 
@@ -589,7 +585,7 @@ class RepositoryManagerTests: XCTestCase {
                 delegate: nil
             )
 
-            _ = try manager.lookup(repository: testRepository, observabilityScope: observability.topScope)
+            _ = try await manager.lookup(repository: testRepository, observabilityScope: observability.topScope)
             testDiagnostics(observability.diagnostics) { result in
                 result.check(
                     diagnostic: .contains("is not valid git repository for '\(testRepository)', will fetch again"),
@@ -717,8 +713,8 @@ extension RepositoryManager {
         repository: RepositorySpecifier,
         updateStrategy: RepositoryUpdateStrategy = .always,
         observabilityScope: ObservabilityScope
-    ) throws -> RepositoryHandle {
-        return try temp_await {
+    ) async throws -> RepositoryHandle {
+        return try await safe_async {
             self.lookup(
                 package: .init(url: SourceControlURL(repository.url)),
                 repository: repository,


### PR DESCRIPTION
Adopt async/await in more tests

### Motivation:

Same as before. async/await good

### Modifications:

Moved multiple test targets to async/await

### Result:

Only three uses of `temp_await` remain in test targets after this PR. 