### PR TITLE
Verify that the pinned version is still available

### DIFF
--- a/Sources/PackageGraph/PackageContainer.swift
+++ b/Sources/PackageGraph/PackageContainer.swift
@@ -40,6 +40,8 @@ public protocol PackageContainer {
     /// The identifier for the package.
     var package: PackageReference { get }
 
+    var shouldInvalidatePinnedVersions: Bool { get }
+
     /// Returns true if the tools version is compatible at the given version.
     func isToolsVersionCompatible(at version: Version) -> Bool
 
@@ -103,6 +105,10 @@ extension PackageContainer {
 
     public func versionsDescending() throws -> [Version] {
         try self.versionsAscending().reversed()
+    }
+
+    public var shouldInvalidatePinnedVersions: Bool {
+        return true
     }
 }
 

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
@@ -79,9 +79,17 @@ internal final class PubGrubPackageContainer {
         var versionSet = term.requirement
 
         // Restrict the selection to the pinned version if is allowed by the current requirements.
-        if let pinnedVersion {
+        if let pinnedVersion = self.pinnedVersion {
             if versionSet.contains(pinnedVersion) {
-                versionSet = .exact(pinnedVersion)
+                if !self.underlying.shouldInvalidatePinnedVersions {
+                    versionSet = .exact(pinnedVersion)
+                } else {
+                    // Make sure the pinned version is still available
+                    let version = try self.underlying.versionsDescending().first { pinnedVersion == $0 }
+                    if version != nil {
+                        return version
+                    }
+                }
             }
         }
 

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -96,6 +96,7 @@ private struct LocalPackageContainer: PackageContainer {
     /// The managed dependency if the package is not a root package.
     let dependency: Workspace.ManagedDependency?
     let currentToolsVersion: ToolsVersion
+    let shouldInvalidatePinnedVersions = false
 
     func versionsAscending() throws -> [Version] {
         switch dependency?.state {

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -1460,6 +1460,34 @@ final class PubgrubTests: XCTestCase {
         ])
     }
 
+    func testMissingPin() throws {
+        // This checks that we can drop pins that are no longer available but still keep the ones
+        // which fit the constraints.
+        try builder.serve("a", at: v1, with: ["a": ["b": (.versionSet(v1Range), .specific(["b"]))]])
+        try builder.serve("a", at: v1_1)
+        try builder.serve("b", at: v1)
+        try builder.serve("b", at: v1_1)
+
+        let dependencies = try builder.create(dependencies: [
+            "a": (.versionSet(v1Range), .specific(["a"])),
+        ])
+
+        // Here c is pinned to v1.1, but it is no longer available, so the resolver should fall back
+        // to v1.
+        let pinsStore = try builder.create(pinsStore: [
+            "a": (.version(v1), .specific(["a"])),
+            "b": (.version("1.2.0"), .specific(["b"])),
+        ])
+
+        let resolver = builder.create(pins: pinsStore.pins)
+        let result = resolver.solve(constraints: dependencies)
+
+        AssertResult(result, [
+            ("a", .version(v1)),
+            ("b", .version(v1_1)),
+        ])
+    }
+
     func testBranchedBasedPin() throws {
         // This test ensures that we get the SHA listed in Package.resolved for branch-based
         // dependencies.


### PR DESCRIPTION
This brings back the changes from #5898, but we only apply the change if we are actually resolving, not in the preflight resolution. This is kinda clunky, but I don't see a better way to do this without doing some more fundamental changes to the way to preflight resolution works.

rdar://109487355
