### PR TITLE
Revert of "Lock scratch directory during tool execution"

### DIFF
--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -196,8 +196,8 @@ extension FileSystem {
     }
 
     /// Execute the given block while holding the lock.
-    public func withLock<T>(on path: AbsolutePath, type: FileLock.LockType, blocking: Bool = true, _ body: () throws -> T) throws -> T {
-        try self.withLock(on: path.underlying, type: type, blocking: blocking, body)
+    public func withLock<T>(on path: AbsolutePath, type: FileLock.LockType, _ body: () throws -> T) throws -> T {
+        try self.withLock(on: path.underlying, type: type, body)
     }
 
     /// Returns any known item replacement directories for a given path. These may be used by platform-specific


### PR DESCRIPTION
We're seeing hangs in self-hosted jobs since merging this and I can't repro locally, so let's try this speculative revert to see whether it resolves the issues.

Reverts apple/swift-package-manager#7269