### PR TITLE
Allow reading `Package.swift` with the executable bit set

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1105,7 +1105,7 @@ private class GitFileSystemView: FileSystem {
         case .symlink:
             let path = try repository.readLink(hash: hash)
             return try readFileContents(AbsolutePath(validating: path))
-        case .blob:
+        case .blob, .executableBlob:
             return try self.repository.readBlob(hash: hash)
         default:
             throw InternalError("unsupported git entry type \(entry.type) at path \(path)")

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -291,6 +291,7 @@ class GitRepositoryTests: XCTestCase {
             // Check read of a file.
             XCTAssertEqual(try view.readFileContents("/test-file-1.txt"), test1FileContents)
             XCTAssertEqual(try view.readFileContents("/subdir/test-file-2.txt"), test2FileContents)
+            XCTAssertEqual(try view.readFileContents("/test-file-3.sh"), test3FileContents)
         }
     }
 


### PR DESCRIPTION
786c5131ed5ec823d3be90ad31923123fcaccd56 added support for symlinks, but didn't handle `executableBlob` in the added `switch`. `executableBlob` is the returned type for a file with the executable bit set, so needs to be handled in the same way as a regular `blob`.