### PR TITLE
Clarify that Xcode issues are not tracked in `BUG_REPORT.yml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -6,7 +6,7 @@ body:
   id: cat-preferences
   attributes:
     label: "Is it reproducible with SwiftPM command-line tools: `swift build`, `swift test`, `swift package` etc?"
-    description: Issues related to closed-source software such as Xcode are not tracked by this repository and will be closed.
+    description: "Issues related to closed-source software such as Xcode are not tracked by this repository and will be closed. Use https://feedbackassistant.apple.com instead."
     options:
       - label: Confirmed reproduction steps with SwiftPM CLI. 
         required: true

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -2,6 +2,14 @@ name: Bug Report
 description: Something isn't working as expected
 labels: [bug]
 body:
+- type: checkboxes
+  id: cat-preferences
+  attributes:
+    label: Is it reproducible with SwiftPM command-line tools: `swift build`, `swift test`, `swift package` etc?
+    description: Issues related to closed-source software such as Xcode are not tracked by this repository and will be closed.
+    options:
+      - label: Confirmed reproduction steps with SwiftPM CLI. 
+        required: true
 - type: textarea
   attributes:
     label: Description

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -5,7 +5,7 @@ body:
 - type: checkboxes
   id: cat-preferences
   attributes:
-    label: Is it reproducible with SwiftPM command-line tools: `swift build`, `swift test`, `swift package` etc?
+    label: "Is it reproducible with SwiftPM command-line tools: `swift build`, `swift test`, `swift package` etc?"
     description: Issues related to closed-source software such as Xcode are not tracked by this repository and will be closed.
     options:
       - label: Confirmed reproduction steps with SwiftPM CLI. 

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -6,7 +6,7 @@ body:
   id: cat-preferences
   attributes:
     label: "Is it reproducible with SwiftPM command-line tools: `swift build`, `swift test`, `swift package` etc?"
-    description: "Issues related to closed-source software such as Xcode are not tracked by this repository and will be closed. Use https://feedbackassistant.apple.com instead."
+    description: "Issues related to closed-source software are not tracked by this repository and will be closed. For Xcode, please file a feedback at https://feedbackassistant.apple.com instead."
     options:
       - label: Confirmed reproduction steps with SwiftPM CLI. 
         required: true


### PR DESCRIPTION
We're seeing a large amount of issues created that are unrelated to this repository. We need to add a clear warning to our issue template that such issues will be closed.
