### PR TITLE
Allow specifying testing libraries for `swift package init`

### DIFF
--- a/Sources/Commands/PackageTools/Init.swift
+++ b/Sources/Commands/PackageTools/Init.swift
@@ -14,6 +14,7 @@ import ArgumentParser
 import Basics
 import CoreCommands
 import Workspace
+import SPMBuildCore
 
 extension SwiftPackageTool {
     struct Init: SwiftCommand {
@@ -38,6 +39,18 @@ extension SwiftPackageTool {
                 """))
         var initMode: InitPackage.PackageType = .library
 
+        /// Whether to enable support for XCTest.
+        @Flag(name: .customLong("xctest"),
+              inversion: .prefixedEnableDisable,
+              help: "Enable support for XCTest")
+        var enableXCTestSupport: Bool = true
+
+        /// Whether to enable support for swift-testing.
+        @Flag(name: .customLong("experimental-swift-testing"),
+              inversion: .prefixedEnableDisable,
+              help: "Enable experimental support for swift-testing")
+        var enableSwiftTestingLibrarySupport: Bool = false
+
         @Option(name: .customLong("name"), help: "Provide custom package name")
         var packageName: String?
 
@@ -46,10 +59,18 @@ extension SwiftPackageTool {
                 throw InternalError("Could not find the current working directory")
             }
 
+            var testingLibraries: Set<BuildParameters.Testing.Library> = []
+            if enableXCTestSupport {
+                testingLibraries.insert(.xctest)
+            }
+            if enableSwiftTestingLibrarySupport {
+                testingLibraries.insert(.swiftTesting)
+            }
             let packageName = self.packageName ?? cwd.basename
             let initPackage = try InitPackage(
                 name: packageName,
                 packageType: initMode,
+                supportedTestingLibraries: testingLibraries,
                 destinationPath: cwd,
                 installedSwiftPMConfiguration: swiftTool.getHostToolchain().installedSwiftPMConfiguration,
                 fileSystem: swiftTool.fileSystem

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Testing.swift
@@ -98,7 +98,7 @@ extension BuildParameters {
         public var testProductStyle: TestProductStyle
 
         /// The testing libraries supported by the package manager.
-        public enum Library: String, Codable {
+        public enum Library: String, Codable, CustomStringConvertible {
             /// The XCTest library.
             ///
             /// This case represents both the open-source swift-corelibs-xctest
@@ -107,6 +107,10 @@ extension BuildParameters {
 
             /// The swift-testing library.
             case swiftTesting = "swift-testing"
+
+            public var description: String {
+                rawValue
+            }
         }
 
         /// Which testing library to use for this build.

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -444,12 +444,13 @@ extension InitPackage {
     public convenience init(
         name: String,
         packageType: PackageType,
+        supportedTestingLibraries: Set<BuildParameters.Testing.Library> = [.xctest],
         destinationPath: AbsolutePath,
         fileSystem: FileSystem
     ) throws {
         try self.init(
             name: name,
-            options: InitPackageOptions(packageType: packageType),
+            options: InitPackageOptions(packageType: packageType, supportedTestingLibraries: supportedTestingLibraries),
             destinationPath: destinationPath,
             installedSwiftPMConfiguration: .default,
             fileSystem: fileSystem

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -74,7 +74,8 @@ final class PackageToolTests: CommandsTestCase {
 	
 	func testInitUsage() throws {
 		let stdout = try execute(["init", "--help"]).stdout
-		XCTAssertMatch(stdout, .contains("USAGE: swift package init [--type <type>] [--name <name>]"))
+		XCTAssertMatch(stdout, .contains("USAGE: swift package init [--type <type>] "))
+		XCTAssertMatch(stdout, .contains(" [--name <name>]"))
 	}
 	
 	func testInitOptionsHelp() throws {


### PR DESCRIPTION
This PR adds `-enable-experimental-swift-testing` (and `-disable-xctest` and their inverses) to `swift package init`. These options behave, broadly, the same as they do for `swift test`. They determine which testing library a new package will use and adjust the generated template to match.

It is important to note that any combination of the two libraries is supported: a developer may wish to use only one or the other, or both, or may wish to opt out of a test target entirely. All four combinations are supported, however for simplicity's sake if both libraries are enabled, we only generate example code for swift-testing.

Note that right now, correct macro target support is impeded by https://github.com/apple/swift-syntax/issues/2400. I don't think that issue blocks a change here (since it's in an experimental feature anyway!) but it does mean that `swift package init --type macro --enable-experimental-swift-testing` produces some dead tests. Once that issue is resolved, we can revise the template to produce meaningful tests instead.

Resolves rdar://99279056.
