### PR TITLE
[5.10] Filter `codesign` messages

### DIFF
--- a/Fixtures/Miscellaneous/DoNotFilterLinkerDiagnostics/Package.swift
+++ b/Fixtures/Miscellaneous/DoNotFilterLinkerDiagnostics/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "DoNotFilterLinkerDiagnostics",
+    targets: [
+        .executableTarget(
+            name: "DoNotFilterLinkerDiagnostics",
+            linkerSettings: [
+                .linkedLibrary("z"),
+                .unsafeFlags(["-lz"]),
+                // should produce: ld: warning: ignoring duplicate libraries: '-lz'
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/DoNotFilterLinkerDiagnostics/Sources/DoNotFilterLinkerDiagnostics/main.swift
+++ b/Fixtures/Miscellaneous/DoNotFilterLinkerDiagnostics/Sources/DoNotFilterLinkerDiagnostics/main.swift
@@ -1,0 +1,4 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+print("Hello, world!")

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -787,8 +787,10 @@ final class BuildOperationBuildSystemDelegateHandler: LLBuildBuildSystemDelegate
         process: ProcessHandle,
         result: CommandExtendedResult
     ) {
+        // FIXME: This should really happen at the command-level and is just a stopgap measure.
+        let shouldFilterOutput = !self.logLevel.isVerbose && command.verboseDescription.hasPrefix("codesign ") && result.result != .failed
         queue.async {
-            if let buffer = self.nonSwiftMessageBuffers[command.name] {
+            if let buffer = self.nonSwiftMessageBuffers[command.name], !shouldFilterOutput {
                 self.progressAnimation.clear()
                 self.outputStream.send(buffer)
                 self.outputStream.flush()

--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SPMTestSupport
+import XCTest
+
+import var TSCBasic.localFileSystem
+
+final class BuildSystemDelegateTests: XCTestCase {
+    func testDoNotFilterLinkerDiagnostics() throws {
+        try fixture(name: "Miscellaneous/DoNotFilterLinkerDiagnostics") { fixturePath in
+            #if !os(macOS)
+            // These linker diagnostics are only produced on macOS.
+            try XCTSkipIf(true, "test is only supported on macOS")
+            #endif
+            let (fullLog, _) = try executeSwiftBuild(fixturePath)
+            XCTAssertTrue(fullLog.contains("ld: warning: ignoring duplicate libraries: '-lz'"), "log didn't contain expected linker diagnostics")
+        }
+    }
+
+    func testFilterNonFatalCodesignMessages() throws {
+        // Note: we can re-use the `TestableExe` fixture here since we just need an executable.
+        try fixture(name: "Miscellaneous/TestableExe") { fixturePath in
+            _ = try executeSwiftBuild(fixturePath)
+            let execPath = fixturePath.appending(components: ".build", "debug", "TestableExe1")
+            XCTAssertTrue(localFileSystem.exists(execPath), "executable not found at '\(execPath)'")
+            try localFileSystem.removeFileTree(execPath)
+            let (fullLog, _) = try executeSwiftBuild(fixturePath)
+            XCTAssertFalse(fullLog.contains("replacing existing signature"), "log contained non-fatal codesigning messages")
+        }
+    }
+}


### PR DESCRIPTION
* **Explanation**: 

SwiftPM is code signing any binaries it produces on macOS in 5.10. Whenever a binary get relinked and resigned during incremental builds, it verbatim emits informational diagnostics to the log, which should only happen in verbose mode. Especially in projects which multiple binaries, this can make the log difficult to follow and may lead to confusion of users.

* **Scope**: Any users on macOS will see this issue.
* **Risk**: In theory, this change could lead to other diagnostics not being emitted, but the change is scoped to only code signing tasks, so the risk for this is very low.
* **Testing**: Some new tests for SwiftPM's logging were added as part of this.
* **Reviewer**: @MaxDesiatov
* **Main branch PR**: https://github.com/apple/swift-package-manager/pull/7285