### PR TITLE
Filter `codesign` messages

### DIFF
--- a/Fixtures/Miscellaneous/DoNotFilterLinkerDiagnostics/Package.swift
+++ b/Fixtures/Miscellaneous/DoNotFilterLinkerDiagnostics/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.11
+
+import PackageDescription
+
+let package = Package(
+    name: "DoNotFilterLinkerDiagnostics",
+    targets: [
+        .executableTarget(
+            name: "DoNotFilterLinkerDiagnostics",
+            linkerSettings: [
+                .linkedLibrary("z"),
+                .unsafeFlags(["-lz"]),
+                // should produce: ld: warning: ignoring duplicate libraries: '-lz'
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/DoNotFilterLinkerDiagnostics/Sources/DoNotFilterLinkerDiagnostics/main.swift
+++ b/Fixtures/Miscellaneous/DoNotFilterLinkerDiagnostics/Sources/DoNotFilterLinkerDiagnostics/main.swift
@@ -1,0 +1,4 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+print("Hello, world!")

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -826,8 +826,10 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         process: ProcessHandle,
         result: CommandExtendedResult
     ) {
+        // FIXME: This should really happen at the command-level and is just a stopgap measure.
+        let shouldFilterOutput = !self.logLevel.isVerbose && command.verboseDescription.hasPrefix("codesign ") && result.result != .failed
         queue.async {
-            if let buffer = self.nonSwiftMessageBuffers[command.name] {
+            if let buffer = self.nonSwiftMessageBuffers[command.name], !shouldFilterOutput {
                 self.progressAnimation.clear()
                 self.outputStream.send(buffer)
                 self.outputStream.flush()

--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SPMTestSupport
+import XCTest
+
+import var TSCBasic.localFileSystem
+
+final class BuildSystemDelegateTests: XCTestCase {
+    func testDoNotFilterLinkerDiagnostics() throws {
+        try fixture(name: "Miscellaneous/DoNotFilterLinkerDiagnostics") { fixturePath in
+            #if !os(macOS)
+            // These linker diagnostics are only produced on macOS.
+            try XCTSkipIf(true, "test is only supported on macOS")
+            #endif
+            let (fullLog, _) = try executeSwiftBuild(fixturePath)
+            XCTAssertTrue(fullLog.contains("ld: warning: ignoring duplicate libraries: '-lz'"), "log didn't contain expected linker diagnostics")
+        }
+    }
+
+    func testFilterNonFatalCodesignMessages() throws {
+        // Note: we can re-use the `TestableExe` fixture here since we just need an executable.
+        try fixture(name: "Miscellaneous/TestableExe") { fixturePath in
+            _ = try executeSwiftBuild(fixturePath)
+            let execPath = fixturePath.appending(components: ".build", "debug", "TestableExe1")
+            XCTAssertTrue(localFileSystem.exists(execPath), "executable not found at '\(execPath)'")
+            try localFileSystem.removeFileTree(execPath)
+            let (fullLog, _) = try executeSwiftBuild(fixturePath)
+            XCTAssertFalse(fullLog.contains("replacing existing signature"), "log contained non-fatal codesigning messages")
+        }
+    }
+}


### PR DESCRIPTION
Right now we end up with this output on relink:

```
/Users/neonacho/Projects/public/swift-package-manager/.build/arm64-apple-macosx/debug/swift-bootstrap: replacing existing signature
```

This change specifically filters any output from `codesign` commands which haven't failed and we aren't in verbose mode.

This should eventually be possible at the command level, but for the time being this allows us to avoid shipping SwiftPM with this messy output.

rdar://118937939
