### PR TITLE
Fix CLI linker path arguments

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -352,7 +352,7 @@ public final class UserToolchain: Toolchain {
         var swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
 
         if let linker = swiftSDK.toolset.knownTools[.linker]?.path {
-            swiftCompilerFlags += ["-ld-path=\(linker)"]
+            swiftCompilerFlags += ["-ld-path", linker.pathString]
         }
 
         guard let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath else {


### PR DESCRIPTION
Fixes `swiftCompilerFlags` value for linker path. In particular this fixes case when the linker path contains a space character
