### PR TITLE
Mark global var as constant in `ConcurrencyHelpers.swift`

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -41,7 +41,7 @@ public func temp_await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {
 
 extension DispatchQueue {
     // a shared concurrent queue for running concurrent asynchronous operations
-    public static var sharedConcurrent = DispatchQueue(
+    public static let sharedConcurrent = DispatchQueue(
         label: "swift.org.swiftpm.shared.concurrent",
         attributes: .concurrent
     )


### PR DESCRIPTION
For some reason this global `DispatchQueue.sharedConcurrent` binding was marked as mutable. It should be a constant.
