### PR TITLE
Revert "Avoid using `temp_await` in `SwiftTestTool.swift`"

### DIFF
--- a/Sources/swift-package-manager/SwiftPM.swift
+++ b/Sources/swift-package-manager/SwiftPM.swift
@@ -31,7 +31,7 @@ struct SwiftPM {
         case "swift-experimental-sdk":
             await SwiftSDKTool.main()
         case "swift-test":
-            await SwiftTestTool.main()
+            SwiftTestTool.main()
         case "swift-run":
             SwiftRunTool.main()
         case "swift-package-collection":

--- a/Sources/swift-test/CMakeLists.txt
+++ b/Sources/swift-test/CMakeLists.txt
@@ -7,12 +7,9 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_executable(swift-test
-  Entrypoint.swift)
+  main.swift)
 target_link_libraries(swift-test PRIVATE
   Commands)
-
-target_compile_options(swift-test PRIVATE
-  -parse-as-library)
 
 install(TARGETS swift-test
   RUNTIME DESTINATION bin)

--- a/Sources/swift-test/main.swift
+++ b/Sources/swift-test/main.swift
@@ -12,9 +12,4 @@
 
 import Commands
 
-@main
-struct Entrypoint {
-    static func main() async {
-        await SwiftTestTool.main()
-    }
-}
+SwiftTestTool.main()


### PR DESCRIPTION
Reverts apple/swift-package-manager#7016 to fix macOS CI regression:

```
duplicate symbol '_async_MainTu' in:
    /Users/ec2-user/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/.build/x86_64-apple-macosx/debug/swift_package.build/Entrypoint.swift.o
    /Users/ec2-user/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/.build/x86_64-apple-macosx/debug/swift_test.build/Entrypoint.swift.o
duplicate symbol '_async_Main' in:
    /Users/ec2-user/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/.build/x86_64-apple-macosx/debug/swift_package.build/Entrypoint.swift.o
    /Users/ec2-user/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/.build/x86_64-apple-macosx/debug/swift_test.build/Entrypoint.swift.o
ld: 2 duplicate symbols for architecture x86_64
```

This error was fixed in Swift 5.10, which is not available on CI yet.