### PR TITLE
 Inherit host Swift SDK's toolset paths to fallback to host tools

### DIFF
--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -17,6 +17,7 @@ import class Foundation.NSLock
 import class Foundation.ProcessInfo
 import PackageGraph
 import PackageLoading
+@_spi(SwiftPMInternal)
 import PackageModel
 import SPMBuildCore
 import Workspace

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -599,6 +599,7 @@ public struct SwiftSDK: Equatable {
     }
 
     /// Computes the target Swift SDK for the given options.
+    @_spi(SwiftPMInternal)
     public static func deriveTargetSwiftSDK(
       hostSwiftSDK: SwiftSDK,
       hostTriple: Triple,

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+@_spi(SwiftPMInternal)
 @testable import PackageModel
 import SPMTestSupport
 import XCTest


### PR DESCRIPTION
Fallback to host SDK tools if target SDK doesn't have tools.

### Motivation:

Currently, Swift SDK fallbacks to system `PATH` search path for tools that are not found in the SDK. Usually, host compiler tool is capable to cross compile but just lacks some of artifacts like platform libraries.
In that case, we don't need to have a separate compiler tools in target-specific Swift SDK, so we can share the host compiler tools as long as the host Swift and target Swift are the same version.

### Modifications:

This patch makes Swift SDK fallback to host Swift SDK tools if the target Swift SDK doesn't have such tools. 

### Result:

This unlocks eliminating compiler tools from target-specific Swift SDKs, and will result in a smaller SDK size. Also makes it easier to build host platform independent Swift SDK.
