### PR TITLE
command plugins: Add a 'progress' diagnostic message at default verbosity

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Plugins/diagnostics-stub/diagnostics_stub.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Plugins/diagnostics-stub/diagnostics_stub.swift
@@ -13,6 +13,10 @@ struct diagnostics_stub: CommandPlugin {
         }
 
         // Diagnostics are collected by SwiftPM and printed to standard error, depending on the current log verbosity level.
+        if arguments.contains("progress") {
+           Diagnostics.progress("command plugin: Diagnostics.progress")     // prefixed with [plugin_name]
+        }
+
         if arguments.contains("remark") {
            Diagnostics.remark("command plugin: Diagnostics.remark")     // prefixed with 'info:' when printed
         }

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -53,6 +53,11 @@ final class PluginDelegate: PluginInvocationDelegate {
         swiftTool.observabilityScope.emit(diagnostic)
     }
 
+    func pluginEmittedProgress(_ message: String) {
+        swiftTool.outputStream.write("[\(plugin.name)] \(message)\n")
+        swiftTool.outputStream.flush()
+    }
+
     func pluginRequestedBuildOperation(
         subset: PluginInvocationBuildSubset,
         parameters: PluginInvocationBuildParameters,

--- a/Sources/PackagePlugin/Diagnostics.swift
+++ b/Sources/PackagePlugin/Diagnostics.swift
@@ -49,4 +49,9 @@ public struct Diagnostics {
     public static func remark(_ message: String, file: String? = #file, line: Int? = #line) {
         self.emit(.remark, message, file: file, line: line)
     }
+
+    /// Emits a progress message
+    public static func progress(_ message: String) {
+        try? pluginHostConnection.sendMessage(.emitProgress(message: message))
+    }
 }

--- a/Sources/PackagePlugin/PluginMessages.swift
+++ b/Sources/PackagePlugin/PluginMessages.swift
@@ -269,7 +269,10 @@ enum PluginToHostMessage: Codable {
         enum DiagnosticSeverity: String, Codable {
             case error, warning, remark
         }
-    
+
+    /// The plugin emits a progress message.
+    case emitProgress(message: String)
+
     /// The plugin defines a build command.
     case defineBuildCommand(configuration: CommandConfiguration, inputFiles: [URL], outputFiles: [URL])
 

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -240,7 +240,10 @@ extension PluginTarget {
                         diagnostic = .info(message, metadata: metadata)
                     }
                     self.invocationDelegate.pluginEmittedDiagnostic(diagnostic)
-                    
+
+                case .emitProgress(let message):
+                    self.invocationDelegate.pluginEmittedProgress(message)
+
                 case .defineBuildCommand(let config, let inputFiles, let outputFiles):
                     if config.version != 2 {
                         throw PluginEvaluationError.pluginUsesIncompatibleVersion(expected: 2, actual: config.version)
@@ -485,7 +488,9 @@ extension PackageGraph {
                         dispatchPrecondition(condition: .onQueue(delegateQueue))
                         outputData.append(contentsOf: data)
                     }
-                    
+
+                    func pluginEmittedProgress(_ message: String) {}
+
                     func pluginEmittedDiagnostic(_ diagnostic: Basics.Diagnostic) {
                         dispatchPrecondition(condition: .onQueue(delegateQueue))
                         diagnostics.append(diagnostic)
@@ -818,6 +823,9 @@ public protocol PluginInvocationDelegate {
     
     /// Called when a plugin emits a diagnostic through the PackagePlugin APIs.
     func pluginEmittedDiagnostic(_: Basics.Diagnostic)
+
+    /// Called when a plugin emits a progress message through the PackagePlugin APIs.
+    func pluginEmittedProgress(_: String)
 
     /// Called when a plugin defines a build command through the PackagePlugin APIs.
     func pluginDefinedBuildCommand(displayName: String?, executable: AbsolutePath, arguments: [String], environment: [String: String], workingDirectory: AbsolutePath?, inputFiles: [AbsolutePath], outputFiles: [AbsolutePath])

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -1886,6 +1886,7 @@ final class PackageToolTests: CommandsTestCase {
         // Match patterns for expected messages
         let isEmpty = StringPattern.equal("")
         let isOnlyPrint = StringPattern.equal("command plugin: print\n")
+        let containsProgress = StringPattern.contains("[diagnostics-stub] command plugin: Diagnostics.progress")
         let containsRemark = StringPattern.contains("command plugin: Diagnostics.remark")
         let containsWarning = StringPattern.contains("command plugin: Diagnostics.warning")
         let containsError = StringPattern.contains("command plugin: Diagnostics.error")
@@ -1915,18 +1916,25 @@ final class PackageToolTests: CommandsTestCase {
                 XCTAssertMatch(stderr, isEmpty)
             }
 
-            try runPlugin(flags: [], diagnostics: ["print", "remark"]) { stdout, stderr in
-            	XCTAssertMatch(stdout, isOnlyPrint)
-                XCTAssertMatch(stderr, isEmpty)
+            try runPlugin(flags: [], diagnostics: ["print", "progress"]) { stdout, stderr in
+                XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
             }
 
-            try runPlugin(flags: [], diagnostics: ["print", "remark", "warning"]) { stdout, stderr in
+            try runPlugin(flags: [], diagnostics: ["print", "progress", "remark"]) { stdout, stderr in
             	XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
+            }
+
+            try runPlugin(flags: [], diagnostics: ["print", "progress", "remark", "warning"]) { stdout, stderr in
+            	XCTAssertMatch(stdout, isOnlyPrint)
+            	XCTAssertMatch(stderr, containsProgress)
                 XCTAssertMatch(stderr, containsWarning)
             }
 
-         	try runPluginWithError(flags: [], diagnostics: ["print", "remark", "warning", "error"]) { stdout, stderr in
+         	try runPluginWithError(flags: [], diagnostics: ["print", "progress", "remark", "warning", "error"]) { stdout, stderr in
                 XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
                 XCTAssertMatch(stderr, containsWarning)
                 XCTAssertMatch(stderr, containsError)
             }
@@ -1940,18 +1948,24 @@ final class PackageToolTests: CommandsTestCase {
                 XCTAssertMatch(stderr, isEmpty)
             }
 
-            try runPlugin(flags: ["-q"], diagnostics: ["print", "remark"]) { stdout, stderr in
+            try runPlugin(flags: ["-q"], diagnostics: ["print", "progress"]) { stdout, stderr in
             	XCTAssertMatch(stdout, isOnlyPrint)
-                XCTAssertMatch(stderr, isEmpty)
+                XCTAssertMatch(stderr, containsProgress)
             }
 
-            try runPlugin(flags: ["-q"], diagnostics: ["print", "remark", "warning"]) { stdout, stderr in
+            try runPlugin(flags: ["-q"], diagnostics: ["print", "progress", "remark"]) { stdout, stderr in
             	XCTAssertMatch(stdout, isOnlyPrint)
-                XCTAssertMatch(stderr, isEmpty)
+                XCTAssertMatch(stderr, containsProgress)
             }
 
-            try runPluginWithError(flags: ["-q"], diagnostics: ["print", "remark", "warning", "error"]) { stdout, stderr in
+            try runPlugin(flags: ["-q"], diagnostics: ["print", "progress", "remark", "warning"]) { stdout, stderr in
             	XCTAssertMatch(stdout, isOnlyPrint)
+                XCTAssertMatch(stderr, containsProgress)
+            }
+
+            try runPluginWithError(flags: ["-q"], diagnostics: ["print", "progress", "remark", "warning", "error"]) { stdout, stderr in
+            	XCTAssertMatch(stdout, isOnlyPrint)
+            	XCTAssertMatch(stderr, containsProgress)
             	XCTAssertNoMatch(stderr, containsRemark)
                 XCTAssertNoMatch(stderr, containsWarning)
                 XCTAssertMatch(stderr, containsError)
@@ -1967,19 +1981,27 @@ final class PackageToolTests: CommandsTestCase {
                 // At this level stderr contains extra compiler output even if the plugin does not print diagnostics
             }
 
-            try runPlugin(flags: ["-v"], diagnostics: ["print", "remark"]) { stdout, stderr in
+            try runPlugin(flags: ["-v"], diagnostics: ["print", "progress"]) { stdout, stderr in
             	XCTAssertMatch(stdout, isOnlyPrint)
+            	XCTAssertMatch(stderr, containsProgress)
+            }
+
+            try runPlugin(flags: ["-v"], diagnostics: ["print", "progress", "remark"]) { stdout, stderr in
+            	XCTAssertMatch(stdout, isOnlyPrint)
+            	XCTAssertMatch(stderr, containsProgress)
                 XCTAssertMatch(stderr, containsRemark)
             }
 
-            try runPlugin(flags: ["-v"], diagnostics: ["print", "remark", "warning"]) { stdout, stderr in
+            try runPlugin(flags: ["-v"], diagnostics: ["print", "progress", "remark", "warning"]) { stdout, stderr in
             	XCTAssertMatch(stdout, isOnlyPrint)
+            	XCTAssertMatch(stderr, containsProgress)
                 XCTAssertMatch(stderr, containsRemark)
                 XCTAssertMatch(stderr, containsWarning)
             }
 
-            try runPluginWithError(flags: ["-v"], diagnostics: ["print", "remark", "warning", "error"]) { stdout, stderr in
+            try runPluginWithError(flags: ["-v"], diagnostics: ["print", "progress", "remark", "warning", "error"]) { stdout, stderr in
             	XCTAssertMatch(stdout, isOnlyPrint)
+            	XCTAssertMatch(stderr, containsProgress)
             	XCTAssertMatch(stderr, containsRemark)
                 XCTAssertMatch(stderr, containsWarning)
                 XCTAssertMatch(stderr, containsError)

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -478,6 +478,8 @@ class PluginTests: XCTestCase {
                     print("[DIAG] \(diagnostic)")
                     diagnostics.append(diagnostic)
                 }
+
+                func pluginEmittedProgress(_ message: String) {}
             }
 
             // Helper function to invoke a plugin with given input and to check its outputs.
@@ -767,6 +769,8 @@ class PluginTests: XCTestCase {
                     dispatchPrecondition(condition: .onQueue(delegateQueue))
                     diagnostics.append(diagnostic)
                 }
+
+                func pluginEmittedProgress(_ message: String) {}
             }
 
             // Find the relevant plugin.


### PR DESCRIPTION
This change adds a 'progress' message to the diagnostics which a plugin can send back to SwiftPM.   This message is printed to standard error at the default verbosity level.

 ### Motivation:

Currently, a plugin can write output to standard output or send diagnostics which SwiftPM writes to standard error.   If the plugin spawns long-running operations we might want to print progress messages to let the user know that it is still running.   The existing options all have compromises:

* Anything the plugin prints to its standard output or standard error is echoed to SwiftPM's standard output, but we may want to keep progress information separate from other plugin outputs - the plugin might be called as part of a shell pipeline where a downstream process will consume its output, for example.
* The existing diagnostic messages - remark (info), warning and error - are all suppressed at the default verbosity level.
* Increasing the level with `-v` causes SwiftPM to print lots of extra logging information from the build, which swamps the plugin info messages.

This commit adds a 'progress' message which SwiftPM will print to standard error at the default verbosity level, allowing progress to be shown without polluting standard output or pulling in additional build logging which might not be relevant to the user.

 ### Modifications:

* `Diagnostics.progress` takes a message as a string and passes it to SwiftPM, which prints it to standard error.

From the plugin programmer's point of view `Diagnostics.progress` is logically a diagnostics message, however it is a new type in the SwiftPM <-> plugin protocol because extending the existing diagnostics enum would require extensive changes to add a the new message and in many existing cases it would not be relevant.

 ### Result:

A plugin can show the user that it is making progress by printing messages which SwiftPM will echoed to stderr at the default verbosity level.

Example output (`diagnostics-stub` is the name of the plugin in `Package.swift`):
```
% swift-package print-diagnostics progress
[diagnostics-stub] command plugin: Diagnostics.progress
```