### PR TITLE
Exercise bootstrapping with the XCBuild codepath in `build-using-self`

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -88,6 +88,10 @@ def add_build_args(parser):
     """Configures the parser with the arguments necessary for build-related actions."""
     add_global_args(parser)
     parser.add_argument(
+        "--swift-build-path",
+        help="path to the prebuilt SwiftPM `swift-build` binary",
+        metavar="PATH")
+    parser.add_argument(
         "--swiftc-path",
         help="path to the swift compiler",
         metavar="PATH")
@@ -154,7 +158,7 @@ def add_build_args(parser):
         default=[])
     parser.add_argument(
         "--cross-compile-config",
-        help="Swift flags to cross-compile SPM with itself")
+        help="Swift flags to cross-compile SwiftPM with itself")
 
 def add_test_args(parser):
     """Configures the parser with the arguments necessary for the test action."""
@@ -640,7 +644,7 @@ def build_swiftpm_with_swiftpm(args, integrated_swift_driver):
         swiftpm_args.append(os.path.join(args.bootstrap_dir, "bin/swift-bootstrap"))
     else:
         note("Building SwiftPM (with a prebuilt swift-build)")
-        swiftpm_args.append(os.path.join(os.path.split(args.swiftc_path)[0], "swift-build"))
+        swiftpm_args.append(args.swift_build_path or os.path.join(os.path.split(args.swiftc_path)[0], "swift-build"))
         swiftpm_args.append("--disable-sandbox")
 
         # Enforce resolved versions to avoid stray dependencies that aren't local.

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -224,8 +224,9 @@ def parse_build_args(args):
 
     args.swiftc_path = get_swiftc_path(args)
     args.clang_path = get_tool_path(args, "clang")
-    args.cmake_path = get_tool_path(args, "cmake")
-    args.ninja_path = get_tool_path(args, "ninja")
+    if not args.skip_cmake_bootstrap:
+        args.cmake_path = get_tool_path(args, "cmake")
+        args.ninja_path = get_tool_path(args, "ninja")
     args.ar_path = get_tool_path(args, "ar")
     args.ranlib_path = get_tool_path(args, "ranlib")
     if args.cross_compile_hosts:

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -24,20 +24,22 @@ export SWIFTCI_IS_SELF_HOSTED=1
 set -x
 
 # Perform package update in order to get the latest commits for the dependencies.
-swift package update
-swift build -c $CONFIGURATION
-swift test -c $CONFIGURATION --parallel
+#swift package update
+#swift build -c $CONFIGURATION
+#swift test -c $CONFIGURATION --parallel
 
 # Run the integration tests with just built SwiftPM.
-export SWIFTPM_BIN_DIR=$(swift build -c $CONFIGURATION --show-bin-path)
+#export SWIFTPM_BIN_DIR=$(swift build -c $CONFIGURATION --show-bin-path)
 cd IntegrationTests
 # Perform package update in order to get the latest commits for the dependencies.
-swift package update
-$SWIFTPM_BIN_DIR/swift-test --parallel
+#swift package update
+#$SWIFTPM_BIN_DIR/swift-test --parallel
 
 if [ "$(uname)" == "Darwin" ]; then
   cd ..
   echo "Current working directory is ${PWD}"
+  echo "Current PATH is ${PATH}"
+  echo "Possible CMake paths:\n$(ls -l /usr/local/bin/cmake /opt/homebrew/bin/cmake)"
   echo "Bootstrapping with the XCBuild codepath..."
   rm -rf .build
   ./Utilities/bootstrap build --release --cross-compile-hosts macosx-arm64 --cmake-path $(which cmake)

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -44,6 +44,6 @@ if [ "$(uname)" == "Darwin" ]; then
   rm -rf .build
   ./Utilities/bootstrap build --release \
     --cross-compile-hosts macosx-arm64 \
-    --cmake-path $(which cmake) \
-    --ninja-path $(which ninja)
+    --skip-cmake-bootstrap \
+    --swift-build-path "${SWIFTPM_BIN_DIR}/swift-build"
 fi

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -38,8 +38,8 @@ cd IntegrationTests
 if [ "$(uname)" == "Darwin" ]; then
   cd ..
   echo "Current working directory is ${PWD}"
-  echo "Current PATH is ${PATH}"
-  echo "Possible CMake paths:\n$(ls -l /usr/local/bin/cmake /opt/homebrew/bin/cmake)"
+  # Make sure Homebrew installation of CMake can be found
+  export PATH="/usr/local/bin:/opt/homebrew/bin:${PATH}"
   echo "Bootstrapping with the XCBuild codepath..."
   rm -rf .build
   ./Utilities/bootstrap build --release --cross-compile-hosts macosx-arm64 --cmake-path $(which cmake)

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -36,6 +36,8 @@ swift package update
 $SWIFTPM_BIN_DIR/swift-test --parallel
 
 if [ "$(uname)" == "Darwin" ]; then
+  cd ..
+  echo "Current working directory is ${PWD}"
   echo "Bootstrapping with the XCBuild codepath..."
   rm -rf .build
   ./Utilities/bootstrap build --release --cross-compile-hosts macosx-arm64

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -34,3 +34,8 @@ cd IntegrationTests
 # Perform package update in order to get the latest commits for the dependencies.
 swift package update
 $SWIFTPM_BIN_DIR/swift-test --parallel
+
+if [ "$(uname)" == "Darwin" ]; then
+  echo "Bootstrapping with the XCBuild codepath..."
+  ./Utilities/bootstrap --release --cross-compile-hosts macosx-arm64
+fi

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -37,5 +37,6 @@ $SWIFTPM_BIN_DIR/swift-test --parallel
 
 if [ "$(uname)" == "Darwin" ]; then
   echo "Bootstrapping with the XCBuild codepath..."
-  ./Utilities/bootstrap --release --cross-compile-hosts macosx-arm64
+  rm -rf .build
+  ./Utilities/bootstrap build --release --cross-compile-hosts macosx-arm64
 fi

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -38,8 +38,6 @@ $SWIFTPM_BIN_DIR/swift-test --parallel
 if [ "$(uname)" == "Darwin" ]; then
   cd ..
   echo "Current working directory is ${PWD}"
-  # Make sure Homebrew installation of CMake can be found
-  export PATH="/usr/local/bin:/opt/homebrew/bin:${PATH}"
   echo "Bootstrapping with the XCBuild codepath..."
   ./Utilities/bootstrap build --release \
     --cross-compile-hosts macosx-arm64 \

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -41,7 +41,6 @@ if [ "$(uname)" == "Darwin" ]; then
   # Make sure Homebrew installation of CMake can be found
   export PATH="/usr/local/bin:/opt/homebrew/bin:${PATH}"
   echo "Bootstrapping with the XCBuild codepath..."
-  rm -rf .build
   ./Utilities/bootstrap build --release \
     --cross-compile-hosts macosx-arm64 \
     --skip-cmake-bootstrap \

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -26,14 +26,14 @@ set -x
 # Perform package update in order to get the latest commits for the dependencies.
 swift package update
 swift build -c $CONFIGURATION
-#swift test -c $CONFIGURATION --parallel
+swift test -c $CONFIGURATION --parallel
 
 # Run the integration tests with just built SwiftPM.
 export SWIFTPM_BIN_DIR=$(swift build -c $CONFIGURATION --show-bin-path)
 cd IntegrationTests
 # Perform package update in order to get the latest commits for the dependencies.
-#swift package update
-#$SWIFTPM_BIN_DIR/swift-test --parallel
+swift package update
+$SWIFTPM_BIN_DIR/swift-test --parallel
 
 if [ "$(uname)" == "Darwin" ]; then
   cd ..

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -24,12 +24,12 @@ export SWIFTCI_IS_SELF_HOSTED=1
 set -x
 
 # Perform package update in order to get the latest commits for the dependencies.
-#swift package update
-#swift build -c $CONFIGURATION
+swift package update
+swift build -c $CONFIGURATION
 #swift test -c $CONFIGURATION --parallel
 
 # Run the integration tests with just built SwiftPM.
-#export SWIFTPM_BIN_DIR=$(swift build -c $CONFIGURATION --show-bin-path)
+export SWIFTPM_BIN_DIR=$(swift build -c $CONFIGURATION --show-bin-path)
 cd IntegrationTests
 # Perform package update in order to get the latest commits for the dependencies.
 #swift package update

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -40,5 +40,5 @@ if [ "$(uname)" == "Darwin" ]; then
   echo "Current working directory is ${PWD}"
   echo "Bootstrapping with the XCBuild codepath..."
   rm -rf .build
-  ./Utilities/bootstrap build --release --cross-compile-hosts macosx-arm64
+  ./Utilities/bootstrap build --release --cross-compile-hosts macosx-arm64 --cmake-path $(which cmake)
 fi

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -42,5 +42,8 @@ if [ "$(uname)" == "Darwin" ]; then
   export PATH="/usr/local/bin:/opt/homebrew/bin:${PATH}"
   echo "Bootstrapping with the XCBuild codepath..."
   rm -rf .build
-  ./Utilities/bootstrap build --release --cross-compile-hosts macosx-arm64 --cmake-path $(which cmake)
+  ./Utilities/bootstrap build --release \
+    --cross-compile-hosts macosx-arm64 \
+    --cmake-path $(which cmake) \
+    --ninja-path $(which ninja)
 fi


### PR DESCRIPTION
This codepath could regress since we previously didn't run it in our PR testing.

With this change on macOS we always try to bootstrap SwiftPM with XCBuild on top of the usual llbuild build and test run.

It does increase the time spent on the macOS self-hosted job, but that job was already multiple times faster than our smoke test jobs, thus we have enough leeway to make it longer with the benefit of better PR testing.
