### PR TITLE
Allow empty targets if plugins are applied to them

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -539,6 +539,20 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         }
 
         for target in targetsToConsider {
+            // If a previously empty target didn't end up adding any sources or resources via plugins, we need to emit a warning.
+            if target.isEmpty(
+                buildToolPluginInvocationResult: buildToolPluginInvocationResults[target.id]?.results,
+                prebuildCommandResults: prebuildCommandResults[target.id]
+            ) {
+                observabilityScope.emit(
+                    .targetHasNoSources(
+                        name: target.name,
+                        type: .regular,
+                        shouldSuggestRelaxedSourceDir: false
+                    )
+                )
+            }
+
             guard let package = graph.package(for: target), package.manifest.toolsVersion >= .v5_3 else {
                 continue
             }

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -14,7 +14,7 @@ import Basics
 import PackageModel
 
 extension Basics.Diagnostic {
-    static func targetHasNoSources(name: String, type: TargetDescription.TargetType, shouldSuggestRelaxedSourceDir: Bool) -> Self {
+    public static func targetHasNoSources(name: String, type: TargetDescription.TargetType, shouldSuggestRelaxedSourceDir: Bool) -> Self {
         let folderName = PackageBuilder.suggestedPredefinedSourceDirectory(type: type)
         var clauses = ["Source files for target \(name) should be located under '\(folderName)/\(name)'"]
         if shouldSuggestRelaxedSourceDir {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -909,10 +909,6 @@ public final class PackageBuilder {
         // FIXME: use identity instead?
         // The name of the bundle, if one is being generated.
         let potentialBundleName = self.manifest.displayName + "_" + potentialModule.name
-
-        if sources.relativePaths.isEmpty && resources.isEmpty && headers.isEmpty {
-            return nil
-        }
         try self.validateSourcesOverlapping(forTarget: potentialModule.name, sources: sources.paths)
 
         // Deal with package plugin targets.
@@ -955,7 +951,7 @@ public final class PackageBuilder {
         }
 
         // Create and return the right kind of target depending on what kind of sources we found.
-        if sources.hasSwiftSources {
+        if sources.hasSwiftSources || (sources.relativePaths.isEmpty && resources.isEmpty && headers.isEmpty) /* assume empty targets to be Swift */ {
             return SwiftTarget(
                 name: potentialModule.name,
                 potentialBundleName: potentialBundleName,


### PR DESCRIPTION
Currently, we warn about and remove empty targets in `PackageBuilder` which can be unexpected if the sole purpose of a target is to host generated sources or resources from plugins. This change makes it so that we treat these targets as Swit targets and potentially remove them later on during the build.

rdar://92858144
