### PR TITLE
Don’t include compiler in the command line arguments

### DIFF
--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -36,7 +36,9 @@ extension ClangTargetBuildDescription: BuildTarget {
 
     public func compileArguments(for fileURL: URL) throws -> [String] {
         let filePath = try resolveSymlinks(try AbsolutePath(validating: fileURL.path))
-        return try self.emitCommandLine(for: filePath)
+        let commandLine = try self.emitCommandLine(for: filePath)
+        // First element on the command line is the compiler itself, not an argument.
+        return Array(commandLine.dropFirst())
     }
 }
 
@@ -54,7 +56,9 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
     func compileArguments(for fileURL: URL) throws -> [String] {
         // Note: we ignore the `fileURL` here as the expectation is that we get a command line for the entire target
         // in case of Swift.
-        return try description.emitCommandLine(scanInvocation: false)
+        let commandLine = try description.emitCommandLine(scanInvocation: false)
+        // First element on the command line is the compiler itself, not an argument.
+        return Array(commandLine.dropFirst())
     }
 }
 

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -51,8 +51,8 @@ class SourceKitLSPAPITests: XCTestCase {
         )
         let description = BuildDescription(buildPlan: plan)
 
-        try description.checkArguments(for: "exe", graph: graph, partialArguments: ["/fake/path/to/swiftc", "-module-name", "exe", "-emit-dependencies", "-emit-module", "-emit-module-path", "/path/to/build/debug/exe.build/exe.swiftmodule"])
-        try description.checkArguments(for: "lib", graph: graph, partialArguments: ["/fake/path/to/swiftc", "-module-name", "lib", "-emit-dependencies", "-emit-module", "-emit-module-path", "/path/to/build/debug/Modules/lib.swiftmodule"])
+        try description.checkArguments(for: "exe", graph: graph, partialArguments: ["-module-name", "exe", "-emit-dependencies", "-emit-module", "-emit-module-path", "/path/to/build/debug/exe.build/exe.swiftmodule"])
+        try description.checkArguments(for: "lib", graph: graph, partialArguments: ["-module-name", "lib", "-emit-dependencies", "-emit-module", "-emit-module-path", "/path/to/build/debug/Modules/lib.swiftmodule"])
     }
 }
 


### PR DESCRIPTION
The compiler itself is part of the command line invocation, not an argument in itself.

rdar://123765692
