### PR TITLE
Clean up `main` function signature in `SwiftPM.swift`

### DIFF
--- a/Sources/swift-package-manager/SwiftPM.swift
+++ b/Sources/swift-package-manager/SwiftPM.swift
@@ -33,8 +33,7 @@ struct SwiftPM {
         }
     }
 
-    @discardableResult
-    private static func main(execName: String?) async -> Bool {
+    private static func main(execName: String?) async {
         switch execName {
         case "swift-package":
             await SwiftPackageCommand.main()
@@ -53,7 +52,5 @@ struct SwiftPM {
         default:
             fatalError("swift-package-manager launched with unexpected name: \(execName ?? "(unknown)")")
         }
-
-        return true
     }
 }


### PR DESCRIPTION
This function always returns `true` result right now, which is discarded. We simply shouldn't return anything at all.