### PR TITLE
Some C++ packages fail to build on Apple platforms

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -243,10 +243,10 @@ public final class ClangTargetBuildDescription {
         // Swift is able to use modules on non-Darwin platforms because it injects its own module maps
         // via vfs. However, nothing does that for C based compilation, and so non-Darwin platforms can't
         // support clang modules.
-        // Note that if modules get enabled for other platforms later, we'll need to verify that
-        // https://github.com/llvm/llvm-project/issues/55980 (crash on C++17 and later) is fixed, or don't
-        // enable modules in the affected modes.
-        let enableModules = triple.isDarwin()
+        // Note that if modules get enabled for other platforms later, they can't be used with C++ until
+        // https://github.com/llvm/llvm-project/issues/55980 (crash on C++17 and later) is fixed.
+        // clang modules aren't fully supported in C++ mode in the current Darwin SDKs.
+        let enableModules = triple.isDarwin() && !isCXX
         if enableModules {
             args += ["-fmodules", "-fmodule-name=" + target.c99name]
         }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2889,14 +2889,14 @@ final class BuildPlanTests: XCTestCase {
         var expectedLibBasicArgs = triple.isDarwin() ? ["-fobjc-arc"] : []
         expectedLibBasicArgs += ["-target", defaultTargetTriple]
         expectedLibBasicArgs += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks"]
-        let shouldHaveModules = triple.isDarwin()
-        if shouldHaveModules {
-            expectedLibBasicArgs += ["-fmodules", "-fmodule-name=lib"]
-        }
+//        let shouldHaveModules = false // FIXME(5473) - support modules on non-Apple platforms, and also for C++ on any platform
+//        if shouldHaveModules {
+//            expectedLibBasicArgs += ["-fmodules", "-fmodule-name=lib"]
+//        }
         expectedLibBasicArgs += ["-I", Pkg.appending(components: "Sources", "lib", "include").pathString]
-        if shouldHaveModules {
-            expectedLibBasicArgs += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
-        }
+//        if shouldHaveModules {
+//            expectedLibBasicArgs += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
+//        }
         expectedLibBasicArgs += [
             triple.isWindows() ? "-gdwarf" : "-g",
             triple.isWindows() ? "-gdwarf" : "-g",


### PR DESCRIPTION
Disable clang modules for C++ compilation on Apple platforms

### Motivation:

I didn't realize that there were some circumstances where passing `-fmodules` would enable clang modules for C++ on Apple platforms.

### Modifications:

Go back to not passing `-fmodules` for Apple platforms.

### Result:

C++ packages should be able to build properly again.