### PR TITLE
Fix test runner build on WASI

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -265,7 +265,14 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
                 struct Runner {
                     static func main() {
                         \#(testObservabilitySetup)
+                        #if os(WASI)
+                        // FIXME: On WASI, XCTest uses `Task` based waiting not to block the whole process, so
+                        // the `XCTMain` call can return the control and the process will exit by `exit(0)` later.
+                        // This is a workaround until we have WASI threads or swift-testing, which does not block threads.
+                        XCTMain(__allDiscoveredTests())
+                        #else
                         XCTMain(__allDiscoveredTests()) as Never
+                        #endif
                     }
                 }
                 """#

--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -130,6 +130,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
         #elseif os(Windows)
         @_exported import CRT
         @_exported import WinSDK
+        #elseif os(WASI)
+        @_exported import WASILibc
         #else
         @_exported import Darwin.C
         #endif
@@ -176,6 +178,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
                                    UInt32.max, UInt32.max, &overlapped) {
                         throw ProcessLockError.unableToAquireLock(errno: Int32(GetLastError()))
                     }
+              #elseif os(WASI)
+                // WASI doesn't support flock
               #else
                 if fileDescriptor == nil {
                     let fd = open(lockFile.path, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
@@ -201,6 +205,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
                 overlapped.OffsetHigh = 0
                 overlapped.hEvent = nil
                 UnlockFileEx(handle, 0, UInt32.max, UInt32.max, &overlapped)
+              #elseif os(WASI)
+                // WASI doesn't support flock
               #else
                 guard let fd = fileDescriptor else { return }
                 flock(fd, LOCK_UN)
@@ -211,6 +217,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
               #if os(Windows)
                 guard let handle = handle else { return }
                 CloseHandle(handle)
+              #elseif os(WASI)
+                // WASI doesn't support flock
               #else
                 guard let fd = fileDescriptor else { return }
                 close(fd)


### PR DESCRIPTION
### Motivation:

The test runner build was failing on WASI after the introduction of the experimental summary output.

### Modifications:

This PR fixes several minor issues to pass `--build-tests` build on WASI:

* Missing `WASILibc` import
* The use of `flock` which is not available on WASI.
* Signature incompatibility of `XCTMain` on WASI.


### Result:

`swift build --build-tests --triple wasm32-unknown-wasi` will pass when compiler supports the target
