### PR TITLE
Add swift-testing support to `swift build --build-tests`

### DIFF
--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -44,7 +44,7 @@ extension SwiftPackageCommand {
 
         /// Which testing libraries to use (and any related options.)
         @OptionGroup()
-        var testingLibraryOptions: TestLibraryOptions
+        var testLibraryOptions: TestLibraryOptions
 
         @Option(name: .customLong("name"), help: "Provide custom package name")
         var packageName: String?
@@ -54,13 +54,13 @@ extension SwiftPackageCommand {
                 throw InternalError("Could not find the current working directory")
             }
 
-            // NOTE: Do not use testingLibraryOptions.enabledTestingLibraries(swiftCommandState:) here
+            // NOTE: Do not use testLibraryOptions.enabledTestingLibraries(swiftCommandState:) here
             // because the package doesn't exist yet, so there are no dependencies for it to query.
             var testingLibraries: Set<BuildParameters.Testing.Library> = []
-            if testingLibraryOptions.enableXCTestSupport {
+            if testLibraryOptions.enableXCTestSupport {
                 testingLibraries.insert(.xctest)
             }
-            if testingLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport == true {
+            if testLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport == true {
                 testingLibraries.insert(.swiftTesting)
             }
             let packageName = self.packageName ?? cwd.basename

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -42,17 +42,9 @@ extension SwiftPackageCommand {
                 """))
         var initMode: InitPackage.PackageType = .library
 
-        /// Whether to enable support for XCTest.
-        @Flag(name: .customLong("xctest"),
-              inversion: .prefixedEnableDisable,
-              help: "Enable support for XCTest")
-        var enableXCTestSupport: Bool = true
-
-        /// Whether to enable support for swift-testing.
-        @Flag(name: .customLong("experimental-swift-testing"),
-              inversion: .prefixedEnableDisable,
-              help: "Enable experimental support for swift-testing")
-        var enableSwiftTestingLibrarySupport: Bool = false
+        /// Which testing libraries to use (and any related options.)
+        @OptionGroup()
+        var testingLibraryOptions: TestLibraryOptions
 
         @Option(name: .customLong("name"), help: "Provide custom package name")
         var packageName: String?
@@ -62,11 +54,13 @@ extension SwiftPackageCommand {
                 throw InternalError("Could not find the current working directory")
             }
 
+            // NOTE: Do not use testingLibraryOptions.enabledTestingLibraries(swiftCommandState:) here
+            // because the package doesn't exist yet, so there are no dependencies for it to query.
             var testingLibraries: Set<BuildParameters.Testing.Library> = []
-            if enableXCTestSupport {
+            if testingLibraryOptions.enableXCTestSupport {
                 testingLibraries.insert(.xctest)
             }
-            if enableSwiftTestingLibrarySupport {
+            if testingLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport == true {
                 testingLibraries.insert(.swiftTesting)
             }
             let packageName = self.packageName ?? cwd.basename

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -99,14 +99,14 @@ struct BuildCommandOptions: ParsableArguments {
 
     /// Which testing libraries to use (and any related options.)
     @OptionGroup()
-    var testingLibraryOptions: TestLibraryOptions
+    var testLibraryOptions: TestLibraryOptions
 
     func validate() throws {
         // If --build-tests was not specified, it does not make sense to enable
         // or disable either testing library.
         if !buildTests {
-            if testingLibraryOptions.explicitlyEnableXCTestSupport != nil
-                || testingLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport != nil {
+            if testLibraryOptions.explicitlyEnableXCTestSupport != nil
+                || testLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport != nil {
                 throw StringError("pass --build-tests to build test targets")
             }
         }
@@ -154,7 +154,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
         }
         if case .allIncludingTests = subset {
             var buildParameters = try swiftCommandState.productsBuildParameters
-            for library in try options.testingLibraryOptions.enabledTestingLibraries(swiftCommandState: swiftCommandState) {
+            for library in try options.testLibraryOptions.enabledTestingLibraries(swiftCommandState: swiftCommandState) {
                 buildParameters.testingParameters = .init(
                     configuration: buildParameters.configuration,
                     targetTriple: buildParameters.triple,

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -96,6 +96,21 @@ struct BuildCommandOptions: ParsableArguments {
     /// If should link the Swift stdlib statically.
     @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
     public var shouldLinkStaticSwiftStdlib: Bool = false
+
+    /// Which testing libraries to use (and any related options.)
+    @OptionGroup()
+    var testingLibraryOptions: TestLibraryOptions
+
+    func validate() throws {
+        // If --build-tests was not specified, it does not make sense to enable
+        // or disable either testing library.
+        if !buildTests {
+            if testingLibraryOptions.explicitlyEnableXCTestSupport != nil
+                || testingLibraryOptions.explicitlyEnableSwiftTestingLibrarySupport != nil {
+                throw StringError("pass --build-tests to build test targets")
+            }
+        }
+    }
 }
 
 /// swift-build command namespace
@@ -137,9 +152,26 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
         guard let subset = options.buildSubset(observabilityScope: swiftCommandState.observabilityScope) else {
             throw ExitCode.failure
         }
+        if case .allIncludingTests = subset {
+            var buildParameters = try swiftCommandState.productsBuildParameters
+            for library in try options.testingLibraryOptions.enabledTestingLibraries(swiftCommandState: swiftCommandState) {
+                buildParameters.testingParameters = .init(
+                    configuration: buildParameters.configuration,
+                    targetTriple: buildParameters.triple,
+                    library: library
+                )
+                try build(swiftCommandState, subset: subset, buildParameters: buildParameters)
+            }
+        } else {
+            try build(swiftCommandState, subset: subset)
+        }
+    }
+
+    private func build(_ swiftCommandState: SwiftCommandState, subset: BuildSubset, buildParameters: BuildParameters? = nil) throws {
         let buildSystem = try swiftCommandState.createBuildSystem(
             explicitProduct: options.product,
             shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib,
+            productsBuildParameters: buildParameters,
             // command result output goes on stdout
             // ie "swift build" should output to stdout
             outputStream: TSCBasic.stdoutStream

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -150,7 +150,9 @@ struct TestLibraryOptions: ParsableArguments {
     }
 
     /// Get the set of enabled testing libraries.
-    func enabledTestingLibraries(swiftCommandState: SwiftCommandState) throws -> Set<BuildParameters.Testing.Library> {
+    func enabledTestingLibraries(
+        swiftCommandState: SwiftCommandState
+    ) throws -> Set<BuildParameters.Testing.Library> {
         var result = Set<BuildParameters.Testing.Library>()
 
         if enableXCTestSupport {

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -716,6 +716,10 @@ extension SwiftTestCommand {
         @OptionGroup()
         var sharedOptions: SharedOptions
 
+        /// Which testing libraries to use (and any related options.)
+        @OptionGroup()
+        var testingLibraryOptions: TestLibraryOptions
+
         // for deprecated passthrough from SwiftTestTool (parse will fail otherwise)
         @Flag(name: [.customLong("list-tests"), .customShort("l")], help: .hidden)
         var _deprecated_passthrough: Bool = false


### PR DESCRIPTION
This PR generalizes the enable/disable XCTest/swift-testing options from `swift test` and `swift package init` and adds them to `swift build --build-tests` so that it is possible to build all test content without actually running the tests. If neither flag is specified, the default test content is built (always XCTest, and swift-testing if it's a dependency, same as `swift test`.)

I don't have unit tests for this work because SwiftPM cannot currently reference or link to swift-testing in CI. I'm open to ideas here.

Resolves #7375.