### PR TITLE
Replace uses of `package` with `@_spi(SwiftPMInternal)`

### DIFF
--- a/Sources/Basics/Collections/IdentifiableSet.swift
+++ b/Sources/Basics/Collections/IdentifiableSet.swift
@@ -67,7 +67,7 @@ public struct IdentifiableSet<Element: Identifiable>: Collection {
     }
 
     public func intersection(_ otherSequence: some Sequence<Element>) -> Self {
-        var keysToRemove = Set(self.storage.keys).subtracting(otherSequence.map(\.id))
+        let keysToRemove = Set(self.storage.keys).subtracting(otherSequence.map(\.id))
         var result = Self()
         for key in keysToRemove {
             result.storage.removeValue(forKey: key)

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -225,7 +225,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// source files as well as directories to which any changes should cause us to reevaluate the build plan.
     public let prebuildCommandResults: [ResolvedTarget.ID: [PrebuildCommandResult]]
 
-    package private(set) var derivedTestTargetsMap: [ResolvedProduct.ID: [ResolvedTarget]] = [:]
+    @_spi(SwiftPMInternal)
+    public private(set) var derivedTestTargetsMap: [ResolvedProduct.ID: [ResolvedTarget]] = [:]
 
     /// Cache for pkgConfig flags.
     private var pkgConfigCache = [SystemLibraryTarget: (cFlags: [String], libs: [String])]()

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -180,7 +180,7 @@ public struct PackageGraph {
     }
 
     /// Computes a map from each executable target in any of the root packages to the corresponding test targets.
-    package func computeTestTargetsForExecutableTargets() throws -> [ResolvedTarget.ID: [ResolvedTarget]] {
+    func computeTestTargetsForExecutableTargets() throws -> [ResolvedTarget.ID: [ResolvedTarget]] {
         var result = [ResolvedTarget.ID: [ResolvedTarget]]()
 
         let rootTargets = IdentifiableSet(rootPackages.flatMap { $0.targets })

--- a/Sources/SPMTestSupport/MockBuildTestHelper.swift
+++ b/Sources/SPMTestSupport/MockBuildTestHelper.swift
@@ -11,7 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+
+@_spi(SwiftPMInternal)
 import Build
+
 import PackageModel
 import SPMBuildCore
 import TSCUtility

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import PackageGraph
+@testable import PackageGraph
 import PackageLoading
 import PackageModel
 @testable import SPMBuildCore


### PR DESCRIPTION
There are certain build configurations that currently fail due to the use of `package`. We can use `@_spi(SwiftPMInternal)` in the meantime.
