### PR TITLE
Move the `SourceKitLSPAPI` target to the `SwiftPM` product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,6 @@ let swiftPMDataModelProduct = (
         "PackageMetadata",
         "PackageModel",
         "SourceControl",
-        "SourceKitLSPAPI",
         "Workspace",
     ]
 )
@@ -58,6 +57,7 @@ let swiftPMProduct = (
     targets: swiftPMDataModelProduct.targets + [
         "Build",
         "LLBuildManifest",
+        "SourceKitLSPAPI",
         "SPMLLBuild",
     ]
 )


### PR DESCRIPTION
Traditionally, we have tried to keep swift-driver and llbuild dependencies out of the `libSwiftPMDataModel` product, in fact that is the main motivation for its existence. `SourceKitLSPAPI` depends on the build parts of SwiftPM, so it should not be part of the data model library.