### PR TITLE
Move `swiftpm-project-settings.el` settings to `.dir-locals.el`

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,19 +1,5 @@
-;;; Directory Local Variables
+;;; Directory Local Variables            -*- no-byte-compile: t -*-
 ;;; For more information see (info "(emacs) Directory Variables")
 
-
-((nil
-  (eval .
-        ;; Auto-load the swiftpm project settings.
-        (unless (featurep 'swiftpm-project-settings)
-          (message "loading 'swiftpm-project-settings")
-          ;; Make sure the project's own utils directory is in the load path,
-          ;; but don't override any one the user might have set up.
-          (add-to-list
-           'load-path
-           (concat
-            (let ((dlff (dir-locals-find-file default-directory)))
-              (if (listp dlff) (car dlff) (file-name-directory dlff)))
-            "Utilities/Emacs")
-           :append)
-          (require 'swiftpm-project-settings)))))
+((nil . ((c-basic-offset . 4)))
+ (swift-mode . ((swift-mode:basic-offset . 4))))

--- a/Utilities/Emacs/swiftpm-project-settings.el
+++ b/Utilities/Emacs/swiftpm-project-settings.el
@@ -1,8 +1,0 @@
-;; swiftpm project settings.
-
-(require 'swift-mode)
-
-(setq c-basic-offset 4)
-(setq swift-basic-offset 4)
-
-(provide 'swiftpm-project-settings)


### PR DESCRIPTION
Directory-local variables have been moved so that they are set directly
in `.dir-locals.el`.

### Motivation:

The variables set in `swiftpm-project-settings.el` can be set directly
in `dir-locals.el`. There is no reason to move them to a separate file,
and in fact doing that will automatically make Emacs flag the dir-locals
as unsafe, since it will be being requested to evaluate a block of code,
instead of setting known-safe variables.

### Modifications:

`Utilities/Emacs/swiftpm-project-settings.el` has been removed. All variables
set in it have been moved to `.dir-locals.el` itself. This allows the evaluation
of all directory locals to be considered safe.

Additionally, `swift-basic-offset` was changed to `swift-mode:basic-offset`.
That appears to be the proper variable for setting indent width for Swift in Emacs.

### Result:

Emacs users can edit the project more peacefully.
