### PR TITLE
Fix `./Utilities/soundness.sh` regressions

### DIFF
--- a/Tests/BasicsTests/FileSystem/PathShimTests.swift
+++ b/Tests/BasicsTests/FileSystem/PathShimTests.swift
@@ -1,18 +1,20 @@
-/*
- This source file is part of the Swift.org open source project
-
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
- Licensed under Apache License v2.0 with Runtime Library Exception
-
- See http://swift.org/LICENSE.txt for license information
- See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
 
 import Basics
 import Foundation
 import XCTest
 
-class PathShimTests : XCTestCase {
+class PathShimTests: XCTestCase {
     func testRescursiveDirectoryCreation() {
         // For the tests we'll need a temporary directory.
         try! withTemporaryDirectory(removeTreeOnDeinit: true) { path in
@@ -29,50 +31,51 @@ class PathShimTests : XCTestCase {
     }
 }
 
-class WalkTests : XCTestCase {
+class WalkTests: XCTestCase {
     func testNonRecursive() throws {
-      #if os(Android)
+        #if os(Android)
         let root = "/system"
         var expected: [AbsolutePath] = [
             "\(root)/usr",
             "\(root)/bin",
-            "\(root)/xbin"
+            "\(root)/xbin",
         ]
-      #elseif os(Windows)
+        #elseif os(Windows)
         let root = ProcessInfo.processInfo.environment["SystemRoot"]!
         var expected: [AbsolutePath] = [
-          "\(root)/System32",
-          "\(root)/SysWOW64",
+            "\(root)/System32",
+            "\(root)/SysWOW64",
         ]
-      #else
+        #else
         let root = ""
         var expected: [AbsolutePath] = [
             "/usr",
             "/bin",
-            "/sbin"
+            "/sbin",
         ]
-      #endif
+        #endif
         for x in try walk(AbsolutePath(validating: "\(root)/"), recursively: false) {
             if let i = expected.firstIndex(of: x) {
                 expected.remove(at: i)
             }
-          #if os(Android)
+            #if os(Android)
             XCTAssertEqual(3, x.components.count)
-          #elseif os(Windows)
+            #elseif os(Windows)
             XCTAssertEqual((root as NSString).pathComponents.count + 2, x.components.count)
-          #else
+            #else
             XCTAssertEqual(2, x.components.count)
-          #endif
+            #endif
         }
         XCTAssertEqual(expected.count, 0)
     }
 
     func testRecursive() {
-        let root = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory.parentDirectory.appending(component: "Sources")
+        let root = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory.parentDirectory
+            .appending(component: "Sources")
         var expected = [
             root.appending(component: "Basics"),
             root.appending(component: "Build"),
-            root.appending(component: "Commands")
+            root.appending(component: "Commands"),
         ]
         for x in try! walk(root) {
             if let i = expected.firstIndex(of: x) {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4282,11 +4282,9 @@ final class BuildPlanTests: XCTestCase {
                     .anySequence,
                     "-DFOO",
                     "-cxx-interoperability-mode=default",
-                    "-Xcc",
-                    "-std=c++17",
+                    "-Xcc", "-std=c++17",
                     "-g",
-                    "-Xcc",
-                    "-g",
+                    "-Xcc", "-g",
                     .end,
                 ]
             )
@@ -5809,7 +5807,7 @@ final class BuildPlanTests: XCTestCase {
                         }
                     }
                 }
-                """
+            """
         )
 
         let observability = ObservabilitySystem.makeForTesting()

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -841,20 +841,26 @@ final class BuildPlanTests: XCTestCase {
             let bSwift = bPath.appending("B.swift")
             let cSwift = cPath.appending("C.swift")
             try localFileSystem.writeFileContents(main, string: "baz();")
-            try localFileSystem.writeFileContents(aSwift, string:
+            try localFileSystem.writeFileContents(
+                aSwift,
+                string:
                 """
                 import B;\
                 import C;\
                 public func baz() { bar() }
                 """
             )
-            try localFileSystem.writeFileContents(bSwift, string:
+            try localFileSystem.writeFileContents(
+                bSwift,
+                string:
                 """
                 import C;
                 public func bar() { foo() }
                 """
             )
-            try localFileSystem.writeFileContents(cSwift, string:
+            try localFileSystem.writeFileContents(
+                cSwift,
+                string:
                 "public func foo() {}"
             )
 
@@ -1013,7 +1019,16 @@ final class BuildPlanTests: XCTestCase {
             let contents: String = try fs.readFileContents(yaml)
             let swiftGetVersionFilePath = try XCTUnwrap(llbuild.swiftGetVersionFiles.first?.value)
             XCTAssertMatch(contents, .contains("""
-                    inputs: ["\(Pkg.appending(components: "Sources", "exe", "main.swift").escapedPathString)","\(swiftGetVersionFilePath.escapedPathString)","\(buildPath.appending(components: "Modules", "PkgLib.swiftmodule").escapedPathString)","\(buildPath.appending(components: "exe.build", "sources").escapedPathString)"]
+                inputs: ["\(
+                    Pkg.appending(components: "Sources", "exe", "main.swift")
+                        .escapedPathString
+            )","\(swiftGetVersionFilePath.escapedPathString)","\(
+                buildPath
+                    .appending(components: "Modules", "PkgLib.swiftmodule").escapedPathString
+            )","\(
+                buildPath
+                    .appending(components: "exe.build", "sources").escapedPathString
+            )"]
                 """))
         }
 
@@ -1042,8 +1057,14 @@ final class BuildPlanTests: XCTestCase {
             let buildPath = plan.productsBuildPath
             let swiftGetVersionFilePath = try XCTUnwrap(llbuild.swiftGetVersionFiles.first?.value)
             XCTAssertMatch(contents, .contains("""
-                    inputs: ["\(Pkg.appending(components: "Sources", "exe", "main.swift").escapedPathString)","\(swiftGetVersionFilePath.escapedPathString)","\(buildPath.appending(components: "exe.build", "sources").escapedPathString)"]
-                """))
+                inputs: ["\(
+                    Pkg.appending(components: "Sources", "exe", "main.swift")
+                        .escapedPathString
+            )","\(swiftGetVersionFilePath.escapedPathString)","\(
+                buildPath
+                    .appending(components: "exe.build", "sources").escapedPathString
+            )"]
+            """))
         }
     }
 
@@ -2008,12 +2029,12 @@ final class BuildPlanTests: XCTestCase {
                 "@\(buildPath.appending(components: "PkgPackageTests.product", "Objects.LinkFileList"))",
             ] + rpathsForBackdeployment + [
                 "-target", "\(hostTriple.tripleString(forPlatformVersion: version))",
-                 "-Xlinker", "-add_ast_path", "-Xlinker",
-                 buildPath.appending(components: "Modules", "Foo.swiftmodule").pathString,
-                 "-Xlinker", "-add_ast_path", "-Xlinker",
-                 buildPath.appending(components: "Modules", "FooTests.swiftmodule").pathString,
-                 "-g"
-             ]
+                "-Xlinker", "-add_ast_path", "-Xlinker",
+                buildPath.appending(components: "Modules", "Foo.swiftmodule").pathString,
+                "-Xlinker", "-add_ast_path", "-Xlinker",
+                buildPath.appending(components: "Modules", "FooTests.swiftmodule").pathString,
+                "-g",
+            ]
         )
         #elseif os(Windows)
         XCTAssertEqual(try result.buildProduct(for: "PkgPackageTests").linkArguments(), [
@@ -3999,7 +4020,7 @@ final class BuildPlanTests: XCTestCase {
                         .init(tool: .linker, kind: .unsafeFlags(["-Ilfoo", "-L", "lbar"])),
                     ]
                 ),
-                try TargetDescription(
+                TargetDescription(
                     name: "MySwiftTests", type: .test,
                     settings: [
                         .init(tool: .swift, kind: .interoperabilityMode(.Cxx)),
@@ -4252,7 +4273,20 @@ final class BuildPlanTests: XCTestCase {
             )
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-            XCTAssertMatch(exe, [.anySequence, "-DFOO", "-cxx-interoperability-mode=default", "-Xcc", "-std=c++17", "-g", "-Xcc", "-g", .end])
+            XCTAssertMatch(
+                exe,
+                [
+                    .anySequence,
+                    "-DFOO",
+                    "-cxx-interoperability-mode=default",
+                    "-Xcc",
+                    "-std=c++17",
+                    "-g",
+                    "-Xcc",
+                    "-g",
+                    .end,
+                ]
+            )
 
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
             XCTAssertMatch(
@@ -4752,10 +4786,22 @@ final class BuildPlanTests: XCTestCase {
         let suffix = ""
         #endif
         XCTAssertMatch(contents, .contains("""
-                inputs: ["\(PkgA.appending(components: "Sources", "swiftlib", "lib.swift").escapedPathString)","\(swiftGetVersionFilePath.escapedPathString)","\(buildPath.appending(components: "exe\(suffix)").escapedPathString)","\(buildPath.appending(components: "swiftlib.build", "sources").escapedPathString)"]
-                outputs: ["\(buildPath.appending(components: "swiftlib.build", "lib.swift.o").escapedPathString)","\(buildPath.escapedPathString)
-            """))
-    }
+            inputs: ["\(
+                PkgA.appending(components: "Sources", "swiftlib", "lib.swift")
+                    .escapedPathString
+        )","\(swiftGetVersionFilePath.escapedPathString)","\(
+            buildPath
+                .appending(components: "exe\(suffix)").escapedPathString
+        )","\(
+            buildPath
+                .appending(components: "swiftlib.build", "sources").escapedPathString
+        )"]
+            outputs: ["\(
+                buildPath.appending(components: "swiftlib.build", "lib.swift.o")
+                    .escapedPathString
+        )","\(buildPath.escapedPathString)
+        """))
+        }
 
     func testObjCHeader1() throws {
         let PkgA = AbsolutePath("/PkgA")
@@ -4836,12 +4882,13 @@ final class BuildPlanTests: XCTestCase {
         try llbuild.generateManifest(at: yaml)
         let contents: String = try fs.readFileContents(yaml)
         XCTAssertMatch(contents, .contains("""
-              "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
-                tool: clang
-                inputs: ["\(buildPath.appending(components: "Modules", "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
-                outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
-                description: "Compiling Bar main.m"
-            """))
+          "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
+            tool: clang
+            inputs: ["\(buildPath.appending(components: "Modules", "Foo.swiftmodule").escapedPathString)","\(PkgA
+            .appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+            outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
+            description: "Compiling Bar main.m"
+        """))
     }
 
     func testObjCHeader2() throws {
@@ -4945,12 +4992,13 @@ final class BuildPlanTests: XCTestCase {
         try llbuild.generateManifest(at: yaml)
         let contents: String = try fs.readFileContents(yaml)
         XCTAssertMatch(contents, .contains("""
-               "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
-                 tool: clang
-                 inputs: ["\(buildPath.appending(components: "Modules", "Foo.swiftmodule").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
-                 outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
-                 description: "Compiling Bar main.m"
-             """))
+          "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
+            tool: clang
+            inputs: ["\(buildPath.appending(components: "Modules", "Foo.swiftmodule").escapedPathString)","\(PkgA
+            .appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+            outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
+            description: "Compiling Bar main.m"
+        """))
     }
 
     func testObjCHeader3() throws {
@@ -5060,12 +5108,15 @@ final class BuildPlanTests: XCTestCase {
         try llbuild.generateManifest(at: yaml)
         let contents: String = try fs.readFileContents(yaml)
         XCTAssertMatch(contents, .contains("""
-               "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
-                 tool: clang
-                 inputs: ["\(buildPath.appending(components: "\(dynamicLibraryPrefix)Foo\(dynamicLibraryExtension)").escapedPathString)","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
-                 outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
-                 description: "Compiling Bar main.m"
-             """))
+          "\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)":
+            tool: clang
+            inputs: ["\(
+                buildPath.appending(components: "\(dynamicLibraryPrefix)Foo\(dynamicLibraryExtension)")
+                    .escapedPathString
+        )","\(PkgA.appending(components: "Sources", "Bar", "main.m").escapedPathString)"]
+            outputs: ["\(buildPath.appending(components: "Bar.build", "main.m.o").escapedPathString)"]
+            description: "Compiling Bar main.m"
+        """))
     }
 
     func testModulewrap() throws {
@@ -5117,21 +5168,39 @@ final class BuildPlanTests: XCTestCase {
         try llbuild.generateManifest(at: yaml)
         let contents: String = try fs.readFileContents(yaml)
         XCTAssertMatch(contents, .contains("""
-              "\(buildPath.appending(components: "exe.build", "exe.swiftmodule.o").escapedPathString)":
-                tool: shell
-                inputs: ["\(buildPath.appending(components: "exe.build", "exe.swiftmodule").escapedPathString)"]
-                outputs: ["\(buildPath.appending(components: "exe.build", "exe.swiftmodule.o").escapedPathString)"]
-                description: "Wrapping AST for exe for debugging"
-                args: ["\(result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.escapedPathString)","-modulewrap","\(buildPath.appending(components: "exe.build", "exe.swiftmodule").escapedPathString)","-o","\(buildPath.appending(components: "exe.build", "exe.swiftmodule.o").escapedPathString)","-target","x86_64-unknown-linux-gnu"]
-            """))
+          "\(buildPath.appending(components: "exe.build", "exe.swiftmodule.o").escapedPathString)":
+            tool: shell
+            inputs: ["\(buildPath.appending(components: "exe.build", "exe.swiftmodule").escapedPathString)"]
+            outputs: ["\(buildPath.appending(components: "exe.build", "exe.swiftmodule.o").escapedPathString)"]
+            description: "Wrapping AST for exe for debugging"
+            args: ["\(
+                result.plan.destinationBuildParameters.toolchain.swiftCompilerPath
+                    .escapedPathString
+        )","-modulewrap","\(buildPath.appending(
+            components: "exe.build",
+            "exe.swiftmodule"
+        ).escapedPathString)","-o","\(
+            buildPath.appending(components: "exe.build", "exe.swiftmodule.o")
+                .escapedPathString
+        )","-target","x86_64-unknown-linux-gnu"]
+        """))
         XCTAssertMatch(contents, .contains("""
-              "\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)":
-                tool: shell
-                inputs: ["\(buildPath.appending(components: "Modules", "lib.swiftmodule").escapedPathString)"]
-                outputs: ["\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)"]
-                description: "Wrapping AST for lib for debugging"
-                args: ["\(result.plan.destinationBuildParameters.toolchain.swiftCompilerPath.escapedPathString)","-modulewrap","\(buildPath.appending(components: "Modules", "lib.swiftmodule").escapedPathString)","-o","\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)","-target","x86_64-unknown-linux-gnu"]
-            """))
+          "\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)":
+            tool: shell
+            inputs: ["\(buildPath.appending(components: "Modules", "lib.swiftmodule").escapedPathString)"]
+            outputs: ["\(buildPath.appending(components: "lib.build", "lib.swiftmodule.o").escapedPathString)"]
+            description: "Wrapping AST for lib for debugging"
+            args: ["\(
+                result.plan.destinationBuildParameters.toolchain.swiftCompilerPath
+                    .escapedPathString
+        )","-modulewrap","\(buildPath.appending(
+            components: "Modules",
+            "lib.swiftmodule"
+        ).escapedPathString)","-o","\(
+            buildPath.appending(components: "lib.build", "lib.swiftmodule.o")
+                .escapedPathString
+        )","-target","x86_64-unknown-linux-gnu"]
+        """))
     }
 
     func testArchiving() throws {
@@ -5184,29 +5253,80 @@ final class BuildPlanTests: XCTestCase {
             XCTAssertMatch(contents, .contains("""
               "C.rary-debug.a":
                 tool: shell
-                inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString)","\(buildPath.appending(components: "rary.build", "rary.swiftmodule.o").escapedPathString)","\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
+                inputs: ["\(
+                    buildPath.appending(components: "rary.build", "rary.swift.o")
+                        .escapedPathString
+            )","\(
+                buildPath.appending(components: "rary.build", "rary.swiftmodule.o")
+                    .escapedPathString
+            )","\(
+                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
+                    .escapedPathString
+            )"]
                 outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
                 description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
-                args: ["\(result.plan.destinationBuildParameters.toolchain.librarianPath.escapedPathString)","/LIB","/OUT:\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
-            """))
+                args: ["\(
+                    result.plan.destinationBuildParameters.toolchain.librarianPath
+                        .escapedPathString
+            )","/LIB","/OUT:\(
+                buildPath.appending(components: "library.a")
+                    .escapedPathString
+            )","@\(
+                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
+                    .escapedPathString
+            )"]
+                """))
         } else if result.plan.destinationBuildParameters.triple.isDarwin() {
             XCTAssertMatch(contents, .contains("""
               "C.rary-debug.a":
                 tool: shell
-                inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString)","\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
+                inputs: ["\(
+                    buildPath.appending(components: "rary.build", "rary.swift.o")
+                        .escapedPathString
+            )","\(
+                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
+                    .escapedPathString
+            )"]
                 outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
                 description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
-                args: ["\(result.plan.destinationBuildParameters.toolchain.librarianPath.escapedPathString)","-static","-o","\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
-            """))
-        } else {    // assume `llvm-ar` is the librarian
+                args: ["\(
+                    result.plan.destinationBuildParameters.toolchain.librarianPath
+                        .escapedPathString
+            )","-static","-o","\(
+                buildPath.appending(components: "library.a")
+                    .escapedPathString
+            )","@\(
+                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
+                    .escapedPathString
+            )"]
+                """))
+        } else { // assume `llvm-ar` is the librarian
             XCTAssertMatch(contents, .contains("""
               "C.rary-debug.a":
                 tool: shell
-                inputs: ["\(buildPath.appending(components: "rary.build", "rary.swift.o").escapedPathString)","\(buildPath.appending(components: "rary.build", "rary.swiftmodule.o").escapedPathString)","\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
+                inputs: ["\(
+                    buildPath.appending(components: "rary.build", "rary.swift.o")
+                        .escapedPathString
+            )","\(
+                buildPath.appending(components: "rary.build", "rary.swiftmodule.o")
+                    .escapedPathString
+            )","\(
+                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
+                    .escapedPathString
+            )"]
                 outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
                 description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
-                args: ["\(result.plan.destinationBuildParameters.toolchain.librarianPath.escapedPathString)","crs","\(buildPath.appending(components: "library.a").escapedPathString)","@\(buildPath.appending(components: "rary.product", "Objects.LinkFileList").escapedPathString)"]
-            """))
+                args: ["\(
+                    result.plan.destinationBuildParameters.toolchain.librarianPath
+                        .escapedPathString
+            )","crs","\(
+                buildPath.appending(components: "library.a")
+                    .escapedPathString
+            )","@\(
+                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
+                    .escapedPathString
+            )"]
+                """))
         }
     }
 
@@ -5667,13 +5787,16 @@ final class BuildPlanTests: XCTestCase {
                             "variants": [
                                 {
                                     "path": "all-platforms/mytool",
-                                    "supportedTriples": ["\(artifactTriples.map{ $0.tripleString }.joined(separator: "\", \""))"]
+                                    "supportedTriples": ["\(
+                                        artifactTriples.map(\.tripleString)
+                                            .joined(separator: "\", \"")
+            )"]
                                 }
                             ]
                         }
                     }
                 }
-            """
+                                    """
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -5804,7 +5927,9 @@ final class BuildPlanTests: XCTestCase {
 
         let yamlContents: String = try fs.readFileContents(yaml)
         let inputs: SerializedJSON = """
-            inputs: ["\(AbsolutePath("/Pkg/Snippets/ASnippet.swift"))","\(swiftGetVersionFilePath)","\(AbsolutePath("/Pkg/.build/debug/Modules/Lib.swiftmodule"))"
+            inputs: ["\(AbsolutePath(
+                "/Pkg/Snippets/ASnippet.swift"
+            ))","\(swiftGetVersionFilePath)","\(AbsolutePath("/Pkg/.build/debug/Modules/Lib.swiftmodule"))"
         """
         XCTAssertMatch(yamlContents, .contains(inputs.underlying))
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1018,18 +1018,21 @@ final class BuildPlanTests: XCTestCase {
             try llbuild.generateManifest(at: yaml)
             let contents: String = try fs.readFileContents(yaml)
             let swiftGetVersionFilePath = try XCTUnwrap(llbuild.swiftGetVersionFiles.first?.value)
-            XCTAssertMatch(contents, .contains("""
+            XCTAssertMatch(
+                contents,
+                .contains("""
                 inputs: ["\(
                     Pkg.appending(components: "Sources", "exe", "main.swift")
                         .escapedPathString
-            )","\(swiftGetVersionFilePath.escapedPathString)","\(
+                )","\(swiftGetVersionFilePath.escapedPathString)","\(
                 buildPath
                     .appending(components: "Modules", "PkgLib.swiftmodule").escapedPathString
-            )","\(
+                )","\(
                 buildPath
                     .appending(components: "exe.build", "sources").escapedPathString
-            )"]
-                """))
+                )"]
+                """)
+            )
         }
 
         do {
@@ -5250,83 +5253,94 @@ final class BuildPlanTests: XCTestCase {
         let contents: String = try fs.readFileContents(yaml)
 
         if result.plan.destinationBuildParameters.triple.isWindows() {
-            XCTAssertMatch(contents, .contains("""
-              "C.rary-debug.a":
-                tool: shell
-                inputs: ["\(
-                    buildPath.appending(components: "rary.build", "rary.swift.o")
+            XCTAssertMatch(
+                contents,
+                .contains("""
+                "C.rary-debug.a":
+                    tool: shell
+                    inputs: ["\(
+                        buildPath.appending(components: "rary.build", "rary.swift.o")
+                            .escapedPathString
+                    )","\(
+                    buildPath.appending(components: "rary.build", "rary.swiftmodule.o")
                         .escapedPathString
-            )","\(
-                buildPath.appending(components: "rary.build", "rary.swiftmodule.o")
-                    .escapedPathString
-            )","\(
-                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
-                    .escapedPathString
-            )"]
-                outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
-                description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
-                args: ["\(
-                    result.plan.destinationBuildParameters.toolchain.librarianPath
+                    )","\(
+                    buildPath.appending(components: "rary.product", "Objects.LinkFileList")
                         .escapedPathString
-            )","/LIB","/OUT:\(
-                buildPath.appending(components: "library.a")
-                    .escapedPathString
-            )","@\(
-                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
-                    .escapedPathString
-            )"]
-                """))
+                    )"]
+                    outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
+                    description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
+                    args: ["\(
+                        result.plan.destinationBuildParameters.toolchain.librarianPath
+                            .escapedPathString
+                    )","/LIB","/OUT:\(
+                    buildPath.appending(components: "library.a")
+                        .escapedPathString
+                    )","@\(
+                    buildPath.appending(components: "rary.product", "Objects.LinkFileList")
+                        .escapedPathString
+                    )"]
+                """)
+            )
         } else if result.plan.destinationBuildParameters.triple.isDarwin() {
-            XCTAssertMatch(contents, .contains("""
-              "C.rary-debug.a":
-                tool: shell
-                inputs: ["\(
-                    buildPath.appending(components: "rary.build", "rary.swift.o")
+            XCTAssertMatch(
+                contents,
+                .contains(
+                """
+                "C.rary-debug.a":
+                    tool: shell
+                    inputs: ["\(
+                        buildPath.appending(components: "rary.build", "rary.swift.o")
+                            .escapedPathString
+                    )","\(
+                    buildPath.appending(components: "rary.product", "Objects.LinkFileList")
                         .escapedPathString
-            )","\(
-                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
-                    .escapedPathString
-            )"]
-                outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
-                description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
-                args: ["\(
-                    result.plan.destinationBuildParameters.toolchain.librarianPath
+                    )"]
+                    outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
+                    description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
+                    args: ["\(
+                        result.plan.destinationBuildParameters.toolchain.librarianPath
+                            .escapedPathString
+                    )","-static","-o","\(
+                    buildPath.appending(components: "library.a")
                         .escapedPathString
-            )","-static","-o","\(
-                buildPath.appending(components: "library.a")
-                    .escapedPathString
-            )","@\(
-                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
-                    .escapedPathString
-            )"]
-                """))
+                    )","@\(
+                    buildPath.appending(components: "rary.product", "Objects.LinkFileList")
+                        .escapedPathString
+                    )"]
+                """)
+            )
         } else { // assume `llvm-ar` is the librarian
-            XCTAssertMatch(contents, .contains("""
-              "C.rary-debug.a":
-                tool: shell
-                inputs: ["\(
-                    buildPath.appending(components: "rary.build", "rary.swift.o")
+            XCTAssertMatch(
+                contents,
+                .contains(
+                """
+                "C.rary-debug.a":
+                    tool: shell
+                    inputs: ["\(
+                        buildPath.appending(components: "rary.build", "rary.swift.o")
+                            .escapedPathString
+                    )","\(
+                    buildPath.appending(components: "rary.build", "rary.swiftmodule.o")
                         .escapedPathString
-            )","\(
-                buildPath.appending(components: "rary.build", "rary.swiftmodule.o")
-                    .escapedPathString
-            )","\(
-                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
-                    .escapedPathString
-            )"]
-                outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
-                description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
-                args: ["\(
-                    result.plan.destinationBuildParameters.toolchain.librarianPath
+                    )","\(
+                    buildPath.appending(components: "rary.product", "Objects.LinkFileList")
                         .escapedPathString
-            )","crs","\(
-                buildPath.appending(components: "library.a")
-                    .escapedPathString
-            )","@\(
-                buildPath.appending(components: "rary.product", "Objects.LinkFileList")
-                    .escapedPathString
-            )"]
-                """))
+                    )"]
+                    outputs: ["\(buildPath.appending(components: "library.a").escapedPathString)"]
+                    description: "Archiving \(buildPath.appending(components: "library.a").escapedPathString)"
+                    args: ["\(
+                        result.plan.destinationBuildParameters.toolchain.librarianPath
+                            .escapedPathString
+                    )","crs","\(
+                    buildPath.appending(components: "library.a")
+                        .escapedPathString
+                    )","@\(
+                    buildPath.appending(components: "rary.product", "Objects.LinkFileList")
+                        .escapedPathString
+                    )"]
+                """)
+            )
         }
     }
 
@@ -5789,14 +5803,13 @@ final class BuildPlanTests: XCTestCase {
                                     "path": "all-platforms/mytool",
                                     "supportedTriples": ["\(
                                         artifactTriples.map(\.tripleString)
-                                            .joined(separator: "\", \"")
-            )"]
+                                            .joined(separator: "\", \""))"]
                                 }
                             ]
                         }
                     }
                 }
-                                    """
+                """
         )
 
         let observability = ObservabilitySystem.makeForTesting()


### PR DESCRIPTION
Since we don't run this script on CI right now, we have to fix regressions with manual runs of this script and separate PRs created for the fixes in the meantime.