### PR TITLE
Support for prebuilt packages in the SDK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -219,7 +219,7 @@ let package = Package(
             dependencies: ["Basics"],
             exclude: ["CMakeLists.txt", "README.md"],
             resources: [
-                .copy("provided-libraries.json"),
+                .copy("InstalledLibrariesSupport/provided-libraries.json"),
             ]
         ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -217,7 +217,10 @@ let package = Package(
             /** Primitive Package model objects */
             name: "PackageModel",
             dependencies: ["Basics"],
-            exclude: ["CMakeLists.txt", "README.md"]
+            exclude: ["CMakeLists.txt", "README.md"],
+            resources: [
+                .copy("provided-libraries.json"),
+            ]
         ),
 
         .target(

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -267,7 +267,9 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         }
         Self.didEmitUnexpressedDependencies = true
 
-        let availableFrameworks = Dictionary<String, PackageIdentity>(uniqueKeysWithValues: AvailableLibraries.compactMap {
+        // Note: once we switch from the toolchain global metadata, we will have to ensure we can match the right metadata used during the build.
+        let availableLibraries = self.productsBuildParameters.toolchain.providedLibraries
+        let availableFrameworks = Dictionary<String, PackageIdentity>(uniqueKeysWithValues: availableLibraries.compactMap {
             if let identity = Set($0.identities.map(\.identity)).spm_only {
                 return ("\($0.productName!).framework", identity)
             } else {

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -6,6 +6,7 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+add_compile_definitions(SKIP_RESOURCE_SUPPORT)
 add_compile_definitions(USE_IMPL_ONLY_IMPORTS)
 
 add_subdirectory(SPMSQLite3)

--- a/Sources/Commands/PackageTools/EditCommands.swift
+++ b/Sources/Commands/PackageTools/EditCommands.swift
@@ -72,6 +72,7 @@ extension SwiftPackageTool {
                 packageName: packageName,
                 forceRemove: shouldForceRemove,
                 root: swiftTool.getWorkspaceRoot(),
+                availableLibraries: swiftTool.getHostToolchain().providedLibraries,
                 observabilityScope: swiftTool.observabilityScope
             )
         }

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -1324,6 +1324,7 @@ private extension Basics.Diagnostic {
 ///
 /// - Returns: The paths to the build test products.
 private func buildTestsIfNeeded(swiftTool: SwiftTool, buildParameters: BuildParameters, testProduct: String?) throws -> [BuiltTestProduct] {
+    // FIXME: Don't create the build system multiple times, that's extremely wasteful.
     let buildSystem = try swiftTool.createBuildSystem(productsBuildParameters: buildParameters)
 
     let subset = testProduct.map(BuildSubset.product) ?? .allIncludingTests

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -1324,7 +1324,6 @@ private extension Basics.Diagnostic {
 ///
 /// - Returns: The paths to the build test products.
 private func buildTestsIfNeeded(swiftTool: SwiftTool, buildParameters: BuildParameters, testProduct: String?) throws -> [BuiltTestProduct] {
-    // FIXME: Don't create the build system multiple times, that's extremely wasteful.
     let buildSystem = try swiftTool.createBuildSystem(productsBuildParameters: buildParameters)
 
     let subset = testProduct.map(BuildSubset.product) ?? .allIncludingTests

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -32,6 +32,7 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
         logLevel: Diagnostic.Severity?,
         observabilityScope: ObservabilityScope?
     ) throws -> any BuildSystem {
+        let rootPackageInfo = try swiftTool.getRootPackageInformation()
         let testEntryPointPath = productsBuildParameters?.testingParameters.testProductStyle.explicitlySpecifiedEntryPointPath
         return try BuildOperation(
             productsBuildParameters: try productsBuildParameters ?? self.swiftTool.productsBuildParameters,
@@ -50,6 +51,8 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
             ),
             additionalFileRules: FileRuleDescription.swiftpmFileTypes,
             pkgConfigDirectories: self.swiftTool.options.locations.pkgConfigDirectories,
+            dependenciesByRootPackageIdentity: rootPackageInfo.dependecies,
+            targetsByRootPackageIdentity: rootPackageInfo.targets,
             outputStream: outputStream ?? self.swiftTool.outputStream,
             logLevel: logLevel ?? self.swiftTool.logLevel,
             fileSystem: self.swiftTool.fileSystem,

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -48,7 +48,7 @@ import var TSCBasic.stderrStream
 import class TSCBasic.TerminalController
 import class TSCBasic.ThreadSafeOutputByteStream
 
-import var TSCUtility.verbosity
+import TSCUtility // cannot be scoped because of `String.spm_mangleToC99ExtendedIdentifier()`
 
 typealias Diagnostic = Basics.Diagnostic
 
@@ -458,6 +458,29 @@ public final class SwiftTool {
         _workspace = workspace
         _workspaceDelegate = delegate
         return workspace
+    }
+
+    public func getRootPackageInformation() throws -> (dependecies: [PackageIdentity: [PackageIdentity]], targets: [PackageIdentity: [String]]) {
+        let workspace = try self.getActiveWorkspace()
+        let root = try self.getWorkspaceRoot()
+        let rootManifests = try temp_await {
+            workspace.loadRootManifests(
+                packages: root.packages,
+                observabilityScope: self.observabilityScope,
+                completion: $0
+            )
+        }
+
+        var identities = [PackageIdentity: [PackageIdentity]]()
+        var targets = [PackageIdentity: [String]]()
+
+        rootManifests.forEach {
+            let identity = PackageIdentity(path: $0.key)
+            identities[identity] = $0.value.dependencies.map(\.identity)
+            targets[identity] = $0.value.targets.map { $0.name.spm_mangledToC99ExtendedIdentifier() }
+        }
+
+        return (identities, targets)
     }
 
     private func getEditsDirectory() throws -> AbsolutePath {

--- a/Sources/CoreCommands/SwiftTool.swift
+++ b/Sources/CoreCommands/SwiftTool.swift
@@ -604,6 +604,7 @@ public final class SwiftTool {
                 explicitProduct: explicitProduct,
                 forceResolvedVersions: options.resolver.forceResolvedVersions,
                 testEntryPointPath: testEntryPointPath,
+                availableLibraries: self.getHostToolchain().providedLibraries,
                 observabilityScope: self.observabilityScope
             )
 

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(PackageGraph
   PackageGraphRoot.swift
   PackageModel+Extensions.swift
   PackageRequirement.swift
+  PrebuiltPackageContainer.swift
   PinsStore.swift
   Resolution/PubGrub/Assignment.swift
   Resolution/PubGrub/ContainerProvider.swift

--- a/Sources/PackageGraph/PrebuiltPackageContainer.swift
+++ b/Sources/PackageGraph/PrebuiltPackageContainer.swift
@@ -10,21 +10,28 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import PackageModel
 import struct TSCUtility.Version
 
 /// A package container that can represent a prebuilt library from a package.
 public struct PrebuiltPackageContainer: PackageContainer {
+    private let chosenIdentity: LibraryMetadata.Identity
     private let metadata: LibraryMetadata
 
-    public init(metadata: LibraryMetadata) {
+    public init(metadata: LibraryMetadata) throws {
         self.metadata = metadata
+
+        // FIXME: Unclear what is supposed to happen if we have multiple identities.
+        if let identity = metadata.identities.first {
+            self.chosenIdentity = identity
+        } else {
+            let name = metadata.productName.map { "'\($0)' " } ?? ""
+            throw InternalError("provided library \(name)does not specifiy any identities")
+        }
     }
 
     public var package: PackageReference {
-        // TODO: Unclear what is supposed to happen if we have multiple identities...
-        // TODO: Also we should validate early that there is at least one identity
-        let chosenIdentity = metadata.identities.first!
         return .init(identity: chosenIdentity.identity, kind: chosenIdentity.kind)
     }
 

--- a/Sources/PackageGraph/PrebuiltPackageContainer.swift
+++ b/Sources/PackageGraph/PrebuiltPackageContainer.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import PackageModel
+import struct TSCUtility.Version
+
+/// A package container that can represent a prebuilt library from a package.
+public struct PrebuiltPackageContainer: PackageContainer {
+    private let metadata: LibraryMetadata
+
+    public init(metadata: LibraryMetadata) {
+        self.metadata = metadata
+    }
+
+    public var package: PackageReference {
+        // TODO: Unclear what is supposed to happen if we have multiple identities...
+        // TODO: Also we should validate early that there is at least one identity
+        let chosenIdentity = metadata.identities.first!
+        return .init(identity: chosenIdentity.identity, kind: chosenIdentity.kind)
+    }
+
+    public func isToolsVersionCompatible(at version: Version) -> Bool {
+        return true
+    }
+
+    public func toolsVersion(for version: Version) throws -> ToolsVersion {
+        return .v4
+    }
+
+    public func toolsVersionsAppropriateVersionsDescending() throws -> [Version] {
+        return try versionsAscending()
+    }
+
+    public func versionsAscending() throws -> [Version] {
+        return [.init(stringLiteral: metadata.version)]
+    }
+
+    public func getDependencies(at version: Version, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        return []
+    }
+
+    public func getDependencies(at revision: String, productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        return []
+    }
+
+    public func getUnversionedDependencies(productFilter: ProductFilter) throws -> [PackageContainerConstraint] {
+        return []
+    }
+
+    public func loadPackageReference(at boundVersion: BoundVersion) throws -> PackageReference {
+        return package
+    }
+}

--- a/Sources/PackageGraph/Resolution/PubGrub/ContainerProvider.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/ContainerProvider.swift
@@ -74,10 +74,14 @@ final class ContainerProvider {
         }
 
         if let metadata = package.matchingPrebuiltLibrary(in: availableLibraries) {
-            let prebuiltPackageContainer = PrebuiltPackageContainer(metadata: metadata)
-            let pubGrubContainer = PubGrubPackageContainer(underlying: prebuiltPackageContainer, pins: self.pins)
-            self.containersCache[package] = pubGrubContainer
-            return completion(.success(pubGrubContainer))
+            do {
+                let prebuiltPackageContainer = try PrebuiltPackageContainer(metadata: metadata)
+                let pubGrubContainer = PubGrubPackageContainer(underlying: prebuiltPackageContainer, pins: self.pins)
+                self.containersCache[package] = pubGrubContainer
+                return completion(.success(pubGrubContainer))
+            } catch {
+                return completion(.failure(error))
+            }
         }
 
         if let prefetchSync = self.prefetches[package] {

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -858,13 +858,9 @@ extension PackageReference {
                 return nil
             }
         case .remoteSourceControl(let url):
-            if let url = url.url { // FIXME: Use `SourceControlURL` everywhere
-                return availableLibraries.first(
-                    where: { $0.identities.contains(where: { $0 == .sourceControl(url: url) })
-                    })
-            } else {
-                return nil
-            }
+            return availableLibraries.first(where: {
+                $0.identities.contains(where: { $0 == .sourceControl(url: url) })
+            })
         }
     }
 }

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -140,7 +140,11 @@ public struct PubGrubDependencyResolver {
     }
 
     /// Execute the resolution algorithm to find a valid assignment of versions.
-    public func solve(constraints: [Constraint]) -> Result<[DependencyResolverBinding], Error> {
+    public func solve(constraints: [Constraint], preferPrebuiltLibraries: Bool) -> Result<[DependencyResolverBinding], Error> {
+        if !preferPrebuiltLibraries {
+            self.provider.removeCachedContainers(for: AvailableLibraries.flatMap { $0.identities.map { $0.ref } })
+        }
+
         // the graph resolution root
         let root: DependencyResolutionNode
         if constraints.count == 1, let constraint = constraints.first, constraint.package.kind.isRoot {
@@ -156,10 +160,23 @@ public struct PubGrubDependencyResolver {
 
         do {
             // strips state
-            return .success(try self.solve(root: root, constraints: constraints).bindings)
+            let bindings = try self.solve(root: root, constraints: constraints, preferPrebuiltLibraries: preferPrebuiltLibraries).bindings.filter {
+                return !preferPrebuiltLibraries || $0.package.matchingPrebuiltLibrary == nil
+            }
+            return .success(bindings)
         } catch {
             // If version solving failing, build the user-facing diagnostic.
             if let pubGrubError = error as? PubgrubError, let rootCause = pubGrubError.rootCause, let incompatibilities = pubGrubError.incompatibilities {
+                let incompatiblePackages = incompatibilities.map({ $0.key.package })
+                if preferPrebuiltLibraries, incompatiblePackages.contains(where: { $0.matchingPrebuiltLibrary != nil }) {
+                    return .failure(
+                        PubgrubError.potentiallyUnresovableDueToPrebuiltLibrary(
+                            incompatiblePackages,
+                            pubGrubError.description
+                        )
+                    )
+                }
+
                 do {
                     var builder = DiagnosticReportBuilder(
                         root: root,
@@ -180,9 +197,9 @@ public struct PubGrubDependencyResolver {
     /// Find a set of dependencies that fit the given constraints. If dependency
     /// resolution is unable to provide a result, an error is thrown.
     /// - Warning: It is expected that the root package reference has been set  before this is called.
-    internal func solve(root: DependencyResolutionNode, constraints: [Constraint]) throws -> (bindings: [DependencyResolverBinding], state: State) {
+    internal func solve(root: DependencyResolutionNode, constraints: [Constraint], preferPrebuiltLibraries: Bool = false) throws -> (bindings: [DependencyResolverBinding], state: State) {
         // first process inputs
-        let inputs = try self.processInputs(root: root, with: constraints)
+        let inputs = try self.processInputs(root: root, with: constraints, preferPrebuiltLibraries: preferPrebuiltLibraries)
 
         // Prefetch the containers if prefetching is enabled.
         if self.prefetchBasedOnResolvedFile {
@@ -192,7 +209,7 @@ public struct PubGrubDependencyResolver {
             let pins = self.pins.values
                 .map(\.packageRef)
                 .filter { !inputs.overriddenPackages.keys.contains($0) }
-            self.provider.prefetch(containers: pins)
+            self.provider.prefetch(containers: pins, preferPrebuiltLibraries: preferPrebuiltLibraries)
         }
 
         let state = State(root: root, overriddenPackages: inputs.overriddenPackages)
@@ -208,7 +225,7 @@ public struct PubGrubDependencyResolver {
             state.addIncompatibility(incompatibility, at: .topLevel)
         }
 
-        try self.run(state: state)
+        try self.run(state: state, preferPrebuiltLibraries: preferPrebuiltLibraries)
 
         let decisions = state.solution.assignments.filter(\.isDecision)
         var flattenedAssignments: [PackageReference: (binding: BoundVersion, products: ProductFilter)] = [:]
@@ -228,7 +245,7 @@ public struct PubGrubDependencyResolver {
             let products = assignment.term.node.productFilter
 
             // TODO: replace with async/await when available
-            let container = try temp_await { provider.getContainer(for: assignment.term.node.package, completion: $0) }
+            let container = try temp_await { provider.getContainer(for: assignment.term.node.package, preferPrebuiltLibraries: preferPrebuiltLibraries, completion: $0) }
             let updatePackage = try container.underlying.loadPackageReference(at: boundVersion)
 
             if var existing = flattenedAssignments[updatePackage] {
@@ -250,7 +267,7 @@ public struct PubGrubDependencyResolver {
         // Add overridden packages to the result.
         for (package, override) in state.overriddenPackages {
             // TODO: replace with async/await when available
-            let container = try temp_await { provider.getContainer(for: package, completion: $0) }
+            let container = try temp_await { provider.getContainer(for: package, preferPrebuiltLibraries: preferPrebuiltLibraries, completion: $0) }
             let updatePackage = try container.underlying.loadPackageReference(at: override.version)
             finalAssignments.append(.init(
                     package: updatePackage,
@@ -266,7 +283,8 @@ public struct PubGrubDependencyResolver {
 
     private func processInputs(
         root: DependencyResolutionNode,
-        with constraints: [Constraint]
+        with constraints: [Constraint],
+        preferPrebuiltLibraries: Bool
     ) throws -> (
         overriddenPackages: [PackageReference: (version: BoundVersion, products: ProductFilter)],
         rootIncompatibilities: [Incompatibility]
@@ -311,7 +329,7 @@ public struct PubGrubDependencyResolver {
                 // be process at the end. This allows us to override them when there is a non-version
                 // based (unversioned/branch-based) constraint present in the graph.
                 // TODO: replace with async/await when available
-                let container = try temp_await { provider.getContainer(for: node.package, completion: $0) }
+                let container = try temp_await { provider.getContainer(for: node.package, preferPrebuiltLibraries: preferPrebuiltLibraries, completion: $0) }
                 for dependency in try container.underlying.getUnversionedDependencies(productFilter: node.productFilter) {
                     if let versionedBasedConstraints = VersionBasedConstraint.constraints(dependency) {
                         for constraint in versionedBasedConstraints {
@@ -359,7 +377,7 @@ public struct PubGrubDependencyResolver {
             // Process dependencies of this package, similar to the first phase but branch-based dependencies
             // are not allowed to contain local/unversioned packages.
             // TODO: replace with async/await when avail
-            let container = try temp_await { provider.getContainer(for: package, completion: $0) }
+            let container = try temp_await { provider.getContainer(for: package, preferPrebuiltLibraries: preferPrebuiltLibraries, completion: $0) }
 
             // If there is a pin for this revision-based dependency, get
             // the dependencies at the pinned revision instead of using
@@ -442,19 +460,22 @@ public struct PubGrubDependencyResolver {
     /// decisions if nothing else is left to be done.
     /// After this method returns `solution` is either populated with a list of
     /// final version assignments or an error is thrown.
-    private func run(state: State) throws {
+    private func run(state: State, preferPrebuiltLibraries: Bool) throws {
         var next: DependencyResolutionNode? = state.root
 
         while let nxt = next {
             try self.propagate(state: state, node: nxt)
 
             // initiate prefetch of known packages that will be used to make the decision on the next step
-            self.provider.prefetch(containers: state.solution.undecided.map(\.node.package))
+            self.provider.prefetch(
+                containers: state.solution.undecided.map(\.node.package),
+                preferPrebuiltLibraries: preferPrebuiltLibraries
+            )
 
             // If decision making determines that no more decisions are to be
             // made, it returns nil to signal that version solving is done.
             // TODO: replace with async/await when available
-            next = try temp_await { self.makeDecision(state: state, completion: $0) }
+            next = try temp_await { self.makeDecision(state: state, preferPrebuiltLibraries: preferPrebuiltLibraries, completion: $0) }
         }
     }
 
@@ -630,7 +651,7 @@ public struct PubGrubDependencyResolver {
         incompatibility.terms.isEmpty || (incompatibility.terms.count == 1 && incompatibility.terms.first?.node == root)
     }
 
-    private func computeCounts(for terms: [Term], completion: @escaping (Result<[Term: Int], Error>) -> Void) {
+    private func computeCounts(for terms: [Term], preferPrebuiltLibraries: Bool, completion: @escaping (Result<[Term: Int], Error>) -> Void) {
         if terms.isEmpty {
             return completion(.success([:]))
         }
@@ -640,7 +661,7 @@ public struct PubGrubDependencyResolver {
 
         terms.forEach { term in
             sync.enter()
-            provider.getContainer(for: term.node.package) { result in
+            provider.getContainer(for: term.node.package, preferPrebuiltLibraries: preferPrebuiltLibraries) { result in
                 defer { sync.leave() }
                 results[term] = result.flatMap { container in Result(catching: { try container.versionCount(term.requirement) }) }
             }
@@ -655,7 +676,7 @@ public struct PubGrubDependencyResolver {
         }
     }
 
-    internal func makeDecision(state: State, completion: @escaping (Result<DependencyResolutionNode?, Error>) -> Void) {
+    internal func makeDecision(state: State, preferPrebuiltLibraries: Bool = false, completion: @escaping (Result<DependencyResolutionNode?, Error>) -> Void) {
         // If there are no more undecided terms, version solving is complete.
         let undecided = state.solution.undecided
         guard !undecided.isEmpty else {
@@ -664,7 +685,7 @@ public struct PubGrubDependencyResolver {
 
         // Prefer packages with least number of versions that fit the current requirements so we
         // get conflicts (if any) sooner.
-        self.computeCounts(for: undecided) { result in
+        self.computeCounts(for: undecided, preferPrebuiltLibraries: preferPrebuiltLibraries) { result in
             do {
                 let start = DispatchTime.now()
                 let counts = try result.get()
@@ -728,12 +749,15 @@ public extension PubGrubDependencyResolver {
     enum PubgrubError: Swift.Error, CustomStringConvertible {
         case _unresolvable(Incompatibility, [DependencyResolutionNode: [Incompatibility]])
         case unresolvable(String)
+        case potentiallyUnresovableDueToPrebuiltLibrary([PackageReference], String)
 
         public var description: String {
             switch self {
             case ._unresolvable(let rootCause, _):
                 return rootCause.description
             case .unresolvable(let error):
+                return error
+            case .potentiallyUnresovableDueToPrebuiltLibrary(_, let error):
                 return error
             }
         }
@@ -744,6 +768,8 @@ public extension PubGrubDependencyResolver {
                 return rootCause
             case .unresolvable:
                 return nil
+            case .potentiallyUnresovableDueToPrebuiltLibrary:
+                return nil
             }
         }
 
@@ -752,6 +778,8 @@ public extension PubGrubDependencyResolver {
             case ._unresolvable(_, let incompatibilities):
                 return incompatibilities
             case .unresolvable:
+                return nil
+            case .potentiallyUnresovableDueToPrebuiltLibrary:
                 return nil
             }
         }
@@ -794,6 +822,36 @@ private extension PackageRequirement {
             return false
         case .revision:
             return true
+        }
+    }
+}
+
+extension PackageReference {
+    public var matchingPrebuiltLibrary: LibraryMetadata? {
+        switch self.kind {
+        case .fileSystem, .localSourceControl, .root:
+            return nil // can never match a prebuilt library
+        case .registry(let identity):
+            if let registryIdentity = identity.registry {
+                return AvailableLibraries.first(
+                    where: { $0.identities.contains(
+                        where: { $0 == .packageIdentity(
+                            scope: registryIdentity.scope.description,
+                            name: registryIdentity.name.description
+                        )
+                        })
+                    })
+            } else {
+                return nil
+            }
+        case .remoteSourceControl(let url):
+            if let url = url.url { // FIXME: Use `SourceControlURL` everywhere
+                return AvailableLibraries.first(
+                    where: { $0.identities.contains(where: { $0 == .sourceControl(url: url) })
+                    })
+            } else {
+                return nil
+            }
         }
     }
 }

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(PackageModel
   DependencyMapper.swift
   Diagnostics.swift
   IdentityResolver.swift
+  InstalledLibrariesSupport/LibraryMetadata.swift
   InstalledSwiftPMConfiguration.swift
   Manifest/Manifest.swift
   Manifest/PackageConditionDescription.swift

--- a/Sources/PackageModel/InstalledLibrariesSupport/LibraryMetadata.swift
+++ b/Sources/PackageModel/InstalledLibrariesSupport/LibraryMetadata.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public struct LibraryMetadata {
+    public enum Identity: Equatable {
+        case packageIdentity(scope: String, name: String)
+        case sourceControl(url: URL)
+    }
+
+    /// The package from which it was built (e.g., the URL https://github.com/apple/swift-syntax.git)
+    public let identities: [Identity]
+    /// The version that was built (e.g., 509.0.2)
+    public let version: String
+    /// The product name, if it differs from the module name (e.g., SwiftParser).
+    public let productName: String?
+
+    let schemaVersion: Int
+}
+
+extension LibraryMetadata.Identity {
+    public var identity: PackageIdentity {
+        switch self {
+        case .packageIdentity(let scope, let name):
+            return PackageIdentity.plain("\(scope)/\(name)")
+        case .sourceControl(let url):
+            return PackageIdentity(url: .init(url))
+        }
+    }
+
+    public var kind: PackageReference.Kind {
+        switch self {
+        case .packageIdentity:
+            return .registry(self.identity)
+        case .sourceControl(let url):
+            return .remoteSourceControl(.init(url.absoluteString))
+        }
+    }
+
+    public var ref: PackageReference {
+        return PackageReference(identity: self.identity, kind: self.kind)
+    }
+}
+
+// FIXME: Hard-coded metadata, this should be harvested from the used SDK.
+public let AvailableLibraries: [LibraryMetadata] = [
+    .init(
+        identities: [
+            .sourceControl(url: URL(string: "https://github.com/apple/swift-testing.git")!),
+        ],
+        version: "0.4.0",
+        productName: "Testing",
+        schemaVersion: 1
+    )
+]

--- a/Sources/PackageModel/InstalledLibrariesSupport/LibraryMetadata.swift
+++ b/Sources/PackageModel/InstalledLibrariesSupport/LibraryMetadata.swift
@@ -12,8 +12,8 @@
 
 import Foundation
 
-public struct LibraryMetadata {
-    public enum Identity: Equatable {
+public struct LibraryMetadata: Decodable {
+    public enum Identity: Equatable, Decodable {
         case packageIdentity(scope: String, name: String)
         case sourceControl(url: URL)
     }
@@ -51,15 +51,3 @@ extension LibraryMetadata.Identity {
         return PackageReference(identity: self.identity, kind: self.kind)
     }
 }
-
-// FIXME: Hard-coded metadata, this should be harvested from the used SDK.
-public let AvailableLibraries: [LibraryMetadata] = [
-    .init(
-        identities: [
-            .sourceControl(url: URL(string: "https://github.com/apple/swift-testing.git")!),
-        ],
-        version: "0.4.0",
-        productName: "Testing",
-        schemaVersion: 1
-    )
-]

--- a/Sources/PackageModel/InstalledLibrariesSupport/LibraryMetadata.swift
+++ b/Sources/PackageModel/InstalledLibrariesSupport/LibraryMetadata.swift
@@ -10,12 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import Foundation
 
 public struct LibraryMetadata: Decodable {
     public enum Identity: Equatable, Decodable {
         case packageIdentity(scope: String, name: String)
-        case sourceControl(url: URL)
+        case sourceControl(url: SourceControlURL)
     }
 
     /// The package from which it was built (e.g., the URL https://github.com/apple/swift-syntax.git)
@@ -34,7 +35,7 @@ extension LibraryMetadata.Identity {
         case .packageIdentity(let scope, let name):
             return PackageIdentity.plain("\(scope)/\(name)")
         case .sourceControl(let url):
-            return PackageIdentity(url: .init(url))
+            return PackageIdentity(url: url)
         }
     }
 

--- a/Sources/PackageModel/InstalledLibrariesSupport/provided-libraries.json
+++ b/Sources/PackageModel/InstalledLibrariesSupport/provided-libraries.json
@@ -5,7 +5,7 @@
             {
                 "sourceControl":
                 {
-                    "url": "https://github.com/apple/swift-testing.git"
+                    "url": {"urlString": "https://github.com/apple/swift-testing.git"}
                 }
             }
         ],

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -43,6 +43,9 @@ public protocol Toolchain {
     /// Configuration from the used toolchain.
     var installedSwiftPMConfiguration: InstalledSwiftPMConfiguration { get }
 
+    /// Metadata for libraries provided by the used toolchain.
+    var providedLibraries: [LibraryMetadata] { get }
+
     /// The root path to the Swift SDK used by this toolchain.
     var sdkRootPath: AbsolutePath? { get }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -545,6 +545,10 @@ public final class UserToolchain: Toolchain {
         if let customProvidedLibraries {
             self.providedLibraries = customProvidedLibraries
         } else {
+            // When building with CMake, we need to skip resource support.
+            #if SKIP_RESOURCE_SUPPORT
+            let path = self.swiftCompilerPath.parentDirectory.parentDirectory.appending(components: ["share", "pm", "provided-libraries.json"])
+            #else
             let path: AbsolutePath
             if let developmentPath = Bundle.module.path(forResource: "provided-libraries", ofType: "json") {
                 // During development, we should be able to find the metadata file using `Bundle.module`.
@@ -553,6 +557,7 @@ public final class UserToolchain: Toolchain {
                 // When deployed, we can find the metadata file in the toolchain.
                 path = self.swiftCompilerPath.parentDirectory.parentDirectory.appending(components: ["share", "pm", "provided-libraries.json"])
             }
+            #endif
             if localFileSystem.exists(path) {
                 self.providedLibraries = try JSONDecoder.makeWithDefaults().decode(
                     path: path,

--- a/Sources/PackageModel/provided-libraries.json
+++ b/Sources/PackageModel/provided-libraries.json
@@ -1,0 +1,16 @@
+[
+    {
+        "identities":
+        [
+            {
+                "sourceControl":
+                {
+                    "url": "https://github.com/apple/swift-testing.git"
+                }
+            }
+        ],
+        "productName": "Testing",
+        "version": "0.4.0",
+        "schemaVersion": 1
+    }
+]

--- a/Sources/SPMTestSupport/MockBuildTestHelper.swift
+++ b/Sources/SPMTestSupport/MockBuildTestHelper.swift
@@ -38,6 +38,7 @@ public struct MockToolchain: PackageModel.Toolchain {
     public let swiftPluginServerPath: AbsolutePath? = nil
     public let extraFlags = PackageModel.BuildFlags()
     public let installedSwiftPMConfiguration = InstalledSwiftPMConfiguration.default
+    public let providedLibraries = [LibraryMetadata]()
 
     public func getClangCompiler() throws -> AbsolutePath {
         "/fake/path/to/clang"

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -364,7 +364,13 @@ public final class MockWorkspace {
         observability.topScope.trap {
             let rootInput = PackageGraphRootInput(packages: try rootPaths(for: roots))
             let ws = try self.getOrCreateWorkspace()
-            try ws.unedit(packageName: packageName, forceRemove: forceRemove, root: rootInput, observabilityScope: observability.topScope)
+            try ws.unedit(
+                packageName: packageName,
+                forceRemove: forceRemove,
+                root: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
         }
         result(observability.diagnostics)
     }
@@ -461,6 +467,7 @@ public final class MockWorkspace {
             let graph = try workspace.loadPackageGraph(
                 rootInput: rootInput,
                 forceResolvedVersions: forceResolvedVersions,
+                availableLibraries: [], // assume no provided libraries for testing.
                 expectedSigningEntities: expectedSigningEntities,
                 observabilityScope: observability.topScope
             )
@@ -499,6 +506,7 @@ public final class MockWorkspace {
             try workspace.loadPackageGraph(
                 rootInput: rootInput,
                 forceResolvedVersions: forceResolvedVersions,
+                availableLibraries: [], // assume no provided libraries for testing.
                 observabilityScope: observability.topScope
             )
         }
@@ -522,13 +530,18 @@ public final class MockWorkspace {
         )
         let root = PackageGraphRoot(input: rootInput, manifests: rootManifests, observabilityScope: observability.topScope)
 
-        let dependencyManifests = try workspace.loadDependencyManifests(root: root, observabilityScope: observability.topScope)
+        let dependencyManifests = try workspace.loadDependencyManifests(
+            root: root,
+            availableLibraries: [], // assume no provided libraries for testing.
+            observabilityScope: observability.topScope
+        )
 
         let result = try workspace.precomputeResolution(
             root: root,
             dependencyManifests: dependencyManifests,
             pinsStore: pinsStore,
             constraints: [],
+            availableLibraries: [], // assume no provided libraries for testing.
             observabilityScope: observability.topScope
         )
 
@@ -737,7 +750,11 @@ public final class MockWorkspace {
         )
         let rootManifests = try temp_await { workspace.loadRootManifests(packages: rootInput.packages, observabilityScope: observability.topScope, completion: $0) }
         let graphRoot = PackageGraphRoot(input: rootInput, manifests: rootManifests, observabilityScope: observability.topScope)
-        let manifests = try workspace.loadDependencyManifests(root: graphRoot, observabilityScope: observability.topScope)
+        let manifests = try workspace.loadDependencyManifests(
+            root: graphRoot,
+            availableLibraries: [], // assume no provided libraries for testing.
+            observabilityScope: observability.topScope
+        )
         result(manifests, observability.diagnostics)
     }
 

--- a/Sources/SPMTestSupport/Resolver.swift
+++ b/Sources/SPMTestSupport/Resolver.swift
@@ -14,6 +14,6 @@ import PackageGraph
 
 extension PubGrubDependencyResolver {
     public func solve(constraints: [Constraint]) -> Result<[DependencyResolverBinding], Error> {
-        return solve(constraints: constraints, preferPrebuiltLibraries: false)
+        return solve(constraints: constraints, availableLibraries: [], preferPrebuiltLibraries: false)
     }
 }

--- a/Sources/SPMTestSupport/Resolver.swift
+++ b/Sources/SPMTestSupport/Resolver.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import PackageGraph
+
+extension PubGrubDependencyResolver {
+    public func solve(constraints: [Constraint]) -> Result<[DependencyResolverBinding], Error> {
+        return solve(constraints: constraints, preferPrebuiltLibraries: false)
+    }
+}

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -356,6 +356,7 @@ public func loadPackageGraph(
         shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
         createREPLProduct: createREPLProduct,
         customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
+        availableLibraries: [],
         fileSystem: fileSystem,
         observabilityScope: observabilityScope
     )

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -84,6 +84,11 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
                 return completion(.success(container))
             }
 
+            // Match against available prebuilt libraries.
+            if let matchingPrebuiltLibrary = package.matchingPrebuiltLibrary {
+                return completion(.success(PrebuiltPackageContainer(metadata: matchingPrebuiltLibrary)))
+            }
+
             // As we don't have anything else locally, error out.
             completion(.failure(ResolverPrecomputationError.missingPackage(package: package)))
         }

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -44,14 +44,19 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     /// The tools version currently in use.
     let currentToolsVersion: ToolsVersion
 
+    /// The available libraries in the SDK.
+    let availableLibraries: [LibraryMetadata]
+
     init(
         root: PackageGraphRoot,
         dependencyManifests: Workspace.DependencyManifests,
-        currentToolsVersion: ToolsVersion = ToolsVersion.current
+        currentToolsVersion: ToolsVersion = ToolsVersion.current,
+        availableLibraries: [LibraryMetadata]
     ) {
         self.root = root
         self.dependencyManifests = dependencyManifests
         self.currentToolsVersion = currentToolsVersion
+        self.availableLibraries = availableLibraries
     }
 
     func getContainer(
@@ -85,7 +90,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
             }
 
             // Match against available prebuilt libraries.
-            if let matchingPrebuiltLibrary = package.matchingPrebuiltLibrary {
+            if let matchingPrebuiltLibrary = package.matchingPrebuiltLibrary(in: availableLibraries) {
                 return completion(.success(PrebuiltPackageContainer(metadata: matchingPrebuiltLibrary)))
             }
 

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -91,7 +91,11 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
 
             // Match against available prebuilt libraries.
             if let matchingPrebuiltLibrary = package.matchingPrebuiltLibrary(in: availableLibraries) {
-                return completion(.success(PrebuiltPackageContainer(metadata: matchingPrebuiltLibrary)))
+                do {
+                    return completion(.success(try PrebuiltPackageContainer(metadata: matchingPrebuiltLibrary)))
+                } catch {
+                    return completion(.failure(error))
+                }
             }
 
             // As we don't have anything else locally, error out.

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -37,6 +37,7 @@ import class PackageGraph.PinsStore
 import struct PackageGraph.PubGrubDependencyResolver
 import struct PackageGraph.Term
 import class PackageLoading.ManifestLoader
+import struct PackageModel.LibraryMetadata
 import enum PackageModel.PackageDependency
 import struct PackageModel.PackageIdentity
 import struct PackageModel.PackageReference
@@ -56,6 +57,7 @@ extension Workspace {
         root: PackageGraphRootInput,
         packages: [String] = [],
         dryRun: Bool = false,
+        availableLibraries: [LibraryMetadata],
         observabilityScope: ObservabilityScope
     ) throws -> [(PackageReference, Workspace.PackageStateChange)]? {
         let start = DispatchTime.now()
@@ -84,7 +86,11 @@ extension Workspace {
             dependencyMapper: self.dependencyMapper,
             observabilityScope: observabilityScope
         )
-        let currentManifests = try self.loadDependencyManifests(root: graphRoot, observabilityScope: observabilityScope)
+        let currentManifests = try self.loadDependencyManifests(
+            root: graphRoot,
+            availableLibraries: availableLibraries,
+            observabilityScope: observabilityScope
+        )
 
         // Abort if we're unable to load the pinsStore or have any diagnostics.
         guard let pinsStore = observabilityScope.trap({ try self.pinsStore.load() }) else { return nil }
@@ -120,6 +126,7 @@ extension Workspace {
 
         let updateResults = self.resolveDependencies(
             resolver: resolver,
+            availableLibraries: availableLibraries,
             constraints: updateConstraints,
             observabilityScope: observabilityScope
         )
@@ -156,6 +163,7 @@ extension Workspace {
         // Load the updated manifests.
         let updatedDependencyManifests = try self.loadDependencyManifests(
             root: graphRoot,
+            availableLibraries: availableLibraries,
             observabilityScope: observabilityScope
         )
         // If we have missing packages, something is fundamentally wrong with the resolution of the graph
@@ -189,6 +197,7 @@ extension Workspace {
     func _resolve(
         root: PackageGraphRootInput,
         explicitProduct: String?,
+        availableLibraries: [LibraryMetadata],
         resolvedFileStrategy: ResolvedFileStrategy,
         observabilityScope: ObservabilityScope
     ) throws -> DependencyManifests {
@@ -204,6 +213,7 @@ extension Workspace {
             return try self._resolveBasedOnResolvedVersionsFile(
                 root: root,
                 explicitProduct: explicitProduct,
+                availableLibraries: availableLibraries,
                 observabilityScope: observabilityScope
             )
         case .update(let forceResolution):
@@ -240,6 +250,7 @@ extension Workspace {
             let (manifests, precomputationResult) = try self.tryResolveBasedOnResolvedVersionsFile(
                 root: root,
                 explicitProduct: explicitProduct,
+                availableLibraries: availableLibraries,
                 observabilityScope: observabilityScope
             )
             switch precomputationResult {
@@ -263,6 +274,7 @@ extension Workspace {
             return try self.resolveAndUpdateResolvedFile(
                 root: root,
                 explicitProduct: explicitProduct,
+                availableLibraries: availableLibraries,
                 forceResolution: forceResolution,
                 constraints: [],
                 observabilityScope: observabilityScope
@@ -289,11 +301,13 @@ extension Workspace {
     func _resolveBasedOnResolvedVersionsFile(
         root: PackageGraphRootInput,
         explicitProduct: String?,
+        availableLibraries: [LibraryMetadata],
         observabilityScope: ObservabilityScope
     ) throws -> DependencyManifests {
         let (manifests, precomputationResult) = try self.tryResolveBasedOnResolvedVersionsFile(
             root: root,
             explicitProduct: explicitProduct,
+            availableLibraries: availableLibraries,
             observabilityScope: observabilityScope
         )
         switch precomputationResult {
@@ -326,6 +340,7 @@ extension Workspace {
     fileprivate func tryResolveBasedOnResolvedVersionsFile(
         root: PackageGraphRootInput,
         explicitProduct: String?,
+        availableLibraries: [LibraryMetadata],
         observabilityScope: ObservabilityScope
     ) throws -> (DependencyManifests, ResolutionPrecomputationResult) {
         // Ensure the cache path exists.
@@ -350,7 +365,11 @@ extension Workspace {
               !observabilityScope.errorsReported
         else {
             return try (
-                self.loadDependencyManifests(root: graphRoot, observabilityScope: observabilityScope),
+                self.loadDependencyManifests(
+                    root: graphRoot,
+                    availableLibraries: availableLibraries,
+                    observabilityScope: observabilityScope
+                ),
                 .notRequired
             )
         }
@@ -441,6 +460,7 @@ extension Workspace {
         let currentManifests = try self.loadDependencyManifests(
             root: graphRoot,
             automaticallyAddManagedDependencies: true,
+            availableLibraries: availableLibraries,
             observabilityScope: observabilityScope
         )
 
@@ -455,6 +475,7 @@ extension Workspace {
             dependencyManifests: currentManifests,
             pinsStore: pinsStore,
             constraints: [],
+            availableLibraries: availableLibraries,
             observabilityScope: observabilityScope
         )
 
@@ -471,6 +492,7 @@ extension Workspace {
     func resolveAndUpdateResolvedFile(
         root: PackageGraphRootInput,
         explicitProduct: String? = nil,
+        availableLibraries: [LibraryMetadata],
         forceResolution: Bool,
         constraints: [PackageContainerConstraint],
         observabilityScope: ObservabilityScope
@@ -496,7 +518,11 @@ extension Workspace {
             dependencyMapper: self.dependencyMapper,
             observabilityScope: observabilityScope
         )
-        let currentManifests = try self.loadDependencyManifests(root: graphRoot, observabilityScope: observabilityScope)
+        let currentManifests = try self.loadDependencyManifests(
+            root: graphRoot,
+            availableLibraries: availableLibraries,
+            observabilityScope: observabilityScope
+        )
         guard !observabilityScope.errorsReported else {
             return currentManifests
         }
@@ -531,6 +557,7 @@ extension Workspace {
                 dependencyManifests: currentManifests,
                 pinsStore: pinsStore,
                 constraints: constraints,
+                availableLibraries: availableLibraries,
                 observabilityScope: observabilityScope
             )
 
@@ -569,6 +596,7 @@ extension Workspace {
 
         let result = self.resolveDependencies(
             resolver: resolver,
+            availableLibraries: availableLibraries,
             constraints: computedConstraints,
             observabilityScope: observabilityScope
         )
@@ -593,6 +621,7 @@ extension Workspace {
         // Update the pinsStore.
         let updatedDependencyManifests = try self.loadDependencyManifests(
             root: graphRoot,
+            availableLibraries: availableLibraries,
             observabilityScope: observabilityScope
         )
         // If we still have missing packages, something is fundamentally wrong with the resolution of the graph
@@ -801,6 +830,7 @@ extension Workspace {
         dependencyManifests: DependencyManifests,
         pinsStore: PinsStore,
         constraints: [PackageContainerConstraint],
+        availableLibraries: [LibraryMetadata],
         observabilityScope: ObservabilityScope
     ) throws -> ResolutionPrecomputationResult {
         let computedConstraints =
@@ -812,14 +842,19 @@ extension Workspace {
 
         let precomputationProvider = ResolverPrecomputationProvider(
             root: root,
-            dependencyManifests: dependencyManifests
+            dependencyManifests: dependencyManifests,
+            availableLibraries: availableLibraries
         )
         let resolver = PubGrubDependencyResolver(
             provider: precomputationProvider,
             pins: pinsStore.pins,
             observabilityScope: observabilityScope
         )
-        let result = resolver.solve(constraints: computedConstraints, preferPrebuiltLibraries: true)
+        let result = resolver.solve(
+            constraints: computedConstraints,
+            availableLibraries: availableLibraries,
+            preferPrebuiltLibraries: true
+        )
 
         guard !observabilityScope.errorsReported else {
             return .required(reason: .errorsPreviouslyReported)
@@ -1113,14 +1148,23 @@ extension Workspace {
     /// Runs the dependency resolver based on constraints provided and returns the results.
     fileprivate func resolveDependencies(
         resolver: PubGrubDependencyResolver,
+        availableLibraries: [LibraryMetadata],
         constraints: [PackageContainerConstraint],
         observabilityScope: ObservabilityScope
     ) -> [DependencyResolverBinding] {
         os_signpost(.begin, name: SignpostName.pubgrub)
-        var result = resolver.solve(constraints: constraints, preferPrebuiltLibraries: true)
+        var result = resolver.solve(
+            constraints: constraints,
+            availableLibraries: availableLibraries,
+            preferPrebuiltLibraries: true
+        )
         // If the initial resolution failed due to prebuilt libraries, we try to resolve again without prebuilt libraries.
         if case let Result.failure(error as PubGrubDependencyResolver.PubgrubError) = result, case .potentiallyUnresovableDueToPrebuiltLibrary = error {
-            result = resolver.solve(constraints: constraints, preferPrebuiltLibraries: false)
+            result = resolver.solve(
+                constraints: constraints,
+                availableLibraries: availableLibraries,
+                preferPrebuiltLibraries: false
+            )
         }
         os_signpost(.end, name: SignpostName.pubgrub)
 

--- a/Sources/Workspace/Workspace+Editing.swift
+++ b/Sources/Workspace/Workspace+Editing.swift
@@ -15,6 +15,7 @@ import class Basics.ObservabilityScope
 import struct Basics.RelativePath
 import func Basics.temp_await
 import struct PackageGraph.PackageGraphRootInput
+import struct PackageModel.LibraryMetadata
 import struct SourceControl.Revision
 import class TSCBasic.InMemoryFileSystem
 
@@ -169,6 +170,7 @@ extension Workspace {
         dependency: ManagedDependency,
         forceRemove: Bool,
         root: PackageGraphRootInput? = nil,
+        availableLibraries: [LibraryMetadata],
         observabilityScope: ObservabilityScope
     ) throws {
         // Compute if we need to force remove.
@@ -233,6 +235,7 @@ extension Workspace {
             try self._resolve(
                 root: root,
                 explicitProduct: .none,
+                availableLibraries: availableLibraries,
                 resolvedFileStrategy: .update(forceResolution: false),
                 observabilityScope: observabilityScope
             )

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -571,6 +571,11 @@ public class Workspace {
             initializationWarningHandler: initializationWarningHandler
         )
     }
+
+    fileprivate var providedLibraries: [LibraryMetadata] {
+        // Note: Eventually, we should get these from the individual SDKs, but the first step is providing the metadata centrally in the toolchain.
+        return self.hostToolchain.providedLibraries
+    }
 }
 
 // MARK: - Public API
@@ -621,6 +626,7 @@ extension Workspace {
         packageName: String,
         forceRemove: Bool,
         root: PackageGraphRootInput,
+        availableLibraries: [LibraryMetadata],
         observabilityScope: ObservabilityScope
     ) throws {
         guard let dependency = self.state.dependencies[.plain(packageName)] else {
@@ -637,6 +643,7 @@ extension Workspace {
             dependency: dependency,
             forceRemove: forceRemove,
             root: root,
+            availableLibraries: availableLibraries,
             observabilityScope: observabilityScope
         )
     }
@@ -657,6 +664,7 @@ extension Workspace {
         try self._resolve(
             root: root,
             explicitProduct: explicitProduct,
+            availableLibraries: self.providedLibraries,
             resolvedFileStrategy: forceResolvedVersions ? .lockFile : forceResolution ? .update(forceResolution: true) :
                 .bestEffort,
             observabilityScope: observabilityScope
@@ -728,6 +736,7 @@ extension Workspace {
         // Run the resolution.
         try self.resolveAndUpdateResolvedFile(
             root: root,
+            availableLibraries: self.providedLibraries,
             forceResolution: false,
             constraints: [constraint],
             observabilityScope: observabilityScope
@@ -745,6 +754,7 @@ extension Workspace {
         try self._resolveBasedOnResolvedVersionsFile(
             root: root,
             explicitProduct: .none,
+            availableLibraries: self.providedLibraries,
             observabilityScope: observabilityScope
         )
     }
@@ -855,6 +865,7 @@ extension Workspace {
             root: root,
             packages: packages,
             dryRun: dryRun,
+            availableLibraries: self.providedLibraries,
             observabilityScope: observabilityScope
         )
     }
@@ -866,6 +877,7 @@ extension Workspace {
         forceResolvedVersions: Bool = false,
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
         testEntryPointPath: AbsolutePath? = nil,
+        availableLibraries: [LibraryMetadata],
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
         observabilityScope: ObservabilityScope
     ) throws -> PackageGraph {
@@ -885,6 +897,7 @@ extension Workspace {
         let manifests = try self._resolve(
             root: root,
             explicitProduct: explicitProduct,
+            availableLibraries: availableLibraries,
             resolvedFileStrategy: forceResolvedVersions ? .lockFile : .bestEffort,
             observabilityScope: observabilityScope
         )
@@ -911,6 +924,7 @@ extension Workspace {
             createREPLProduct: self.configuration.createREPLProduct,
             customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
             testEntryPointPath: testEntryPointPath,
+            availableLibraries: self.providedLibraries,
             fileSystem: self.fileSystem,
             observabilityScope: observabilityScope
         )
@@ -932,6 +946,7 @@ extension Workspace {
         try self.loadPackageGraph(
             rootInput: PackageGraphRootInput(packages: [rootPath]),
             explicitProduct: explicitProduct,
+            availableLibraries: self.providedLibraries,
             observabilityScope: observabilityScope
         )
     }

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -380,6 +380,7 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
                     partial[item.key] = (manifest: item.value, fs: self.fileSystem)
                 },
                 binaryArtifacts: [:],
+                availableLibraries: [], // assume no provided libraries during bootstrap
                 fileSystem: fileSystem,
                 observabilityScope: observabilityScope
             )

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -314,6 +314,8 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
                     packageGraphLoader: packageGraphLoader,
                     additionalFileRules: [],
                     pkgConfigDirectories: [],
+                    dependenciesByRootPackageIdentity: [:],
+                    targetsByRootPackageIdentity: [:],
                     outputStream: TSCBasic.stdoutStream,
                     logLevel: logLevel,
                     fileSystem: self.fileSystem,

--- a/Tests/BuildTests/BuildOperationTests.swift
+++ b/Tests/BuildTests/BuildOperationTests.swift
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@testable import Build
+@testable import PackageModel
+
+import Basics
+import SPMTestSupport
+import XCTest
+
+import class TSCBasic.BufferedOutputByteStream
+import class TSCBasic.InMemoryFileSystem
+
+final class BuildOperationTests: XCTestCase {
+    func testDetectUnexpressedDependencies() throws {
+        let fs = InMemoryFileSystem(files: [
+            "/path/to/build/debug/Lunch.build/Lunch.d" : "/Best.framework"
+        ])
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let buildOp = BuildOperation(
+            productsBuildParameters: mockBuildParameters(shouldDisableLocalRpath: false),
+            toolsBuildParameters: mockBuildParameters(shouldDisableLocalRpath: false),
+            cacheBuildManifest: false,
+            packageGraphLoader: { fatalError() },
+            additionalFileRules: [],
+            pkgConfigDirectories: [],
+            dependenciesByRootPackageIdentity: [:],
+            targetsByRootPackageIdentity: [:],
+            outputStream: BufferedOutputByteStream(),
+            logLevel: .info,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        buildOp.detectUnexpressedDependencies(
+            availableLibraries: [
+                .init(
+                    identities: [
+                        .sourceControl(url: .init("https://example.com/org/foo"))
+                    ],
+                    version: "1.0.0",
+                    productName: "Best",
+                    schemaVersion: 1
+                )
+            ],
+            targetDependencyMap: ["Lunch": []]
+        )
+
+        XCTAssertEqual(
+            observability.diagnostics.map { $0.message },
+            ["target 'Lunch' has an unexpressed depedency on 'foo'"]
+        )
+    }
+}

--- a/Tests/CommandsTests/PackageToolTests.swift
+++ b/Tests/CommandsTests/PackageToolTests.swift
@@ -3205,7 +3205,11 @@ final class PackageToolTests: CommandsTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let _ = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let _ = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -442,7 +442,11 @@ class PluginTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 2, "\(packageGraph.packages)")
             XCTAssert(packageGraph.rootPackages.count == 1, "\(packageGraph.rootPackages)")
@@ -625,7 +629,11 @@ class PluginTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
             // Make sure that the use of plugins doesn't bleed into the use of plugins by tools.
@@ -719,7 +727,11 @@ class PluginTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
             XCTAssert(packageGraph.rootPackages.count == 1, "\(packageGraph.rootPackages)")
@@ -1031,7 +1043,11 @@ class PluginTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
             XCTAssert(packageGraph.packages.count == 4, "\(packageGraph.packages)")
             XCTAssert(packageGraph.rootPackages.count == 1, "\(packageGraph.rootPackages)")
 

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -94,6 +94,7 @@ final class PackageGraphPerfTests: XCTestCasePerf {
                 identityResolver: identityResolver,
                 externalManifests: externalManifests,
                 binaryArtifacts: [:],
+                availableLibraries: [], // assume no provided libraries for testing.
                 fileSystem: fs,
                 observabilityScope: observability.topScope
             )

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -294,7 +294,11 @@ class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
             
@@ -671,7 +675,11 @@ class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            XCTAssertThrowsError(try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)) { error in
+            XCTAssertThrowsError(try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )) { error in
                 var diagnosed = false
                 if let realError = error as? PackageGraphError,
                    realError.description == "plugin 'MyPlugin' cannot depend on 'FooLib' of type 'library' from package 'foopackage'; this dependency is unsupported" {
@@ -747,7 +755,10 @@ class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            XCTAssertThrowsError(try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)) { error in
+            XCTAssertThrowsError(try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope)) { error in
                 var diagnosed = false
                 if let realError = error as? PackageGraphError,
                    realError.description == "plugin 'MyPlugin' cannot depend on 'MyLibrary' of type 'library'; this dependency is unsupported" {
@@ -854,7 +865,11 @@ class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
 
@@ -1034,7 +1049,11 @@ class PluginInvocationTests: XCTestCase {
             )
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
-            let graph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let graph = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
             let dict = try await workspace.loadPluginImports(packageGraph: graph)
 
             var count = 0
@@ -1179,7 +1198,11 @@ class PluginInvocationTests: XCTestCase {
             XCTAssert(rootManifests.count == 1, "\(rootManifests)")
 
             // Load the package graph.
-            let packageGraph = try workspace.loadPackageGraph(rootInput: rootInput, observabilityScope: observability.topScope)
+            let packageGraph = try workspace.loadPackageGraph(
+                rootInput: rootInput,
+                availableLibraries: [], // assume no provided libraries for testing.
+                observabilityScope: observability.topScope
+            )
             XCTAssertNoDiagnostics(observability.diagnostics)
 
             // Find the build tool plugin.


### PR DESCRIPTION
This should allow satisfying a package dependency with a package in the SDK (or toolchain) based on metadata. If the given prebuilt library is version-compatible, we essentially elide the dependency from the graph. If it is not, we will fetch and build the dependency as normal. If a library with associated metadata is linked without a corresponding package dependency, we'll emit a warning.