### PR TITLE
Enable `--gc-sections` for WebAssembly targets

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -122,15 +122,6 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
                 return ["-Xlinker", "-dead_strip"]
             } else if triple.isWindows() {
                 return ["-Xlinker", "/OPT:REF"]
-            } else if triple.arch == .wasm32 {
-                // FIXME: wasm-ld strips data segments referenced through __start/__stop symbols
-                // during GC, and it removes Swift metadata sections like swift5_protocols
-                // We should add support of SHF_GNU_RETAIN-like flag for __attribute__((retain))
-                // to LLVM and wasm-ld
-                // This workaround is required for not only WASI but also all WebAssembly triples
-                // using wasm-ld (e.g. wasm32-unknown-unknown). So this branch is conditioned by
-                // arch == .wasm32
-                return []
             } else {
                 return ["-Xlinker", "--gc-sections"]
             }


### PR DESCRIPTION
Enable `--gc-sections` back for WebAssembly targets

### Motivation:

We disabled `--gc-sections` for Wasm targets due to a lack of features in the object file format. However, we recently added the missing piece in wasm object file format, so we no longer have any reason to disable it.

### Modifications:

This effectively reverts 3a366cc7fa5daf38476af6627a3881f04e50bb05. After https://github.com/apple/swift/pull/71768, we don't have any reason to disable `--gc-sections` for WebAssembly targets. Note that the new wasm segment flags are only supported by the latest LLVM and wasm-ld, but we can assume that toolchains or Swift SDKs for WebAssembly have wasm-ld built from the latest LLVM.


### Result:

Allow dead code stripping at link time for WebAssembly targets.
