### PR TITLE
Bifurcate SwiftPM library locations

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -1081,14 +1081,15 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         for toolsVersion: ToolsVersion
     ) -> [String] {
         var cmd = [String]()
-        let runtimePath = self.toolchain.swiftPMLibrariesLocation.manifestLibraryPath
+        let libraryPath = self.toolchain.swiftPMLibrariesLocation.manifestLibraryPath
+        let modulesPath = self.toolchain.swiftPMLibrariesLocation.manifestModulesPath
         cmd += ["-swift-version", toolsVersion.swiftLanguageVersion.rawValue]
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
-        if runtimePath.extension == "framework" {
-            cmd += ["-I", runtimePath.parentDirectory.parentDirectory.pathString]
+        if modulesPath.extension == "framework" {
+            cmd += ["-I", modulesPath.parentDirectory.parentDirectory.pathString]
         } else {
-            cmd += ["-I", runtimePath.pathString]
+            cmd += ["-I", modulesPath.pathString]
         }
       #if os(macOS)
         if let sdkRoot = self.toolchain.sdkRootPath ?? self.sdkRoot() {

--- a/Sources/PackageModel/ToolchainConfiguration.swift
+++ b/Sources/PackageModel/ToolchainConfiguration.swift
@@ -78,9 +78,18 @@ public struct ToolchainConfiguration {
 extension ToolchainConfiguration {
     public struct SwiftPMLibrariesLocation {
         public var manifestLibraryPath: AbsolutePath
+        public var manifestModulesPath: AbsolutePath
         public var pluginLibraryPath: AbsolutePath
+        public var pluginModulesPath: AbsolutePath
 
-        public init(manifestLibraryPath: AbsolutePath, manifestLibraryMinimumDeploymentTarget: PlatformVersion? = nil, pluginLibraryPath: AbsolutePath, pluginLibraryMinimumDeploymentTarget: PlatformVersion? = nil) {
+        public init(
+            manifestLibraryPath: AbsolutePath,
+            manifestModulesPath: AbsolutePath? = nil,
+            manifestLibraryMinimumDeploymentTarget: PlatformVersion? = nil,
+            pluginLibraryPath: AbsolutePath,
+            pluginModulesPath: AbsolutePath? = nil,
+            pluginLibraryMinimumDeploymentTarget: PlatformVersion? = nil
+        ) {
             #if os(macOS)
             if let manifestLibraryMinimumDeploymentTarget {
                 self.manifestLibraryMinimumDeploymentTarget = manifestLibraryMinimumDeploymentTarget
@@ -102,7 +111,18 @@ extension ToolchainConfiguration {
             #endif
 
             self.manifestLibraryPath = manifestLibraryPath
+            if let manifestModulesPath {
+                self.manifestModulesPath = manifestModulesPath
+            } else {
+                self.manifestModulesPath = manifestLibraryPath
+            }
+
             self.pluginLibraryPath = pluginLibraryPath
+            if let pluginModulesPath {
+                self.pluginModulesPath = pluginModulesPath
+            } else {
+                self.pluginModulesPath = pluginLibraryPath
+            }
         }
 
         public init(root: AbsolutePath, manifestLibraryMinimumDeploymentTarget: PlatformVersion? = nil, pluginLibraryMinimumDeploymentTarget: PlatformVersion? = nil) {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -699,9 +699,19 @@ public final class UserToolchain: Toolchain {
 
             // this tests if we are debugging / testing SwiftPM with SwiftPM
             if localFileSystem.exists(applicationPath.appending("swift-package")) {
+                // Newer versions of SwiftPM will emit modules to a "Modules" subdirectory, but we're also staying compatible with older versions for development.
+                let modulesPath: AbsolutePath
+                if localFileSystem.exists(applicationPath.appending("Modules")) {
+                    modulesPath = applicationPath.appending("Modules")
+                } else {
+                    modulesPath = applicationPath
+                }
+
                 return .init(
                     manifestLibraryPath: applicationPath,
-                    pluginLibraryPath: applicationPath
+                    manifestModulesPath: modulesPath,
+                    pluginLibraryPath: applicationPath,
+                    pluginModulesPath: modulesPath
                 )
             }
         }

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -141,6 +141,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
 
         // Get access to the path containing the PackagePlugin module and library.
         let pluginLibraryPath = self.toolchain.swiftPMLibrariesLocation.pluginLibraryPath
+        let pluginModulesPath = self.toolchain.swiftPMLibrariesLocation.pluginModulesPath
 
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
@@ -196,10 +197,10 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
 
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode
         // which produces a framework for dynamic package products.
-        if pluginLibraryPath.extension == "framework" {
-            commandLine += ["-I", pluginLibraryPath.parentDirectory.parentDirectory.pathString]
+        if pluginModulesPath.extension == "framework" {
+            commandLine += ["-I", pluginModulesPath.parentDirectory.parentDirectory.pathString]
         } else {
-            commandLine += ["-I", pluginLibraryPath.pathString]
+            commandLine += ["-I", pluginModulesPath.pathString]
         }
         #if os(macOS)
         if let sdkRoot = self.toolchain.sdkRootPath ?? self.sdkRoot() {


### PR DESCRIPTION
When using SwiftPM `PackageDescription` or `PackagePlugin` libraries in an inferior, the corresponding modules are now found in a "Modules" subdirectory, but I didn't adjust the include paths being used for this. It appears that prior versions of the Swift compiler would search for modules recursively but recent versions of 5.11 have stopped doing so, unmasking this existing issue.
