### PR TITLE
Revert "Avoid using `temp_await` on `loadRootPackage`"

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/SwiftPM-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SwiftPM-Package.xcscheme
@@ -839,16 +839,6 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SourceKitLSPAPITests"
-               BuildableName = "SourceKitLSPAPITests"
-               BlueprintName = "SourceKitLSPAPITests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Sources/Commands/PackageTools/Describe.swift
+++ b/Sources/Commands/PackageTools/Describe.swift
@@ -19,7 +19,7 @@ import PackageModel
 import struct TSCBasic.StringError
 
 extension SwiftPackageTool {
-    struct Describe: AsyncSwiftCommand {
+    struct Describe: SwiftCommand {
         static let configuration = CommandConfiguration(
             abstract: "Describe the current package")
         
@@ -29,18 +29,21 @@ extension SwiftPackageTool {
         @Option(help: "json | text")
         var type: DescribeMode = .text
         
-        func run(_ swiftTool: SwiftTool) async throws {
+        func run(_ swiftTool: SwiftTool) throws {
             let workspace = try swiftTool.getActiveWorkspace()
             
             guard let packagePath = try swiftTool.getWorkspaceRoot().packages.first else {
                 throw StringError("unknown package")
             }
             
-            let package = try await workspace.loadRootPackage(
-                at: packagePath,
-                observabilityScope: swiftTool.observabilityScope
-            )
-
+            let package = try temp_await {
+                workspace.loadRootPackage(
+                    at: packagePath,
+                    observabilityScope: swiftTool.observabilityScope,
+                    completion: $0
+                )
+            }
+            
             try self.describe(package, in: type)
         }
         

--- a/Sources/Commands/PackageTools/DumpCommands.swift
+++ b/Sources/Commands/PackageTools/DumpCommands.swift
@@ -97,21 +97,24 @@ enum ExtensionBlockSymbolBehavior: String, EnumerableFlag {
     case omitExtensionBlockSymbols
 }
 
-struct DumpPackage: AsyncSwiftCommand {
+struct DumpPackage: SwiftCommand {
     static let configuration = CommandConfiguration(
         abstract: "Print parsed Package.swift as JSON")
 
     @OptionGroup(visibility: .hidden)
     var globalOptions: GlobalOptions
 
-    func run(_ swiftTool: SwiftTool) async throws {
+    func run(_ swiftTool: SwiftTool) throws {
         let workspace = try swiftTool.getActiveWorkspace()
         let root = try swiftTool.getWorkspaceRoot()
 
-        let rootManifests = try await workspace.loadRootManifests(
-            packages: root.packages,
-            observabilityScope: swiftTool.observabilityScope
-        )
+        let rootManifests = try temp_await {
+            workspace.loadRootManifests(
+                packages: root.packages,
+                observabilityScope: swiftTool.observabilityScope,
+                completion: $0
+            )
+        }
         guard let rootManifest = rootManifests.values.first else {
             throw StringError("invalid manifests at \(root.packages)")
         }

--- a/Sources/Commands/PackageTools/SwiftPackageTool.swift
+++ b/Sources/Commands/PackageTools/SwiftPackageTool.swift
@@ -25,7 +25,7 @@ import XCBuildSupport
 import enum TSCUtility.Diagnostics
 
 /// swift-package tool namespace
-public struct SwiftPackageTool: AsyncParsableCommand {
+public struct SwiftPackageTool: ParsableCommand {
     public static var configuration = CommandConfiguration(
         commandName: "package",
         _superCommandName: "swift",

--- a/Sources/swift-package-manager/SwiftPM.swift
+++ b/Sources/swift-package-manager/SwiftPM.swift
@@ -25,7 +25,7 @@ struct SwiftPM {
     static func main() async {
         switch execName {
         case "swift-package":
-            await SwiftPackageTool.main()
+            SwiftPackageTool.main()
         case "swift-build":
             SwiftBuildTool.main()
         case "swift-experimental-sdk":

--- a/Sources/swift-package/CMakeLists.txt
+++ b/Sources/swift-package/CMakeLists.txt
@@ -7,13 +7,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_executable(swift-package
-  Entrypoint.swift)
+  main.swift)
 target_link_libraries(swift-package PRIVATE
   Commands
   TSCBasic)
-
-target_compile_options(swift-package PRIVATE
-  -parse-as-library)
 
 install(TARGETS swift-package
   RUNTIME DESTINATION bin)

--- a/Sources/swift-package/main.swift
+++ b/Sources/swift-package/main.swift
@@ -12,9 +12,4 @@
 
 import Commands
 
-@main
-struct Entrypoint {
-    static func main() async {
-        await SwiftPackageTool.main()
-    }
-}
+SwiftPackageTool.main()

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -865,7 +865,7 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertNoMatch(workspace.delegate.events, [.contains("updating repo")])
     }
 
-    func testPrecomputeResolution_empty() async throws {
+    func testPrecomputeResolution_empty() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
@@ -905,12 +905,13 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let result = try await workspace.checkPrecomputeResolution()
-        XCTAssertNoDiagnostics(result.diagnostics)
-        XCTAssertEqual(result.result.isRequired, false)
+        try workspace.checkPrecomputeResolution { result in
+            XCTAssertNoDiagnostics(result.diagnostics)
+            XCTAssertEqual(result.result.isRequired, false)
+        }
     }
 
-    func testPrecomputeResolution_newPackages() async throws {
+    func testPrecomputeResolution_newPackages() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
@@ -966,12 +967,13 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let result = try await workspace.checkPrecomputeResolution()
-        XCTAssertNoDiagnostics(result.diagnostics)
-        XCTAssertEqual(result.result, .required(reason: .newPackages(packages: [cRef])))
+        try workspace.checkPrecomputeResolution { result in
+            XCTAssertNoDiagnostics(result.diagnostics)
+            XCTAssertEqual(result.result, .required(reason: .newPackages(packages: [cRef])))
+        }
     }
 
-    func testPrecomputeResolution_requirementChange_versionToBranch() async throws {
+    func testPrecomputeResolution_requirementChange_versionToBranch() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
@@ -1030,16 +1032,17 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let result = try await workspace.checkPrecomputeResolution()
-        XCTAssertNoDiagnostics(result.diagnostics)
-        XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
-            package: cRef,
-            state: .sourceControlCheckout(v1_5),
-            requirement: .revision("master")
-        )))
+        try workspace.checkPrecomputeResolution { result in
+            XCTAssertNoDiagnostics(result.diagnostics)
+            XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
+                package: cRef,
+                state: .sourceControlCheckout(v1_5),
+                requirement: .revision("master")
+            )))
+        }
     }
 
-    func testPrecomputeResolution_requirementChange_versionToRevision() async throws {
+    func testPrecomputeResolution_requirementChange_versionToRevision() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let cPath = RelativePath("C")
@@ -1081,16 +1084,17 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let result = try await testWorkspace.checkPrecomputeResolution()
-        XCTAssertNoDiagnostics(result.diagnostics)
-        XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
-            package: cRef,
-            state: .sourceControlCheckout(v1_5),
-            requirement: .revision("hello")
-        )))
+        try testWorkspace.checkPrecomputeResolution { result in
+            XCTAssertNoDiagnostics(result.diagnostics)
+            XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
+                package: cRef,
+                state: .sourceControlCheckout(v1_5),
+                requirement: .revision("hello")
+            )))
+        }
     }
 
-    func testPrecomputeResolution_requirementChange_localToBranch() async throws {
+    func testPrecomputeResolution_requirementChange_localToBranch() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
@@ -1148,16 +1152,17 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let result = try await workspace.checkPrecomputeResolution()
-        XCTAssertNoDiagnostics(result.diagnostics)
-        XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
-            package: cRef,
-            state: .fileSystem(cPackagePath),
-            requirement: .revision("master")
-        )))
+        try workspace.checkPrecomputeResolution { result in
+            XCTAssertNoDiagnostics(result.diagnostics)
+            XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
+                package: cRef,
+                state: .fileSystem(cPackagePath),
+                requirement: .revision("master")
+            )))
+        }
     }
 
-    func testPrecomputeResolution_requirementChange_versionToLocal() async throws {
+    func testPrecomputeResolution_requirementChange_versionToLocal() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
@@ -1215,16 +1220,17 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let result = try await workspace.checkPrecomputeResolution()
-        XCTAssertNoDiagnostics(result.diagnostics)
-        XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
-            package: cRef,
-            state: .sourceControlCheckout(v1_5),
-            requirement: .unversioned
-        )))
+        try workspace.checkPrecomputeResolution { result in
+            XCTAssertNoDiagnostics(result.diagnostics)
+            XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
+                package: cRef,
+                state: .sourceControlCheckout(v1_5),
+                requirement: .unversioned
+            )))
+        }
     }
 
-    func testPrecomputeResolution_requirementChange_branchToLocal() async throws {
+    func testPrecomputeResolution_requirementChange_branchToLocal() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
@@ -1283,16 +1289,17 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let result = try await workspace.checkPrecomputeResolution()
-        XCTAssertNoDiagnostics(result.diagnostics)
-        XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
-            package: cRef,
-            state: .sourceControlCheckout(master),
-            requirement: .unversioned
-        )))
+        try workspace.checkPrecomputeResolution { result in
+            XCTAssertNoDiagnostics(result.diagnostics)
+            XCTAssertEqual(result.result, .required(reason: .packageRequirementChange(
+                package: cRef,
+                state: .sourceControlCheckout(master),
+                requirement: .unversioned
+            )))
+        }
     }
 
-    func testPrecomputeResolution_other() async throws {
+    func testPrecomputeResolution_other() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
@@ -1351,17 +1358,20 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let result = try await workspace.checkPrecomputeResolution()
-        XCTAssertNoDiagnostics(result.diagnostics)
-        XCTAssertEqual(
-            result.result,
-            .required(reason: .other(
-                "Dependencies could not be resolved because no versions of \'c\' match the requirement 2.0.0..<3.0.0 and root depends on \'c\' 2.0.0..<3.0.0."
-            ))
-        )
+        try workspace.checkPrecomputeResolution { result in
+            XCTAssertNoDiagnostics(result.diagnostics)
+            XCTAssertEqual(
+                result.result,
+                .required(
+                    reason: .other(
+                        "Dependencies could not be resolved because no versions of \'c\' match the requirement 2.0.0..<3.0.0 and root depends on \'c\' 2.0.0..<3.0.0."
+                    )
+                )
+            )
+        }
     }
 
-    func testPrecomputeResolution_notRequired() async throws {
+    func testPrecomputeResolution_notRequired() throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()
         let bPath = RelativePath("B")
@@ -1421,9 +1431,10 @@ final class WorkspaceTests: XCTestCase {
             ]
         )
 
-        let result = try await workspace.checkPrecomputeResolution()
-        XCTAssertNoDiagnostics(result.diagnostics)
-        XCTAssertEqual(result.result.isRequired, false)
+        try workspace.checkPrecomputeResolution { result in
+            XCTAssertNoDiagnostics(result.diagnostics)
+            XCTAssertEqual(result.result.isRequired, false)
+        }
     }
 
     func testLoadingRootManifests() throws {


### PR DESCRIPTION
Reverts apple/swift-package-manager#7009 to fix macOS CI regression:

```
duplicate symbol '_async_MainTu' in:
    /Users/ec2-user/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/.build/x86_64-apple-macosx/debug/swift_package.build/Entrypoint.swift.o
    /Users/ec2-user/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/.build/x86_64-apple-macosx/debug/swift_test.build/Entrypoint.swift.o
duplicate symbol '_async_Main' in:
    /Users/ec2-user/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/.build/x86_64-apple-macosx/debug/swift_package.build/Entrypoint.swift.o
    /Users/ec2-user/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx/branch-main/swiftpm/.build/x86_64-apple-macosx/debug/swift_test.build/Entrypoint.swift.o
ld: 2 duplicate symbols for architecture x86_64
```

This bug was fixed in Swift 5.10, which is not available on CI yet.