### PR TITLE
command plugin Xcode extension name fixed

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -550,7 +550,7 @@ public final class InitPackage {
                 #if canImport(XcodeProjectPlugin)
                 import XcodeProjectPlugin
 
-                extension MyCommandPlugin: XcodeCommandPlugin {
+                extension \(typeName): XcodeCommandPlugin {
                     // Entry point for command plugins applied to Xcode projects.
                     func performCommand(context: XcodePluginContext, arguments: [String]) throws {
                         print("Hello, World!")


### PR DESCRIPTION
template resulting from `swift package init --type command-plugin` did not auto generate the extension name and used boilerplate instead. 

### Motivation:

Seems like a small oversight, not an intentional difference. 

### Modifications:

InitPackage.swift line 553 goes from `extension MyCommandPlugin: XcodeCommandPlugin {` to `extension \(typeName): XcodeCommandPlugin {`

### Result:

Template generates correctly.
