### PR TITLE
Tests: Exercise output and diagnostic messages from command plugins

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/CommandPluginDiagnosticsStub/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginDiagnosticsStub/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "CommandPluginDiagnostics",
+    targets: [
+        .plugin(
+            name: "diagnostics-stub",
+            capability: .command(intent: .custom(
+                verb: "print-diagnostics",
+                description: "Writes diagnostic messages for testing"
+            ))
+        ),
+        .executableTarget(
+            name: "placeholder"
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginDiagnosticsStub/Plugins/diagnostics_stub.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginDiagnosticsStub/Plugins/diagnostics_stub.swift
@@ -1,0 +1,28 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct diagnostics_stub: CommandPlugin {
+    // This is a helper for testing plugin diagnostics.  It sends different messages to SwiftPM depending on its arguments.
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        // Anything a plugin writes to standard output appears on standard output.
+        // Printing to stderr will also go to standard output because SwiftPM combines
+        // stdout and stderr before launching the plugin.
+        if arguments.contains("print") {
+           print("command plugin: print")
+        }
+
+        // Diagnostics are collected by SwiftPM and printed to standard error, depending on the current log verbosity level.
+        if arguments.contains("remark") {
+           Diagnostics.remark("command plugin: Diagnostics.remark")     // prefixed with 'info:' when printed
+        }
+
+        if arguments.contains("warning") {
+           Diagnostics.warning("command plugin: Diagnostics.warning")   // prefixed with 'warning:' when printed
+        }
+
+        if arguments.contains("error") {
+           Diagnostics.error("command plugin: Diagnostics.error")       // prefixed with 'error:' when printed
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginDiagnosticsStub/Sources/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginDiagnosticsStub/Sources/main.swift
@@ -1,0 +1,4 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+print("Hello, world from executable target!")


### PR DESCRIPTION
This test exercises command plugin console output under different verbosity settings:

### Motivation:

There doesn't seem to be a test which checks the handling of diagnostic messages from command plugins in a once place.   This test will help to avoid regressions in this area.

### Modifications:

* A new stub plugin prints to standard output or sends diagnostic output, depending on its arguments
* A new test uses the stub to generate outputs and checks what `swift package` prints to the console at different verbosity levels

### Result:

This test verifies existing functionality.    No change in Swift Package Manager.