### PR TITLE
Generalize test to handle the compiler's new diagnostic printing style

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -89,7 +89,8 @@ class MiscellaneousTestCase: XCTestCase {
                     return XCTFail("failed in an unexpected manner: \(error)")
                 }
                 XCTAssertMatch(error.stdout + error.stderr, .contains("Compiling CompileFails Foo.swift"))
-                XCTAssertMatch(error.stdout + error.stderr, .regex("error: .*\n.*compile_failure"))
+                XCTAssertMatch(error.stdout + error.stderr, .regex(".*compile_failure.*"))
+                XCTAssertMatch(error.stdout + error.stderr, .regex(".*error:.*"))
             }
         }
     }


### PR DESCRIPTION
### Motivation:

The regular expression matching the compiler's output depends on the existing "LLVM" diagnostic style, and does not work with the new "Swift" style.

### Modifications:

Split regex into two independent pieces.

### Result:

The test succeeds with both compiler diagnostic styles.