### PR TITLE
Fix some warnings with `ProcessEnvironmentBlock`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -350,7 +350,7 @@ let package = Package(
             /** Support for building using Xcode's build system */
             name: "XCBuildSupport",
             dependencies: ["SPMBuildCore", "PackageGraph"],
-            exclude: ["CMakeLists.txt", "CODEOWNERS"]
+            exclude: ["CODEOWNERS"]
         ),
         .target(
             /** High level functionality */

--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -20,7 +20,7 @@ import func TSCBasic.tsc_await
 
 public enum Concurrency {
     public static var maxOperations: Int {
-        ProcessEnv.vars["SWIFTPM_MAX_CONCURRENT_OPERATIONS"].flatMap(Int.init) ?? ProcessInfo.processInfo
+        ProcessEnv.block["SWIFTPM_MAX_CONCURRENT_OPERATIONS"].flatMap(Int.init) ?? ProcessInfo.processInfo
             .activeProcessorCount
     }
 }

--- a/Sources/Basics/EnvironmentVariables.swift
+++ b/Sources/Basics/EnvironmentVariables.swift
@@ -11,8 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 import class Foundation.ProcessInfo
+import typealias TSCBasic.ProcessEnvironmentBlock
+import struct TSCBasic.ProcessEnvironmentKey
+import enum TSCBasic.ProcessEnv
 
-public typealias EnvironmentVariables = [String: String]
+public typealias EnvironmentVariables = ProcessEnvironmentBlock
 
 extension EnvironmentVariables {
     public static func empty() -> EnvironmentVariables {
@@ -20,10 +23,10 @@ extension EnvironmentVariables {
     }
 
     public static func process() -> EnvironmentVariables {
-        ProcessInfo.processInfo.environment
+        ProcessEnv.block
     }
 
-    public mutating func prependPath(_ key: String, value: String) {
+    public mutating func prependPath(_ key: ProcessEnvironmentKey, value: String) {
         var values = value.isEmpty ? [] : [value]
         if let existing = self[key], !existing.isEmpty {
             values.append(existing)
@@ -31,7 +34,7 @@ extension EnvironmentVariables {
         self.setPath(key, values)
     }
 
-    public mutating func appendPath(_ key: String, value: String) {
+    public mutating func appendPath(_ key: ProcessEnvironmentKey, value: String) {
         var values = value.isEmpty ? [] : [value]
         if let existing = self[key], !existing.isEmpty {
             values.insert(existing, at: 0)
@@ -39,7 +42,7 @@ extension EnvironmentVariables {
         self.setPath(key, values)
     }
 
-    private mutating func setPath(_ key: String, _ values: [String]) {
+    private mutating func setPath(_ key: ProcessEnvironmentKey, _ values: [String]) {
         #if os(Windows)
         let delimiter = ";"
         #else
@@ -50,12 +53,7 @@ extension EnvironmentVariables {
 
     /// `PATH` variable in the process's environment (`Path` under Windows).
     public var path: String? {
-        #if os(Windows)
-        let pathArg = "Path"
-        #else
-        let pathArg = "PATH"
-        #endif
-        return self[pathArg]
+        ProcessEnv.path
     }
 }
 
@@ -64,7 +62,7 @@ extension EnvironmentVariables {
 // rdar://107029374
 extension EnvironmentVariables {
     // internal for testing
-    static let nonCachableKeys: Set<String> = [
+    static let nonCachableKeys: Set<ProcessEnvironmentKey> = [
         "TERM",
         "TERM_PROGRAM",
         "TERM_PROGRAM_VERSION",

--- a/Sources/Basics/ImportScanning.swift
+++ b/Sources/Basics/ImportScanning.swift
@@ -46,7 +46,7 @@ public struct SwiftcImportScanner: ImportScanner {
                    filePathToScan.pathString,
                    "-scan-dependencies", "-Xfrontend", "-import-prescan"] + self.swiftCompilerFlags
 
-        let result = try await TSCBasic.Process.popen(arguments: cmd, environment: self.swiftCompilerEnvironment)
+        let result = try await TSCBasic.Process.popen(arguments: cmd, environmentBlock: self.swiftCompilerEnvironment)
 
         let stdout = try result.utf8Output()
         return try JSONDecoder.makeWithDefaults().decode(Imports.self, from: stdout).imports

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -759,7 +759,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                 if !pluginConfiguration.disableSandbox {
                     commandLine = try Sandbox.apply(command: commandLine, fileSystem: self.fileSystem, strictness: .writableTemporaryDirectory, writableDirectories: [pluginResult.pluginOutputDirectory])
                 }
-                let processResult = try Process.popen(arguments: commandLine, environment: command.configuration.environment)
+                let processResult = try Process.popen(arguments: commandLine, environmentBlock: command.configuration.environment)
                 let output = try processResult.utf8Output() + processResult.utf8stderrOutput()
                 if processResult.exitStatus != .terminated(code: 0) {
                     throw StringError("failed: \(command)\n\n\(output)")

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -600,7 +600,7 @@ final class PackageStructureCommand: CustomLLBuildCommand {
         var hash = Data()
         hash += try! encoder.encode(self.context.productsBuildParameters)
         hash += try! encoder.encode(self.context.toolsBuildParameters)
-        hash += try! encoder.encode(ProcessEnv.vars)
+        hash += try! encoder.encode(ProcessEnv.block)
         return [UInt8](hash)
     }
 

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -95,7 +95,7 @@ extension BuildParameters {
         get throws {
             // FIXME: We use this hack to let swiftpm's functional test use shared
             // cache so it doesn't become painfully slow.
-            if let path = ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"] {
+            if let path = ProcessEnv.block["SWIFTPM_TESTS_MODULECACHE"] {
                 return try AbsolutePath(validating: path)
             }
             return buildPath.appending("ModuleCache")

--- a/Sources/Commands/PackageTools/InstalledPackages.swift
+++ b/Sources/Commands/PackageTools/InstalledPackages.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+import typealias Basics.EnvironmentVariables
 import CoreCommands
 import Foundation
 import PackageModel
@@ -32,7 +33,7 @@ extension SwiftPackageTool {
         func run(_ tool: SwiftTool) throws {
             let swiftpmBinDir = try tool.fileSystem.getOrCreateSwiftPMInstalledBinariesDirectory()
 
-            let env = ProcessInfo.processInfo.environment
+            let env = EnvironmentVariables.process()
 
             if let path = env.path, !path.contains(swiftpmBinDir.pathString), !globalOptions.logging.quiet {
                 tool.observabilityScope.emit(

--- a/Sources/Commands/SwiftTestTool.swift
+++ b/Sources/Commands/SwiftTestTool.swift
@@ -743,7 +743,7 @@ final class TestRunner {
     // The toolchain to use.
     private let toolchain: UserToolchain
 
-    private let testEnv: [String: String]
+    private let testEnv: EnvironmentVariables
 
     /// ObservabilityScope  to emit diagnostics.
     private let observabilityScope: ObservabilityScope
@@ -777,7 +777,7 @@ final class TestRunner {
         additionalArguments: [String],
         cancellator: Cancellator,
         toolchain: UserToolchain,
-        testEnv: [String: String],
+        testEnv: EnvironmentVariables,
         observabilityScope: ObservabilityScope,
         library: BuildParameters.Testing.Library
     ) {
@@ -835,7 +835,11 @@ final class TestRunner {
                 stdout: outputHandler,
                 stderr: outputHandler
             )
-            let process = TSCBasic.Process(arguments: try args(forTestAt: path), environment: self.testEnv, outputRedirection: outputRedirection)
+            let process = TSCBasic.Process(
+                arguments: try args(forTestAt: path),
+                environmentBlock: self.testEnv,
+                outputRedirection: outputRedirection
+            )
             guard let terminationKey = self.cancellator.register(process) else {
                 return false // terminating
             }

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -119,7 +119,7 @@ enum TestingSupport {
                 sanitizers: sanitizers
             )
 
-            try TSCBasic.Process.checkNonZeroExit(arguments: args, environment: env)
+            try TSCBasic.Process.checkNonZeroExit(arguments: args, environmentBlock: env)
             // Read the temporary file's content.
             return try swiftTool.fileSystem.readFileContents(AbsolutePath(tempFile.path))
         }

--- a/Sources/DriverSupport/SPMSwiftDriverExecutor.swift
+++ b/Sources/DriverSupport/SPMSwiftDriverExecutor.swift
@@ -31,11 +31,11 @@ public final class SPMSwiftDriverExecutor: DriverExecutor {
     
     public let resolver: ArgsResolver
     let fileSystem: FileSystem
-    let env: EnvironmentVariables
-    
+    let env: [String: String]
+
     public init(resolver: ArgsResolver,
          fileSystem: FileSystem,
-         env: EnvironmentVariables) {
+         env: [String: String]) {
         self.resolver = resolver
         self.fileSystem = fileSystem
         self.env = env

--- a/Sources/LLBuildManifest/LLBuildManifestWriter.swift
+++ b/Sources/LLBuildManifest/LLBuildManifestWriter.swift
@@ -184,12 +184,12 @@ public struct ManifestToolStream {
         }
     }
 
-    public subscript(key: String) -> [String: String] {
+    public subscript(key: String) -> EnvironmentVariables {
         get { fatalError() }
         set {
             self.buffer += "    \(key):\n"
-            for (key, value) in newValue.sorted(by: { $0.key < $1.key }) {
-                self.buffer += "      \(key.asJSON): \(value.asJSON)\n"
+            for (key, value) in newValue.sorted(by: { $0.key.value < $1.key.value }) {
+                self.buffer += "      \(key.value.asJSON): \(value.asJSON)\n"
             }
         }
     }

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -857,7 +857,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         // FIXME: Workaround for the module cache bug that's been haunting Swift CI
         // <rdar://problem/48443680>
-        let moduleCachePath = try (ProcessEnv.vars["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"]).flatMap{ try AbsolutePath(validating: $0) }
+        let moduleCachePath = try (
+            ProcessEnv.block["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.block["SWIFTPM_TESTS_MODULECACHE"]
+        ).flatMap { try AbsolutePath(validating: $0) }
 
         var cmd: [String] = []
         cmd += [self.toolchain.swiftCompilerPathForManifests.pathString]
@@ -955,7 +957,11 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     evaluationResult.compilerCommandLine = cmd
 
                     // Compile the manifest.
-                    TSCBasic.Process.popen(arguments: cmd, environment: self.toolchain.swiftCompilerEnvironment, queue: callbackQueue) { result in
+                    TSCBasic.Process.popen(
+                        arguments: cmd,
+                        environmentBlock: self.toolchain.swiftCompilerEnvironment,
+                        queue: callbackQueue
+                    ) { result in
                         dispatchPrecondition(condition: .onQueue(callbackQueue))
 
                         var cleanupIfError = DelayableAction(target: tmpDir, action: cleanupTmpDir)
@@ -1047,14 +1053,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                             )
                         }
 
-                        var environment = ProcessEnv.vars
+                        var environment = ProcessEnv.block
                         #if os(Windows)
                         let windowsPathComponent = runtimePath.pathString.replacingOccurrences(of: "/", with: "\\")
                         environment["Path"] = "\(windowsPathComponent);\(environment["Path"] ?? "")"
                         #endif
 
                         let cleanupAfterRunning = cleanupIfError.delay()
-                        TSCBasic.Process.popen(arguments: cmd, environment: environment, queue: callbackQueue) { result in
+                        TSCBasic.Process.popen(arguments: cmd, environmentBlock: environment, queue: callbackQueue) { result in
                             dispatchPrecondition(condition: .onQueue(callbackQueue))
 
                             defer { cleanupAfterRunning.perform() }
@@ -1236,8 +1242,8 @@ extension ManifestLoader {
             stream.send(packageLocation)
             stream.send(manifestContents)
             stream.send(toolsVersion.description)
-            for (key, value) in env.sorted(by: { $0.key > $1.key }) {
-                stream.send(key).send(value)
+            for (key, value) in env.sorted(by: { $0.key.value > $1.key.value }) {
+                stream.send(key.value).send(value)
             }
             stream.send(swiftpmVersion)
             return stream.bytes.sha256Checksum
@@ -1301,6 +1307,6 @@ extension ManifestLoader {
 
 extension ProcessEnv {
     fileprivate static var cachableVars: EnvironmentVariables {
-        Self.vars.cachable
+        Self.block.cachable
     }
 }

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -126,7 +126,7 @@ public struct PkgConfig {
 
     private static var envSearchPaths: [AbsolutePath] {
         get throws {
-            if let configPath = ProcessEnv.vars["PKG_CONFIG_PATH"] {
+            if let configPath = ProcessEnv.block["PKG_CONFIG_PATH"] {
                 #if os(Windows)
                 return try configPath.split(separator: ";").map({ try AbsolutePath(validating: String($0)) })
                 #else
@@ -183,7 +183,7 @@ internal struct PkgConfigParser {
         variables["pcfiledir"] = pcFile.parentDirectory.pathString
 
         // Add pc_sysrootdir variable. This is the path of the sysroot directory for pc files.
-        variables["pc_sysrootdir"] = ProcessEnv.vars["PKG_CONFIG_SYSROOT_DIR"] ?? AbsolutePath.root.pathString
+        variables["pc_sysrootdir"] = ProcessEnv.block["PKG_CONFIG_SYSROOT_DIR"] ?? AbsolutePath.root.pathString
 
         let fileContents: String = try fileSystem.readFileContents(pcFile)
         for line in fileContents.components(separatedBy: "\n") {

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -14,6 +14,7 @@ import Basics
 import Foundation
 
 import class TSCBasic.Process
+import struct TSCBasic.ProcessEnvironmentKey
 
 #if os(Windows)
 private let hostExecutableSuffix = ".exe"
@@ -117,7 +118,7 @@ public final class UserToolchain: Toolchain {
         searchPaths: [AbsolutePath],
         environment: EnvironmentVariables
     ) -> AbsolutePath? {
-        lookupExecutablePath(filename: environment[variable], searchPaths: searchPaths)
+        lookupExecutablePath(filename: environment[.init(variable)], searchPaths: searchPaths)
     }
 
     private static func getTool(_ name: String, binDirectories: [AbsolutePath]) throws -> AbsolutePath {
@@ -755,7 +756,7 @@ public final class UserToolchain: Toolchain {
     private static func derivePluginServerPath(triple: Triple) throws -> AbsolutePath? {
         if triple.isDarwin() {
             let pluginServerPathFindArgs = ["/usr/bin/xcrun", "--find", "swift-plugin-server"]
-            if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: pluginServerPathFindArgs, environment: [:])
+            if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: pluginServerPathFindArgs, environmentBlock: [:])
                 .spm_chomp() {
                 return try AbsolutePath(validating: path)
             }
@@ -772,7 +773,7 @@ public final class UserToolchain: Toolchain {
         if triple.isDarwin() {
             // XCTest is optional on macOS, for example when Xcode is not installed
             let xctestFindArgs = ["/usr/bin/xcrun", "--sdk", "macosx", "--find", "xctest"]
-            if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: xctestFindArgs, environment: environment)
+            if let path = try? TSCBasic.Process.checkNonZeroExit(arguments: xctestFindArgs, environmentBlock: environment)
                 .spm_chomp()
             {
                 return try AbsolutePath(validating: path)

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -175,8 +175,8 @@ public enum BuildSystemUtilities {
     /// Returns the build path from the environment, if present.
     public static func getEnvBuildPath(workingDir: AbsolutePath) throws -> AbsolutePath? {
         // Don't rely on build path from env for SwiftPM's own tests.
-        guard ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"] == nil else { return nil }
-        guard let env = ProcessEnv.vars["SWIFTPM_BUILD_DIR"] else { return nil }
+        guard ProcessEnv.block["SWIFTPM_TESTS_MODULECACHE"] == nil else { return nil }
+        guard let env = ProcessEnv.block["SWIFTPM_BUILD_DIR"] else { return nil }
         return try AbsolutePath(validating: env, relativeTo: workingDir)
     }
 }

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -496,7 +496,7 @@ extension PackageGraph {
                         diagnostics.append(diagnostic)
                     }
 
-                    func pluginDefinedBuildCommand(displayName: String?, executable: AbsolutePath, arguments: [String], environment: [String : String], workingDirectory: AbsolutePath?, inputFiles: [AbsolutePath], outputFiles: [AbsolutePath]) {
+                    func pluginDefinedBuildCommand(displayName: String?, executable: AbsolutePath, arguments: [String], environment: EnvironmentVariables, workingDirectory: AbsolutePath?, inputFiles: [AbsolutePath], outputFiles: [AbsolutePath]) {
                         dispatchPrecondition(condition: .onQueue(delegateQueue))
                         buildCommands.append(.init(
                             configuration: .init(
@@ -509,7 +509,7 @@ extension PackageGraph {
                             outputFiles: outputFiles))
                     }
                     
-                    func pluginDefinedPrebuildCommand(displayName: String?, executable: AbsolutePath, arguments: [String], environment: [String : String], workingDirectory: AbsolutePath?, outputFilesDirectory: AbsolutePath) -> Bool {
+                    func pluginDefinedPrebuildCommand(displayName: String?, executable: AbsolutePath, arguments: [String], environment: EnvironmentVariables, workingDirectory: AbsolutePath?, outputFilesDirectory: AbsolutePath) -> Bool {
                         dispatchPrecondition(condition: .onQueue(delegateQueue))
                         // executable must exist before running prebuild command
                         if builtToolNames.contains(executable.basename) {
@@ -783,7 +783,7 @@ public struct BuildToolPluginInvocationResult {
         public var displayName: String?
         public var executable: AbsolutePath
         public var arguments: [String]
-        public var environment: [String: String]
+        public var environment: EnvironmentVariables
         public var workingDirectory: AbsolutePath?
     }
 

--- a/Sources/SPMTestSupport/MockManifestLoader.swift
+++ b/Sources/SPMTestSupport/MockManifestLoader.swift
@@ -179,7 +179,8 @@ extension ManifestLoader {
 /// WARNING! This method is not thread-safe. POSIX environments are shared
 /// between threads. This means that when this method is called simultaneously
 /// from different threads, the environment will neither be setup nor restored
-/// correctly.
+/// correctl
+@available(*, deprecated, message: "This implementation does not account for case insensitivity on Windows")
 public func withCustomEnv(_ env: [String: String], body: () async throws -> Void) async throws {
     let state = env.map { ($0, $1) }
     let restore = {

--- a/Sources/SPMTestSupport/SwiftPMProduct.swift
+++ b/Sources/SPMTestSupport/SwiftPMProduct.swift
@@ -74,7 +74,7 @@ extension SwiftPM {
     public func execute(
         _ args: [String] = [],
         packagePath: AbsolutePath? = nil,
-        env: [String: String]? = nil
+        env: EnvironmentVariables? = nil
     ) throws -> (stdout: String, stderr: String) {
         let result = try executeProcess(
             args,
@@ -98,9 +98,9 @@ extension SwiftPM {
     private func executeProcess(
         _ args: [String],
         packagePath: AbsolutePath? = nil,
-        env: [String: String]? = nil
+        env: EnvironmentVariables? = nil
     ) throws -> ProcessResult {
-        var environment = ProcessInfo.processInfo.environment
+        var environment = EnvironmentVariables.process()
 #if !os(Windows)
         environment["SDKROOT"] = nil
 #endif
@@ -129,7 +129,7 @@ extension SwiftPM {
         }
         completeArgs += args
         
-        return try Process.popen(arguments: completeArgs, environment: environment)
+        return try Process.popen(arguments: completeArgs, environmentBlock: environment)
     }
 }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -42,12 +42,12 @@ private struct GitShellHelper {
     /// output as a string.
     func run(
         _ args: [String],
-        environment: EnvironmentVariables = Git.environment,
+        environment: EnvironmentVariables = Git.environmentBlock,
         outputRedirection: TSCBasic.Process.OutputRedirection = .collect
     ) throws -> String {
         let process = TSCBasic.Process(
             arguments: [Git.tool] + args,
-            environment: environment,
+            environmentBlock: environment,
             outputRedirection: outputRedirection
         )
         let result: ProcessResult
@@ -68,7 +68,7 @@ private struct GitShellHelper {
             // Handle a failure to even launch the Git tool by synthesizing a result that we can wrap an error around.
             let result = ProcessResult(
                 arguments: process.arguments,
-                environment: process.environment,
+                environmentBlock: process.environmentBlock,
                 exitStatus: .terminated(code: -1),
                 output: .failure(error),
                 stderrOutput: .failure(error)
@@ -97,7 +97,7 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
     @discardableResult
     private func callGit(
         _ args: [String],
-        environment: EnvironmentVariables = Git.environment,
+        environment: EnvironmentVariables = Git.environmentBlock,
         repository: RepositorySpecifier,
         failureMessage: String = "",
         progress: FetchProgress.Handler? = nil
@@ -119,7 +119,7 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
             } catch let error as GitShellError {
                 let result = ProcessResult(
                     arguments: error.result.arguments,
-                    environment: error.result.environment,
+                    environmentBlock: error.result.environmentBlock,
                     exitStatus: error.result.exitStatus,
                     output: .success(stdoutBytes),
                     stderrOutput: .success(stderrBytes)
@@ -138,7 +138,7 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
     @discardableResult
     private func callGit(
         _ args: String...,
-        environment: EnvironmentVariables = Git.environment,
+        environment: EnvironmentVariables = Git.environmentBlock,
         repository: RepositorySpecifier,
         failureMessage: String = "",
         progress: FetchProgress.Handler? = nil
@@ -440,7 +440,7 @@ public final class GitRepository: Repository, WorkingCheckout {
     @discardableResult
     private func callGit(
         _ args: String...,
-        environment: EnvironmentVariables = Git.environment,
+        environment: EnvironmentVariables = Git.environmentBlock,
         failureMessage: String = "",
         progress: FetchProgress.Handler? = nil
     ) throws -> String {
@@ -461,7 +461,7 @@ public final class GitRepository: Repository, WorkingCheckout {
             } catch let error as GitShellError {
                 let result = ProcessResult(
                     arguments: error.result.arguments,
-                    environment: error.result.environment,
+                    environmentBlock: error.result.environmentBlock,
                     exitStatus: error.result.exitStatus,
                     output: .success(stdoutBytes),
                     stderrOutput: .success(stderrBytes)

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -209,7 +209,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         #endif
 
         // Honor any module cache override that's set in the environment.
-        let moduleCachePath = ProcessEnv.vars["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"]
+        let moduleCachePath = ProcessEnv.block["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.block["SWIFTPM_TESTS_MODULECACHE"]
         if let moduleCachePath {
             commandLine += ["-module-cache-path", moduleCachePath]
         }
@@ -252,7 +252,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         do {
             // Include the full compiler arguments and environment, and the contents of the source files.
             var stringToHash = commandLine.description
-            for (key, value) in toolchain.swiftCompilerEnvironment.sorted(by: { $0.key < $1.key }) {
+            for (key, value) in toolchain.swiftCompilerEnvironment.sorted(by: { $0.key.value < $1.key.value }) {
                 stringToHash.append("\(key)=\(value)\n")
             }
             for sourceFile in sourceFiles {
@@ -352,7 +352,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         }
         
         // Now invoke the compiler asynchronously.
-        TSCBasic.Process.popen(arguments: commandLine, environment: environment, queue: callbackQueue) {
+        TSCBasic.Process.popen(arguments: commandLine, environmentBlock: environment, queue: callbackQueue) {
             // We are now on our caller's requested callback queue, so we just call the completion handler directly.
             dispatchPrecondition(condition: .onQueue(callbackQueue))
             completion($0.tryMap { process in

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -90,7 +90,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope.makeChildScope(description: "Xcode Build System")
 
-        if let xcbuildTool = ProcessEnv.vars["XCBUILD_TOOL"] {
+        if let xcbuildTool = ProcessEnv.block["XCBUILD_TOOL"] {
             xcbuildPath = try AbsolutePath(validating: xcbuildTool)
         } else {
             let xcodeSelectOutput = try TSCBasic.Process.popen(args: "xcode-select", "-p").utf8Output().spm_chomp()
@@ -155,10 +155,10 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         })
 
         // We need to sanitize the environment we are passing to XCBuild because we could otherwise interfere with its linked dependencies e.g. when we have a custom swift-driver dynamic library in the path.
-        var sanitizedEnvironment = ProcessEnv.vars
+        var sanitizedEnvironment = ProcessEnv.block
         sanitizedEnvironment["DYLD_LIBRARY_PATH"] = nil
 
-        let process = TSCBasic.Process(arguments: arguments, environment: sanitizedEnvironment, outputRedirection: redirection)
+        let process = TSCBasic.Process(arguments: arguments, environmentBlock: sanitizedEnvironment, outputRedirection: redirection)
         try process.launch()
         let result = try process.waitUntilExit()
 

--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -15,6 +15,7 @@ import PackageModel
 import SPMTestSupport
 import XCTest
 import class TSCBasic.Process
+import typealias TSCBasic.ProcessEnvironmentBlock
 
 /// Functional tests of incremental builds.  These are fairly ad hoc at this
 /// point, and because of the time they take, they need to be kept minimal.
@@ -154,13 +155,13 @@ final class IncrementalBuildTests: XCTestCase {
         try fixture(name: "ValidLayouts/SingleModule/Library") { fixturePath in
             let dummySwiftcPath = SwiftPM.xctestBinaryPath(for: "dummy-swiftc")
             let swiftCompilerPath = try UserToolchain.default.swiftCompilerPath
-            let environment = [
+            let environment: ProcessEnvironmentBlock = [
                 "SWIFT_EXEC": dummySwiftcPath.pathString,
                 "SWIFT_ORIGINAL_PATH": swiftCompilerPath.pathString
             ]
             let sdkPathStr = try TSCBasic.Process.checkNonZeroExit(
                 arguments: ["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-path"],
-                environment: environment
+                environmentBlock: environment
             ).spm_chomp()
 
             let newSdkPathStr = "/tmp/../\(sdkPathStr)"

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -19,7 +19,7 @@ import PackageModel
 final class PluginsBuildPlanTests: XCTestCase {
     func testBuildToolsDatabasePath() throws {
         try fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
-            let (stdout, stderr) = try executeSwiftBuild(fixturePath)
+            let (stdout, _) = try executeSwiftBuild(fixturePath)
             XCTAssertMatch(stdout, .contains("Build complete!"))
             XCTAssertTrue(localFileSystem.exists(fixturePath.appending(RelativePath(".build/plugins/tools/build.db"))))
         }

--- a/Tests/CommandsTests/BuildToolTests.swift
+++ b/Tests/CommandsTests/BuildToolTests.swift
@@ -33,7 +33,7 @@ final class BuildToolTests: CommandsTestCase {
     @discardableResult
     private func execute(
         _ args: [String] = [],
-        environment: [String: String]? = nil,
+        environment: EnvironmentVariables? = nil,
         packagePath: AbsolutePath? = nil
     ) throws -> (stdout: String, stderr: String) {
         try SwiftPM.Build.execute(args, packagePath: packagePath, env: environment)

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -236,7 +236,7 @@ class MiscellaneousTestCase: XCTestCase {
             )
 
             let moduleUser = fixturePath.appending("SystemModuleUserClang")
-            let env = ["PKG_CONFIG_PATH": fixturePath.pathString]
+            let env: EnvironmentVariables = ["PKG_CONFIG_PATH": fixturePath.pathString]
             _ = try executeSwiftBuild(moduleUser, env: env)
 
             XCTAssertFileExists(moduleUser.appending(components: ".build", triple.platformBuildPathComponent, "debug", "SystemModuleUserClang"))

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -381,7 +381,7 @@ final class ManifestLoaderCacheTests: XCTestCase {
             try await check(loader: manifestLoader, expectCached: true)
 
             for key in EnvironmentVariables.nonCachableKeys {
-                try await withCustomEnv([key: UUID().uuidString]) {
+                try await withCustomEnv([key.value: UUID().uuidString]) {
                     try await check(loader: manifestLoader, expectCached: true)
                 }
             }


### PR DESCRIPTION
Previous implementation didn't account for case insensitivity on Windows. Cleaning up these warnings fixes that.

This doesn't include APIs exposed by Swift Driver yet, as those are harder to adapt for `ProcessEnvironmentBlock` with significant sources compatibility breakage.
