### PR TITLE
Fix overlapping plugins/products build database access

### DIFF
--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import SPMTestSupport
+import XCTest
+
+final class PluginsBuildPlanTests: XCTestCase {
+    func testBuildToolsDatabasePath() throws {
+        try fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
+            let (stdout, stderr) = try executeSwiftBuild(fixturePath)
+            XCTAssertMatch(stdout, .contains("Build complete!"))
+            XCTAssertTrue(localFileSystem.exists(fixturePath.appending(RelativePath(".build/plugins/tools/build.db"))))
+        }
+    }
+}


### PR DESCRIPTION
This regression was introduced in https://github.com/apple/swift-package-manager/pull/7164/files#diff-7d5950f89d75bc14a591deb8270ebd32308c18248892c7abcb9d0ee3c6b14fd5L201.

We can restore the previous behavior in a hacky way by making sure that build parameters passed to plugin builds and invocations have the database path set in the same way as previously. This somewhat defeats the point of tools/products build parameters isolation, but we're able to isolate it only to a few lines in a single function.

I've added an explicit test case for this in new `PluginsBuildPlanTests.swift` file, so we can be sure it doesn't regress again.

Resolves rdar://120560817
