### PR TITLE
Build direct dependencies of tests for target triple

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -130,7 +130,7 @@ public final class SwiftTargetBuildDescription {
         self.tempsPath.appending(component: self.target.c99name + ".swiftmodule.o")
     }
 
-    /// The path to the swifinterface file after compilation.
+    /// The path to the swiftinterface file after compilation.
     var parseableModuleInterfaceOutputPath: AbsolutePath {
         self.modulesPath.appending(component: self.target.c99name + ".swiftinterface")
     }

--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -92,13 +92,13 @@ extension BuildPlan {
 
         buildProduct.staticTargets = dependencies.staticTargets
         buildProduct.dylibs = try dependencies.dylibs.map {
-            guard let product = productMap[$0.id] else {
+            guard let product = self.productMap[$0.id] else {
                 throw InternalError("unknown product \($0)")
             }
             return product
         }
         buildProduct.objects += try dependencies.staticTargets.flatMap { targetName -> [AbsolutePath] in
-            guard let target = targetMap[targetName.id] else {
+            guard let target = self.targetMap[targetName.id] else {
                 throw InternalError("unknown target \(targetName)")
             }
             return try target.objects

--- a/Sources/PackageGraph/PackageGraph+Loading.swift
+++ b/Sources/PackageGraph/PackageGraph+Loading.swift
@@ -280,7 +280,10 @@ private func createResolvedPackages(
 
     // Resolve module aliases, if specified, for targets and their dependencies
     // across packages. Aliasing will result in target renaming.
-    let moduleAliasingUsed = try resolveModuleAliases(packageBuilders: packageBuilders, observabilityScope: observabilityScope)
+    let moduleAliasingUsed = try resolveModuleAliases(
+        packageBuilders: packageBuilders,
+        observabilityScope: observabilityScope
+    )
 
     // Scan and validate the dependencies
     for packageBuilder in packageBuilders {

--- a/Sources/PackageGraph/PackageGraph.swift
+++ b/Sources/PackageGraph/PackageGraph.swift
@@ -79,10 +79,14 @@ public struct PackageGraph {
     /// Returns true if a given target is present in root packages and is not excluded for the given build environment.
     public func isInRootPackages(_ target: ResolvedTarget, satisfying buildEnvironment: BuildEnvironment) -> Bool {
         // FIXME: This can be easily cached.
-        return rootPackages.reduce(into: IdentifiableSet<ResolvedTarget>()) { (accumulator: inout IdentifiableSet<ResolvedTarget>, package: ResolvedPackage) in
+        return rootPackages.reduce(
+            into: IdentifiableSet<ResolvedTarget>()
+        ) { (accumulator: inout IdentifiableSet<ResolvedTarget>, package: ResolvedPackage) in
             let allDependencies = package.targets.flatMap { $0.dependencies }
             let unsatisfiedDependencies = allDependencies.filter { !$0.satisfies(buildEnvironment) }
-            let unsatisfiedDependencyTargets = unsatisfiedDependencies.compactMap { (dep: ResolvedTarget.Dependency) -> ResolvedTarget? in
+            let unsatisfiedDependencyTargets = unsatisfiedDependencies.compactMap { (
+                dep: ResolvedTarget.Dependency
+            ) -> ResolvedTarget? in
                 switch dep {
                 case .target(let target, _):
                     return target
@@ -152,7 +156,7 @@ public struct PackageGraph {
         for package in self.packages {
             let targetsToInclude: [ResolvedTarget]
             if rootPackages.contains(id: package.id) {
-                targetsToInclude = package.targets
+                targetsToInclude = Array(package.targets)
             } else {
                 // Don't include tests targets from non-root packages so swift-test doesn't
                 // try to run them.

--- a/Sources/PackageGraph/Resolution/ResolvedProduct.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedProduct.swift
@@ -30,7 +30,7 @@ public struct ResolvedProduct {
     public let underlying: Product
 
     /// The top level targets contained in this product.
-    public private(set) var targets: IdentifiableSet<ResolvedTarget>
+    public internal(set) var targets: IdentifiableSet<ResolvedTarget>
 
     /// Executable target for test entry point file.
     public let testEntryPointTarget: ResolvedTarget?

--- a/Sources/PackageGraph/Resolution/ResolvedTarget.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedTarget.swift
@@ -133,7 +133,7 @@ public struct ResolvedTarget {
     public let underlying: Target
 
     /// The dependencies of this target.
-    public private(set) var dependencies: [Dependency]
+    public internal(set) var dependencies: [Dependency]
 
     /// The default localization for resources.
     public let defaultLocalization: String?

--- a/Tests/BuildTests/CrossCompilationBuildTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildTests.swift
@@ -70,12 +70,17 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         let macroProduct = try XCTUnwrap(macroProducts.first)
         XCTAssertEqual(macroProduct.buildParameters.triple, toolsTriple)
 
-        // FIXME: check for  *toolsTriple*
+        // FIXME: check for *toolsTriple*
         let mmioTarget = try XCTUnwrap(plan.targets.first { try $0.swiftTarget().target.name == "MMIO" }?.swiftTarget())
-        let compileArguments = try mmioTarget.compileArguments()
+        let compileArguments = try mmioTarget.emitCommandLine()
         XCTAssertMatch(
             compileArguments,
-            ["-Xfrontend", "-load-plugin-executable", "-Xfrontend", .contains(toolsTriple.tripleString)]
+            [
+                "-I", .equal(mmioTarget.moduleOutputPath.parentDirectory.pathString),
+                .anySequence,
+                "-Xfrontend", "-load-plugin-executable",
+                "-Xfrontend", .contains(toolsTriple.tripleString)
+            ]
         )
     }
 }


### PR DESCRIPTION
`assertMacroExpansion` requires macros to be compiled for target platform and evaluated in-process. We can't handle the case of indirect macro dependencies cleanly, those will be still compiled for the host. Supersedes https://github.com/apple/swift-package-manager/pull/7349.

This doesn't contain tests to expedite the fix and unblock broken CI jobs, but I've verified locally that test products of the `Examples` package in `apple/swift-syntax` repo can be built successfully and these tests all pass.