### PR TITLE
Move PackageRegistryTool to async/await

### DIFF
--- a/Sources/PackageRegistryTool/PackageRegistryTool.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool.swift
@@ -19,7 +19,7 @@ import PackageRegistry
 import Workspace
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
-public struct SwiftPackageRegistryTool: ParsableCommand {
+public struct SwiftPackageRegistryTool: AsyncParsableCommand {
     public static var configuration = CommandConfiguration(
         commandName: "package-registry",
         _superCommandName: "swift",
@@ -41,7 +41,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
 
     public init() {}
 
-    struct Set: SwiftCommand {
+    struct Set: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Set a custom registry"
         )
@@ -62,7 +62,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
             self.url
         }
 
-        func run(_ swiftTool: SwiftTool) throws {
+        func run(_ swiftTool: SwiftTool) async throws {
             try self.registryURL.validateRegistryURL()
 
             let scope = try scope.map(PackageIdentity.Scope.init(validating:))
@@ -84,7 +84,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         }
     }
 
-    struct Unset: SwiftCommand {
+    struct Unset: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Remove a configured registry"
         )
@@ -98,7 +98,7 @@ public struct SwiftPackageRegistryTool: ParsableCommand {
         @Option(help: "Associate the registry with a given scope")
         var scope: String?
 
-        func run(_ swiftTool: SwiftTool) throws {
+        func run(_ swiftTool: SwiftTool) async throws {
             let scope = try scope.map(PackageIdentity.Scope.init(validating:))
 
             let unset: (inout RegistryConfiguration) throws -> Void = { configuration in

--- a/Sources/swift-package-manager/SwiftPM.swift
+++ b/Sources/swift-package-manager/SwiftPM.swift
@@ -37,7 +37,7 @@ struct SwiftPM {
         case "swift-package-collection":
             SwiftPackageCollectionsTool.main()
         case "swift-package-registry":
-            SwiftPackageRegistryTool.main()
+            await SwiftPackageRegistryTool.main()
         default:
             fatalError("swift-package-manager launched with unexpected name: \(execName ?? "(unknown)")")
         }

--- a/Sources/swift-package-registry/runner.swift
+++ b/Sources/swift-package-registry/runner.swift
@@ -15,7 +15,7 @@ import PackageRegistryTool
 
 @main
 struct Runner {
-    static func main() {
-        SwiftPackageRegistryTool.main()
+    static func main() async {
+        await SwiftPackageRegistryTool.main()
     }
 }


### PR DESCRIPTION
Move PackageRegistryTool to async/await

### Motivation:

Continue replacing older concurrency primitives with native async/await

### Modifications:

Replace all usage of temp_await with actual async/await in the PackageRegistryTool

### Result:

One additional executable target that is natively async/await
