### PR TITLE
[cxx-interop] Do not pass the C++ standard if C++ interop is not enabled

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -565,11 +565,13 @@ public final class SwiftTargetBuildDescription {
                 let dependencySwiftFlags = dependencyScope.evaluate(.OTHER_SWIFT_FLAGS)
                 if let interopModeFlag = dependencySwiftFlags.first(where: { $0.hasPrefix("-cxx-interoperability-mode=") }) {
                     args += [interopModeFlag]
+                    if interopModeFlag != "-cxx-interoperability-mode=off" {
+                        if let cxxStandard = self.package.manifest.cxxLanguageStandard {
+                            args += ["-Xcc", "-std=\(cxxStandard)"]
+                        }
+                    }
                     break
                 }
-            }
-            if let cxxStandard = self.package.manifest.cxxLanguageStandard {
-                args += ["-Xcc", "-std=\(cxxStandard)"]
             }
         default: break
         }


### PR DESCRIPTION
This fixes the Swift PR testing failures.

### Motivation:

If C++ interop is not enabled, SwiftPM should not pass `-Xcc -std=c++17` flags.

### Result:

Only pass these flags if C++ interop is enabled.