### PR TITLE
Move and refactor `ProgressAnimation` code from TSC

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -51,7 +51,11 @@ add_library(Basics
   Netrc.swift
   Observability.swift
   OSSignpost.swift
-  ProgressAnimation.swift
+  ProgressAnimation/NinjaProgressAnimation.swift
+  ProgressAnimation/PercentProgressAnimation.swift
+  ProgressAnimation/ProgressAnimationProtocol.swift
+  ProgressAnimation/SingleLinePercentProgressAnimation.swift
+  ProgressAnimation/ThrottledProgressAnimation.swift
   SQLite.swift
   Sandbox.swift
   SendableTimeInterval.swift

--- a/Sources/Basics/ProgressAnimation/NinjaProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/NinjaProgressAnimation.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import class TSCBasic.TerminalController
+import protocol TSCBasic.WritableByteStream
+
+extension ProgressAnimation {
+    /// A ninja-like progress animation that adapts to the provided output stream.
+    @_spi(SwiftPMInternal_ProgressAnimation)
+    public static func ninja(
+        stream: WritableByteStream,
+        verbose: Bool
+    ) -> any ProgressAnimationProtocol {
+        Self.dynamic(
+            stream: stream,
+            verbose: verbose,
+            ttyTerminalAnimationFactory: { RedrawingNinjaProgressAnimation(terminal: $0) },
+            dumbTerminalAnimationFactory: { SingleLinePercentProgressAnimation(stream: stream, header: nil) },
+            defaultAnimationFactory: { MultiLineNinjaProgressAnimation(stream: stream) })
+    }
+}
+
+/// A redrawing ninja-like progress animation.
+final class RedrawingNinjaProgressAnimation: ProgressAnimationProtocol {
+    private let terminal: TerminalController
+    private var hasDisplayedProgress = false
+
+    init(terminal: TerminalController) {
+        self.terminal = terminal
+    }
+
+    func update(step: Int, total: Int, text: String) {
+        assert(step <= total)
+
+        terminal.clearLine()
+
+        let progressText = "[\(step)/\(total)] \(text)"
+        let width = terminal.width
+        if progressText.utf8.count > width {
+            let suffix = "…"
+            terminal.write(String(progressText.prefix(width - suffix.utf8.count)))
+            terminal.write(suffix)
+        } else {
+            terminal.write(progressText)
+        }
+
+        hasDisplayedProgress = true
+    }
+
+    func complete(success: Bool) {
+        if hasDisplayedProgress {
+            terminal.endLine()
+        }
+    }
+
+    func clear() {
+        terminal.clearLine()
+    }
+}
+
+/// A multi-line ninja-like progress animation.
+final class MultiLineNinjaProgressAnimation: ProgressAnimationProtocol {
+    private struct Info: Equatable {
+        let step: Int
+        let total: Int
+        let text: String
+    }
+
+    private let stream: WritableByteStream
+    private var lastDisplayedText: String? = nil
+
+    init(stream: WritableByteStream) {
+        self.stream = stream
+    }
+
+    func update(step: Int, total: Int, text: String) {
+        assert(step <= total)
+
+        guard text != lastDisplayedText else { return }
+
+        stream.send("[\(step)/\(total)] ").send(text)
+        stream.send("\n")
+        stream.flush()
+        lastDisplayedText = text
+    }
+
+    func complete(success: Bool) {
+    }
+
+    func clear() {
+    }
+}

--- a/Sources/Basics/ProgressAnimation/NinjaProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/NinjaProgressAnimation.swift
@@ -15,7 +15,7 @@ import protocol TSCBasic.WritableByteStream
 
 extension ProgressAnimation {
     /// A ninja-like progress animation that adapts to the provided output stream.
-    @_spi(SwiftPMInternal_ProgressAnimation)
+    @_spi(SwiftPMInternal)
     public static func ninja(
         stream: WritableByteStream,
         verbose: Bool

--- a/Sources/Basics/ProgressAnimation/NinjaProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/NinjaProgressAnimation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Sources/Basics/ProgressAnimation/NinjaProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/NinjaProgressAnimation.swift
@@ -25,7 +25,8 @@ extension ProgressAnimation {
             verbose: verbose,
             ttyTerminalAnimationFactory: { RedrawingNinjaProgressAnimation(terminal: $0) },
             dumbTerminalAnimationFactory: { SingleLinePercentProgressAnimation(stream: stream, header: nil) },
-            defaultAnimationFactory: { MultiLineNinjaProgressAnimation(stream: stream) })
+            defaultAnimationFactory: { MultiLineNinjaProgressAnimation(stream: stream) }
+        )
     }
 }
 

--- a/Sources/Basics/ProgressAnimation/PercentProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/PercentProgressAnimation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Sources/Basics/ProgressAnimation/PercentProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/PercentProgressAnimation.swift
@@ -15,7 +15,7 @@ import protocol TSCBasic.WritableByteStream
 
 extension ProgressAnimation {
     /// A percent-based progress animation that adapts to the provided output stream.
-    @_spi(SwiftPMInternal_ProgressAnimation)
+    @_spi(SwiftPMInternal)
     public static func percent(
         stream: WritableByteStream,
         verbose: Bool,

--- a/Sources/Basics/ProgressAnimation/PercentProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/PercentProgressAnimation.swift
@@ -26,7 +26,8 @@ extension ProgressAnimation {
             verbose: verbose,
             ttyTerminalAnimationFactory: { RedrawingPercentProgressAnimation(terminal: $0, header: header) },
             dumbTerminalAnimationFactory: { SingleLinePercentProgressAnimation(stream: stream, header: header) },
-            defaultAnimationFactory: { MultiLinePercentProgressAnimation(stream: stream, header: header) })
+            defaultAnimationFactory: { MultiLinePercentProgressAnimation(stream: stream, header: header) }
+        )
     }
 }
 

--- a/Sources/Basics/ProgressAnimation/PercentProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/PercentProgressAnimation.swift
@@ -1,0 +1,138 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import class TSCBasic.TerminalController
+import protocol TSCBasic.WritableByteStream
+
+extension ProgressAnimation {
+    /// A percent-based progress animation that adapts to the provided output stream.
+    @_spi(SwiftPMInternal_ProgressAnimation)
+    public static func percent(
+        stream: WritableByteStream,
+        verbose: Bool,
+        header: String
+    ) -> any ProgressAnimationProtocol {
+        Self.dynamic(
+            stream: stream,
+            verbose: verbose,
+            ttyTerminalAnimationFactory: { RedrawingPercentProgressAnimation(terminal: $0, header: header) },
+            dumbTerminalAnimationFactory: { SingleLinePercentProgressAnimation(stream: stream, header: header) },
+            defaultAnimationFactory: { MultiLinePercentProgressAnimation(stream: stream, header: header) })
+    }
+}
+
+/// A redrawing lit-like progress animation.
+final class RedrawingPercentProgressAnimation: ProgressAnimationProtocol {
+    private let terminal: TerminalController
+    private let header: String
+    private var hasDisplayedHeader = false
+
+    init(terminal: TerminalController, header: String) {
+        self.terminal = terminal
+        self.header = header
+    }
+
+    /// Creates repeating string for count times.
+    /// If count is negative, returns empty string.
+    private func repeating(string: String, count: Int) -> String {
+        return String(repeating: string, count: max(count, 0))
+    }
+
+    func update(step: Int, total: Int, text: String) {
+        assert(step <= total)
+
+        let width = terminal.width
+        if !hasDisplayedHeader {
+            let spaceCount = width / 2 - header.utf8.count / 2
+            terminal.write(repeating(string: " ", count: spaceCount))
+            terminal.write(header, inColor: .cyan, bold: true)
+            terminal.endLine()
+            hasDisplayedHeader = true
+        } else {
+            terminal.moveCursor(up: 1)
+        }
+
+        terminal.clearLine()
+        let percentage = step * 100 / total
+        let paddedPercentage = percentage < 10 ? " \(percentage)" : "\(percentage)"
+        let prefix = "\(paddedPercentage)% " + terminal.wrap("[", inColor: .green, bold: true)
+        terminal.write(prefix)
+
+        let barWidth = width - prefix.utf8.count
+        let n = Int(Double(barWidth) * Double(percentage) / 100.0)
+
+        terminal.write(repeating(string: "=", count: n) + repeating(string: "-", count: barWidth - n), inColor: .green)
+        terminal.write("]", inColor: .green, bold: true)
+        terminal.endLine()
+
+        terminal.clearLine()
+        if text.utf8.count > width {
+            let prefix = "…"
+            terminal.write(prefix)
+            terminal.write(String(text.suffix(width - prefix.utf8.count)))
+        } else {
+            terminal.write(text)
+        }
+    }
+
+    func complete(success: Bool) {
+        terminal.endLine()
+        terminal.endLine()
+    }
+
+    func clear() {
+        terminal.clearLine()
+        terminal.moveCursor(up: 1)
+        terminal.clearLine()
+    }
+}
+
+/// A multi-line percent-based progress animation.
+final class MultiLinePercentProgressAnimation: ProgressAnimationProtocol {
+    private struct Info: Equatable {
+        let percentage: Int
+        let text: String
+    }
+
+    private let stream: WritableByteStream
+    private let header: String
+    private var hasDisplayedHeader = false
+    private var lastDisplayedText: String? = nil
+
+    init(stream: WritableByteStream, header: String) {
+        self.stream = stream
+        self.header = header
+    }
+
+    func update(step: Int, total: Int, text: String) {
+        assert(step <= total)
+
+        if !hasDisplayedHeader, !header.isEmpty {
+            stream.send(header)
+            stream.send("\n")
+            stream.flush()
+            hasDisplayedHeader = true
+        }
+
+        let percentage = step * 100 / total
+        stream.send("\(percentage)%: ").send(text)
+        stream.send("\n")
+        stream.flush()
+        lastDisplayedText = text
+    }
+
+    func complete(success: Bool) {
+    }
+
+    func clear() {
+    }
+}

--- a/Sources/Basics/ProgressAnimation/ProgressAnimationProtocol.swift
+++ b/Sources/Basics/ProgressAnimation/ProgressAnimationProtocol.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Sources/Basics/ProgressAnimation/ProgressAnimationProtocol.swift
+++ b/Sources/Basics/ProgressAnimation/ProgressAnimationProtocol.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import class TSCBasic.TerminalController
+import class TSCBasic.LocalFileOutputByteStream
+import protocol TSCBasic.WritableByteStream
+import protocol TSCUtility.ProgressAnimationProtocol
+
+@_spi(SwiftPMInternal_ProgressAnimation)
+public typealias ProgressAnimationProtocol = TSCUtility.ProgressAnimationProtocol
+
+/// Namespace to nest public progress animations under.
+@_spi(SwiftPMInternal_ProgressAnimation)
+public enum ProgressAnimation {
+    static func dynamic(
+        stream: WritableByteStream,
+        verbose: Bool,
+        ttyTerminalAnimationFactory: (TerminalController) -> any ProgressAnimationProtocol,
+        dumbTerminalAnimationFactory: () -> any ProgressAnimationProtocol,
+        defaultAnimationFactory: () -> any ProgressAnimationProtocol
+    ) -> any ProgressAnimationProtocol {
+        if let terminal = TerminalController(stream: stream), !verbose {
+            return ttyTerminalAnimationFactory(terminal)
+        } else if let fileStream = stream as? LocalFileOutputByteStream,
+                  TerminalController.terminalType(fileStream) == .dumb
+        {
+            return dumbTerminalAnimationFactory()
+        } else {
+            return defaultAnimationFactory()
+        }
+    }
+}
+

--- a/Sources/Basics/ProgressAnimation/ProgressAnimationProtocol.swift
+++ b/Sources/Basics/ProgressAnimation/ProgressAnimationProtocol.swift
@@ -15,11 +15,11 @@ import class TSCBasic.LocalFileOutputByteStream
 import protocol TSCBasic.WritableByteStream
 import protocol TSCUtility.ProgressAnimationProtocol
 
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 public typealias ProgressAnimationProtocol = TSCUtility.ProgressAnimationProtocol
 
 /// Namespace to nest public progress animations under.
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 public enum ProgressAnimation {
     static func dynamic(
         stream: WritableByteStream,

--- a/Sources/Basics/ProgressAnimation/ProgressAnimationProtocol.swift
+++ b/Sources/Basics/ProgressAnimation/ProgressAnimationProtocol.swift
@@ -21,6 +21,23 @@ public typealias ProgressAnimationProtocol = TSCUtility.ProgressAnimationProtoco
 /// Namespace to nest public progress animations under.
 @_spi(SwiftPMInternal)
 public enum ProgressAnimation {
+    /// Dynamically create a progress animation based on the current stream
+    /// capabilities and desired verbosity.
+    ///
+    /// - Parameters:
+    ///   - stream: A stream to write animations into.
+    ///   - verbose: The verbosity level of other output in the system.
+    ///   - ttyTerminalAnimationFactory: A progress animation to use when the
+    ///     output stream is connected to a terminal with support for special
+    ///     escape sequences.
+    ///   - dumbTerminalAnimationFactory: A progress animation to use when the
+    ///     output stream is connected to a terminal without support for special
+    ///     escape sequences for clearing lines or controlling cursor positions.
+    ///   - defaultAnimationFactory: A progress animation to use when the
+    ///     desired output is verbose or the output stream verbose or is not
+    ///     connected to a terminal, e.g. a pipe or file.
+    /// - Returns: A progress animation instance matching the stream
+    ///   capabilities and desired verbosity.
     static func dynamic(
         stream: WritableByteStream,
         verbose: Bool,

--- a/Sources/Basics/ProgressAnimation/SingleLinePercentProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/SingleLinePercentProgressAnimation.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import class TSCBasic.TerminalController
+import protocol TSCBasic.WritableByteStream
+
+/// A single line percent-based progress animation.
+final class SingleLinePercentProgressAnimation: ProgressAnimationProtocol {
+    private let stream: WritableByteStream
+    private let header: String?
+    private var displayedPercentages: Set<Int> = []
+    private var hasDisplayedHeader = false
+
+    init(stream: WritableByteStream, header: String?) {
+        self.stream = stream
+        self.header = header
+    }
+
+    func update(step: Int, total: Int, text: String) {
+        if let header = header, !hasDisplayedHeader {
+            stream.send(header)
+            stream.send("\n")
+            stream.flush()
+            hasDisplayedHeader = true
+        }
+
+        let percentage = step * 100 / total
+        let roundedPercentage = Int(Double(percentage / 10).rounded(.down)) * 10
+        if percentage != 100, !displayedPercentages.contains(roundedPercentage) {
+            stream.send(String(roundedPercentage)).send(".. ")
+            displayedPercentages.insert(roundedPercentage)
+        }
+
+        stream.flush()
+    }
+
+    func complete(success: Bool) {
+        if success {
+            stream.send("OK")
+            stream.flush()
+        }
+    }
+
+    func clear() {
+    }
+}

--- a/Sources/Basics/ProgressAnimation/SingleLinePercentProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/SingleLinePercentProgressAnimation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information

--- a/Sources/Basics/ProgressAnimation/ThrottledProgressAnimation.swift
+++ b/Sources/Basics/ProgressAnimation/ThrottledProgressAnimation.swift
@@ -56,9 +56,9 @@ final class ThrottledProgressAnimation: ProgressAnimationProtocol {
     }
 }
 
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 extension ProgressAnimationProtocol {
-    @_spi(SwiftPMInternal_ProgressAnimation)
+    @_spi(SwiftPMInternal)
     public func throttled<C: Clock>(
         now: @escaping () -> C.Instant,
         interval: C.Duration,
@@ -67,7 +67,7 @@ extension ProgressAnimationProtocol {
         ThrottledProgressAnimation(self, now: now, interval: interval, clock: clock)
     }
 
-    @_spi(SwiftPMInternal_ProgressAnimation)
+    @_spi(SwiftPMInternal)
     public func throttled<C: Clock>(
         clock: C,
         interval: C.Duration
@@ -75,7 +75,7 @@ extension ProgressAnimationProtocol {
         self.throttled(now: { clock.now }, interval: interval, clock: C.self)
     }
 
-    @_spi(SwiftPMInternal_ProgressAnimation)
+    @_spi(SwiftPMInternal)
     public func throttled(
         interval: ContinuousClock.Duration
     )  -> some ProgressAnimationProtocol  {

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -609,7 +609,8 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         // Figure out which progress bar we have to use during the build.
         let progressAnimation = ProgressAnimation.ninja(
             stream: self.outputStream,
-            verbose: self.logLevel.isVerbose)
+            verbose: self.logLevel.isVerbose
+        )
         let buildExecutionContext = BuildExecutionContext(
             productsBuildParameters: self.productsBuildParameters,
             toolsBuildParameters: self.toolsBuildParameters,

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SwiftPMInternal_ProgressAnimation)
 import Basics
 import LLBuildManifest
 import PackageGraph
@@ -26,9 +27,6 @@ import enum TSCBasic.ProcessEnv
 import struct TSCBasic.RegEx
 
 import enum TSCUtility.Diagnostics
-import class TSCUtility.MultiLineNinjaProgressAnimation
-import class TSCUtility.NinjaProgressAnimation
-import protocol TSCUtility.ProgressAnimationProtocol
 
 #if USE_IMPL_ONLY_IMPORTS
 @_implementationOnly import DriverSupport
@@ -609,10 +607,9 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     /// building the package structure target.
     private func createBuildSystem(buildDescription: BuildDescription?) throws -> SPMLLBuild.BuildSystem {
         // Figure out which progress bar we have to use during the build.
-        let progressAnimation: ProgressAnimationProtocol = self.logLevel.isVerbose
-            ? MultiLineNinjaProgressAnimation(stream: self.outputStream)
-            : NinjaProgressAnimation(stream: self.outputStream)
-
+        let progressAnimation = ProgressAnimation.ninja(
+            stream: self.outputStream,
+            verbose: self.logLevel.isVerbose)
         let buildExecutionContext = BuildExecutionContext(
             productsBuildParameters: self.productsBuildParameters,
             toolsBuildParameters: self.toolsBuildParameters,

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 import Basics
 import LLBuildManifest
 import PackageGraph

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 import Basics
 import Dispatch
 import Foundation

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SwiftPMInternal_ProgressAnimation)
 import Basics
 import Dispatch
 import Foundation
@@ -28,7 +29,6 @@ import class TSCBasic.ThreadSafeOutputByteStream
 
 import class TSCUtility.IndexStore
 import class TSCUtility.IndexStoreAPI
-import protocol TSCUtility.ProgressAnimationProtocol
 
 #if canImport(llbuildSwift)
 typealias LLBuildBuildSystemDelegate = llbuildSwift.BuildSystemDelegate

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+@_spi(SwiftPMInternal_ProgressAnimation)
 import Basics
 import CoreCommands
 import Dispatch
@@ -28,10 +29,6 @@ import enum TSCBasic.ProcessEnv
 import var TSCBasic.stdoutStream
 import class TSCBasic.SynchronizedQueue
 import class TSCBasic.Thread
-
-import class TSCUtility.NinjaProgressAnimation
-import class TSCUtility.PercentProgressAnimation
-import protocol TSCUtility.ProgressAnimationProtocol
 
 private enum TestError: Swift.Error {
     case invalidListTestJSONData(context: String, underlyingError: Error? = nil)
@@ -930,9 +927,14 @@ final class ParallelTestRunner {
         // command's result output goes on stdout
         // ie "swift test" should output to stdout
         if ProcessEnv.vars["SWIFTPM_TEST_RUNNER_PROGRESS_BAR"] == "lit" {
-            progressAnimation = PercentProgressAnimation(stream: TSCBasic.stdoutStream, header: "Testing:")
+            self.progressAnimation = ProgressAnimation.percent(
+                stream: TSCBasic.stdoutStream,
+                verbose: false,
+                header: "Testing:")
         } else {
-            progressAnimation = NinjaProgressAnimation(stream: TSCBasic.stdoutStream)
+            self.progressAnimation = ProgressAnimation.ninja(
+                stream: TSCBasic.stdoutStream,
+                verbose: false)
         }
 
         self.buildOptions = buildOptions

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -930,11 +930,13 @@ final class ParallelTestRunner {
             self.progressAnimation = ProgressAnimation.percent(
                 stream: TSCBasic.stdoutStream,
                 verbose: false,
-                header: "Testing:")
+                header: "Testing:"
+            )
         } else {
             self.progressAnimation = ProgressAnimation.ninja(
                 stream: TSCBasic.stdoutStream,
-                verbose: false)
+                verbose: false
+            )
         }
 
         self.buildOptions = buildOptions

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 import Basics
 import CoreCommands
 import Dispatch

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -48,10 +48,6 @@ import var TSCBasic.stderrStream
 import class TSCBasic.TerminalController
 import class TSCBasic.ThreadSafeOutputByteStream
 
-import class TSCUtility.MultiLineNinjaProgressAnimation
-import class TSCUtility.NinjaProgressAnimation
-import class TSCUtility.PercentProgressAnimation
-import protocol TSCUtility.ProgressAnimationProtocol
 import var TSCUtility.verbosity
 
 typealias Diagnostic = Basics.Diagnostic

--- a/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
+++ b/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 import Basics
 import Dispatch
 

--- a/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
+++ b/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
@@ -10,17 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-
+@_spi(SwiftPMInternal_ProgressAnimation)
 import Basics
 import Dispatch
 
 import protocol TSCBasic.OutputByteStream
 import class TSCBasic.TerminalController
 import class TSCBasic.ThreadSafeOutputByteStream
-
-import class TSCUtility.MultiLineNinjaProgressAnimation
-import class TSCUtility.NinjaProgressAnimation
-import protocol TSCUtility.ProgressAnimationProtocol
 
 public struct SwiftToolObservabilityHandler: ObservabilityHandlerProvider {
     private let outputHandler: OutputHandler
@@ -76,9 +72,9 @@ public struct SwiftToolObservabilityHandler: ObservabilityHandlerProvider {
             self.logLevel = logLevel
             self.outputStream = outputStream
             self.writer = InteractiveWriter(stream: outputStream)
-            self.progressAnimation = logLevel.isVerbose ?
-                MultiLineNinjaProgressAnimation(stream: outputStream) :
-                NinjaProgressAnimation(stream: outputStream)
+            self.progressAnimation = ProgressAnimation.ninja(
+                stream: self.outputStream,
+                verbose: self.logLevel.isVerbose)
         }
 
         func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {

--- a/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
+++ b/Sources/CoreCommands/SwiftToolObservabilityHandler.swift
@@ -74,7 +74,8 @@ public struct SwiftToolObservabilityHandler: ObservabilityHandlerProvider {
             self.writer = InteractiveWriter(stream: outputStream)
             self.progressAnimation = ProgressAnimation.ninja(
                 stream: self.outputStream,
-                verbose: self.logLevel.isVerbose)
+                verbose: self.logLevel.isVerbose
+            )
         }
 
         func handleDiagnostic(scope: ObservabilityScope, diagnostic: Basics.Diagnostic) {

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: can't write `import actor Basics.HTTPClient`, importing the whole module because of that :(
+@_spi(SwiftPMInternal_ProgressAnimation)
 import Basics
 import struct Foundation.URL
 import protocol TSCBasic.FileSystem

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: can't write `import actor Basics.HTTPClient`, importing the whole module because of that :(
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 import Basics
 import struct Foundation.URL
 import protocol TSCBasic.FileSystem

--- a/Sources/SwiftSDKTool/InstallSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/InstallSwiftSDK.swift
@@ -11,14 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-@_spi(SwiftPMInternal)
+@_spi(SwiftPMInternal_ProgressAnimation)
 import Basics
 import CoreCommands
 import Foundation
 import PackageModel
 
 import var TSCBasic.stdoutStream
-import class TSCUtility.PercentProgressAnimation
 
 public struct InstallSwiftSDK: SwiftSDKSubcommand {
     public static let configuration = CommandConfiguration(
@@ -50,9 +49,9 @@ public struct InstallSwiftSDK: SwiftSDKSubcommand {
             fileSystem: self.fileSystem,
             observabilityScope: observabilityScope,
             outputHandler: { print($0.description) },
-            downloadProgressAnimation: ThrottledProgressAnimation(
-                PercentProgressAnimation(stream: stdoutStream, header: "Downloading"), interval: .milliseconds(300)
-            )
+            downloadProgressAnimation: ProgressAnimation
+                .percent(stream: stdoutStream, verbose: false, header: "Downloading")
+                .throttled(interval: .milliseconds(300))
         )
         try await store.install(
             bundlePathOrURL: bundlePathOrURL,

--- a/Sources/SwiftSDKTool/InstallSwiftSDK.swift
+++ b/Sources/SwiftSDKTool/InstallSwiftSDK.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 import Basics
 import CoreCommands
 import Foundation

--- a/Sources/XCBuildSupport/XCBuildDelegate.swift
+++ b/Sources/XCBuildSupport/XCBuildDelegate.swift
@@ -145,9 +145,8 @@ private extension Basics.Diagnostic {
     }
 }
 
-// FIXME: Move to TSC.
+@available(*, deprecated, message: "use ProgressAnimation.ninja(stream:) instead")
 public final class VerboseProgressAnimation: ProgressAnimationProtocol {
-
     private let stream: OutputByteStream
 
     public init(stream: OutputByteStream) {

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -250,7 +250,8 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         let progressAnimation = ProgressAnimation.percent(
             stream: self.outputStream,
             verbose: self.logLevel.isVerbose,
-            header: "")
+            header: ""
+        )
         let delegate = XCBuildDelegate(
             buildSystem: self,
             outputStream: self.outputStream,

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(SwiftPMInternal_ProgressAnimation)
 import Basics
 import Dispatch
 import class Foundation.JSONEncoder
@@ -23,9 +24,7 @@ import enum TSCBasic.ProcessEnv
 import func TSCBasic.withTemporaryFile
 import func TSCBasic.memoize
 
-import class TSCUtility.MultiLinePercentProgressAnimation
 import enum TSCUtility.Diagnostics
-import protocol TSCUtility.ProgressAnimationProtocol
 
 public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     private let buildParameters: BuildParameters
@@ -248,9 +247,10 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
 
     /// Returns a new instance of `XCBuildDelegate` for a build operation.
     private func createBuildDelegate() -> XCBuildDelegate {
-        let progressAnimation: ProgressAnimationProtocol = self.logLevel.isVerbose
-            ? VerboseProgressAnimation(stream: self.outputStream)
-            : MultiLinePercentProgressAnimation(stream: self.outputStream, header: "")
+        let progressAnimation = ProgressAnimation.percent(
+            stream: self.outputStream,
+            verbose: self.logLevel.isVerbose,
+            header: "")
         let delegate = XCBuildDelegate(
             buildSystem: self,
             outputStream: self.outputStream,

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 import Basics
 import Dispatch
 import class Foundation.JSONEncoder

--- a/Tests/BasicsTests/ProgressAnimationTests.swift
+++ b/Tests/BasicsTests/ProgressAnimationTests.swift
@@ -12,9 +12,8 @@
 
 import _Concurrency
 import XCTest
-import protocol TSCUtility.ProgressAnimationProtocol
 
-@_spi(SwiftPMInternal)
+@_spi(SwiftPMInternal_ProgressAnimation)
 @testable
 import Basics
 

--- a/Tests/BasicsTests/ProgressAnimationTests.swift
+++ b/Tests/BasicsTests/ProgressAnimationTests.swift
@@ -13,7 +13,7 @@
 import _Concurrency
 import XCTest
 
-@_spi(SwiftPMInternal_ProgressAnimation)
+@_spi(SwiftPMInternal)
 @testable
 import Basics
 


### PR DESCRIPTION
SwiftPM uses ProgressAnimation from TSCUtilities in a variety of inconsistent manners across various swift-something commands. This commit replaces the uses of ProgressAnimation throughout SwiftPM with common entrypoints and lays the ground work for creating multi-line parallel progress animations as seen in tools like `bazel build` and `docker build`.