### PR TITLE
[5.10] Bump swift-syntax version in the macro template

### DIFF
--- a/Utilities/config.json
+++ b/Utilities/config.json
@@ -1,1 +1,1 @@
-{"version":1,"swiftSyntaxVersionForMacroTemplate":{"major":509,"minor":0,"patch":0}}
+{"version":1,"swiftSyntaxVersionForMacroTemplate":{"major":510,"minor":0,"patch":0, "prereleaseIdentifier":"latest"}}


### PR DESCRIPTION
(cherry picked from commit db00c3e1947aeb9c1906ee6330fb587eda940f02)

* **Explanation**: Bumps the swift-syntax version in the macro template to 5.10. `-latest` allows using pre-release tags until 510 is tagged in swift-syntax.
* **Scope**: Templates
* **Risk**: Very low - updates a template to use the tag corresponding to this release.
* **Testing**: Manual testing with a modified config in the toolchain
* **Reviewer**: @bnbarham 
* **Main branch PR**: https://github.com/apple/swift-package-manager/pull/7339
* **Radar**: rdar://121857631