### PR TITLE
Add `swift test --no-parallel`

### DIFF
--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -122,6 +122,7 @@ struct TestToolOptions: ParsableArguments {
 
     /// If tests should run in parallel mode.
     @Flag(name: .customLong("parallel"),
+          inversion: .prefixedNo,
           help: "Run the tests in parallel.")
     var shouldRunInParallel: Bool = false
 
@@ -553,7 +554,9 @@ public struct SwiftTestTool: SwiftCommand {
         // Validation for --num-workers.
         if let workers = options.numberOfWorkers {
 
-            // The --num-worker option should be called with --parallel.
+            // The --num-worker option should be called with --parallel. Since
+            // this option does not affect swift-testing at this time, we can
+            // effectively ignore that it defaults to enabling parallelization.
             guard options.shouldRunInParallel else {
                 throw StringError("--num-workers must be used with --parallel")
             }

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -92,6 +92,14 @@ final class TestToolTests: CommandsTestCase {
             XCTAssertThrowsCommandExecutionError(try SwiftPM.Test.execute(packagePath: fixturePath)) { error in
                 // in "swift test" test output goes to stdout
                 XCTAssertMatch(error.stdout, .contains("Executed 2 tests"))
+                XCTAssertNoMatch(error.stdout, .contains("[3/3]"))
+            }
+
+            // Try --no-parallel.
+            XCTAssertThrowsCommandExecutionError(try SwiftPM.Test.execute(["--no-parallel"], packagePath: fixturePath)) { error in
+                // in "swift test" test output goes to stdout
+                XCTAssertMatch(error.stdout, .contains("Executed 2 tests"))
+                XCTAssertNoMatch(error.stdout, .contains("[3/3]"))
             }
 
             // Run tests in parallel.


### PR DESCRIPTION
This PR makes the `--parallel` flag on the swift-test subtool invertible with a "no" prefix.

We want swift-testing to default to enabling parallelization, but we don't want to break XCTest (which for historical reasons strongly prefers serial testing.) Deprecating `--parallel` and replacing it with `--{enable,disable}-parallelism` or similar seems a bit heavy-handed. Swift Argument Parser gives us the option to use a "no" prefix instead which means that the existing `--parallel` option will continue to work as intended.

Support for `--no-parallel` in swift-testing is here: https://github.com/apple/swift-testing/pull/174