### PR TITLE
Bump swift-syntax version in the macro template

### DIFF
--- a/Utilities/config.json
+++ b/Utilities/config.json
@@ -1,1 +1,1 @@
-{"version":1,"swiftSyntaxVersionForMacroTemplate":{"major":509,"minor":0,"patch":0}}
+{"version":1,"swiftSyntaxVersionForMacroTemplate":{"major":510,"minor":0,"patch":0, "prereleaseIdentifier":"latest"}}


### PR DESCRIPTION
We use the "-latest" signifier to avoid confusion here, but basically this means we'll use any "-prerelease" tags and also the final release once it is out.