### PR TITLE
Optimize for type checker in `embedInCode` with `[UInt8](arrayLiteral:)`

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -355,7 +355,12 @@ public final class SwiftTargetBuildDescription {
             let variableName = $0.path.basename.spm_mangledToC99ExtendedIdentifier()
             let fileContent = try Data(contentsOf: URL(fileURLWithPath: $0.path.pathString)).map { String($0) }.joined(separator: ",")
 
-            content += "static let \(variableName): [UInt8] = [\(fileContent)]\n"
+            /// Typical array literal requires complicated type inference, therefore slow to parse.
+            /// This slows down compilation greatly if source file size is > 100KB.
+            /// - With typical array syntax, compilation of 300KB file on M1 machine took 20 seconds.
+            /// - With this certain syntax, compilation of 300KB file on M1 machine took 2-3 seconds.
+            /// - Reference: https://forums.swift.org/t/why-is-swift-so-slow-timeout-in-compiling-this-code/61382/23
+            content += "static let \(variableName) = [UInt8](arrayLiteral: \(fileContent))\n"
         }
 
         content += "}"


### PR DESCRIPTION
Produces faster compiled code for embedded file contents.

### Motivation:
Old code produces typical array literal code that requires complicated compiler type inferences, and it slowed down compilation greatly.
For example, 

### Modifications:
Updated to use a certain syntax that is known to be faster.
Details are well explained in [this thread](https://forums.swift.org/t/why-is-swift-so-slow-timeout-in-compiling-this-code/61382/23).

For the generated code for a 300KB file on M1 machine,
- With old array syntax, took 20 seconds.
- With new array syntax, took 2-3 seconds.
