### PR TITLE
[NFC] Fix some of the new Swift `main` snapshots warnings

### DIFF
--- a/Sources/Basics/Vendor/Triple.swift
+++ b/Sources/Basics/Vendor/Triple.swift
@@ -426,7 +426,7 @@ extension Triple {
     }
   }
 
-  public enum Arch: String, CaseIterable {
+  public enum Arch: String, CaseIterable, Decodable {
     /// ARM (little endian): arm, armv.*, xscale
     case arm
     // ARM (big endian): armeb

--- a/Sources/Commands/PackageTools/Init.swift
+++ b/Sources/Commands/PackageTools/Init.swift
@@ -83,7 +83,7 @@ extension SwiftPackageTool {
     }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension InitPackage.PackageType: ExpressibleByArgument {}
 #else
 extension InitPackage.PackageType: @retroactive ExpressibleByArgument {}

--- a/Sources/Commands/PackageTools/Init.swift
+++ b/Sources/Commands/PackageTools/Init.swift
@@ -83,4 +83,8 @@ extension SwiftPackageTool {
     }
 }
 
+#if swift(<5.10)
 extension InitPackage.PackageType: ExpressibleByArgument {}
+#else
+extension InitPackage.PackageType: @retroactive ExpressibleByArgument {}
+#endif

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -328,7 +328,7 @@ extension SerializedDiagnostics.SourceLocation {
     }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension SerializedDiagnostics.SourceLocation: DiagnosticLocation {}
 #else
 extension SerializedDiagnostics.SourceLocation: @retroactive DiagnosticLocation {}

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -322,8 +322,14 @@ extension PackageGraph {
     }
 }
 
-extension SerializedDiagnostics.SourceLocation: DiagnosticLocation {
+extension SerializedDiagnostics.SourceLocation {
     public var description: String {
         return "\(filename):\(line):\(column)"
     }
 }
+
+#if swift(<5.10)
+extension SerializedDiagnostics.SourceLocation: DiagnosticLocation {}
+#else
+extension SerializedDiagnostics.SourceLocation: @retroactive DiagnosticLocation {}
+#endif

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -536,13 +536,13 @@ public struct LinkerOptions: ParsableArguments {
 
 // MARK: - Extensions
 
-extension BuildConfiguration: ExpressibleByArgument {
+extension BuildConfiguration {
     public init?(argument: String) {
         self.init(rawValue: argument)
     }
 }
 
-extension AbsolutePath: ExpressibleByArgument {
+extension AbsolutePath {
     public init?(argument: String) {
         if let cwd = localFileSystem.currentWorkingDirectory {
             guard let path = try? AbsolutePath(validating: argument, relativeTo: cwd) else {
@@ -564,13 +564,13 @@ extension AbsolutePath: ExpressibleByArgument {
     }
 }
 
-extension WorkspaceConfiguration.CheckingMode: ExpressibleByArgument {
+extension WorkspaceConfiguration.CheckingMode {
     public init?(argument: String) {
         self.init(rawValue: argument)
     }
 }
 
-extension Sanitizer: ExpressibleByArgument {
+extension Sanitizer {
     public init?(argument: String) {
         if let sanitizer = Sanitizer(rawValue: argument) {
             self = sanitizer
@@ -591,18 +591,34 @@ extension Sanitizer: ExpressibleByArgument {
     }
 }
 
-extension BuildSystemProvider.Kind: ExpressibleByArgument {}
-
-extension Version: ExpressibleByArgument {}
-
-extension PackageIdentity: ExpressibleByArgument {
+extension PackageIdentity {
     public init?(argument: String) {
         self = .plain(argument)
     }
 }
 
-extension URL: ExpressibleByArgument {
+extension URL {
     public init?(argument: String) {
         self.init(string: argument)
     }
 }
+
+#if swift(<5.10)
+extension BuildConfiguration: ExpressibleByArgument {}
+extension AbsolutePath: ExpressibleByArgument {}
+extension WorkspaceConfiguration.CheckingMode: ExpressibleByArgument {}
+extension Sanitizer: ExpressibleByArgument {}
+extension BuildSystemProvider.Kind: ExpressibleByArgument {}
+extension Version: ExpressibleByArgument {}
+extension PackageIdentity: ExpressibleByArgument {}
+extension URL: ExpressibleByArgument {}
+#else
+extension BuildConfiguration: @retroactive ExpressibleByArgument {}
+extension AbsolutePath: @retroactive ExpressibleByArgument {}
+extension WorkspaceConfiguration.CheckingMode: @retroactive ExpressibleByArgument {}
+extension Sanitizer: @retroactive ExpressibleByArgument {}
+extension BuildSystemProvider.Kind: @retroactive ExpressibleByArgument {}
+extension Version: @retroactive ExpressibleByArgument {}
+extension PackageIdentity: @retroactive ExpressibleByArgument {}
+extension URL: @retroactive ExpressibleByArgument {}
+#endif

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -603,7 +603,7 @@ extension URL {
     }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension BuildConfiguration: ExpressibleByArgument {}
 extension AbsolutePath: ExpressibleByArgument {}
 extension WorkspaceConfiguration.CheckingMode: ExpressibleByArgument {}

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -1081,7 +1081,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         for toolsVersion: ToolsVersion
     ) -> [String] {
         var cmd = [String]()
-        let libraryPath = self.toolchain.swiftPMLibrariesLocation.manifestLibraryPath
         let modulesPath = self.toolchain.swiftPMLibrariesLocation.manifestModulesPath
         cmd += ["-swift-version", toolsVersion.swiftLanguageVersion.rawValue]
         // if runtimePath is set to "PackageFrameworks" that means we could be developing SwiftPM in Xcode

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -925,3 +925,28 @@ struct SwiftSDKMetadataV4: Decodable {
     /// Mapping of triple strings to corresponding properties of such target triple.
     let targetTriples: [String: TripleProperties]
 }
+
+extension Optional where Wrapped == AbsolutePath {
+    fileprivate var configurationString: String {
+        self?.pathString ?? "not set"
+    }
+}
+
+extension Optional where Wrapped == [AbsolutePath] {
+    fileprivate var configurationString: String {
+        self?.map(\.pathString).description ?? "not set"
+    }
+}
+
+extension SwiftSDK.PathsConfiguration: CustomStringConvertible {
+    public var description: String {
+        """
+        sdkRootPath: \(sdkRootPath.configurationString)
+        swiftResourcesPath: \(swiftResourcesPath.configurationString)
+        swiftStaticResourcesPath: \(swiftStaticResourcesPath.configurationString)
+        includeSearchPaths: \(includeSearchPaths.configurationString)
+        librarySearchPaths: \(librarySearchPaths.configurationString)
+        toolsetPaths: \(toolsetPaths.configurationString)
+        """
+    }
+}

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -243,7 +243,7 @@ extension SignatureFormat {
     }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension SignatureFormat: ExpressibleByArgument {}
 #else
 extension SignatureFormat: @retroactive ExpressibleByArgument {}

--- a/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool+Publish.swift
@@ -237,11 +237,17 @@ extension SwiftPackageRegistryTool {
     }
 }
 
-extension SignatureFormat: ExpressibleByArgument {
+extension SignatureFormat {
     public init?(argument: String) {
         self.init(rawValue: argument.lowercased())
     }
 }
+
+#if swift(<5.10)
+extension SignatureFormat: ExpressibleByArgument {}
+#else
+extension SignatureFormat: @retroactive ExpressibleByArgument {}
+#endif
 
 enum MetadataLocation {
     case sourceTree(AbsolutePath)

--- a/Sources/SPMBuildCore/XCFrameworkMetadata.swift
+++ b/Sources/SPMBuildCore/XCFrameworkMetadata.swift
@@ -84,5 +84,3 @@ extension XCFrameworkMetadata.Library: Decodable {
         case variant = "SupportedPlatformVariant"
     }
 }
-
-extension Triple.Arch: Decodable {}

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -375,21 +375,19 @@ extension FileSystem {
     }
 }
 
-extension URL: ExpressibleByStringLiteral {
+extension URL {
     public init(_ value: StringLiteralType) {
         self.init(string: value)!
     }
 }
 
-extension URL: ExpressibleByStringInterpolation {
+extension URL {
     public init(stringLiteral value: String) {
         self.init(string: value)!
     }
 }
 
-extension PackageIdentity: ExpressibleByStringLiteral {}
-
-extension PackageIdentity: ExpressibleByStringInterpolation {
+extension PackageIdentity {
     public init(stringLiteral value: String) {
         self = Self.plain(value)
     }
@@ -401,13 +399,13 @@ extension PackageIdentity {
     }
 }
 
-extension AbsolutePath: ExpressibleByStringLiteral {
+extension AbsolutePath {
     public init(_ value: StringLiteralType) {
         try! self.init(validating: value)
     }
 }
 
-extension AbsolutePath: ExpressibleByStringInterpolation {
+extension AbsolutePath {
     public init(stringLiteral value: String) {
         try! self.init(validating: value)
     }
@@ -429,13 +427,13 @@ extension RelativePath {
     }
 }
 
-extension RelativePath: ExpressibleByStringLiteral {
+extension RelativePath {
     public init(_ value: StringLiteralType) {
         try! self.init(validating: value)
     }
 }
 
-extension RelativePath: ExpressibleByStringInterpolation {
+extension RelativePath {
     public init(stringLiteral value: String) {
         try! self.init(validating: value)
     }
@@ -458,3 +456,23 @@ extension InitPackage {
         )
     }
 }
+
+#if swift(<5.10)
+extension RelativePath: ExpressibleByStringLiteral {}
+extension RelativePath: ExpressibleByStringInterpolation {}
+extension URL: ExpressibleByStringLiteral {}
+extension URL: ExpressibleByStringInterpolation {}
+extension PackageIdentity: ExpressibleByStringLiteral {}
+extension PackageIdentity: ExpressibleByStringInterpolation {}
+extension AbsolutePath: ExpressibleByStringLiteral {}
+extension AbsolutePath: ExpressibleByStringInterpolation {}
+#else
+extension RelativePath: @retroactive ExpressibleByStringLiteral {}
+extension RelativePath: @retroactive ExpressibleByStringInterpolation {}
+extension URL: @retroactive ExpressibleByStringLiteral {}
+extension URL: @retroactive ExpressibleByStringInterpolation {}
+extension PackageIdentity: @retroactive ExpressibleByStringLiteral {}
+extension PackageIdentity: @retroactive ExpressibleByStringInterpolation {}
+extension AbsolutePath: @retroactive ExpressibleByStringLiteral {}
+extension AbsolutePath: @retroactive ExpressibleByStringInterpolation {}
+#endif

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -457,7 +457,7 @@ extension InitPackage {
     }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension RelativePath: ExpressibleByStringLiteral {}
 extension RelativePath: ExpressibleByStringInterpolation {}
 extension URL: ExpressibleByStringLiteral {}

--- a/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
+++ b/Sources/SwiftSDKTool/Configuration/ShowConfiguration.swift
@@ -48,28 +48,3 @@ struct ShowConfiguration: ConfigurationSubcommand {
         print(swiftSDK.pathsConfiguration)
     }
 }
-
-extension SwiftSDK.PathsConfiguration: CustomStringConvertible {
-    public var description: String {
-        """
-        sdkRootPath: \(sdkRootPath.configurationString)
-        swiftResourcesPath: \(swiftResourcesPath.configurationString)
-        swiftStaticResourcesPath: \(swiftStaticResourcesPath.configurationString)
-        includeSearchPaths: \(includeSearchPaths.configurationString)
-        librarySearchPaths: \(librarySearchPaths.configurationString)
-        toolsetPaths: \(toolsetPaths.configurationString)
-        """
-    }
-}
-
-extension Optional where Wrapped == AbsolutePath {
-    fileprivate var configurationString: String {
-        self?.pathString ?? "not set"
-    }
-}
-
-extension Optional where Wrapped == [AbsolutePath] {
-    fileprivate var configurationString: String {
-        self?.map(\.pathString).description ?? "not set"
-    }
-}

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -195,7 +195,7 @@ extension Basics.Diagnostic {
     }
 }
 
-extension FileSystemError: CustomStringConvertible {
+extension FileSystemError {
     public var description: String {
         guard let path else {
             switch self.kind {
@@ -246,3 +246,9 @@ extension FileSystemError: CustomStringConvertible {
         }
     }
 }
+
+#if swift(<5.10)
+extension FileSystemError: CustomStringConvertible {}
+#else
+extension FileSystemError: @retroactive CustomStringConvertible {}
+#endif

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -247,7 +247,7 @@ extension FileSystemError {
     }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension FileSystemError: CustomStringConvertible {}
 #else
 extension FileSystemError: @retroactive CustomStringConvertible {}

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1456,7 +1456,7 @@ private func warnToStderr(_ message: String) {
 }
 
 // used for manifest validation
-#if swift(<5.10)
+#if swift(<5.11)
 extension RepositoryManager: ManifestSourceControlValidator {}
 #else
 extension RepositoryManager: @retroactive ManifestSourceControlValidator {}

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1456,7 +1456,11 @@ private func warnToStderr(_ message: String) {
 }
 
 // used for manifest validation
+#if swift(<5.10)
 extension RepositoryManager: ManifestSourceControlValidator {}
+#else
+extension RepositoryManager: @retroactive ManifestSourceControlValidator {}
+#endif
 
 extension ContainerUpdateStrategy {
     var repositoryUpdateStrategy: RepositoryUpdateStrategy {

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -471,7 +471,7 @@ extension BuildConfiguration {
     }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension AbsolutePath: ExpressibleByArgument {}
 extension BuildConfiguration: ExpressibleByArgument {}
 #else

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -443,7 +443,7 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
 }
 
 // TODO: move to shared area
-extension AbsolutePath: ExpressibleByArgument {
+extension AbsolutePath {
     public init?(argument: String) {
         if let cwd: AbsolutePath = localFileSystem.currentWorkingDirectory {
             guard let path = try? AbsolutePath(validating: argument, relativeTo: cwd) else {
@@ -465,8 +465,16 @@ extension AbsolutePath: ExpressibleByArgument {
     }
 }
 
-extension BuildConfiguration: ExpressibleByArgument {
+extension BuildConfiguration {
     public init?(argument: String) {
         self.init(rawValue: argument)
     }
 }
+
+#if swift(<5.10)
+extension AbsolutePath: ExpressibleByArgument {}
+extension BuildConfiguration: ExpressibleByArgument {}
+#else
+extension AbsolutePath: @retroactive ExpressibleByArgument {}
+extension BuildConfiguration: @retroactive ExpressibleByArgument {}
+#endif

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -182,7 +182,7 @@ private extension VersionSetSpecifier {
     }
 }
 
-extension ProductFilter: JSONSerializable, JSONMappable {
+extension ProductFilter {
     public func toJSON() -> JSON {
         switch self {
         case .everything:
@@ -200,3 +200,9 @@ extension ProductFilter: JSONSerializable, JSONMappable {
         }
     }
 }
+
+#if swift(<5.10)
+extension ProductFilter: JSONSerializable, JSONMappable {}
+#else
+extension ProductFilter: @retroactive JSONSerializable, @retroactive JSONMappable {}
+#endif

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -201,7 +201,7 @@ extension ProductFilter {
     }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension ProductFilter: JSONSerializable, JSONMappable {}
 #else
 extension ProductFilter: @retroactive JSONSerializable, @retroactive JSONMappable {}

--- a/Tests/PackageGraphTests/DependencyResolverTests.swift
+++ b/Tests/PackageGraphTests/DependencyResolverTests.swift
@@ -42,12 +42,6 @@ private let v1_1Range: VersionSetSpecifier = .range("1.1.0" ..< "1.2.0")
 private let v1_1_0Range: VersionSetSpecifier = .range("1.1.0" ..< "1.1.1")
 private let v2_0_0Range: VersionSetSpecifier = .range("2.0.0" ..< "2.0.1")
 
-extension PackageReference: Comparable {
-    public static func < (lhs: PackageReference, rhs: PackageReference) -> Bool {
-        return lhs.identity < rhs.identity
-    }
-}
-
 class DependencyResolverTests: XCTestCase {
     func testVersionSetSpecifier() {
         // Check `contains`.

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -3292,7 +3292,7 @@ extension PackageReference {
     }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension Term: ExpressibleByStringLiteral {}
 extension PackageReference: ExpressibleByStringLiteral {}
 #else

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -3240,7 +3240,7 @@ class DependencyGraphBuilder {
     }
 }
 
-extension Term: ExpressibleByStringLiteral {
+extension Term {
     init(_ value: String) {
         self.init(stringLiteral: value)
     }
@@ -3285,12 +3285,21 @@ extension Term: ExpressibleByStringLiteral {
 }
 
 
-extension PackageReference: ExpressibleByStringLiteral {
+extension PackageReference {
     public init(stringLiteral value: String) {
         let ref = PackageReference.localSourceControl(identity: .plain(value), path: .root)
         self = ref
     }
 }
+
+#if swift(<5.10)
+extension Term: ExpressibleByStringLiteral {}
+extension PackageReference: ExpressibleByStringLiteral {}
+#else
+extension Term: @retroactive ExpressibleByStringLiteral {}
+extension PackageReference: @retroactive ExpressibleByStringLiteral {}
+#endif
+
 extension Result where Success == [DependencyResolverBinding] {
     var errorMsg: String? {
         switch self {

--- a/Tests/PackageGraphTests/TopologicalSortTests.swift
+++ b/Tests/PackageGraphTests/TopologicalSortTests.swift
@@ -34,7 +34,7 @@ extension Int {
     public var id: Self { self }
 }
 
-#if swift(<5.10)
+#if swift(<5.11)
 extension Int: Identifiable {}
 #else
 extension Int: @retroactive Identifiable {}

--- a/Tests/PackageGraphTests/TopologicalSortTests.swift
+++ b/Tests/PackageGraphTests/TopologicalSortTests.swift
@@ -30,9 +30,15 @@ private func XCTAssertThrows<T: Swift.Error>(
     }
 }
 
-extension Int: Identifiable {
+extension Int {
     public var id: Self { self }
 }
+
+#if swift(<5.10)
+extension Int: Identifiable {}
+#else
+extension Int: @retroactive Identifiable {}
+#endif
 
 private func topologicalSort(_ nodes: [Int], _ successors: [Int: [Int]]) throws -> [Int] {
     return try topologicalSort(nodes, successors: { successors[$0] ?? [] })


### PR DESCRIPTION
### Motivation:

Swift snapshots off `main` warn about `@retroactive` attribute not present on retroactively added protocol conformance, i.e. when a type and a protocol it conforms to are coming from different modules.

### Modifications:

Added `@retroactive` attribute conditionally when built with Swift versions lower than 5.10. Also fixed a few other warnings that were introduced recently with an unused `let` binding and an unused `Comparable` conformance.

### Result:

Reduced number of warnings when building with Swift `main` snapshots. New concurrency warnings appearing in Swift `main` are untouched here, as they require much more invasive changes to fix `Sendable` conformances.
