### PR TITLE
[5.10] Enable `-user-module-version` for 5.10

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -621,7 +621,12 @@ public final class SwiftTargetBuildDescription {
         }
 
         // Pass `-user-module-version` for versioned packages that aren't pre-releases.
-        if let version = package.manifest.version, version.prereleaseIdentifiers.isEmpty, version.buildMetadataIdentifiers.isEmpty, toolsVersion >= .vNext {
+        if
+          let version = package.manifest.version, 
+          version.prereleaseIdentifiers.isEmpty &&
+          version.buildMetadataIdentifiers.isEmpty &&
+          toolsVersion >= .v5_10
+        {
             args += ["-user-module-version", version.description]
         }
 


### PR DESCRIPTION
Following up on https://github.com/apple/swift-package-manager/pull/6795#issuecomment-1895830600, cherry-pick of https://github.com/apple/swift-package-manager/pull/7263.

* **Explanation**:  `#if canImport(LibFoo, _version: "1.2.3")` is not currently supported by SwiftPM, as this feature was gated on `.vNext`, even though it landed before SwiftPM 5.10 branched off.
* **Scope**: Isolated to llbuild integration and packages that use `swift-tools-version: 5.10`, have a valid semantic version with no prerelease or build metadata identifiers.
* **Risk**: Low. It's a source-compatible change that has been previously exposed to tests in SwiftPM - just passes user-module-version through.
* **Testing**: Has a corresponding test in both `release/5.10` and `main` already. 
* **Issue**: rdar://121124842
* **Reviewer**:  @neonichu on https://github.com/apple/swift-package-manager/pull/7263
