### PR TITLE
Allow tools-versions to be specified later in the manifest

### DIFF
--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -31,6 +31,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     public static let v5_8 = ToolsVersion(version: "5.8.0")
     public static let v5_9 = ToolsVersion(version: "5.9.0")
     public static let v5_10 = ToolsVersion(version: "5.10.0")
+    public static let v5_11 = ToolsVersion(version: "5.11.0")
     public static let vNext = ToolsVersion(version: "999.0.0")
 
     /// The current tools version in use.


### PR DESCRIPTION
It doesn't seem particularly necessary to require tools-versions to be specified in the first line of the manifest, e.g. users may want to write comments at the top of the file. This changes the parsing to look at all lines of the manifest subsequently in case of errors. If no tools-version is found in the entire file, the original error as determined by the first line will be thrown. If a tools-version specification is found, but is for a version prior to 5.11, a specific error message is thrown to avoid users to write backwards-incompatible manifests when using 5.11.

rdar://118484544
