### PR TITLE
Optional xcframework support for Linux

### DIFF
--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -96,7 +96,7 @@ extension Triple.OS {
     /// Returns a representation of the receiver that can be compared with platform strings declared in an XCFramework.
     fileprivate var asXCFrameworkPlatformString: String? {
         switch self {
-        case .darwin, .linux, .wasi, .win32, .openbsd, .noneOS:
+        case .darwin, .wasi, .win32, .openbsd, .noneOS:
             return nil // XCFrameworks do not support any of these platforms today.
         case .macosx:
             return "macos"
@@ -106,6 +106,8 @@ extension Triple.OS {
             return "tvos"
         case .watchos:
             return "watchos"
+        case .linux:
+            return ProcessInfo.processInfo.environment["_SWIFTPM_EXPERIMENTAL_LINUX_XCFRAMEWORK"] == "1" ? "linux" : nil
         default:
             return nil // XCFrameworks do not support any of these platforms today.
         }


### PR DESCRIPTION
Provide experimental support for XCFrameworks for Linux for well-defined, identical, deployments.

### Motivation:

Providing informal, experimental support for (very) heterogenous cluster deployments on Linux as discussed previously in https://github.com/apple/swift-package-manager/issues/5714

It allows for deployments which use XCFrameworks and library evolution on identically patches / toolchains on Linux as an interim escape hatch until wider support might be available. 

### Modifications:

Enable XCFrameworks for Linux if the `_SWIFTPM_EXPERIMENTAL_LINUX_XCFRAMEWORK` environment variable is set.

### Result:

Users may experiment with library evolution and XCFrameworks on Linux without having to roll their own toolchains while waiting for wider support for shared libraries / evolution on Linux in general.

The default behavior remains unchanged and there should be zero impact for users who doesn't set this environment variable.