### PR TITLE
Build: pass through `Embedded` flag to link jobs

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -877,7 +877,11 @@ public final class PackageBuilder {
         }
 
         // Create the build setting assignment table for this target.
-        let buildSettings = try self.buildSettings(for: manifestTarget, targetRoot: potentialModule.path, cxxLanguageStandard: self.manifest.cxxLanguageStandard)
+        let buildSettings = try self.buildSettings(
+            for: manifestTarget,
+            targetRoot: potentialModule.path,
+            cxxLanguageStandard: self.manifest.cxxLanguageStandard
+        )
 
         // Compute the path to public headers directory.
         let publicHeaderComponent = manifestTarget.publicHeadersPath ?? ClangTarget.defaultPublicHeadersComponent
@@ -969,6 +973,7 @@ public final class PackageBuilder {
                 packageAccess: potentialModule.packageAccess,
                 swiftVersion: try self.swiftVersion(),
                 buildSettings: buildSettings,
+                buildSettingsDescription: manifestTarget.settings,
                 usesUnsafeFlags: manifestTarget.usesUnsafeFlags
             )
         } else {
@@ -1011,14 +1016,18 @@ public final class PackageBuilder {
                 ignored: ignored,
                 dependencies: dependencies,
                 buildSettings: buildSettings,
+                buildSettingsDescription: manifestTarget.settings,
                 usesUnsafeFlags: manifestTarget.usesUnsafeFlags
             )
         }
     }
 
     /// Creates build setting assignment table for the given target.
-    func buildSettings(for target: TargetDescription?, targetRoot: AbsolutePath, cxxLanguageStandard: String? = nil) throws -> BuildSettings
-        .AssignmentTable
+    func buildSettings(
+        for target: TargetDescription?,
+        targetRoot: AbsolutePath,
+        cxxLanguageStandard: String? = nil
+    ) throws -> BuildSettings.AssignmentTable
     {
         var table = BuildSettings.AssignmentTable()
         guard let target else { return table }
@@ -1653,23 +1662,21 @@ extension PackageBuilder {
                 let sources = Sources(paths: [sourceFile], root: sourceFile.parentDirectory)
                 let buildSettings: BuildSettings.AssignmentTable
 
-                do {
-                    let targetDescription = try TargetDescription(
-                        name: name,
-                        dependencies: dependencies
-                            .map {
-                                TargetDescription.Dependency.target(name: $0.name)
-                            },
-                        path: sourceFile.parentDirectory.pathString,
-                        sources: [sourceFile.pathString],
-                        type: .executable,
-                        packageAccess: false
-                    )
-                    buildSettings = try self.buildSettings(
-                        for: targetDescription,
-                        targetRoot: sourceFile.parentDirectory
-                    )
-                }
+                let targetDescription = try TargetDescription(
+                    name: name,
+                    dependencies: dependencies
+                        .map {
+                            TargetDescription.Dependency.target(name: $0.name)
+                        },
+                    path: sourceFile.parentDirectory.pathString,
+                    sources: [sourceFile.pathString],
+                    type: .executable,
+                    packageAccess: false
+                )
+                buildSettings = try self.buildSettings(
+                    for: targetDescription,
+                    targetRoot: sourceFile.parentDirectory
+                )
 
                 return SwiftTarget(
                     name: name,
@@ -1680,6 +1687,7 @@ extension PackageBuilder {
                     packageAccess: false,
                     swiftVersion: try swiftVersion(),
                     buildSettings: buildSettings,
+                    buildSettingsDescription: targetDescription.settings,
                     usesUnsafeFlags: false
                 )
             }

--- a/Sources/PackageModel/Target/BinaryTarget.swift
+++ b/Sources/PackageModel/Target/BinaryTarget.swift
@@ -41,6 +41,7 @@ public final class BinaryTarget: Target {
             dependencies: [],
             packageAccess: false,
             buildSettings: .init(),
+            buildSettingsDescription: [],
             pluginUsages: [],
             usesUnsafeFlags: false
         )

--- a/Sources/PackageModel/Target/ClangTarget.swift
+++ b/Sources/PackageModel/Target/ClangTarget.swift
@@ -53,6 +53,7 @@ public final class ClangTarget: Target {
         others: [AbsolutePath] = [],
         dependencies: [Target.Dependency] = [],
         buildSettings: BuildSettings.AssignmentTable = .init(),
+        buildSettingsDescription: [TargetBuildSettingDescription.Setting],
         usesUnsafeFlags: Bool
     ) throws {
         guard includeDir.isDescendantOfOrEqual(to: sources.root) else {
@@ -76,6 +77,7 @@ public final class ClangTarget: Target {
             dependencies: dependencies,
             packageAccess: false,
             buildSettings: buildSettings,
+            buildSettingsDescription: buildSettingsDescription,
             pluginUsages: [],
             usesUnsafeFlags: usesUnsafeFlags
         )

--- a/Sources/PackageModel/Target/ClangTarget.swift
+++ b/Sources/PackageModel/Target/ClangTarget.swift
@@ -53,7 +53,7 @@ public final class ClangTarget: Target {
         others: [AbsolutePath] = [],
         dependencies: [Target.Dependency] = [],
         buildSettings: BuildSettings.AssignmentTable = .init(),
-        buildSettingsDescription: [TargetBuildSettingDescription.Setting],
+        buildSettingsDescription: [TargetBuildSettingDescription.Setting] = [],
         usesUnsafeFlags: Bool
     ) throws {
         guard includeDir.isDescendantOfOrEqual(to: sources.root) else {

--- a/Sources/PackageModel/Target/PluginTarget.swift
+++ b/Sources/PackageModel/Target/PluginTarget.swift
@@ -36,6 +36,7 @@ public final class PluginTarget: Target {
             dependencies: dependencies,
             packageAccess: packageAccess,
             buildSettings: .init(),
+            buildSettingsDescription: [],
             pluginUsages: [],
             usesUnsafeFlags: false
         )

--- a/Sources/PackageModel/Target/SwiftTarget.swift
+++ b/Sources/PackageModel/Target/SwiftTarget.swift
@@ -33,6 +33,7 @@ public final class SwiftTarget: Target {
             dependencies: dependencies,
             packageAccess: packageAccess,
             buildSettings: .init(),
+            buildSettingsDescription: [],
             pluginUsages: [],
             usesUnsafeFlags: false
         )
@@ -54,6 +55,7 @@ public final class SwiftTarget: Target {
         packageAccess: Bool,
         swiftVersion: SwiftLanguageVersion,
         buildSettings: BuildSettings.AssignmentTable = .init(),
+        buildSettingsDescription: [TargetBuildSettingDescription.Setting] = [],
         pluginUsages: [PluginUsage] = [],
         usesUnsafeFlags: Bool
     ) {
@@ -70,6 +72,7 @@ public final class SwiftTarget: Target {
             dependencies: dependencies,
             packageAccess: packageAccess,
             buildSettings: buildSettings,
+            buildSettingsDescription: buildSettingsDescription,
             pluginUsages: pluginUsages,
             usesUnsafeFlags: usesUnsafeFlags
         )
@@ -100,6 +103,7 @@ public final class SwiftTarget: Target {
             dependencies: dependencies,
             packageAccess: packageAccess,
             buildSettings: .init(),
+            buildSettingsDescription: [],
             pluginUsages: [],
             usesUnsafeFlags: false
         )

--- a/Sources/PackageModel/Target/SystemLibraryTarget.swift
+++ b/Sources/PackageModel/Target/SystemLibraryTarget.swift
@@ -43,6 +43,7 @@ public final class SystemLibraryTarget: Target {
             dependencies: [],
             packageAccess: false,
             buildSettings: .init(),
+            buildSettingsDescription: [],
             pluginUsages: [],
             usesUnsafeFlags: false
         )

--- a/Sources/PackageModel/Target/Target.swift
+++ b/Sources/PackageModel/Target/Target.swift
@@ -233,6 +233,9 @@ public class Target: PolymorphicCodableProtocol {
     /// The build settings assignments of this target.
     public let buildSettings: BuildSettings.AssignmentTable
 
+    @_spi(SwiftPMInternal)
+    public let buildSettingsDescription: [TargetBuildSettingDescription.Setting]
+
     /// The usages of package plugins by this target.
     public let pluginUsages: [PluginUsage]
 
@@ -251,6 +254,7 @@ public class Target: PolymorphicCodableProtocol {
         dependencies: [Target.Dependency],
         packageAccess: Bool,
         buildSettings: BuildSettings.AssignmentTable,
+        buildSettingsDescription: [TargetBuildSettingDescription.Setting],
         pluginUsages: [PluginUsage],
         usesUnsafeFlags: Bool
     ) {
@@ -266,12 +270,27 @@ public class Target: PolymorphicCodableProtocol {
         self.c99name = self.name.spm_mangledToC99ExtendedIdentifier()
         self.packageAccess = packageAccess
         self.buildSettings = buildSettings
+        self.buildSettingsDescription = buildSettingsDescription
         self.pluginUsages = pluginUsages
         self.usesUnsafeFlags = usesUnsafeFlags
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, potentialBundleName, defaultLocalization, platforms, type, path, sources, resources, ignored, others, packageAccess, buildSettings, pluginUsages, usesUnsafeFlags
+        case name
+        case potentialBundleName
+        case defaultLocalization
+        case platforms
+        case type
+        case path
+        case sources
+        case resources
+        case ignored
+        case others
+        case packageAccess
+        case buildSettings
+        case buildSettingsDescription
+        case pluginUsages
+        case usesUnsafeFlags
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -289,6 +308,7 @@ public class Target: PolymorphicCodableProtocol {
         try container.encode(others, forKey: .others)
         try container.encode(packageAccess, forKey: .packageAccess)
         try container.encode(buildSettings, forKey: .buildSettings)
+        try container.encode(buildSettingsDescription, forKey: .buildSettingsDescription)
         // FIXME: pluginUsages property is skipped on purpose as it points to
         // the actual target dependency object.
         try container.encode(usesUnsafeFlags, forKey: .usesUnsafeFlags)
@@ -310,6 +330,10 @@ public class Target: PolymorphicCodableProtocol {
         self.c99name = self.name.spm_mangledToC99ExtendedIdentifier()
         self.packageAccess = try container.decode(Bool.self, forKey: .packageAccess)
         self.buildSettings = try container.decode(BuildSettings.AssignmentTable.self, forKey: .buildSettings)
+        self.buildSettingsDescription = try container.decode(
+            [TargetBuildSettingDescription.Setting].self,
+            forKey: .buildSettingsDescription
+        )
         // FIXME: pluginUsages property is skipped on purpose as it points to
         // the actual target dependency object.
         self.pluginUsages = []

--- a/Tests/BuildTests/ProductBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ProductBuildDescriptionTests.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@testable
+import Build
+
+import class Basics.ObservabilitySystem
+import class TSCBasic.InMemoryFileSystem
+
+import class PackageModel.Manifest
+import struct PackageModel.TargetDescription
+
+@testable
+import struct PackageGraph.ResolvedProduct
+
+import func SPMTestSupport.loadPackageGraph
+import func SPMTestSupport.mockBuildParameters
+import func SPMTestSupport.XCTAssertNoDiagnostics
+import XCTest
+
+final class ProductBuildDescriptionTests: XCTestCase {
+    func testEmbeddedProducts() throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Pkg/Sources/exe/main.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadPackageGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    targets: [
+                        TargetDescription(
+                            name: "exe",
+                            settings: [.init(tool: .swift, kind: .enableExperimentalFeature("Embedded"))]
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let id = ResolvedProduct.ID(targetName: "exe", packageIdentity: .plain("pkg"), buildTriple: .destination)
+        let package = try XCTUnwrap(graph.rootPackages.first)
+        let product = try XCTUnwrap(graph.allProducts[id])
+
+        let buildDescription = try ProductBuildDescription(
+            package: package,
+            product: product,
+            toolsVersion: .v5_9,
+            buildParameters: mockBuildParameters(environment: .init(platform: .macOS)),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertTrue(
+            try buildDescription.linkArguments()
+                .joined(separator: " ")
+                .contains("-enable-experimental-feature Embedded")
+        )
+    }
+}

--- a/Tests/BuildTests/ProductBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ProductBuildDescriptionTests.swift
@@ -53,7 +53,7 @@ final class ProductBuildDescriptionTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let id = ResolvedProduct.ID(targetName: "exe", packageIdentity: .plain("pkg"), buildTriple: .destination)
+        let id = ResolvedProduct.ID(productName: "exe", packageIdentity: .plain("pkg"), buildTriple: .destination)
         let package = try XCTUnwrap(graph.rootPackages.first)
         let product = try XCTUnwrap(graph.allProducts[id])
 


### PR DESCRIPTION
### Motivation:

Without passing this flag, Swift Driver links such products as if they're not built for embedded platforms at all, passing incorrect flags to the linker. This is not reproducible when using plain `swiftc`, as that combines both compile and link jobs by default, but SwiftPM prefers to run those separately, which requires this special handling.

### Modifications:

Directly checking in `ProductBuildDescription/linkArguments` whether all of the product's targets are built in the embedded mode. If so, we're passing the embedded mode flag to Swift Driver.

Unfortunately, `BuildSettings.AssignmentTable` is formed too early in the build process right in `PackageModel`, while we still need to run checks specific build settings quite late in the build stage. Because of that, there's no clean way to check if `Embedded` flag is passed other than directly rendering `BuildSettings.Scope` to a string and running a substring check on that. In the future we should move `BuildSettings` out of `PackageModel`, ensuring that SwiftPM clients don't rely on this behavior anymore.

### Result:

Products that have targets using Embedded Swift can be built with SwiftPM, assuming that Swift Driver handles other linker flags correctly.