### PR TITLE
Don't lock if we don't have a package root

### DIFF
--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -901,6 +901,9 @@ public final class SwiftTool {
     }
 
     fileprivate func acquireLockIfNeeded() throws {
+        guard packageRoot != nil else {
+            return
+        }
         assert(workspaceLockState == .needsLocking, "attempting to `acquireLockIfNeeded()` from unexpected state: \(workspaceLockState)")
         guard workspaceLock == nil else {
             throw InternalError("acquireLockIfNeeded() called multiple times")


### PR DESCRIPTION
It seems like for reasons we have a fallback scratch directory even if we couldn't determine a package root, but it doesn't seem as if we should lock that since it is likely not the scratch directory we want.