### PR TITLE
Revert "Skip tests which need `-suppress-warnings` to work if it doesn't work"

### DIFF
--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -111,29 +111,6 @@ extension UserToolchain {
         }
     }
 
-    public func supportsSuppressWarnings() -> Bool {
-        do {
-            try testWithTemporaryDirectory { tmpPath in
-                let inputPath = tmpPath.appending("best.swift")
-                try localFileSystem.writeFileContents(inputPath, string: "let foo: String? = \"bar\"\nprint(foo)\n")
-                let outputPath = tmpPath.appending("foo")
-                let serializedDiagnosticsPath = tmpPath.appending("out.dia")
-                let toolchainPath = self.swiftCompilerPath.parentDirectory.parentDirectory
-                try Process.checkNonZeroExit(arguments: ["/usr/bin/xcrun", "--toolchain", toolchainPath.pathString, "swiftc", inputPath.pathString, "-Xfrontend", "-serialize-diagnostics-path", "-Xfrontend", serializedDiagnosticsPath.pathString, "-o", outputPath.pathString, "-suppress-warnings"])
-
-                let diaFileContents = try localFileSystem.readFileContents(serializedDiagnosticsPath)
-                let diagnosticsSet = try SerializedDiagnostics(bytes: diaFileContents)
-
-                if diagnosticsSet.diagnostics.contains(where: { $0.text.contains("warning") }) {
-                    throw StringError("does not support suppressing warnings")
-                }
-            }
-            return true
-        } catch {
-            return false
-        }
-    }
-
     // This builds a trivial program with `-warnings-as-errors`, if it fails, the compiler in use generates warnings by default and is not suitable for testing warnings as errors behaviors.
     public func supportsWarningsAsErrors() -> Bool {
         do {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -630,8 +630,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testNoWarningFromRemoteDependencies() throws {
-        try XCTSkipIf(!UserToolchain.default.supportsSuppressWarnings(), "skipping because test environment doesn't support suppressing warnings")
-
         try fixture(name: "Miscellaneous/DependenciesWarnings") { path in
             // prepare the deps as git sources
             let dependency1Path = path.appending("dep1")
@@ -649,8 +647,6 @@ class MiscellaneousTestCase: XCTestCase {
     }
 
     func testNoWarningFromRemoteDependenciesWithWarningsAsErrors() throws {
-        try XCTSkipIf(!UserToolchain.default.supportsSuppressWarnings(), "skipping because test environment doesn't support suppressing warnings")
-
         try fixture(name: "Miscellaneous/DependenciesWarnings2") { path in
             // prepare the deps as git sources
             let dependency1Path = path.appending("dep1")


### PR DESCRIPTION
This reverts commit 6ba5b96ab587c204bd7a799ccaf2ae24be208853 since the underlying issue has since been fixed.