### PR TITLE
Reduce use of raw `\n` to improve cross-platform compatibility

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -196,7 +196,7 @@ public final class SwiftTargetBuildDescription {
     // but it is the closest to accurate we can do at this point
     func containsAtMain(fileSystem: FileSystem, path: AbsolutePath) throws -> Bool {
         let content: String = try self.fileSystem.readFileContents(path)
-        let lines = content.split(separator: "\n").compactMap { String($0).spm_chuzzle() }
+        let lines = content.split(whereSeparator: { $0.isNewline }).map { $0.trimmingCharacters(in: .whitespaces) }
 
         var multilineComment = false
         for line in lines {

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -503,7 +503,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                         metadata.pluginName = result.plugin.name
                         return metadata
                     }
-                    for line in result.textOutput.split(separator: "\n") {
+                    for line in result.textOutput.split(whereSeparator: { $0.isNewline }) {
                         diagnosticsEmitter.emit(info: line)
                     }
                     for diag in result.diagnostics {

--- a/Sources/SPMTestSupport/MockRegistry.swift
+++ b/Sources/SPMTestSupport/MockRegistry.swift
@@ -450,7 +450,7 @@ private struct MockRegistryArchiver: Archiver {
 
     private func readFileContents(_ path: AbsolutePath) throws -> [String] {
         let content: String = try self.fileSystem.readFileContents(path)
-        return content.split(separator: "\n").map(String.init)
+        return content.split(whereSeparator: { $0.isNewline }).map(String.init)
     }
 }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -505,7 +505,7 @@ public final class GitRepository: Repository, WorkingCheckout {
                 "remote",
                 failureMessage: "Couldn’t get the list of remotes"
             )
-            let remoteNames = remoteNamesOutput.split(separator: "\n").map(String.init)
+            let remoteNames = remoteNamesOutput.split(whereSeparator: { $0.isNewline }).map(String.init)
             return try remoteNames.map { name in
                 // For each remote get the url.
                 let url = try callGit(
@@ -529,7 +529,7 @@ public final class GitRepository: Repository, WorkingCheckout {
         try self.cachedBranches.memoize {
             try self.lock.withLock {
                 let branches = try callGit("branch", "-l", failureMessage: "Couldn’t get the list of branches")
-                return branches.split(separator: "\n").map { $0.dropFirst(2) }.map(String.init)
+                return branches.split(whereSeparator: { $0.isNewline }).map { $0.dropFirst(2) }.map(String.init)
             }
         }
     }
@@ -546,7 +546,7 @@ public final class GitRepository: Repository, WorkingCheckout {
                     "-l",
                     failureMessage: "Couldn’t get the list of tags"
                 )
-                return tagList.split(separator: "\n").map(String.init)
+                return tagList.split(whereSeparator: { $0.isNewline }).map(String.init)
             }
         }
     }
@@ -780,7 +780,7 @@ public final class GitRepository: Repository, WorkingCheckout {
                 output = try error.result.utf8Output().spm_chomp()
             }
 
-            return stringPaths.map(output.split(separator: "\n").map {
+            return stringPaths.map(output.split(whereSeparator: { $0.isNewline }).map {
                 let string = String($0).replacingOccurrences(of: "\\\\", with: "\\")
                 if string.utf8.first == UInt8(ascii: "\"") {
                     return String(string.dropFirst(1).dropLast(1))

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -369,7 +369,7 @@ final class BuildToolTests: CommandsTestCase {
             do {
                 let result = try execute(packagePath: fixturePath)
                 XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
-                let lines = result.stdout.split(separator: "\n")
+                let lines = result.stdout.split(whereSeparator: { $0.isNewline })
                 XCTAssertMatch(String(lines.last!), .regex("Build complete! \\([0-9]*\\.[0-9]*s\\)"))
             }
 
@@ -382,7 +382,7 @@ final class BuildToolTests: CommandsTestCase {
                 // test third time, to make sure message is presented even when nothing to build (cached)
                 let result = try execute(packagePath: fixturePath)
                 XCTAssertNoMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
-                let lines = result.stdout.split(separator: "\n")
+                let lines = result.stdout.split(whereSeparator: { $0.isNewline })
                 XCTAssertMatch(String(lines.last!), .regex("Build complete! \\([0-9]*\\.[0-9]*s\\)"))
             }
         }

--- a/Tests/CommandsTests/RunToolTests.swift
+++ b/Tests/CommandsTests/RunToolTests.swift
@@ -79,7 +79,7 @@ final class RunToolTests: CommandsTestCase {
     func testUnreachableExecutable() throws {
         try fixture(name: "Miscellaneous/UnreachableTargets") { fixturePath in
             let (output, _) = try execute(["bexec"], packagePath: fixturePath.appending("A"))
-            let outputLines = output.split(separator: "\n")
+            let outputLines = output.split(whereSeparator: { $0.isNewline })
             XCTAssertMatch(String(outputLines[0]), .contains("BTarget2"))
         }
     }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -474,7 +474,7 @@ class PluginTests: XCTestCase {
                 func pluginEmittedOutput(_ data: Data) {
                     // Add each line of emitted output as a `.info` diagnostic.
                     dispatchPrecondition(condition: .onQueue(delegateQueue))
-                    let textlines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+                    let textlines = String(decoding: data, as: UTF8.self).split(whereSeparator: { $0.isNewline })
                     print(textlines.map{ "[TEXT] \($0)" }.joined(separator: "\n"))
                     diagnostics.append(contentsOf: textlines.map{
                         Basics.Diagnostic(severity: .info, message: String($0), metadata: .none)
@@ -756,7 +756,7 @@ class PluginTests: XCTestCase {
                 func pluginEmittedOutput(_ data: Data) {
                     // Add each line of emitted output as a `.info` diagnostic.
                     dispatchPrecondition(condition: .onQueue(delegateQueue))
-                    let textlines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+                    let textlines = String(decoding: data, as: UTF8.self).split(whereSeparator: { $0.isNewline })
                     diagnostics.append(contentsOf: textlines.map{
                         Basics.Diagnostic(severity: .info, message: String($0), metadata: .none)
                     })


### PR DESCRIPTION
This is really just a start, there are a few hundred more occurences of raw `\n` in the codebase that may or may not be problematic.