### PR TITLE
Make `PackageModel` resources optional

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -73,6 +73,16 @@ automatic linking type with `-auto` suffix appended to product's name.
 */
 let autoProducts = [swiftPMProduct, swiftPMDataModelProduct]
 
+
+let packageModelResources: [Resource]
+if ProcessInfo.processInfo.environment["SWIFTPM_USE_LIBRARIES_METADATA"] == nil {
+    packageModelResources = []
+} else {
+    packageModelResources = [
+        .copy("InstalledLibrariesSupport/provided-libraries.json"),
+    ]
+}
+
 let package = Package(
     name: "SwiftPM",
     platforms: [
@@ -218,9 +228,7 @@ let package = Package(
             name: "PackageModel",
             dependencies: ["Basics"],
             exclude: ["CMakeLists.txt", "README.md"],
-            resources: [
-                .copy("InstalledLibrariesSupport/provided-libraries.json"),
-            ]
+            resources: packageModelResources
         ),
 
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -74,13 +74,16 @@ automatic linking type with `-auto` suffix appended to product's name.
 let autoProducts = [swiftPMProduct, swiftPMDataModelProduct]
 
 
+let packageModelResourcesSettings: [SwiftSetting]
 let packageModelResources: [Resource]
 if ProcessInfo.processInfo.environment["SWIFTPM_USE_LIBRARIES_METADATA"] == nil {
     packageModelResources = []
+    packageModelResourcesSettings = [.define("SKIP_RESOURCE_SUPPORT")]
 } else {
     packageModelResources = [
         .copy("InstalledLibrariesSupport/provided-libraries.json"),
     ]
+    packageModelResourcesSettings = []
 }
 
 let package = Package(
@@ -228,7 +231,8 @@ let package = Package(
             name: "PackageModel",
             dependencies: ["Basics"],
             exclude: ["CMakeLists.txt", "README.md"],
-            resources: packageModelResources
+            resources: packageModelResources,
+            swiftSettings: packageModelResourcesSettings
         ),
 
         .target(

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -545,7 +545,7 @@ public final class UserToolchain: Toolchain {
         if let customProvidedLibraries {
             self.providedLibraries = customProvidedLibraries
         } else {
-            // When building with CMake, we need to skip resource support.
+            // When building with CMake or `swift build --build-system xcode`, we need to skip resource support.
             #if SKIP_RESOURCE_SUPPORT
             let path = self.swiftCompilerPath.parentDirectory.parentDirectory.appending(components: ["share", "pm", "provided-libraries.json"])
             #else


### PR DESCRIPTION
https://github.com/apple/swift-package-manager/pull/7337 is breaking toolchain builds, so we should pass `SKIP_RESOURCE_SUPPORT` by default to avoid that.