### PR TITLE
Only output when tests fail if --quiet flag is present

### DIFF
--- a/Fixtures/Miscellaneous/TestQuietFail/.gitignore
+++ b/Fixtures/Miscellaneous/TestQuietFail/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Fixtures/Miscellaneous/TestQuietFail/Package.swift
+++ b/Fixtures/Miscellaneous/TestQuietFail/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Example",
+    targets: [
+        .target(
+            name: "Example",
+            dependencies: []),
+        .testTarget(
+            name: "ExampleTests",
+            dependencies: ["Example"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestQuietFail/Sources/Example/Example.swift
+++ b/Fixtures/Miscellaneous/TestQuietFail/Sources/Example/Example.swift
@@ -1,0 +1,4 @@
+struct Example {
+    var text = "Hello, World!"
+    var bool = false
+}

--- a/Fixtures/Miscellaneous/TestQuietFail/Tests/ExampleTests/Tests.swift
+++ b/Fixtures/Miscellaneous/TestQuietFail/Tests/ExampleTests/Tests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Example
+
+class SomeTests: XCTestCase {
+    func testFail1() {
+        XCTAssertEqual(Example().text, "hello, failure")
+    }
+    
+    func testFail2() {
+        XCTAssertEqual(Example().bool, true)
+    }
+}

--- a/Fixtures/Miscellaneous/TestQuietPass/.gitignore
+++ b/Fixtures/Miscellaneous/TestQuietPass/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Fixtures/Miscellaneous/TestQuietPass/Package.swift
+++ b/Fixtures/Miscellaneous/TestQuietPass/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Example",
+    targets: [
+        .target(
+            name: "Example",
+            dependencies: []),
+        .testTarget(
+            name: "ExampleTests",
+            dependencies: ["Example"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestQuietPass/Sources/Example/Example.swift
+++ b/Fixtures/Miscellaneous/TestQuietPass/Sources/Example/Example.swift
@@ -1,0 +1,4 @@
+struct Example {
+    var text = "Hello, World!"
+    var bool = false
+}

--- a/Fixtures/Miscellaneous/TestQuietPass/Tests/ExampleTests/Tests.swift
+++ b/Fixtures/Miscellaneous/TestQuietPass/Tests/ExampleTests/Tests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Example
+
+class SomeTests: XCTestCase {
+    func testPass1() {
+        XCTAssertEqual(Example().text, "Hello, World!")
+    }
+    
+    func testPass2() {
+        XCTAssertEqual(Example().bool, false)
+    }
+}

--- a/Fixtures/Miscellaneous/TestQuietPassFail/.gitignore
+++ b/Fixtures/Miscellaneous/TestQuietPassFail/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Fixtures/Miscellaneous/TestQuietPassFail/Package.swift
+++ b/Fixtures/Miscellaneous/TestQuietPassFail/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Example",
+    targets: [
+        .target(
+            name: "Example",
+            dependencies: []),
+        .testTarget(
+            name: "ExampleTests",
+            dependencies: ["Example"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestQuietPassFail/Sources/Example/Example.swift
+++ b/Fixtures/Miscellaneous/TestQuietPassFail/Sources/Example/Example.swift
@@ -1,0 +1,4 @@
+struct Example {
+    var text = "Hello, World!"
+    var bool = false
+}

--- a/Fixtures/Miscellaneous/TestQuietPassFail/Tests/ExampleTests/Tests.swift
+++ b/Fixtures/Miscellaneous/TestQuietPassFail/Tests/ExampleTests/Tests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Example
+
+class SomeTests: XCTestCase {
+    func testPass1() {
+        XCTAssertEqual(Example().text, "Hello, World!")
+    }
+    
+    func testPass2() {
+        XCTAssertEqual(Example().bool, false)
+    }
+
+    func testFail1() {
+        XCTAssertEqual(Example().text, "hello, failure")
+    }
+    
+    func testFail2() {
+        XCTAssertEqual(Example().bool, true)
+    }
+}

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -194,6 +194,168 @@ final class TestToolTests: CommandsTestCase {
         }
     }
 
+    func testSwiftTestQuiet() throws {
+        try fixture(name: "Miscellaneous/TestQuietPass") { fixturePath in
+            let (stdout, _) = try SwiftPM.Test.execute(["--quiet"], packagePath: fixturePath)
+            // in "swift test" test output goes to stdout
+            XCTAssertNoMatch(stdout, .contains("testPass1"))
+            XCTAssertNoMatch(stdout, .contains("testPass2"))
+            XCTAssertEqual(stdout, "")
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietPass") { fixturePath in
+            let (stdout, _) = try SwiftPM.Test.execute(["--quiet", "--parallel"], packagePath: fixturePath)
+            // in "swift test" test output goes to stdout
+            XCTAssertNoMatch(stdout, .contains("testPass1"))
+            XCTAssertNoMatch(stdout, .contains("testPass2"))
+            XCTAssertEqual(stdout, "")
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietFail") { fixturePath in
+            XCTAssertThrows(try SwiftPM.Test.execute(["--quiet"], packagePath: fixturePath)) { (error: SwiftPMError) in
+                switch error {
+                case .packagePathNotFound:
+                    return false
+
+                case .executionFailure(_, let stdout, _):
+                    // in "swift test" test output goes to stdout
+                    XCTAssertMatch(stdout, .contains("testFail1"))
+                    XCTAssertMatch(stdout, .contains("testFail2"))
+                    return true
+                }
+            }
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietFail") { fixturePath in
+            XCTAssertThrows(try SwiftPM.Test.execute(["--quiet", "--parallel"], packagePath: fixturePath)) { (error: SwiftPMError) in
+                switch error {
+                case .packagePathNotFound:
+                    return false
+
+                case .executionFailure(_, let stdout, _):
+                    // in "swift test" test output goes to stdout
+                    XCTAssertMatch(stdout, .contains("testFail1"))
+                    XCTAssertMatch(stdout, .contains("testFail2"))
+                    return true
+                }
+            }
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietPassFail") { fixturePath in
+            XCTAssertThrows(try SwiftPM.Test.execute(["--quiet"], packagePath: fixturePath)) { (error: SwiftPMError) in
+                switch error {
+                case .packagePathNotFound:
+                    return false
+
+                case .executionFailure(_, let stdout, _):
+                    // in "swift test" test output goes to stdout
+                    XCTAssertMatch(stdout, .contains("testPass1"))
+                    XCTAssertMatch(stdout, .contains("testPass2"))
+                    XCTAssertMatch(stdout, .contains("testFail1"))
+                    XCTAssertMatch(stdout, .contains("testFail2"))
+                    return true
+                }
+            }
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietPassFail") { fixturePath in
+            XCTAssertThrows(try SwiftPM.Test.execute(["--quiet", "--parallel"], packagePath: fixturePath)) { (error: SwiftPMError) in
+                switch error {
+                case .packagePathNotFound:
+                    return false
+
+                case .executionFailure(_, let stdout, _):
+                    // in "swift test" test output goes to stdout
+                    XCTAssertMatch(stdout, .contains("testPass1"))
+                    XCTAssertMatch(stdout, .contains("testPass2"))
+                    XCTAssertMatch(stdout, .contains("testFail1"))
+                    XCTAssertMatch(stdout, .contains("testFail2"))
+                    return true
+                }
+            }
+        }
+    }
+
+    func testSwiftTestDefaultNoQuiet() throws {
+        try fixture(name: "Miscellaneous/TestQuietPass") { fixturePath in
+            let (stdout, _) = try SwiftPM.Test.execute(packagePath: fixturePath)
+            // in "swift test" test output goes to stdout
+            XCTAssertMatch(stdout, .contains("testPass1"))
+            XCTAssertMatch(stdout, .contains("testPass2"))
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietPass") { fixturePath in
+            let (stdout, _) = try SwiftPM.Test.execute(["--parallel"], packagePath: fixturePath)
+            // in "swift test" test output goes to stdout
+            XCTAssertMatch(stdout, .contains("testPass1"))
+            XCTAssertMatch(stdout, .contains("testPass2"))
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietFail") { fixturePath in
+            XCTAssertThrows(try SwiftPM.Test.execute(packagePath: fixturePath)) { (error: SwiftPMError) in
+                switch error {
+                case .packagePathNotFound:
+                    return false
+
+                case .executionFailure(_, let stdout, _):
+                    // in "swift test" test output goes to stdout
+                    XCTAssertMatch(stdout, .contains("testFail1"))
+                    XCTAssertMatch(stdout, .contains("testFail2"))
+                    return true
+                }
+            }
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietFail") { fixturePath in
+            XCTAssertThrows(try SwiftPM.Test.execute(["--parallel"], packagePath: fixturePath)) { (error: SwiftPMError) in
+                switch error {
+                case .packagePathNotFound:
+                    return false
+
+                case .executionFailure(_, let stdout, _):
+                    // in "swift test" test output goes to stdout
+                    XCTAssertMatch(stdout, .contains("testFail1"))
+                    XCTAssertMatch(stdout, .contains("testFail2"))
+                    return true
+                }
+            }
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietPassFail") { fixturePath in
+            XCTAssertThrows(try SwiftPM.Test.execute(packagePath: fixturePath)) { (error: SwiftPMError) in
+                switch error {
+                case .packagePathNotFound:
+                    return false
+
+                case .executionFailure(_, let stdout, _):
+                    // in "swift test" test output goes to stdout
+                    XCTAssertMatch(stdout, .contains("testPass1"))
+                    XCTAssertMatch(stdout, .contains("testPass2"))
+                    XCTAssertMatch(stdout, .contains("testFail1"))
+                    XCTAssertMatch(stdout, .contains("testFail2"))
+                    return true
+                }
+            }
+        }
+
+        try fixture(name: "Miscellaneous/TestQuietPassFail") { fixturePath in
+            XCTAssertThrows(try SwiftPM.Test.execute(["--parallel"], packagePath: fixturePath)) { (error: SwiftPMError) in
+                switch error {
+                case .packagePathNotFound:
+                    return false
+
+                case .executionFailure(_, let stdout, _):
+                    // in "swift test" test output goes to stdout
+                    XCTAssertMatch(stdout, .contains("testPass1"))
+                    XCTAssertMatch(stdout, .contains("testPass2"))
+                    XCTAssertMatch(stdout, .contains("testFail1"))
+                    XCTAssertMatch(stdout, .contains("testFail2"))
+                    return true
+                }
+            }
+        }
+    }
+
     func testEnableTestDiscoveryDeprecation() throws {
         let compilerDiagnosticFlags = ["-Xswiftc", "-Xfrontend", "-Xswiftc", "-Rmodule-interface-rebuild"]
         #if canImport(Darwin)


### PR DESCRIPTION
Only output when tests fail if the `--quiet` flag is present.

### Motivation:

Resolves the latest conversation on #4395 concerning how the `--quiet` flag doesn't do what it advertises when used with `swift test` and `swift build`.

### Modifications:

- When not testing in parallel, and `--quiet` is present, collect output until tests finish and print output to stdout conditionally.
- Pass `LoggingOptions` into `ParallelTestRunner`.
- Determine if any of the parallel tests failed and, if so, output all test results (regardless of passing status) if `--quiet` is present.
- Adds three new test fixtures (`TestQuietPass`, `TestQuietPassFail`, `TestQuietFail`) for testing the quiet flag
- Adds tests for the `--quiet` flag when all tests pass, when some tests pass/fail, when all tests fail.

### Result:

If tests pass successfully and the `--quiet` flag is present, nothing will be output. Output as normal when tests fail. The only notable change to output in the failure case is that when running tests in parallel (`--parallel`), the progress animation is not updated. 
