### PR TITLE
Implementation of same-package product dependencies

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -135,6 +135,9 @@ extension BuildPlan {
                 switch $0 {
                 case .product:
                     return nil
+                case .innerProduct:
+                    // TODO: Does this just mean that we can't @testable inner products? (seems fair enough?)
+                    return nil
                 case .target(let target, _):
                     return target
                 }

--- a/Sources/Commands/Utilities/MermaidPackageSerializer.swift
+++ b/Sources/Commands/Utilities/MermaidPackageSerializer.swift
@@ -115,6 +115,14 @@ extension MermaidPackageSerializer.Node {
                 border: .hexagon,
                 subgraph: product.package
             )
+        case let .innerProduct(product, _):
+            // TODO: Do we need a subgraph here?
+            self.init(
+                id: product.name,
+                title: product.name,
+                border: .hexagon,
+                subgraph: nil
+            )
         case let .target(target, _):
             self.init(target: target)
         }

--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -157,6 +157,7 @@ enum Serialization {
 
         case target(name: String, condition: Condition?)
         case product(name: String, package: String?, moduleAliases: [String: String]?, condition: Condition?)
+        case innerProduct(name: String, condition: Condition?)
         case byName(name: String, condition: Condition?)
     }
 

--- a/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -204,6 +204,11 @@ extension Serialization.TargetDependency {
                 moduleAliases: moduleAliases,
                 condition: condition.map { .init($0) }
             )
+        case .innerProductItem(let name, let condition):
+            self = .innerProduct(
+                name: name,
+                condition: condition.map { .init($0) }
+            )
         case .byNameItem(let name, let condition):
             self = .byName(name: name, condition: condition.map { .init($0) })
         }

--- a/Sources/PackageDescription/Target.swift
+++ b/Sources/PackageDescription/Target.swift
@@ -57,6 +57,13 @@ public final class Target {
         ///    - moduleAlias: The module aliases for targets in the product.
         ///    - condition: A condition that limits the application of the target dependency. For example, only apply a dependency for a specific platform.
         case productItem(name: String, package: String?, moduleAliases: [String: String]?, condition: TargetDependencyCondition?)
+        /// A dependency on a product in the current package.
+        ///
+        /// - Parameters:
+        ///    - name: The name of the product.
+        ///    - moduleAlias: The module aliases for targets in the product.
+        ///    - condition: A condition that limits the application of the target dependency. For example, only apply a dependency for a specific platform.
+        case innerProductItem(name: String, condition: TargetDependencyCondition?)
         /// A by-name dependency on either a target or a product.
         ///
         /// - Parameters:
@@ -1261,6 +1268,20 @@ extension Target.Dependency {
 @available(_PackageDescription, obsoleted: 5.2, message: "the 'package' argument is mandatory as of tools version 5.2")
     public static func product(name: String, package: String? = nil) -> Target.Dependency {
         return .productItem(name: name, package: package, moduleAliases: nil, condition: nil)
+    }
+
+    /// Creates a dependency on a product from the same package.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the product.
+    ///   - condition: A condition that limits the application of the target dependency. For example, only apply a
+    ///       dependency for a specific platform.
+    /// - Returns: A `Target.Dependency` instance.
+    public static func product(
+        name: String,
+        condition: TargetDependencyCondition? = nil
+    ) -> Target.Dependency {
+        return .innerProductItem(name: name, condition: condition)
     }
 
     /// Creates a dependency that resolves to either a target or a product with the specified name.

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -338,6 +338,8 @@ extension TargetDescription.Dependency {
                 package = try identityResolver.mappedIdentity(for: .plain(packageName)).description
             }
             self = .product(name: name, package: package, moduleAliases: moduleAliases, condition: condition.map { .init($0) })
+        case .innerProduct(let name, let condition):
+            self = .innerProduct(name: name, condition: condition.map { .init($0) })
         case .byName(let name, let condition):
             self = .byName(name: name, condition: condition.map { .init($0) })
         }

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -196,6 +196,9 @@ public struct ManifestValidator {
                             validPackages: self.manifest.dependencies
                         ))
                     }
+                case .innerProduct:
+                    // TODO: Diagnose any possible issues here
+                    break
                 case .byName(let name, _):
                     // Don't diagnose root manifests so we can emit a better diagnostic during package loading.
                     if !self.manifest.packageKind.isRoot &&

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -653,18 +653,23 @@ public final class PackageBuilder {
             // No reference of this target in manifest, i.e. it has no dependencies.
             guard let target = self.manifest.targetMap[$0.name] else { return [] }
             // Collect the successors from declared dependencies.
-            var successors: [PotentialModule] = target.dependencies.compactMap {
+            var successors: [PotentialModule] = target.dependencies.flatMap {
                 switch $0 {
                 case .target(let name, _):
                     // Since we already checked above that all referenced targets
                     // has to present, we always expect this target to be present in
                     // potentialModules dictionary.
-                    return potentialModuleMap[name]!
+                    return [potentialModuleMap[name]!]
                 case .product:
-                    return nil
+                    return []
+                case .innerProduct(let product, _):
+                    guard let product = self.manifest.products.first(where: { $0.name == product }) else {
+                        return []
+                    }
+                    return product.targets.compactMap { potentialModuleMap[$0] }
                 case .byName(let name, _):
                     // By name dependency may or may not be a target dependency.
-                    return potentialModuleMap[name]
+                    return potentialModuleMap[name].map { [$0] } ?? []
                 }
             }
             // If there are plugin usages, consider them to be dependencies too.
@@ -722,6 +727,11 @@ public final class PackageBuilder {
                         try validateModuleAliases(moduleAliases)
                         return .product(
                             .init(name: name, package: package, moduleAliases: moduleAliases),
+                            conditions: buildConditions(from: condition)
+                        )
+                    case .innerProduct(let name, let condition):
+                        return .innerProduct(
+                            .init(name: name),
                             conditions: buildConditions(from: condition)
                         )
                     case .byName(let name, let condition):
@@ -1583,7 +1593,7 @@ extension Manifest {
                 switch $0 {
                 case .target(let name, _):
                     return name
-                case .byName, .product:
+                case .byName, .product, .innerProduct:
                     return nil
                 }
             }
@@ -1633,6 +1643,8 @@ extension Target.Dependency {
             return "target-\(name)"
         case .product:
             return "product-\(name)"
+        case .innerProduct:
+            return "innerproduct-\(name)"
         }
     }
 }

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -389,6 +389,9 @@ public final class Manifest: Sendable {
             } else { // < 5.2
                 registry.unknown.insert(product)
             }
+        case .innerProduct:
+            // All products in the root package are already requested by definition.
+            break
         case .byName(let product, _):
             if self.toolsVersion < .v5_2 {
                 // A by‐name entry might be a product from anywhere.

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -27,6 +27,7 @@ public struct TargetDescription: Hashable, Encodable, Sendable {
     public enum Dependency: Hashable, Sendable {
         case target(name: String, condition: PackageConditionDescription?)
         case product(name: String, package: String?, moduleAliases: [String: String]? = nil, condition: PackageConditionDescription?)
+        case innerProduct(name: String, condition: PackageConditionDescription?)
         case byName(name: String, condition: PackageConditionDescription?)
 
         public static func target(name: String) -> Dependency {
@@ -245,7 +246,7 @@ public struct TargetDescription: Hashable, Encodable, Sendable {
 
 extension TargetDescription.Dependency: Codable {
     private enum CodingKeys: String, CodingKey {
-        case target, product, byName
+        case target, product, innerProduct, byName
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -261,6 +262,10 @@ extension TargetDescription.Dependency: Codable {
             try unkeyedContainer.encode(a2)
             try unkeyedContainer.encode(a3)
             try unkeyedContainer.encode(a4)
+        case let .innerProduct(a1, a2):
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .innerProduct)
+            try unkeyedContainer.encode(a1)
+            try unkeyedContainer.encode(a2)
         case let .byName(a1, a2):
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .byName)
             try unkeyedContainer.encode(a1)
@@ -286,6 +291,11 @@ extension TargetDescription.Dependency: Codable {
             let a3 = try unkeyedValues.decode([String: String].self)
             let a4 = try unkeyedValues.decodeIfPresent(PackageConditionDescription.self)
             self = .product(name: a1, package: a2, moduleAliases: a3, condition: a4)
+        case .innerProduct:
+            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
+            let a1 = try unkeyedValues.decode(String.self)
+            let a2 = try unkeyedValues.decodeIfPresent(PackageConditionDescription.self)
+            self = .innerProduct(name: a1, condition: a2)
         case .byName:
             var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
             let a1 = try unkeyedValues.decode(String.self)

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -346,6 +346,13 @@ fileprivate extension SourceCodeFragment {
             }
             self.init(enum: "product", subnodes: params)
             
+        case .innerProduct(name: let name, condition: let condition):
+            params.append(SourceCodeFragment(key: "name", string: name))
+            if let condition {
+                params.append(SourceCodeFragment(key: "condition", subnode: SourceCodeFragment(from: condition)))
+            }
+            self.init(enum: "product", subnodes: params)
+
         case .byName(name: let name, condition: let condition):
             if let condition {
                 params.append(SourceCodeFragment(key: "name", string: name))

--- a/Sources/PackageModel/Target/Target.swift
+++ b/Sources/PackageModel/Target/Target.swift
@@ -75,6 +75,17 @@ public class Target: PolymorphicCodableProtocol {
         }
     }
 
+    /// A reference to a product within the same package as a target dependency.
+    public struct InnerProductReference: Codable {
+        /// The name of the product dependency.
+        public let name: String
+
+        /// Creates an inner product reference instance.
+        public init(name: String) {
+            self.name = name
+        }
+    }
+
     /// A target dependency to a target or product.
     public enum Dependency {
         /// A dependency referencing another target, with conditions.
@@ -82,6 +93,9 @@ public class Target: PolymorphicCodableProtocol {
 
         /// A dependency referencing a product, with conditions.
         case product(_ product: ProductReference, conditions: [PackageCondition])
+
+        /// A dependency referencing a product in the same package, with conditions.
+        case innerProduct(_ product: InnerProductReference, conditions: [PackageCondition])
 
         /// The target if the dependency is a target dependency.
         public var target: Target? {
@@ -101,12 +115,23 @@ public class Target: PolymorphicCodableProtocol {
             }
         }
 
+        /// The inner product reference if the dependency is an inner product dependency.
+        public var innerProduct: InnerProductReference? {
+            if case .innerProduct(let product, _) = self {
+                return product
+            } else {
+                return nil
+            }
+        }
+
         /// The dependency conditions.
         public var conditions: [PackageCondition] {
             switch self {
             case .target(_, let conditions):
                 return conditions
             case .product(_, let conditions):
+                return conditions
+            case .innerProduct(_, let conditions):
                 return conditions
             }
         }
@@ -117,6 +142,8 @@ public class Target: PolymorphicCodableProtocol {
             case .target(let target, _):
                 return target.name
             case .product(let product, _):
+                return product.name
+            case .innerProduct(let product, _):
                 return product.name
             }
         }

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -677,6 +677,15 @@ public extension PluginTarget {
                 }
                 builtToolName = productRef.name
                 executableOrBinaryTarget = executableTarget
+            case .innerProduct(let productRef, _):
+                guard
+                    let product = packageGraph.allProducts.first(where: { $0.name == productRef.name }),
+                    let executableTarget = product.targets.map({ $0.underlying }).executables.spm_only
+                else {
+                    throw StringError("no product named \(productRef.name)")
+                }
+                builtToolName = productRef.name
+                executableOrBinaryTarget = executableTarget
             }
 
             // For a binary target we create a `vendedTool`.
@@ -723,6 +732,7 @@ fileprivate extension Target.Dependency {
         switch self {
         case .target(_, let conditions): return conditions
         case .product(_, let conditions): return conditions
+        case .innerProduct(_, let conditions): return conditions
         }
     }
 


### PR DESCRIPTION
The implementation accompanying [an evolution proposal](https://github.com/apple/swift-evolution/blob/40afeb9eed259eb2b54dc46f18265946489a2409/proposals/NNNN-swiftpm-targets-same-package-product-dependencies.md) that would allow targets to depend on products within the same package.

### Motivation:

These changes allows dynamic linking between sibling targets, alleviating code-size and type-casting issues in certain situations. They also allow for executables to implement plugin systems without resorting to nested packages. See the proposal for motivating examples.

### Modifications:

- Created the `Target.Dependency.product(name:conditions:)` overload
- Added suitable representations for same-package products (a.k.a. `innerProduct`s) throughout SwiftPM's serialization, package model, and package builder code
- Updated `PackageBuilder.swift` and `PackageGraph+Loading.swift` to correctly construct and build package graphs containing same-package product dependencies

### Result:

Targets can now depend on products within the same package by using the `Target.Dependency.product(name: ..., conditions: ...)` static method when creating a target's dependencies.

### Tasks

- [x] Allow targets to depend on products within the same package
- [ ] Check for cycles
- [ ] Add tests
- [ ] Ensure that plugins can't depend on same-package products when it wouldn't make sense (will have to make that more rigorous)