### PR TITLE
Update minimum deployment target to macOS 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -76,8 +76,8 @@ let autoProducts = [swiftPMProduct, swiftPMDataModelProduct]
 let package = Package(
     name: "SwiftPM",
     platforms: [
-        .macOS(.v12),
-        .iOS(.v15)
+        .macOS(.v13),
+        .iOS(.v16)
     ],
     products:
         autoProducts.flatMap {

--- a/Sources/Basics/FileSystem/TSCAdapters.swift
+++ b/Sources/Basics/FileSystem/TSCAdapters.swift
@@ -59,7 +59,6 @@ public func withTemporaryDirectory<Result>(
     }
 }
 
-@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public func withTemporaryDirectory<Result>(
     dir: AbsolutePath? = nil, prefix: String = "TemporaryDirectory", removeTreeOnDeinit: Bool = false,
     _ body: (AbsolutePath) async throws -> Result

--- a/Sources/Basics/JSON+Extensions.swift
+++ b/Sources/Basics/JSON+Extensions.swift
@@ -114,13 +114,7 @@ extension JSONEncoder {
             outputFormatting.insert(.prettyPrinted)
         }
         if !escapeSlashes {
-            #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-            if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
-                outputFormatting.insert(.withoutEscapingSlashes)
-            }
-            #elseif compiler(>=5.3)
             outputFormatting.insert(.withoutEscapingSlashes)
-            #endif
         }
 
         encoder.outputFormatting = outputFormatting

--- a/Sources/PackageRegistryTool/PackageRegistryTool.swift
+++ b/Sources/PackageRegistryTool/PackageRegistryTool.swift
@@ -18,7 +18,6 @@ import PackageModel
 import PackageRegistry
 import Workspace
 
-@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 public struct SwiftPackageRegistryTool: AsyncParsableCommand {
     public static var configuration = CommandConfiguration(
         commandName: "package-registry",

--- a/Tests/BasicsTests/NetrcTests.swift
+++ b/Tests/BasicsTests/NetrcTests.swift
@@ -13,8 +13,6 @@
 import Basics
 import XCTest
 
-/// Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
-/// which is only available in macOS 10.13+ at this time.
 class NetrcTests: XCTestCase {
     /// should load machines for a given inline format
     func testLoadMachinesInline() throws {

--- a/Tests/CommandsTests/TestToolTests.swift
+++ b/Tests/CommandsTests/TestToolTests.swift
@@ -286,10 +286,6 @@ final class TestToolTests: CommandsTestCase {
             "Skipping \(#function) because swift-testing tests are not explicitly enabled"
         )
 
-        if #unavailable(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, visionOS 1.0) {
-            throw XCTSkip("swift-testing unavailable")
-        }
-
         try fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
             do {
                 let (stdout, _) = try SwiftPM.Test.execute(["--enable-experimental-swift-testing", "--disable-xctest"], packagePath: fixturePath)

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -67,27 +67,9 @@ extension SourceKitLSPAPI.BuildDescription {
         }
 
         let arguments = try buildTarget.compileArguments(for: file)
-        let result = arguments.firstIndex(of: partialArguments) != nil
+        let result = arguments.contains(partialArguments)
 
         XCTAssertTrue(result, "could not match \(partialArguments) to actual arguments \(arguments)")
         return result
-    }
-}
-
-// Since 'contains' is only available in macOS SDKs 13.0 or newer, we need our own little implementation.
-extension RandomAccessCollection where Element: Equatable {
-    fileprivate func firstIndex(of pattern: some RandomAccessCollection<Element>) -> Index? {
-        guard !pattern.isEmpty && count >= pattern.count else {
-            return nil
-        }
-
-        var i = startIndex
-        for _ in 0..<(count - pattern.count + 1) {
-            if self[i...].starts(with: pattern) {
-                return i
-            }
-            i = self.index(after: i)
-        }
-        return nil
     }
 }


### PR DESCRIPTION
Allows us to delete some existing backwards compatibility code.