### PR TITLE
[5.10] Set `file-system` as `device-agnostic` in build manifest

### DIFF
--- a/Sources/LLBuildManifest/LLBuildManifestWriter.swift
+++ b/Sources/LLBuildManifest/LLBuildManifestWriter.swift
@@ -21,6 +21,7 @@ public struct LLBuildManifestWriter {
     private var buffer = """
     client:
       name: basic
+      file-system: device-agnostic
     tools: {}
 
     """

--- a/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
+++ b/Tests/LLBuildManifestTests/LLBuildManifestTests.swift
@@ -71,6 +71,7 @@ final class LLBuildManifestTests: XCTestCase {
         XCTAssertEqual(contents.replacingOccurrences(of: "\\\\", with: "\\"), """
             client:
               name: basic
+              file-system: device-agnostic
             tools: {}
             targets:
               "main": ["<Foo>"]
@@ -125,6 +126,7 @@ final class LLBuildManifestTests: XCTestCase {
         XCTAssertEqual(contents.replacingOccurrences(of: "\\\\", with: "\\"), """
             client:
               name: basic
+              file-system: device-agnostic
             tools: {}
             targets:
               "main": ["\(root.appending(components: "file.out"))"]
@@ -189,6 +191,7 @@ final class LLBuildManifestTests: XCTestCase {
         XCTAssertEqual(contents.replacingOccurrences(of: "\\\\", with: "\\"), """
             client:
               name: basic
+              file-system: device-agnostic
             tools: {}
             targets:
               "": ["<C.mutate>"]


### PR DESCRIPTION
Cherry-pick of  #7052.

### Motivation:

This is the default mode in XCBuild, and allows incremental builds to work across reboots on APFS. It would also likely address https://github.com/apple/swift-package-manager/issues/4651.

### Modifications:

Set `file-system` as `device-agnostic` in the generated build manifest

### Result:

Restarting your system (or inode changes) doesn't invoke unnecessary builds

Related to rdar://96403757.
