### PR TITLE
Clean up product dependency API

### DIFF
--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -1263,18 +1263,6 @@ extension Target.Dependency {
         return .productItem(name: name, package: package, moduleAliases: nil, condition: nil)
     }
 
-    /// Creates a dependency on a product from a dependent package.
-    ///
-    /// - Parameters:
-    ///   - name: The name of the product.
-    ///   - moduleAliases: The module aliases for targets in the product.
-    ///   - package: The name of the package.
-    /// - Returns: A `Target.Dependency` instance.
-    @available(_PackageDescription, introduced: 5.7)
-    public static func product(name: String, package: String? = nil, moduleAliases: [String: String]? = nil) -> Target.Dependency {
-        return .productItem(name: name, package: package, moduleAliases: moduleAliases, condition: nil)
-    }
-
     /// Creates a dependency that resolves to either a target or a product with the specified name.
     ///
     /// - Parameter name: The name of the dependency, either a target or a product.

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -191,7 +191,7 @@ public struct ManifestValidator {
                 case .product(_, let packageName, _, _):
                     if self.manifest.packageDependency(referencedBy: targetDependency) == nil {
                         diagnostics.append(.unknownTargetPackageDependency(
-                            packageName: packageName ?? "unknown package name",
+                            packageName: packageName,
                             targetName: target.name,
                             validPackages: self.manifest.dependencies
                         ))
@@ -262,8 +262,14 @@ extension Basics.Diagnostic {
         .error("unknown dependency '\(dependency)' in target '\(targetName)'; valid dependencies are: \(validDependencies.map{ "\($0.descriptionForValidation)" }.joined(separator: ", "))")
     }
 
-    static func unknownTargetPackageDependency(packageName: String, targetName: String, validPackages: [PackageDependency]) -> Self {
-        .error("unknown package '\(packageName)' in dependencies of target '\(targetName)'; valid packages are: \(validPackages.map{ "\($0.descriptionForValidation)" }.joined(separator: ", "))")
+    static func unknownTargetPackageDependency(packageName: String?, targetName: String, validPackages: [PackageDependency]) -> Self {
+        let messagePrefix: String
+        if let packageName {
+            messagePrefix = "unknown package '\(packageName)'"
+        } else {
+            messagePrefix = "undeclared package"
+        }
+        return .error("\(messagePrefix) in dependencies of target '\(targetName)'; valid packages are: \(validPackages.map{ "\($0.descriptionForValidation)" }.joined(separator: ", "))")
     }
 
     static func invalidBinaryLocation(targetName: String) -> Self {


### PR DESCRIPTION
As part of https://github.com/apple/swift-evolution/blob/main/proposals/0339-module-aliasing-for-disambiguation.md, a new API with an optional `package` parameter was accidentally added. We can safely remove this API since #4203 added validation that prohibited the use of product declarations without a package anyway. As part of this, I also cleaned up that diagnostic since "unknown package 'unknown package name'" looks quite ugly.

rdar://114303935
fixes #7158