### PR TITLE
Include out-of-target resources

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -229,7 +229,15 @@ public struct TargetSourcesBuilder {
         return Self.computeRule(for: path, toolsVersion: toolsVersion, rules: rules, declaredResources: [], declaredSources: nil, observabilityScope: observabilityScope)
     }
 
-    private static func computeRule(for path: AbsolutePath, toolsVersion: ToolsVersion, rules: [FileRuleDescription], declaredResources: [(path: AbsolutePath, rule: TargetDescription.Resource.Rule)], declaredSources: [AbsolutePath]?, matchingResourceRuleHandler: (AbsolutePath) -> () = { _ in }, observabilityScope: ObservabilityScope) -> FileRuleDescription.Rule {
+    private static func computeRule(
+        for path: AbsolutePath, 
+        toolsVersion: ToolsVersion,
+        rules: [FileRuleDescription],
+        declaredResources: [(path: AbsolutePath, rule: TargetDescription.Resource.Rule)],
+        declaredSources: [AbsolutePath]?,
+        matchingResourceRuleHandler: (AbsolutePath) -> () = { _ in },
+        observabilityScope: ObservabilityScope
+    ) -> FileRuleDescription.Rule {
         var matchedRule: FileRuleDescription.Rule = .none
 
         // First match any resources explicitly declared in the manifest file.

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -34,6 +34,9 @@ public struct TargetSourcesBuilder {
     /// The list of declared sources in the package manifest.
     public let declaredSources: [AbsolutePath]?
 
+    /// The list of declared resources in the package manifest.
+    public let declaredResources: [(path: AbsolutePath, rule: TargetDescription.Resource.Rule)]
+
     /// The default localization.
     public let defaultLocalization: String?
 
@@ -103,6 +106,10 @@ public struct TargetSourcesBuilder {
         }
         self.declaredSources = declaredSources?.spm_uniqueElements()
 
+        self.declaredResources = (try? target.resources.map {
+            (path: try AbsolutePath(validating: $0.path, relativeTo: path), rule: $0.rule)
+        }) ?? []
+
         self.excludedPaths.forEach { exclude in
             if let message = validTargetPath(at: exclude), self.packageKind.emitAuthorWarnings {
                 let warning = "Invalid Exclude '\(exclude)': \(message)."
@@ -162,14 +169,39 @@ public struct TargetSourcesBuilder {
         let contents = self.computeContents()
         var pathToRule: [AbsolutePath: FileRuleDescription.Rule] = [:]
 
+        var handledResources = [AbsolutePath]()
         for path in contents {
-            pathToRule[path] = try self.computeRule(for: path)
+            pathToRule[path] = Self.computeRule(
+                for: path,
+                toolsVersion: toolsVersion,
+                rules: rules,
+                declaredResources: declaredResources,
+                declaredSources: declaredSources,
+                matchingResourceRuleHandler: {
+                    handledResources.append($0)
+                },
+                observabilityScope: observabilityScope
+            )
+        }
+
+        let additionalResources: [Resource]
+        if toolsVersion >= .v5_11 {
+            additionalResources = declaredResources.compactMap { resource in
+                if handledResources.contains(resource.path) {
+                    return nil
+                } else {
+                    print("Found unhandled resource at \(resource.path)")
+                    return self.resource(for: resource.path, with: .init(resource.rule))
+                }
+            }
+        } else {
+            additionalResources = []
         }
 
         let headers = pathToRule.lazy.filter { $0.value == .header }.map { $0.key }.sorted()
         let compilePaths = pathToRule.lazy.filter { $0.value == .compile }.map { $0.key }
         let sources = Sources(paths: Array(compilePaths), root: targetPath)
-        let resources: [Resource] = pathToRule.compactMap { resource(for: $0.key, with: $0.value) }
+        let resources: [Resource] = pathToRule.compactMap { resource(for: $0.key, with: $0.value) } + additionalResources
         let ignored = pathToRule.filter { $0.value == .ignored }.map { $0.key }
         let others = pathToRule.filter { $0.value == .none }.map { $0.key }
 
@@ -197,7 +229,7 @@ public struct TargetSourcesBuilder {
         return Self.computeRule(for: path, toolsVersion: toolsVersion, rules: rules, declaredResources: [], declaredSources: nil, observabilityScope: observabilityScope)
     }
 
-    private static func computeRule(for path: AbsolutePath, toolsVersion: ToolsVersion, rules: [FileRuleDescription], declaredResources: [(path: AbsolutePath, rule: TargetDescription.Resource.Rule)], declaredSources: [AbsolutePath]?, observabilityScope: ObservabilityScope) -> FileRuleDescription.Rule {
+    private static func computeRule(for path: AbsolutePath, toolsVersion: ToolsVersion, rules: [FileRuleDescription], declaredResources: [(path: AbsolutePath, rule: TargetDescription.Resource.Rule)], declaredSources: [AbsolutePath]?, matchingResourceRuleHandler: (AbsolutePath) -> () = { _ in }, observabilityScope: ObservabilityScope) -> FileRuleDescription.Rule {
         var matchedRule: FileRuleDescription.Rule = .none
 
         // First match any resources explicitly declared in the manifest file.
@@ -208,6 +240,7 @@ public struct TargetSourcesBuilder {
                     observabilityScope.emit(error: "duplicate resource rule '\(declaredResource.rule)' found for file at '\(path)'")
                 }
                 matchedRule = .init(declaredResource.rule)
+                matchingResourceRuleHandler(declaredResource.path)
             }
         }
 
@@ -257,11 +290,6 @@ public struct TargetSourcesBuilder {
         }
 
         return matchedRule
-    }
-
-    private func computeRule(for path: AbsolutePath) throws -> FileRuleDescription.Rule {
-        let declaredResources = try target.resources.map { (path: try AbsolutePath(validating: $0.path, relativeTo: self.targetPath), rule: $0.rule) }
-        return Self.computeRule(for: path, toolsVersion: toolsVersion, rules: rules, declaredResources: declaredResources, declaredSources: declaredSources, observabilityScope: observabilityScope)
     }
 
     /// Returns the `Resource` file associated with a file and a particular rule, if there is one.

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -128,4 +128,50 @@ class ResourcesTests: XCTestCase {
             XCTAssertEqual(result.stdout, "hello world\n\n")
         }
     }
+
+    func testResourcesOutsideOfTargetCanBeIncluded() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let packageDir = tmpPath.appending(components: "MyPackage")
+
+            let manifestFile = packageDir.appending("Package.swift")
+            try localFileSystem.createDirectory(manifestFile.parentDirectory, recursive: true)
+            try localFileSystem.writeFileContents(
+                manifestFile,
+                string: """
+                // swift-tools-version: 5.11
+                import PackageDescription
+                let package = Package(name: "MyPackage",
+                    targets: [
+                        .executableTarget(
+                            name: "exec",
+                            resources: [.copy("../resources")]
+                        )
+                    ])
+                """)
+
+            let targetSourceFile = packageDir.appending(components: "Sources", "exec", "main.swift")
+            try localFileSystem.createDirectory(targetSourceFile.parentDirectory, recursive: true)
+            try localFileSystem.writeFileContents(targetSourceFile, string: """
+            import Foundation
+            print(Bundle.module.resourcePath ?? "<empty>")
+            """)
+
+            let resource = packageDir.appending(components: "Sources", "resources", "best.txt")
+            try localFileSystem.createDirectory(resource.parentDirectory, recursive: true)
+            try localFileSystem.writeFileContents(resource, string: "best")
+
+            let (_, stderr) = try executeSwiftBuild(packageDir)
+            // Filter some unrelated output that could show up on stderr.
+            let filteredStderr = stderr.components(separatedBy: "\n").filter { !$0.contains("[logging]") }.joined(separator: "\n")
+            XCTAssertEqual(filteredStderr, "", "unexpectedly received error output: \(stderr)")
+
+            let builtProductsDir = packageDir.appending(components: [".build", "debug"])
+            // On Apple platforms, it's going to be `.bundle` and elsewhere `.resources`.
+            let potentialResourceBundleName = try XCTUnwrap(localFileSystem.getDirectoryContents(builtProductsDir).filter { $0.hasPrefix("MyPackage_exec.") }.first)
+            let resourcePath = builtProductsDir.appending(components: [potentialResourceBundleName, "resources", "best.txt"])
+            XCTAssertTrue(localFileSystem.exists(resourcePath), "resource file wasn't copied by the build")
+            let contents = try String(contentsOfFile: resourcePath.pathString)
+            XCTAssertEqual(contents, "best", "unexpected resource contents: \(contents)")
+        }
+    }
 }


### PR DESCRIPTION
It is possible to declare references to resources outside of ones target and it doesn't seem like that should be problematic in any way. Currently, these declarations essentially get ignored because the algorithm looks at files inside the target and applies rules to them, so any unmatched rules simply get ignored. In the grand scheme of things it may make sense to change that approach in a more fundamental way, but to fix this particular problem we can simply record all rules that were used and apply the unmatched rules after that initial processing has finished. Since this is a significant behavior change, we only do it for tools-version 5.11 or later.

rdar://119040426
resolves #6982