### PR TITLE
[5.10] Fix test runner build on WASI

### DIFF
--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -130,6 +130,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
         #elseif os(Windows)
         @_exported import CRT
         @_exported import WinSDK
+        #elseif os(WASI)
+        @_exported import WASILibc
         #else
         @_exported import Darwin.C
         #endif
@@ -176,6 +178,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
                                    UInt32.max, UInt32.max, &overlapped) {
                         throw ProcessLockError.unableToAquireLock(errno: Int32(GetLastError()))
                     }
+              #elseif os(WASI)
+                // WASI doesn't support flock
               #else
                 if fileDescriptor == nil {
                     let fd = open(lockFile.path, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
@@ -201,6 +205,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
                 overlapped.OffsetHigh = 0
                 overlapped.hEvent = nil
                 UnlockFileEx(handle, 0, UInt32.max, UInt32.max, &overlapped)
+              #elseif os(WASI)
+                // WASI doesn't support flock
               #else
                 guard let fd = fileDescriptor else { return }
                 flock(fd, LOCK_UN)
@@ -211,6 +217,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
               #if os(Windows)
                 guard let handle = handle else { return }
                 CloseHandle(handle)
+              #elseif os(WASI)
+                // WASI doesn't support flock
               #else
                 guard let fd = fileDescriptor else { return }
                 close(fd)


### PR DESCRIPTION
🍒 https://github.com/apple/swift-package-manager/pull/7341

* **Explanation**:  `swift build --build-tests` fails on WASI after the experimental summary output, which is introduced in 5.10. This affects not only experimental-summary mode but also the default output mode.
* **Scope**: Test build targeting WebAssembly
* **Risk**: Low, only affects to WebAssembly targets
* **Testing**: Integration test with WebAssembly Swift SDK on CI is infeasible, so I manually tested. We can ensure there is no breakage on other platforms on CI.
* **Reviewer**: @MaxDesiatov 
* **Main branch PR**: https://github.com/apple/swift-package-manager/pull/7341