### PR TITLE
Prevent build tasks from decreasing

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -1006,7 +1006,7 @@ private struct CommandTaskTracker {
         case .isScanning:
             self.totalCount += 1
         case .isUpToDate:
-            self.totalCount -= 1
+            self.finishedCount += 1
         case .isComplete:
             self.finishedCount += 1
         @unknown default:


### PR DESCRIPTION
Currently SwiftPM will reduce the total number of jobs in the CLI output if llbuild determines a task does not need to be run. This results in confusing output to the user where as the build progresses the number of completed tasks strictly increases but the total can fluctuate. This commit updates the task counting logic to consider "up to date" build operations as complete instead of reducing the total count leading to clearer progress output.