### PR TITLE
[5.10] Gate new tests on `supportsSDKDependentTests()`

### DIFF
--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import PackageModel
 import SPMTestSupport
 import XCTest
 
@@ -17,6 +18,7 @@ import var TSCBasic.localFileSystem
 
 final class BuildSystemDelegateTests: XCTestCase {
     func testDoNotFilterLinkerDiagnostics() throws {
+        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
         try fixture(name: "Miscellaneous/DoNotFilterLinkerDiagnostics") { fixturePath in
             #if !os(macOS)
             // These linker diagnostics are only produced on macOS.
@@ -28,6 +30,7 @@ final class BuildSystemDelegateTests: XCTestCase {
     }
 
     func testFilterNonFatalCodesignMessages() throws {
+        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
         // Note: we can re-use the `TestableExe` fixture here since we just need an executable.
         try fixture(name: "Miscellaneous/TestableExe") { fixturePath in
             _ = try executeSwiftBuild(fixturePath)


### PR DESCRIPTION
(cherry picked from commit 8bc47da51b786171795b18ce8d203df3fc9d12db)

* **Explanation**: 

We have been seeing flakiness of tests requiring the SDK (e.g. compiling manifests or running tests) for quite some time on the smoke test macOS CI. Some new tests were recently added which fall under this category but haven't been marked with the appropriate skipping clauses.

* **Scope**: smoke test CI runs on macOS
* **Risk**: none, this is a test-only change
* **Testing**: this is a test-only change
* **Reviewer**: @bnbarham 
* **Main branch PR**: https://github.com/apple/swift-package-manager/pull/7305