### PR TITLE
Linux packages fail to build with LLVM 18 and Apple 2023 versions of clang

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -239,23 +239,15 @@ public final class ClangTargetBuildDescription {
         }
 
         // Enable Clang module flags, if appropriate.
-        let enableModules: Bool
         let triple = self.buildParameters.triple
-        if toolsVersion < .v5_8 {
-            // For version < 5.8, we enable them except in these cases:
-            // 1. on Darwin when compiling for C++, because C++ modules are disabled on Apple-built Clang releases
-            // 2. on Windows when compiling for any language, because of issues with the Windows SDK
-            // 3. on Android when compiling for any language, because of issues with the Android SDK
-            enableModules = !(triple.isDarwin() && isCXX) && !triple.isWindows() && !triple.isAndroid()
-        } else {
-            // For version >= 5.8, we disable them when compiling for C++ regardless of platforms, see:
-            // https://github.com/llvm/llvm-project/issues/55980 for clang frontend crash when module
-            // enabled for C++ on c++17 standard and above.
-            enableModules = !isCXX && !triple.isWindows() && !triple.isAndroid()
-        }
-
+        // Swift is able to use modules on non-Darwin platforms because it injects its own module maps
+        // via vfs. However, nothing does that for C based compilation, and so non-Darwin platforms can't
+        // support clang modules.
+        // Note that if modules get enabled for other platforms later, we'll need to verify that
+        // https://github.com/llvm/llvm-project/issues/55980 (crash on C++17 and later) is fixed, or don't
+        // enable modules in the affected modes.
+        let enableModules = triple.isDarwin()
         if enableModules {
-            // Using modules currently conflicts with the Windows and Android SDKs.
             args += ["-fmodules", "-fmodule-name=" + target.c99name]
         }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1353,11 +1353,11 @@ final class BuildPlanTests: XCTestCase {
         args += ["-target", defaultTargetTriple]
         args += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks"]
-        #if !os(Windows) // FIXME(5473) - modules flags on Windows dropped
+        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
         args += ["-fmodules", "-fmodule-name=extlib"]
         #endif
         args += ["-I", ExtPkg.appending(components: "Sources", "extlib", "include").pathString]
-        #if !os(Windows) // FIXME(5473) - modules flags on Windows dropped
+        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
         args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
         #endif
 
@@ -1382,7 +1382,7 @@ final class BuildPlanTests: XCTestCase {
 
         args += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks"]
-        #if !os(Windows) // FIXME(5473) - modules flags on Windows dropped
+        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
         args += ["-fmodules", "-fmodule-name=exe"]
         #endif
         args += [
@@ -1392,7 +1392,7 @@ final class BuildPlanTests: XCTestCase {
             "-I", ExtPkg.appending(components: "Sources", "extlib", "include").pathString,
             "-fmodule-map-file=\(buildPath.appending(components: "extlib.build", "module.modulemap"))",
         ]
-        #if !os(Windows) // FIXME(5473) - modules flags on Windows dropped
+        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
         args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
         #endif
         args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
@@ -1710,11 +1710,11 @@ final class BuildPlanTests: XCTestCase {
 
         args += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks"]
-        #if !os(Windows) // FIXME(5473) - modules flags on Windows dropped
+        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
         args += ["-fmodules", "-fmodule-name=lib"]
         #endif
         args += ["-I", Pkg.appending(components: "Sources", "lib", "include").pathString]
-        #if !os(Windows) // FIXME(5473) - modules flags on Windows dropped
+        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
         args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
         #endif
         args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
@@ -2866,11 +2866,11 @@ final class BuildPlanTests: XCTestCase {
         var expectedExeBasicArgs = triple.isDarwin() ? ["-fobjc-arc"] : []
         expectedExeBasicArgs += ["-target", defaultTargetTriple]
         expectedExeBasicArgs += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks"]
-        #if !os(Windows) // FIXME(5473) - modules flags on Windows dropped
+        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
         expectedExeBasicArgs += ["-fmodules", "-fmodule-name=exe"]
         #endif
         expectedExeBasicArgs += ["-I", Pkg.appending(components: "Sources", "exe", "include").pathString]
-        #if !os(Windows) // FIXME(5473) - modules flags on Windows dropped
+        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
         expectedExeBasicArgs += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
         #endif
 
@@ -2889,7 +2889,7 @@ final class BuildPlanTests: XCTestCase {
         var expectedLibBasicArgs = triple.isDarwin() ? ["-fobjc-arc"] : []
         expectedLibBasicArgs += ["-target", defaultTargetTriple]
         expectedLibBasicArgs += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks"]
-        let shouldHaveModules = !(triple.isDarwin() || triple.isWindows() || triple.isAndroid())
+        let shouldHaveModules = triple.isDarwin()
         if shouldHaveModules {
             expectedLibBasicArgs += ["-fmodules", "-fmodule-name=lib"]
         }
@@ -3455,9 +3455,8 @@ final class BuildPlanTests: XCTestCase {
         let args = [
             "-target", "wasm32-unknown-wasi",
             "-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1",
-            "-fblocks", "-fmodules", "-fmodule-name=lib",
+            "-fblocks",
             "-I", Pkg.appending(components: "Sources", "lib", "include").pathString,
-            "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))",
             "-g",
         ]
         XCTAssertEqual(try lib.basicArguments(isCXX: false), args)


### PR DESCRIPTION
Newer versions of clang add builtin modules for its C Standard Library headers. This creates problems* when building with a single module map that tries to absorb all of the OS/SDK dependencies, which is what all non-Apple platforms currently do in SwiftPM.

This works for Swift targets because the Swift compiler injects module maps via vfs for non-Apple platforms. However, clang doesn't do anything similar for C-based targets, and so they fail to build.

For now, don't build with modules for any SwiftPM C-based targets on non-Apple platforms.

\* Some problems are module cycles and headers being absorbed into unexpected modules. clang modules generally expect that OS/SDK headers are covered by module maps, and _not_ absorbed into whatever module happens to include them first.

rdar://120716498