### PR TITLE
Add XDG Base Directory Specification support

### DIFF
--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -215,7 +215,7 @@ extension FileSystem {
     /// or under $XDG_CONFIG_HOME/swiftpm if the environmental variable is defined
     public var dotSwiftPM: AbsolutePath {
         get throws {
-            if let configurationDirectory = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"] {
+            if let configurationDirectory = EnvironmentVariables.process()["XDG_CONFIG_HOME"] {
                 return try AbsolutePath(validating: configurationDirectory).appending("swiftpm")
             } else {
                 return try self.homeDirectory.appending(".swiftpm")

--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -12,7 +12,6 @@
 
 import struct Foundation.Data
 import class Foundation.FileManager
-import class Foundation.ProcessInfo
 import struct Foundation.UUID
 import SystemPackage
 

--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -12,6 +12,7 @@
 
 import struct Foundation.Data
 import class Foundation.FileManager
+import class Foundation.ProcessInfo
 import struct Foundation.UUID
 import SystemPackage
 
@@ -211,9 +212,14 @@ extension FileSystem {
 
 extension FileSystem {
     /// SwiftPM directory under user's home directory (~/.swiftpm)
+    /// or under $XDG_CONFIG_HOME/swiftpm if the environmental variable is defined
     public var dotSwiftPM: AbsolutePath {
         get throws {
-            try self.homeDirectory.appending(".swiftpm")
+            if let configurationDirectory = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"] {
+                return try AbsolutePath(validating: configurationDirectory).appending("swiftpm")
+            } else {
+                return try self.homeDirectory.appending(".swiftpm")
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation:

As discussed in #6204, users would like to have a clean home directory.
And in the discussions following the merge of #3430, it seems there is a willingness to adhere to the XDG spec, and support `~/.config/swiftpm`.

### Modifications:

If the `XDG_CONFIG_HOME` environmental variable is defined, use `$XDG_CONFIG_HOME/swiftpm` as the root `dotSwiftPM` directory.

### Result:

The symlinks that were previously stored in `~/.swiftpm` are now stored in `$XDG_CONFIG_HOME/swiftpm` when this variable is defined, therefore not cluttering the home directory of users.

Closes #6204 
