### PR TITLE
Fix swiftc selection for the case no swiftc found in Swift SDK

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -128,6 +128,8 @@ public final class UserToolchain: Toolchain {
                 continue
             }
             toolPath = path
+            // Take the first match.
+            break
         }
         guard let toolPath else {
             throw InvalidToolchainDiagnostic("could not find CLI tool `\(name)` at any of these directories: \(binDirectories)")


### PR DESCRIPTION
Fix `PATH` executable selection in `UserToolchain`

### Motivation:

When `swiftc` is not in the toolchain bin directory of Swift SDK, system swiftc in PATH should be used. But the current implementation of `UserToolchain` always picks the last found entry in the PATH instead of the first one. This behavior was introduced by 22c249317fa5171f17a0e41efe81e69e054a3d75

The causes actual issues when:
1. More than two `swiftc` are in `PATH`
2. The invoked `swift-build` is placed from outside of toolchain bin directory

Then it uses the last found `swiftc` in `PATH` even though we expect the first one.

### Modifications:

Fixed the order of `PATH` selection to prefer the first entry.

### Result:

The first found `swiftc` is used as well as shell PATH selection.