### PR TITLE
Benchmarks: add `PackageGraphBenchmarks` target

### DIFF
--- a/Benchmarks/Benchmarks/PackageGraphBenchmarks/PackageGraphBenchmarks.swift
+++ b/Benchmarks/Benchmarks/PackageGraphBenchmarks/PackageGraphBenchmarks.swift
@@ -1,0 +1,22 @@
+import Basics
+import Benchmark
+import PackageModel
+import Workspace
+
+let benchmarks = {
+    Benchmark(
+        "Package graph loading",
+        configuration: .init(
+            metrics: BenchmarkMetric.all,
+            maxDuration: .seconds(10)
+        )
+    ) { benchmark in
+        let path = try AbsolutePath(validating: #file).parentDirectory.parentDirectory.parentDirectory
+        let workspace = try Workspace(fileSystem: localFileSystem, location: .init(forRootPackage: path, fileSystem: localFileSystem))
+        let system = ObservabilitySystem { _, _ in }
+
+        for _ in benchmark.scaledIterations {
+            try workspace.loadPackageGraph(rootPath: path, observabilityScope: system.topScope)
+        }
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 5.7
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftPMBenchmarks",
+    platforms: [
+        .macOS("14"),
+    ],
+    dependencies: [
+        .package(path: "../"),
+        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.13.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "PackageGraphBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "SwiftPMDataModel", package: "SwiftPM"),
+            ],
+            path: "Benchmarks/PackageGraphBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark"),
+            ]
+        ),
+    ]
+)


### PR DESCRIPTION
This adds a dependency on the [`package-benchmark`](https://github.com/ordo-one/package-benchmark) library, isolated to the new `Benchmarks` folder. Thus it doesn't touch CMake or self-hosted builds, and one can only pull the library if they run `swift package benchmark` in the `Benchmarks` directory.

A single benchmark is added that loads SwiftPM's `Package.swift` and builds a package graph for it. For posterity, here's the output we get from it:

```
╒══════════════════════════════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╤═════════╕
│ Metric                           │      p0 │     p25 │     p50 │     p75 │     p90 │     p99 │    p100 │ Samples │
╞══════════════════════════════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╪═════════╡
│ (Alloc + Retain) - Release Δ     │    2703 │    2703 │    2703 │    2703 │    2703 │    2703 │    2703 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Bytes (read physical)            │       0 │       0 │       0 │       0 │       0 │       0 │       0 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Bytes (write physical)           │    8192 │    8192 │    8192 │    8192 │    8192 │    8192 │    8192 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Context switches                 │     114 │     119 │     121 │     123 │     124 │     127 │     127 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Malloc (large)                   │       0 │       0 │       0 │       0 │       0 │       0 │       0 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Malloc (small)                   │    6032 │    6059 │    6123 │    6443 │    7627 │    9511 │    9511 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Malloc (total)                   │    6032 │    6059 │    6123 │    6443 │    7627 │    9511 │    9511 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Malloc / free Δ (K)              │       0 │      81 │     131 │     295 │    1278 │    1572 │    1572 │      22 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (allocated resident) (M)  │      19 │      23 │      24 │      25 │      25 │      25 │      25 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (resident peak) (M)       │      40 │      42 │      42 │      43 │      43 │      44 │      44 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Memory (virtual peak) (G)        │     418 │     418 │     418 │     418 │     418 │     418 │     418 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Object allocs                    │    4434 │    4451 │    4459 │    4479 │    4499 │    4506 │    4506 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Releases (K)                     │      22 │      22 │      22 │      22 │      22 │      22 │      22 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Retains (K)                      │      15 │      15 │      15 │      15 │      15 │      15 │      15 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Syscalls (total)                 │    1208 │    1227 │    1234 │    1244 │    1256 │    1258 │    1258 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Threads (peak)                   │       8 │       9 │       9 │       9 │       9 │       9 │       9 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Threads (running)                │       2 │       4 │       4 │       4 │       4 │       4 │       4 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Throughput (# / s)               │       3 │       3 │       2 │       2 │       2 │       2 │       2 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (system CPU) (ms)           │       5 │       8 │       9 │      12 │      13 │      17 │      17 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (total CPU) (ms)            │      10 │      13 │      14 │      16 │      18 │      21 │      21 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (user CPU) (μs)             │    4605 │    4870 │    4886 │    5029 │    5107 │    5201 │    5201 │      25 │
├──────────────────────────────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Time (wall clock) (ms)           │     394 │     398 │     402 │     408 │     412 │     427 │     427 │      25 │
╘══════════════════════════════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╧═════════╛
```
