### PR TITLE
Remove myself from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,10 +8,6 @@
 # (W), PGP key ID and fingerprint (P), description (D), and snail-mail address
 # (S).
 
-# N: Boris Buegling
-# E: bbuegling@apple.com
-# D: Package Manager
-
 # N: Tomer Doron
 # E: tomer@apple.com
 # D: Package Manager
@@ -28,4 +24,4 @@
 
 # The following lines are used by GitHub to automatically recommend reviewers.
 
-* @bnbarham @MaxDesiatov @neonichu @tomerd
+* @bnbarham @MaxDesiatov @tomerd


### PR DESCRIPTION
Seems like a good time to ship this since I am wrapping up my last few PRs and this way I don't get added as reviewer to new PRs which will set the correct expectation that I won't be doing any future code reviews.
