### PR TITLE
Added missing `plugin` verb

### DIFF
--- a/Documentation/Plugins.md
+++ b/Documentation/Plugins.md
@@ -56,7 +56,7 @@ This will cause SwiftPM to call the plugin, passing it a simplified version of t
 Unlike build tool plugins, which are invoked as needed when SwiftPM constructs the build task graph, command plugins are only invoked directly by the user.  This is done through the `swift` `package` command line interface:
 
 ```shell
-❯ swift package my-plugin --my-flag my-parameter
+❯ swift package plugin my-plugin --my-flag my-parameter
 ```
 
 Any command line arguments that appear after the invocation verb defined by the plugin are passed unmodified to the plugin — in this case, `--my-flag` and `my-parameter`.  This is commonly used in order to narrow down the application of a command to one or more targets, through the convention of one or more occurrences of a `--target` option with the name of the target(s).


### PR DESCRIPTION
Added missing `plugin` verb in SwiftPM Plugins Docs example.

### Motivation:

Example showing how to run a plugin from the command line doesn't actually work. 
```
swift package MyCommandPlugin
error: Unknown subcommand or plugin name ‘MyCommandPlugin’

```
### Modifications:

Added the word 'plugin' to the example.

### Result:

Example now shows syntactically correct command.