### PR TITLE
Hide more llbuild-specific APIs

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -22,17 +22,17 @@ import struct SPMBuildCore.PrebuildCommandResult
 import enum TSCBasic.ProcessEnv
 
 /// Target description for a Clang target i.e. C language family target.
-public final class ClangTargetBuildDescription {
+package final class ClangTargetBuildDescription {
     /// The target described by this target.
-    public let target: ResolvedTarget
+    package let target: ResolvedTarget
 
     /// The underlying clang target.
-    public let clangTarget: ClangTarget
+    package let clangTarget: ClangTarget
 
     /// The tools version of the package that declared the target.  This can
     /// can be used to conditionalize semantically significant changes in how
     /// a target is built.
-    public let toolsVersion: ToolsVersion
+    package let toolsVersion: ToolsVersion
 
     /// The build parameters.
     let buildParameters: BuildParameters
@@ -43,7 +43,7 @@ public final class ClangTargetBuildDescription {
     }
 
     /// The list of all resource files in the target, including the derived ones.
-    public var resources: [Resource] {
+    package var resources: [Resource] {
         self.target.underlying.resources + self.pluginDerivedResources
     }
 
@@ -61,7 +61,7 @@ public final class ClangTargetBuildDescription {
     }
 
     /// The modulemap file for this target, if any.
-    public private(set) var moduleMap: AbsolutePath?
+    package private(set) var moduleMap: AbsolutePath?
 
     /// Path to the temporary directory for this target.
     var tempsPath: AbsolutePath
@@ -78,13 +78,13 @@ public final class ClangTargetBuildDescription {
     private var pluginDerivedResources: [Resource]
 
     /// Path to the resource accessor header file, if generated.
-    public private(set) var resourceAccessorHeaderFile: AbsolutePath?
+    package private(set) var resourceAccessorHeaderFile: AbsolutePath?
 
     /// Path to the resource Info.plist file, if generated.
-    public private(set) var resourceBundleInfoPlistPath: AbsolutePath?
+    package private(set) var resourceBundleInfoPlistPath: AbsolutePath?
 
     /// The objects in this target.
-    public var objects: [AbsolutePath] {
+    package var objects: [AbsolutePath] {
         get throws {
             try compilePaths().map(\.object)
         }
@@ -100,12 +100,12 @@ public final class ClangTargetBuildDescription {
     private let fileSystem: FileSystem
 
     /// If this target is a test target.
-    public var isTestTarget: Bool {
+    package var isTestTarget: Bool {
         target.type == .test
     }
 
     /// The results of applying any build tool plugins to this target.
-    public let buildToolPluginInvocationResults: [BuildToolPluginInvocationResult]
+    package let buildToolPluginInvocationResults: [BuildToolPluginInvocationResult]
 
     /// Create a new target description with target and build parameters.
     init(
@@ -182,7 +182,7 @@ public final class ClangTargetBuildDescription {
     }
 
     /// An array of tuples containing filename, source, object and dependency path for each of the source in this target.
-    public func compilePaths()
+    package func compilePaths()
         throws -> [(filename: RelativePath, source: AbsolutePath, object: AbsolutePath, deps: AbsolutePath)]
     {
         let sources = [
@@ -206,7 +206,7 @@ public final class ClangTargetBuildDescription {
     /// NOTE: The parameter to specify whether to get C++ semantics is currently optional, but this is only for revlock
     /// avoidance with clients. Callers should always specify what they want based either the user's indication or on a
     /// default value (possibly based on the filename suffix).
-    public func basicArguments(
+    package func basicArguments(
         isCXX isCXXOverride: Bool? = .none,
         isC: Bool = false
     ) throws -> [String] {
@@ -308,7 +308,7 @@ public final class ClangTargetBuildDescription {
         return args
     }
 
-    public func emitCommandLine(for filePath: AbsolutePath) throws -> [String] {
+    package func emitCommandLine(for filePath: AbsolutePath) throws -> [String] {
         let standards = [
             (clangTarget.cxxLanguageStandard, SupportedLanguageExtension.cppExtensions),
             (clangTarget.cLanguageStandard, SupportedLanguageExtension.cExtensions),

--- a/Sources/Build/BuildDescription/PluginDescription.swift
+++ b/Sources/Build/BuildDescription/PluginDescription.swift
@@ -21,24 +21,24 @@ import protocol Basics.FileSystem
 /// But because the package graph and build plan are not loaded for incremental
 /// builds, this information is included in the BuildDescription, and the plugin
 /// targets are compiled directly.
-public final class PluginDescription: Codable {
+package final class PluginDescription: Codable {
     /// The identity of the package in which the plugin is defined.
-    public let package: PackageIdentity
+    package let package: PackageIdentity
 
     /// The name of the plugin target in that package (this is also the name of
     /// the plugin).
-    public let targetName: String
+    package let targetName: String
 
     /// The names of any plugin products in that package that vend the plugin
     /// to other packages.
-    public let productNames: [String]
+    package let productNames: [String]
 
     /// The tools version of the package that declared the target. This affects
     /// the API that is available in the PackagePlugin module.
-    public let toolsVersion: ToolsVersion
+    package let toolsVersion: ToolsVersion
 
     /// Swift source files that comprise the plugin.
-    public let sources: Sources
+    package let sources: Sources
 
     /// Initialize a new plugin target description. The target is expected to be
     /// a `PluginTarget`.

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -21,25 +21,25 @@ import SPMBuildCore
 import struct TSCBasic.SortedArray
 
 /// The build description for a product.
-public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription {
+package final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription {
     /// The reference to the product.
-    public let package: ResolvedPackage
+    package let package: ResolvedPackage
 
     /// The reference to the product.
-    public let product: ResolvedProduct
+    package let product: ResolvedProduct
 
     /// The tools version of the package that declared the product.  This can
     /// can be used to conditionalize semantically significant changes in how
     /// a target is built.
-    public let toolsVersion: ToolsVersion
+    package let toolsVersion: ToolsVersion
 
     /// The build parameters.
-    public let buildParameters: BuildParameters
+    package let buildParameters: BuildParameters
 
     /// All object files to link into this product.
     ///
     // Computed during build planning.
-    public internal(set) var objects = SortedArray<AbsolutePath>()
+    package internal(set) var objects = SortedArray<AbsolutePath>()
 
     /// The dynamic libraries this product needs to link with.
     // Computed during build planning.
@@ -128,7 +128,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     }
 
     /// The arguments to the librarian to create a static library.
-    public func archiveArguments() throws -> [String] {
+    package func archiveArguments() throws -> [String] {
         let librarian = self.buildParameters.toolchain.librarianPath.pathString
         let triple = self.buildParameters.triple
         if triple.isWindows(), librarian.hasSuffix("link") || librarian.hasSuffix("link.exe") {
@@ -141,7 +141,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     }
 
     /// The arguments to link and create this product.
-    public func linkArguments() throws -> [String] {
+    package func linkArguments() throws -> [String] {
         var args = [buildParameters.toolchain.swiftCompilerPath.pathString]
         args += self.buildParameters.sanitizers.linkSwiftFlags()
         args += self.additionalFlags
@@ -390,7 +390,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 }
 
 extension SortedArray where Element == AbsolutePath {
-    public static func +=<S: Sequence>(lhs: inout SortedArray, rhs: S) where S.Iterator.Element == AbsolutePath {
+    package static func +=<S: Sequence>(lhs: inout SortedArray, rhs: S) where S.Iterator.Element == AbsolutePath {
         lhs.insert(contentsOf: rhs)
     }
 }

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -28,19 +28,19 @@ import DriverSupport
 import struct TSCBasic.ByteString
 
 /// Target description for a Swift target.
-public final class SwiftTargetBuildDescription {
+package final class SwiftTargetBuildDescription {
     /// The package this target belongs to.
-    public let package: ResolvedPackage
+    package let package: ResolvedPackage
 
     /// The target described by this target.
-    public let target: ResolvedTarget
+    package let target: ResolvedTarget
 
     private let swiftTarget: SwiftTarget
 
     /// The tools version of the package that declared the target.  This can
     /// can be used to conditionalize semantically significant changes in how
     /// a target is built.
-    public let toolsVersion: ToolsVersion
+    package let toolsVersion: ToolsVersion
 
     /// The build parameters.
     let buildParameters: BuildParameters
@@ -77,22 +77,22 @@ public final class SwiftTargetBuildDescription {
     }
 
     /// The list of all source files in the target, including the derived ones.
-    public var sources: [AbsolutePath] {
+    package var sources: [AbsolutePath] {
         self.target.sources.paths + self.derivedSources.paths + self.pluginDerivedSources.paths
     }
 
-    public var sourcesFileListPath: AbsolutePath {
+    package var sourcesFileListPath: AbsolutePath {
         self.tempsPath.appending(component: "sources")
     }
 
     /// The list of all resource files in the target, including the derived ones.
-    public var resources: [Resource] {
+    package var resources: [Resource] {
         self.target.underlying.resources + self.pluginDerivedResources
     }
 
     /// The objects in this target, containing either machine code or bitcode
     /// depending on the build parameters used.
-    public var objects: [AbsolutePath] {
+    package var objects: [AbsolutePath] {
         get throws {
             let relativeSources = self.target.sources.relativePaths
                 + self.derivedSources.relativePaths
@@ -112,7 +112,7 @@ public final class SwiftTargetBuildDescription {
     }
 
     /// The path to the swiftmodule file after compilation.
-    public var moduleOutputPath: AbsolutePath { // note: needs to be public because of sourcekit-lsp
+    package var moduleOutputPath: AbsolutePath { // note: needs to be package because of sourcekit-lsp
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
         let triple = buildParameters.triple
         let allowLinkingAgainstExecutables = (triple.isDarwin() || triple.isLinux() || triple.isWindows()) && self.toolsVersion >= .v5_5
@@ -133,7 +133,7 @@ public final class SwiftTargetBuildDescription {
     }
 
     /// Path to the resource Info.plist file, if generated.
-    public private(set) var resourceBundleInfoPlistPath: AbsolutePath?
+    package private(set) var resourceBundleInfoPlistPath: AbsolutePath?
 
     /// Paths to the binary libraries the target depends on.
     var libraryBinaryPaths: Set<AbsolutePath> = []
@@ -148,7 +148,7 @@ public final class SwiftTargetBuildDescription {
 
     /// Describes the purpose of a test target, including any special roles such as containing a list of discovered
     /// tests or serving as the manifest target which contains the main entry point.
-    public enum TestTargetRole {
+    package enum TestTargetRole {
         /// An ordinary test target, defined explicitly in a package, containing test code.
         case `default`
 
@@ -163,10 +163,10 @@ public final class SwiftTargetBuildDescription {
         case entryPoint(isSynthesized: Bool)
     }
 
-    public let testTargetRole: TestTargetRole?
+    package let testTargetRole: TestTargetRole?
 
     /// If this target is a test target.
-    public var isTestTarget: Bool {
+    package var isTestTarget: Bool {
         self.testTargetRole != nil
     }
 
@@ -228,13 +228,13 @@ public final class SwiftTargetBuildDescription {
     private(set) var moduleMap: AbsolutePath?
 
     /// The results of applying any build tool plugins to this target.
-    public let buildToolPluginInvocationResults: [BuildToolPluginInvocationResult]
+    package let buildToolPluginInvocationResults: [BuildToolPluginInvocationResult]
 
     /// The results of running any prebuild commands for this target.
-    public let prebuildCommandResults: [PrebuildCommandResult]
+    package let prebuildCommandResults: [PrebuildCommandResult]
 
     /// Any macro products that this target requires to build.
-    public let requiredMacroProducts: [ResolvedProduct]
+    package let requiredMacroProducts: [ResolvedProduct]
 
     /// ObservabilityScope with which to emit diagnostics
     private let observabilityScope: ObservabilityScope
@@ -474,7 +474,7 @@ public final class SwiftTargetBuildDescription {
     }
 
     /// The arguments needed to compile this target.
-    public func compileArguments() throws -> [String] {
+    package func compileArguments() throws -> [String] {
         var args = [String]()
         args += try self.buildParameters.targetTripleArgs(for: self.target)
         args += ["-swift-version", self.swiftVersion.rawValue]
@@ -650,7 +650,7 @@ public final class SwiftTargetBuildDescription {
 
     /// When `scanInvocation` argument is set to `true`, omit the side-effect producing arguments
     /// such as emitting a module or supplementary outputs.
-    public func emitCommandLine(scanInvocation: Bool = false) throws -> [String] {
+    package func emitCommandLine(scanInvocation: Bool = false) throws -> [String] {
         var result: [String] = []
         result.append(self.buildParameters.toolchain.swiftCompilerPath.pathString)
 

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -112,7 +112,7 @@ package final class SwiftTargetBuildDescription {
     }
 
     /// The path to the swiftmodule file after compilation.
-    package var moduleOutputPath: AbsolutePath { // note: needs to be package because of sourcekit-lsp
+    public var moduleOutputPath: AbsolutePath { // note: needs to be `public` because of sourcekit-lsp
         // If we're an executable and we're not allowing test targets to link against us, we hide the module.
         let triple = buildParameters.triple
         let allowLinkingAgainstExecutables = (triple.isDarwin() || triple.isLinux() || triple.isWindows()) && self.toolsVersion >= .v5_5

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -17,12 +17,12 @@ import struct PackageModel.ToolsVersion
 import struct SPMBuildCore.BuildToolPluginInvocationResult
 import struct SPMBuildCore.BuildParameters
 
-public enum BuildDescriptionError: Swift.Error {
+package enum BuildDescriptionError: Swift.Error {
     case requestedFileNotPartOfTarget(targetName: String, requestedFilePath: AbsolutePath)
 }
 
 /// A target description which can either be for a Swift or Clang target.
-public enum TargetBuildDescription {
+package enum TargetBuildDescription {
     /// Swift target description.
     case swift(SwiftTargetBuildDescription)
 

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -188,7 +188,7 @@ extension LLBuildManifestBuilder {
     // dependency graph of B. The driver is then responsible for the necessary post-processing
     // to merge the dependency graphs and plan the build for A, using artifacts of B as explicit
     // inputs.
-    public func addTargetsToExplicitBuildManifest() throws {
+    package func addTargetsToExplicitBuildManifest() throws {
         // Sort the product targets in topological order in order to collect and "bubble up"
         // their respective dependency graphs to the depending targets.
         let nodes: [ResolvedTarget.Dependency] = try self.plan.targetMap.keys.compactMap {

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -27,7 +27,7 @@ import enum TSCBasic.ProcessEnv
 import func TSCBasic.topologicalSort
 
 /// High-level interface to ``LLBuildManifest`` and ``LLBuildManifestWriter``.
-public class LLBuildManifestBuilder {
+package class LLBuildManifestBuilder {
     enum Error: Swift.Error {
         case ldPathDriverOptionUnavailable(option: String)
 
@@ -39,11 +39,11 @@ public class LLBuildManifestBuilder {
         }
     }
 
-    public enum TargetKind {
+    package enum TargetKind {
         case main
         case test
 
-        public var targetName: String {
+        package var targetName: String {
             switch self {
             case .main: return "main"
             case .test: return "test"
@@ -52,24 +52,24 @@ public class LLBuildManifestBuilder {
     }
 
     /// The build plan to work on.
-    public let plan: BuildPlan
+    package let plan: BuildPlan
 
     /// Whether to sandbox commands from build tool plugins.
-    public let disableSandboxForPluginCommands: Bool
+    package let disableSandboxForPluginCommands: Bool
 
     /// File system reference.
     let fileSystem: any FileSystem
 
     /// ObservabilityScope with which to emit diagnostics
-    public let observabilityScope: ObservabilityScope
+    package let observabilityScope: ObservabilityScope
 
-    public internal(set) var manifest: LLBuildManifest = .init()
+    package internal(set) var manifest: LLBuildManifest = .init()
 
     /// Mapping from Swift compiler path to Swift get version files.
     var swiftGetVersionFiles = [AbsolutePath: AbsolutePath]()
 
     /// Create a new builder with a build plan.
-    public init(
+    package init(
         _ plan: BuildPlan,
         disableSandboxForPluginCommands: Bool = false,
         fileSystem: any FileSystem,
@@ -85,7 +85,7 @@ public class LLBuildManifestBuilder {
 
     /// Generate build manifest at the given path.
     @discardableResult
-    public func generateManifest(at path: AbsolutePath) throws -> LLBuildManifest {
+    package func generateManifest(at path: AbsolutePath) throws -> LLBuildManifest {
         self.swiftGetVersionFiles.removeAll()
 
         self.manifest.createTarget(TargetKind.main.targetName)
@@ -317,21 +317,21 @@ extension TargetBuildDescription {
 }
 
 extension ResolvedTarget {
-    public func getCommandName(config: String) -> String {
+    package func getCommandName(config: String) -> String {
         "C." + self.getLLBuildTargetName(config: config)
     }
 
-    public func getLLBuildTargetName(config: String) -> String {
+    package func getLLBuildTargetName(config: String) -> String {
         "\(name)-\(config).module"
     }
 
-    public func getLLBuildResourcesCmdName(config: String) -> String {
+    package func getLLBuildResourcesCmdName(config: String) -> String {
         "\(name)-\(config).module-resources"
     }
 }
 
 extension ResolvedProduct {
-    public func getLLBuildTargetName(config: String) throws -> String {
+    package func getLLBuildTargetName(config: String) throws -> String {
         let potentialExecutableTargetName = "\(name)-\(config).exe"
         let potentialLibraryTargetName = "\(name)-\(config).dylib"
 
@@ -357,7 +357,7 @@ extension ResolvedProduct {
         }
     }
 
-    public func getCommandName(config: String) throws -> String {
+    package func getCommandName(config: String) throws -> String {
         try "C." + self.getLLBuildTargetName(config: config)
     }
 }

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -42,7 +42,7 @@ import SwiftDriver
 
 package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildSystem, BuildErrorAdviceProvider {
     /// The delegate used by the build system.
-    public weak var delegate: SPMBuildCore.BuildSystemDelegate?
+    package weak var delegate: SPMBuildCore.BuildSystemDelegate?
 
     /// Build parameters for products.
     let productsBuildParameters: BuildParameters
@@ -63,12 +63,12 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
     private var buildSystem: SPMLLBuild.BuildSystem?
 
     /// If build manifest caching should be enabled.
-    public let cacheBuildManifest: Bool
+    package let cacheBuildManifest: Bool
 
     /// The build plan that was computed, if any.
-    public private(set) var _buildPlan: BuildPlan?
+    package private(set) var _buildPlan: BuildPlan?
 
-    public var buildPlan: SPMBuildCore.BuildPlan {
+    package var buildPlan: SPMBuildCore.BuildPlan {
         get throws {
             if let buildPlan = _buildPlan {
                 return buildPlan
@@ -96,7 +96,7 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
     /// ObservabilityScope with which to emit diagnostics.
     private let observabilityScope: ObservabilityScope
 
-    public var builtTestProducts: [BuiltTestProduct] {
+    package var builtTestProducts: [BuiltTestProduct] {
         (try? getBuildDescription())?.builtTestProducts ?? []
     }
 
@@ -112,7 +112,7 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
     /// Map of  root package identities by target names which are declared in them.
     private let rootPackageIdentityByTargetName: [String: PackageIdentity]
 
-    public init(
+    package init(
         productsBuildParameters: BuildParameters,
         toolsBuildParameters: BuildParameters,
         cacheBuildManifest: Bool,
@@ -149,7 +149,7 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
         self.observabilityScope = observabilityScope.makeChildScope(description: "Build Operation")
     }
 
-    public func getPackageGraph() throws -> ModulesGraph {
+    package func getPackageGraph() throws -> ModulesGraph {
         try self.packageGraph.memoize {
             try self.packageGraphLoader()
         }
@@ -159,7 +159,7 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
     ///
     /// This will try skip build planning if build manifest caching is enabled
     /// and the package structure hasn't changed.
-    public func getBuildDescription(subset: BuildSubset? = nil) throws -> BuildDescription {
+    package func getBuildDescription(subset: BuildSubset? = nil) throws -> BuildDescription {
         return try self.buildDescription.memoize {
             if self.cacheBuildManifest {
                 do {
@@ -187,12 +187,12 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
         }
     }
 
-    public func getBuildManifest() throws -> LLBuildManifest {
+    package func getBuildManifest() throws -> LLBuildManifest {
         return try self.plan().manifest
     }
 
     /// Cancel the active build operation.
-    public func cancel(deadline: DispatchTime) throws {
+    package func cancel(deadline: DispatchTime) throws {
         buildSystem?.cancel()
     }
 
@@ -336,7 +336,7 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
     }
 
     /// Perform a build using the given build description and subset.
-    public func build(subset: BuildSubset) throws {
+    package func build(subset: BuildSubset) throws {
         guard !self.productsBuildParameters.shouldSkipBuilding else {
             return
         }
@@ -784,7 +784,7 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
         }
     }
 
-    public func provideBuildErrorAdvice(for target: String, command: String, message: String) -> String? {
+    package func provideBuildErrorAdvice(for target: String, command: String, message: String) -> String? {
         // Find the target for which the error was emitted.  If we don't find it, we can't give any advice.
         guard let _ = self._buildPlan?.targets.first(where: { $0.target.name == target }) else { return nil }
 
@@ -808,7 +808,7 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
         return nil
     }
 
-    public func packageStructureChanged() -> Bool {
+    package func packageStructureChanged() -> Bool {
         do {
             _ = try self.plan()
         }
@@ -824,7 +824,7 @@ package final class BuildOperation: PackageStructureDelegate, SPMBuildCore.Build
 }
 
 extension BuildOperation {
-    public struct PluginConfiguration {
+    package struct PluginConfiguration {
         /// Entity responsible for compiling and running plugin scripts.
         let scriptRunner: PluginScriptRunner
 
@@ -834,7 +834,7 @@ extension BuildOperation {
         /// Whether to sandbox commands from build tool plugins.
         let disableSandbox: Bool
 
-        public init(scriptRunner: PluginScriptRunner, workDirectory: AbsolutePath, disableSandbox: Bool) {
+        package init(scriptRunner: PluginScriptRunner, workDirectory: AbsolutePath, disableSandbox: Bool) {
             self.scriptRunner = scriptRunner
             self.workDirectory = workDirectory
             self.disableSandbox = disableSandbox

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -166,7 +166,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
                 import XCTest
 
                 @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-                package func __allDiscoveredTests() -> [XCTestCaseEntry] {
+                public func __allDiscoveredTests() -> [XCTestCaseEntry] {
                     \#(testsKeyword) tests = [XCTestCaseEntry]()
 
                     \#(testsByModule.keys.map { "tests += __\($0)__allTests()" }.joined(separator: "\n    "))

--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -166,7 +166,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
                 import XCTest
 
                 @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
-                public func __allDiscoveredTests() -> [XCTestCaseEntry] {
+                package func __allDiscoveredTests() -> [XCTestCaseEntry] {
                     \#(testsKeyword) tests = [XCTestCaseEntry]()
 
                     \#(testsByModule.keys.map { "tests += __\($0)__allTests()" }.joined(separator: "\n    "))
@@ -202,7 +202,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
 }
 
 extension TestEntryPointTool {
-    public static func mainFileName(for library: BuildParameters.Testing.Library) -> String {
+    package static func mainFileName(for library: BuildParameters.Testing.Library) -> String {
         "runner-\(library).swift"
     }
 }
@@ -321,10 +321,10 @@ private final class InProcessTool: Tool {
 }
 
 /// Contains the description of the build that is needed during the execution.
-public struct BuildDescription: Codable {
-    public typealias CommandName = String
-    public typealias TargetName = String
-    public typealias CommandLineFlag = String
+package struct BuildDescription: Codable {
+    package typealias CommandName = String
+    package typealias TargetName = String
+    package typealias CommandLineFlag = String
 
     /// The Swift compiler invocation targets.
     let swiftCommands: [LLBuildManifest.CmdName: SwiftCompilerTool]
@@ -358,12 +358,12 @@ public struct BuildDescription: Codable {
     let generatedSourceTargetSet: Set<TargetName>
 
     /// The built test products.
-    public let builtTestProducts: [BuiltTestProduct]
+    package let builtTestProducts: [BuiltTestProduct]
 
     /// Distilled information about any plugins defined in the package.
     let pluginDescriptions: [PluginDescription]
 
-    public init(
+    package init(
         plan: BuildPlan,
         swiftCommands: [LLBuildManifest.CmdName: SwiftCompilerTool],
         swiftFrontendCommands: [LLBuildManifest.CmdName: SwiftFrontendTool],
@@ -420,13 +420,13 @@ public struct BuildDescription: Codable {
         self.pluginDescriptions = pluginDescriptions
     }
 
-    public func write(fileSystem: Basics.FileSystem, path: AbsolutePath) throws {
+    package func write(fileSystem: Basics.FileSystem, path: AbsolutePath) throws {
         let encoder = JSONEncoder.makeWithDefaults()
         let data = try encoder.encode(self)
         try fileSystem.writeFileContents(path, bytes: ByteString(data))
     }
 
-    public static func load(fileSystem: Basics.FileSystem, path: AbsolutePath) throws -> BuildDescription {
+    package static func load(fileSystem: Basics.FileSystem, path: AbsolutePath) throws -> BuildDescription {
         let contents: Data = try fileSystem.readFileContents(path)
         let decoder = JSONDecoder.makeWithDefaults()
         return try decoder.decode(BuildDescription.self, from: contents)
@@ -434,14 +434,14 @@ public struct BuildDescription: Codable {
 }
 
 /// A provider of advice about build errors.
-public protocol BuildErrorAdviceProvider {
+package protocol BuildErrorAdviceProvider {
     /// Invoked after a command fails and an error message is detected in the output. Should return a string containing
     /// advice or additional information, if any, based on the build plan.
     func provideBuildErrorAdvice(for target: String, command: String, message: String) -> String?
 }
 
 /// The context available during build execution.
-public final class BuildExecutionContext {
+package final class BuildExecutionContext {
     /// Build parameters for products.
     let productsBuildParameters: BuildParameters
 
@@ -464,7 +464,7 @@ public final class BuildExecutionContext {
 
     let observabilityScope: ObservabilityScope
 
-    public init(
+    package init(
         productsBuildParameters: BuildParameters,
         toolsBuildParameters: BuildParameters,
         buildDescription: BuildDescription? = nil,
@@ -590,7 +590,7 @@ final class WriteAuxiliaryFileCommand: CustomLLBuildCommand {
     }
 }
 
-public protocol PackageStructureDelegate {
+package protocol PackageStructureDelegate {
     func packageStructureChanged() -> Bool
 }
 

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -91,7 +91,7 @@ extension [String] {
 
 extension BuildParameters {
     /// Returns the directory to be used for module cache.
-    public var moduleCache: AbsolutePath {
+    package var moduleCache: AbsolutePath {
         get throws {
             // FIXME: We use this hack to let swiftpm's functional test use shared
             // cache so it doesn't become painfully slow.
@@ -128,7 +128,7 @@ extension BuildParameters {
     }
 
     /// Computes the target triple arguments for a given resolved target.
-    public func targetTripleArgs(for target: ResolvedTarget) throws -> [String] {
+    package func targetTripleArgs(for target: ResolvedTarget) throws -> [String] {
         var args = ["-target"]
 
         // Compute the triple string for Darwin platform using the platform version.
@@ -164,11 +164,11 @@ extension BuildParameters {
 
 /// A build plan for a package graph.
 public class BuildPlan: SPMBuildCore.BuildPlan {
-    public enum Error: Swift.Error, CustomStringConvertible, Equatable {
+    package enum Error: Swift.Error, CustomStringConvertible, Equatable {
         /// There is no buildable target in the graph.
         case noBuildableTarget
 
-        public var description: String {
+        package var description: String {
             switch self {
             case .noBuildableTarget:
                 return """
@@ -196,20 +196,20 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     }
 
     /// The package graph.
-    public let graph: ModulesGraph
+    package let graph: ModulesGraph
 
     /// The target build description map.
-    public let targetMap: [ResolvedTarget.ID: TargetBuildDescription]
+    package let targetMap: [ResolvedTarget.ID: TargetBuildDescription]
 
     /// The product build description map.
-    public let productMap: [ResolvedProduct.ID: ProductBuildDescription]
+    package let productMap: [ResolvedProduct.ID: ProductBuildDescription]
 
     /// The plugin descriptions. Plugins are represented in the package graph
     /// as targets, but they are not directly included in the build graph.
-    public let pluginDescriptions: [PluginDescription]
+    package let pluginDescriptions: [PluginDescription]
 
     /// The build targets.
-    public var targets: AnySequence<TargetBuildDescription> {
+    package var targets: AnySequence<TargetBuildDescription> {
         AnySequence(self.targetMap.values)
     }
 
@@ -219,11 +219,11 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     }
 
     /// The results of invoking any build tool plugins used by targets in this build.
-    public let buildToolPluginInvocationResults: [ResolvedTarget.ID: [BuildToolPluginInvocationResult]]
+    package let buildToolPluginInvocationResults: [ResolvedTarget.ID: [BuildToolPluginInvocationResult]]
 
     /// The results of running any prebuild commands for the targets in this build.  This includes any derived
     /// source files as well as directories to which any changes should cause us to reevaluate the build plan.
-    public let prebuildCommandResults: [ResolvedTarget.ID: [PrebuildCommandResult]]
+    package let prebuildCommandResults: [ResolvedTarget.ID: [PrebuildCommandResult]]
 
     package private(set) var derivedTestTargetsMap: [ResolvedProduct.ID: [ResolvedTarget]] = [:]
 
@@ -246,7 +246,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     let observabilityScope: ObservabilityScope
 
     @available(*, deprecated, renamed: "init(productsBuildParameters:toolsBuildParameters:graph:)")
-    public convenience init(
+    package convenience init(
         buildParameters: BuildParameters,
         graph: ModulesGraph,
         additionalFileRules: [FileRuleDescription] = [],
@@ -268,7 +268,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     }
 
     /// Create a build plan with a package graph and explicitly distinct build parameters for products and tools.
-    public init(
+    package init(
         productsBuildParameters: BuildParameters,
         toolsBuildParameters: BuildParameters,
         graph: ModulesGraph,

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -246,7 +246,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     let observabilityScope: ObservabilityScope
 
     @available(*, deprecated, renamed: "init(productsBuildParameters:toolsBuildParameters:graph:)")
-    package convenience init(
+    public convenience init(
         buildParameters: BuildParameters,
         graph: ModulesGraph,
         additionalFileRules: [FileRuleDescription] = [],
@@ -268,7 +268,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     }
 
     /// Create a build plan with a package graph and explicitly distinct build parameters for products and tools.
-    package init(
+    public init(
         productsBuildParameters: BuildParameters,
         toolsBuildParameters: BuildParameters,
         graph: ModulesGraph,

--- a/Sources/Build/ClangSupport.swift
+++ b/Sources/Build/ClangSupport.swift
@@ -14,7 +14,7 @@ import Basics
 import Foundation
 import PackageModel
 
-public enum ClangSupport {
+package enum ClangSupport {
     private struct Feature: Decodable {
         let name: String
         let value: [String]?
@@ -26,7 +26,7 @@ public enum ClangSupport {
 
     private static var cachedFeatures = ThreadSafeBox<Features>()
 
-    public static func supportsFeature(name: String, toolchain: PackageModel.Toolchain) throws -> Bool {
+    package static func supportsFeature(name: String, toolchain: PackageModel.Toolchain) throws -> Bool {
         let features = try cachedFeatures.memoize {
             let clangPath = try toolchain.getClangCompiler()
             let featuresPath = clangPath.parentDirectory.parentDirectory.appending(components: ["share", "clang", "features.json"])

--- a/Sources/Build/SwiftCompilerOutputParser.swift
+++ b/Sources/Build/SwiftCompilerOutputParser.swift
@@ -16,26 +16,26 @@ import class TSCUtility.JSONMessageStreamingParser
 import protocol TSCUtility.JSONMessageStreamingParserDelegate
 
 /// Represents a message output by the Swift compiler in JSON output mode.
-public struct SwiftCompilerMessage {
-    public enum Kind {
-        public struct Output {
-            public let type: String
-            public let path: String
+package struct SwiftCompilerMessage {
+    package enum Kind {
+        package struct Output {
+            package let type: String
+            package let path: String
 
-            public init(type: String, path: String) {
+            package init(type: String, path: String) {
                 self.type = type
                 self.path = path
             }
         }
 
-        public struct BeganInfo {
-            public let pid: Int
-            public let inputs: [String]
-            public let outputs: [Output]?
-            public let commandExecutable: String
-            public let commandArguments: [String]
+        package struct BeganInfo {
+            package let pid: Int
+            package let inputs: [String]
+            package let outputs: [Output]?
+            package let commandExecutable: String
+            package let commandArguments: [String]
 
-            public init(
+            package init(
                 pid: Int,
                 inputs: [String],
                 outputs: [Output]?,
@@ -50,21 +50,21 @@ public struct SwiftCompilerMessage {
             }
         }
 
-        public struct SkippedInfo {
-            public let inputs: [String]
-            public let outputs: [Output]?
+        package struct SkippedInfo {
+            package let inputs: [String]
+            package let outputs: [Output]?
 
-            public init(inputs: [String], outputs: [SwiftCompilerMessage.Kind.Output]) {
+            package init(inputs: [String], outputs: [SwiftCompilerMessage.Kind.Output]) {
                 self.inputs = inputs
                 self.outputs = outputs
             }
         }
 
-        public struct OutputInfo {
-            public let pid: Int
-            public let output: String?
+        package struct OutputInfo {
+            package let pid: Int
+            package let output: String?
 
-            public init(pid: Int, output: String?) {
+            package init(pid: Int, output: String?) {
                 self.pid = pid
                 self.output = output
             }
@@ -77,17 +77,17 @@ public struct SwiftCompilerMessage {
         case unparsableOutput(String)
     }
 
-    public let name: String
-    public let kind: Kind
+    package let name: String
+    package let kind: Kind
 
-    public init(name: String, kind: SwiftCompilerMessage.Kind) {
+    package init(name: String, kind: SwiftCompilerMessage.Kind) {
         self.name = name
         self.kind = kind
     }
 }
 
 /// Protocol for the parser delegate to get notified of parsing events.
-public protocol SwiftCompilerOutputParserDelegate: AnyObject {
+package protocol SwiftCompilerOutputParserDelegate: AnyObject {
 
     /// Called for each message parsed.
     func swiftCompilerOutputParser(_ parser: SwiftCompilerOutputParser, didParse message: SwiftCompilerMessage)
@@ -97,7 +97,7 @@ public protocol SwiftCompilerOutputParserDelegate: AnyObject {
 }
 
 /// Parser for the Swift compiler JSON output mode.
-public final class SwiftCompilerOutputParser {
+package final class SwiftCompilerOutputParser {
 
     /// The underlying JSON message parser.
     private var jsonParser: JSONMessageStreamingParser<SwiftCompilerOutputParser>!
@@ -106,16 +106,16 @@ public final class SwiftCompilerOutputParser {
     private var hasFailed: Bool
 
     /// Name of the target the compiler is compiling.
-    public let targetName: String
+    package let targetName: String
 
     /// Delegate to notify of parsing events.
-    public weak var delegate: SwiftCompilerOutputParserDelegate?
+    package weak var delegate: SwiftCompilerOutputParserDelegate?
 
     /// Initializes the parser with a delegate to notify of parsing events.
     /// - Parameters:
     ///     - targetName: The name of the target being built.
     ///     - delegate: Delegate to notify of parsing events.
-    public init(targetName: String, delegate: SwiftCompilerOutputParserDelegate) {
+    package init(targetName: String, delegate: SwiftCompilerOutputParserDelegate) {
         self.hasFailed = false
         self.targetName = targetName
         self.delegate = delegate
@@ -128,7 +128,7 @@ public final class SwiftCompilerOutputParser {
     /// Parse the next bytes of the Swift compiler JSON output.
     /// - Note: If a parsing error is encountered, the delegate will be notified and the parser won't accept any further
     ///   input.
-    public func parse<C>(bytes: C) where C: Collection, C.Element == UInt8 {
+    package func parse<C>(bytes: C) where C: Collection, C.Element == UInt8 {
         guard !hasFailed else {
             return
         }
@@ -138,7 +138,7 @@ public final class SwiftCompilerOutputParser {
 }
 
 extension SwiftCompilerOutputParser: JSONMessageStreamingParserDelegate {
-    public func jsonMessageStreamingParser(
+    package func jsonMessageStreamingParser(
         _ parser: JSONMessageStreamingParser<SwiftCompilerOutputParser>,
         didParse message: SwiftCompilerMessage
     ) {
@@ -153,7 +153,7 @@ extension SwiftCompilerOutputParser: JSONMessageStreamingParserDelegate {
         }
     }
 
-    public func jsonMessageStreamingParser(
+    package func jsonMessageStreamingParser(
         _ parser: JSONMessageStreamingParser<SwiftCompilerOutputParser>,
         didParseRawText text: String
     ) {
@@ -165,7 +165,7 @@ extension SwiftCompilerOutputParser: JSONMessageStreamingParserDelegate {
         delegate?.swiftCompilerOutputParser(self, didParse: message)
     }
 
-    public func jsonMessageStreamingParser(
+    package func jsonMessageStreamingParser(
         _ parser: JSONMessageStreamingParser<SwiftCompilerOutputParser>,
         didFailWith error: Error
     ) {
@@ -179,7 +179,7 @@ extension SwiftCompilerMessage: Decodable, Equatable {
         case name
     }
 
-    public init(from decoder: Decoder) throws {
+    package init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
         kind = try Kind(from: decoder)
@@ -191,7 +191,7 @@ extension SwiftCompilerMessage.Kind: Decodable, Equatable {
         case kind
     }
 
-    public init(from decoder: Decoder) throws {
+    package init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(String.self, forKey: .kind)
         switch kind {

--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -12,7 +12,7 @@
 
 import SPMBuildCore
 
-public func generateTestObservationCode(buildParameters: BuildParameters) -> String {
+package func generateTestObservationCode(buildParameters: BuildParameters) -> String {
     guard buildParameters.triple.supportsTestSummary else {
         return ""
     }
@@ -22,8 +22,8 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
         import Foundation
         import XCTest
 
-        public final class SwiftPMXCTestObserver: NSObject {
-            public override init() {
+        package final class SwiftPMXCTestObserver: NSObject {
+            package override init() {
                 super.init()
                 XCTestObservationCenter.shared.addTestObserver(self)
             }
@@ -54,68 +54,68 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
                 }
             }
 
-            public func testBundleWillStart(_ testBundle: Bundle) {
+            package func testBundleWillStart(_ testBundle: Bundle) {
                 let record = TestBundleEventRecord(bundle: .init(testBundle), event: .start)
                 write(record: TestEventRecord(bundleEvent: record))
             }
 
-            public func testSuiteWillStart(_ testSuite: XCTestSuite) {
+            package func testSuiteWillStart(_ testSuite: XCTestSuite) {
                 let record = TestSuiteEventRecord(suite: .init(testSuite), event: .start)
                 write(record: TestEventRecord(suiteEvent: record))
             }
 
-            public func testCaseWillStart(_ testCase: XCTestCase) {
+            package func testCaseWillStart(_ testCase: XCTestCase) {
                 let record = TestCaseEventRecord(testCase: .init(testCase), event: .start)
                 write(record: TestEventRecord(caseEvent: record))
             }
 
             #if canImport(Darwin)
-            public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
+            package func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
                 let record = TestCaseFailureRecord(testCase: .init(testCase), issue: .init(issue), failureKind: .unexpected)
                 write(record: TestEventRecord(caseFailure: record))
             }
 
-            public func testCase(_ testCase: XCTestCase, didRecord expectedFailure: XCTExpectedFailure) {
+            package func testCase(_ testCase: XCTestCase, didRecord expectedFailure: XCTExpectedFailure) {
                 let record = TestCaseFailureRecord(testCase: .init(testCase), issue: .init(expectedFailure.issue), failureKind: .expected(failureReason: expectedFailure.failureReason))
                 write(record: TestEventRecord(caseFailure: record))
             }
             #else
-            public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+            package func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
                 let issue = TestIssue(description: description, inFile: filePath, atLine: lineNumber)
                 let record = TestCaseFailureRecord(testCase: .init(testCase), issue: issue, failureKind: .unexpected)
                 write(record: TestEventRecord(caseFailure: record))
             }
             #endif
 
-            public func testCaseDidFinish(_ testCase: XCTestCase) {
+            package func testCaseDidFinish(_ testCase: XCTestCase) {
                 let record = TestCaseEventRecord(testCase: .init(testCase), event: .finish)
                 write(record: TestEventRecord(caseEvent: record))
             }
 
             #if canImport(Darwin)
-            public func testSuite(_ testSuite: XCTestSuite, didRecord issue: XCTIssue) {
+            package func testSuite(_ testSuite: XCTestSuite, didRecord issue: XCTIssue) {
                 let record = TestSuiteFailureRecord(suite: .init(testSuite), issue: .init(issue), failureKind: .unexpected)
                 write(record: TestEventRecord(suiteFailure: record))
             }
 
-            public func testSuite(_ testSuite: XCTestSuite, didRecord expectedFailure: XCTExpectedFailure) {
+            package func testSuite(_ testSuite: XCTestSuite, didRecord expectedFailure: XCTExpectedFailure) {
                 let record = TestSuiteFailureRecord(suite: .init(testSuite), issue: .init(expectedFailure.issue), failureKind: .expected(failureReason: expectedFailure.failureReason))
                 write(record: TestEventRecord(suiteFailure: record))
             }
             #else
-            public func testSuite(_ testSuite: XCTestSuite, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+            package func testSuite(_ testSuite: XCTestSuite, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
                 let issue = TestIssue(description: description, inFile: filePath, atLine: lineNumber)
                 let record = TestSuiteFailureRecord(suite: .init(testSuite), issue: issue, failureKind: .unexpected)
                 write(record: TestEventRecord(suiteFailure: record))
             }
             #endif
 
-            public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
+            package func testSuiteDidFinish(_ testSuite: XCTestSuite) {
                 let record = TestSuiteEventRecord(suite: .init(testSuite), event: .finish)
                 write(record: TestEventRecord(suiteEvent: record))
             }
 
-            public func testBundleDidFinish(_ testBundle: Bundle) {
+            package func testBundleDidFinish(_ testBundle: Bundle) {
                 let record = TestBundleEventRecord(bundle: .init(testBundle), event: .finish)
                 write(record: TestEventRecord(bundleEvent: record))
             }
@@ -138,7 +138,7 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
 
         import Foundation
 
-        public final class FileLock {
+        package final class FileLock {
           #if os(Windows)
             private var handle: HANDLE?
           #else
@@ -147,11 +147,11 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
 
             private let lockFile: URL
 
-            public init(at lockFile: URL) {
+            package init(at lockFile: URL) {
                 self.lockFile = lockFile
             }
 
-            public func lock() throws {
+            package func lock() throws {
               #if os(Windows)
                 if handle == nil {
                     let h: HANDLE = lockFile.path.withCString(encodedAs: UTF16.self, {
@@ -198,7 +198,7 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
               #endif
             }
 
-            public func unlock() {
+            package func unlock() {
               #if os(Windows)
                 var overlapped = OVERLAPPED()
                 overlapped.Offset = 0
@@ -225,13 +225,13 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
               #endif
             }
 
-            public func withLock<T>(_ body: () throws -> T) throws -> T {
+            package func withLock<T>(_ body: () throws -> T) throws -> T {
                 try lock()
                 defer { unlock() }
                 return try body()
             }
 
-            public func withLock<T>(_ body: () async throws -> T) async throws -> T {
+            package func withLock<T>(_ body: () async throws -> T) async throws -> T {
                 try lock()
                 defer { unlock() }
                 return try await body()

--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -22,8 +22,8 @@ package func generateTestObservationCode(buildParameters: BuildParameters) -> St
         import Foundation
         import XCTest
 
-        package final class SwiftPMXCTestObserver: NSObject {
-            package override init() {
+        public final class SwiftPMXCTestObserver: NSObject {
+            public override init() {
                 super.init()
                 XCTestObservationCenter.shared.addTestObserver(self)
             }

--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -54,68 +54,68 @@ package func generateTestObservationCode(buildParameters: BuildParameters) -> St
                 }
             }
 
-            package func testBundleWillStart(_ testBundle: Bundle) {
+            public func testBundleWillStart(_ testBundle: Bundle) {
                 let record = TestBundleEventRecord(bundle: .init(testBundle), event: .start)
                 write(record: TestEventRecord(bundleEvent: record))
             }
 
-            package func testSuiteWillStart(_ testSuite: XCTestSuite) {
+            public func testSuiteWillStart(_ testSuite: XCTestSuite) {
                 let record = TestSuiteEventRecord(suite: .init(testSuite), event: .start)
                 write(record: TestEventRecord(suiteEvent: record))
             }
 
-            package func testCaseWillStart(_ testCase: XCTestCase) {
+            public func testCaseWillStart(_ testCase: XCTestCase) {
                 let record = TestCaseEventRecord(testCase: .init(testCase), event: .start)
                 write(record: TestEventRecord(caseEvent: record))
             }
 
             #if canImport(Darwin)
-            package func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
+            public func testCase(_ testCase: XCTestCase, didRecord issue: XCTIssue) {
                 let record = TestCaseFailureRecord(testCase: .init(testCase), issue: .init(issue), failureKind: .unexpected)
                 write(record: TestEventRecord(caseFailure: record))
             }
 
-            package func testCase(_ testCase: XCTestCase, didRecord expectedFailure: XCTExpectedFailure) {
+            public func testCase(_ testCase: XCTestCase, didRecord expectedFailure: XCTExpectedFailure) {
                 let record = TestCaseFailureRecord(testCase: .init(testCase), issue: .init(expectedFailure.issue), failureKind: .expected(failureReason: expectedFailure.failureReason))
                 write(record: TestEventRecord(caseFailure: record))
             }
             #else
-            package func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+            public func testCase(_ testCase: XCTestCase, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
                 let issue = TestIssue(description: description, inFile: filePath, atLine: lineNumber)
                 let record = TestCaseFailureRecord(testCase: .init(testCase), issue: issue, failureKind: .unexpected)
                 write(record: TestEventRecord(caseFailure: record))
             }
             #endif
 
-            package func testCaseDidFinish(_ testCase: XCTestCase) {
+            public func testCaseDidFinish(_ testCase: XCTestCase) {
                 let record = TestCaseEventRecord(testCase: .init(testCase), event: .finish)
                 write(record: TestEventRecord(caseEvent: record))
             }
 
             #if canImport(Darwin)
-            package func testSuite(_ testSuite: XCTestSuite, didRecord issue: XCTIssue) {
+            public func testSuite(_ testSuite: XCTestSuite, didRecord issue: XCTIssue) {
                 let record = TestSuiteFailureRecord(suite: .init(testSuite), issue: .init(issue), failureKind: .unexpected)
                 write(record: TestEventRecord(suiteFailure: record))
             }
 
-            package func testSuite(_ testSuite: XCTestSuite, didRecord expectedFailure: XCTExpectedFailure) {
+            public func testSuite(_ testSuite: XCTestSuite, didRecord expectedFailure: XCTExpectedFailure) {
                 let record = TestSuiteFailureRecord(suite: .init(testSuite), issue: .init(expectedFailure.issue), failureKind: .expected(failureReason: expectedFailure.failureReason))
                 write(record: TestEventRecord(suiteFailure: record))
             }
             #else
-            package func testSuite(_ testSuite: XCTestSuite, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
+            public func testSuite(_ testSuite: XCTestSuite, didFailWithDescription description: String, inFile filePath: String?, atLine lineNumber: Int) {
                 let issue = TestIssue(description: description, inFile: filePath, atLine: lineNumber)
                 let record = TestSuiteFailureRecord(suite: .init(testSuite), issue: issue, failureKind: .unexpected)
                 write(record: TestEventRecord(suiteFailure: record))
             }
             #endif
 
-            package func testSuiteDidFinish(_ testSuite: XCTestSuite) {
+            public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
                 let record = TestSuiteEventRecord(suite: .init(testSuite), event: .finish)
                 write(record: TestEventRecord(suiteEvent: record))
             }
 
-            package func testBundleDidFinish(_ testBundle: Bundle) {
+            public func testBundleDidFinish(_ testBundle: Bundle) {
                 let record = TestBundleEventRecord(bundle: .init(testBundle), event: .finish)
                 write(record: TestEventRecord(bundleEvent: record))
             }
@@ -138,7 +138,7 @@ package func generateTestObservationCode(buildParameters: BuildParameters) -> St
 
         import Foundation
 
-        package final class FileLock {
+        public final class FileLock {
           #if os(Windows)
             private var handle: HANDLE?
           #else
@@ -147,11 +147,11 @@ package func generateTestObservationCode(buildParameters: BuildParameters) -> St
 
             private let lockFile: URL
 
-            package init(at lockFile: URL) {
+            public init(at lockFile: URL) {
                 self.lockFile = lockFile
             }
 
-            package func lock() throws {
+            public func lock() throws {
               #if os(Windows)
                 if handle == nil {
                     let h: HANDLE = lockFile.path.withCString(encodedAs: UTF16.self, {
@@ -198,7 +198,7 @@ package func generateTestObservationCode(buildParameters: BuildParameters) -> St
               #endif
             }
 
-            package func unlock() {
+            public func unlock() {
               #if os(Windows)
                 var overlapped = OVERLAPPED()
                 overlapped.Offset = 0
@@ -225,13 +225,13 @@ package func generateTestObservationCode(buildParameters: BuildParameters) -> St
               #endif
             }
 
-            package func withLock<T>(_ body: () throws -> T) throws -> T {
+            public func withLock<T>(_ body: () throws -> T) throws -> T {
                 try lock()
                 defer { unlock() }
                 return try body()
             }
 
-            package func withLock<T>(_ body: () async throws -> T) async throws -> T {
+            public func withLock<T>(_ body: () async throws -> T) async throws -> T {
                 try lock()
                 defer { unlock() }
                 return try await body()

--- a/Sources/LLBuildManifest/Command.swift
+++ b/Sources/LLBuildManifest/Command.swift
@@ -10,12 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct Command {
+package struct Command {
     /// The name of the command.
-    public var name: String
+    package var name: String
 
     /// The tool used for this command.
-    public var tool: ToolProtocol
+    package var tool: ToolProtocol
 
     init(name: String, tool: ToolProtocol) {
         self.name = name

--- a/Sources/LLBuildManifest/LLBuildManifest.swift
+++ b/Sources/LLBuildManifest/LLBuildManifest.swift
@@ -15,14 +15,14 @@ import Foundation
 
 import class TSCBasic.Process
 
-public protocol AuxiliaryFileType {
+package protocol AuxiliaryFileType {
     static var name: String { get }
 
     static func getFileContents(inputs: [Node]) throws -> String
 }
 
-public enum WriteAuxiliary {
-    public static let fileTypes: [AuxiliaryFileType.Type] = [
+package enum WriteAuxiliary {
+    package static let fileTypes: [AuxiliaryFileType.Type] = [
         EntitlementPlist.self,
         LinkFileList.self,
         SourcesFileList.self,
@@ -30,14 +30,14 @@ public enum WriteAuxiliary {
         XCTestInfoPlist.self
     ]
 
-    public struct EntitlementPlist: AuxiliaryFileType {
-        public static let name = "entitlement-plist"
+    package struct EntitlementPlist: AuxiliaryFileType {
+        package static let name = "entitlement-plist"
 
-        public static func computeInputs(entitlement: String) -> [Node] {
+        package static func computeInputs(entitlement: String) -> [Node] {
             [.virtual(Self.name), .virtual(entitlement)]
         }
 
-        public static func getFileContents(inputs: [Node]) throws -> String {
+        package static func getFileContents(inputs: [Node]) throws -> String {
             guard let entitlementName = inputs.last?.extractedVirtualNodeName else {
                 throw Error.undefinedEntitlementName
             }
@@ -54,15 +54,15 @@ public enum WriteAuxiliary {
         }
     }
 
-    public struct LinkFileList: AuxiliaryFileType {
-        public static let name = "link-file-list"
+    package struct LinkFileList: AuxiliaryFileType {
+        package static let name = "link-file-list"
 
         // FIXME: We should extend the `InProcessTool` support to allow us to specify these in a typed way, but today we have to flatten all the inputs into a generic `Node` array (rdar://109844243).
-        public static func computeInputs(objects: [AbsolutePath]) -> [Node] {
+        package static func computeInputs(objects: [AbsolutePath]) -> [Node] {
             return [.virtual(Self.name)] + objects.map { Node.file($0) }
         }
 
-        public static func getFileContents(inputs: [Node]) throws -> String {
+        package static func getFileContents(inputs: [Node]) throws -> String {
             let objects = inputs.compactMap {
                 if $0.kind == .file {
                     return $0.name
@@ -84,14 +84,14 @@ public enum WriteAuxiliary {
         }
     }
 
-    public struct SourcesFileList: AuxiliaryFileType {
-        public static let name = "sources-file-list"
+    package struct SourcesFileList: AuxiliaryFileType {
+        package static let name = "sources-file-list"
 
-        public static func computeInputs(sources: [AbsolutePath]) -> [Node] {
+        package static func computeInputs(sources: [AbsolutePath]) -> [Node] {
             return [.virtual(Self.name)] + sources.map { Node.file($0) }
         }
 
-        public static func getFileContents(inputs: [Node]) throws -> String {
+        package static func getFileContents(inputs: [Node]) throws -> String {
             let sources = inputs.compactMap {
                 if $0.kind == .file {
                     return $0.name
@@ -110,14 +110,14 @@ public enum WriteAuxiliary {
         }
     }
 
-    public struct SwiftGetVersion: AuxiliaryFileType {
-        public static let name = "swift-get-version"
+    package struct SwiftGetVersion: AuxiliaryFileType {
+        package static let name = "swift-get-version"
 
-        public static func computeInputs(swiftCompilerPath: AbsolutePath) -> [Node] {
+        package static func computeInputs(swiftCompilerPath: AbsolutePath) -> [Node] {
             return [.virtual(Self.name), .file(swiftCompilerPath)]
         }
 
-        public static func getFileContents(inputs: [Node]) throws -> String {
+        package static func getFileContents(inputs: [Node]) throws -> String {
             guard let swiftCompilerPathString = inputs.first(where: { $0.kind == .file })?.name else {
                 throw Error.unknownSwiftCompilerPath
             }
@@ -130,14 +130,14 @@ public enum WriteAuxiliary {
         }
     }
 
-    public struct XCTestInfoPlist: AuxiliaryFileType {
-        public static let name = "xctest-info-plist"
+    package struct XCTestInfoPlist: AuxiliaryFileType {
+        package static let name = "xctest-info-plist"
 
-        public static func computeInputs(principalClass: String) -> [Node] {
+        package static func computeInputs(principalClass: String) -> [Node] {
             return [.virtual(Self.name), .virtual(principalClass)]
         }
 
-        public static func getFileContents(inputs: [Node]) throws -> String {
+        package static func getFileContents(inputs: [Node]) throws -> String {
             guard let principalClass = inputs.last?.extractedVirtualNodeName else {
                 throw Error.undefinedPrincipalClass
             }
@@ -161,23 +161,23 @@ public enum WriteAuxiliary {
     }
 }
 
-public struct LLBuildManifest {
-    public typealias TargetName = String
-    public typealias CmdName = String
+package struct LLBuildManifest {
+    package typealias TargetName = String
+    package typealias CmdName = String
 
     /// The targets in the manifest.
-    public private(set) var targets: [TargetName: Target] = [:]
+    package private(set) var targets: [TargetName: Target] = [:]
 
     /// The commands in the manifest.
-    public private(set) var commands: [CmdName: Command] = [:]
+    package private(set) var commands: [CmdName: Command] = [:]
 
     /// The default target to build.
-    public var defaultTarget: String = ""
+    package var defaultTarget: String = ""
 
-    public init() {
+    package init() {
     }
 
-    public func getCmdToolMap<T: ToolProtocol>(kind: T.Type) -> [CmdName: T] {
+    package func getCmdToolMap<T: ToolProtocol>(kind: T.Type) -> [CmdName: T] {
         var result = [CmdName: T]()
         for (cmdName, cmd) in commands {
             if let tool = cmd.tool as? T {
@@ -187,16 +187,16 @@ public struct LLBuildManifest {
         return result
     }
 
-    public mutating func createTarget(_ name: TargetName) {
+    package mutating func createTarget(_ name: TargetName) {
         guard !targets.keys.contains(name) else { return }
         targets[name] = Target(name: name, nodes: [])
     }
 
-    public mutating func addNode(_ node: Node, toTarget target: TargetName) {
+    package mutating func addNode(_ node: Node, toTarget target: TargetName) {
         targets[target, default: Target(name: target, nodes: [])].nodes.append(node)
     }
 
-    public mutating func addPhonyCmd(
+    package mutating func addPhonyCmd(
         name: String,
         inputs: [Node],
         outputs: [Node]
@@ -206,7 +206,7 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addTestDiscoveryCmd(
+    package mutating func addTestDiscoveryCmd(
         name: String,
         inputs: [Node],
         outputs: [Node]
@@ -216,7 +216,7 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addTestEntryPointCmd(
+    package mutating func addTestEntryPointCmd(
         name: String,
         inputs: [Node],
         outputs: [Node]
@@ -226,7 +226,7 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addCopyCmd(
+    package mutating func addCopyCmd(
         name: String,
         inputs: [Node],
         outputs: [Node]
@@ -236,14 +236,14 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addEntitlementPlistCommand(entitlement: String, outputPath: AbsolutePath) {
+    package mutating func addEntitlementPlistCommand(entitlement: String, outputPath: AbsolutePath) {
         let inputs = WriteAuxiliary.EntitlementPlist.computeInputs(entitlement: entitlement)
         let tool = WriteAuxiliaryFile(inputs: inputs, outputFilePath: outputPath)
         let name = outputPath.pathString
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addWriteLinkFileListCommand(
+    package mutating func addWriteLinkFileListCommand(
         objects: [AbsolutePath],
         linkFileListPath: AbsolutePath
     ) {
@@ -253,7 +253,7 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addWriteSourcesFileListCommand(
+    package mutating func addWriteSourcesFileListCommand(
         sources: [AbsolutePath],
         sourcesFileListPath: AbsolutePath
     ) {
@@ -263,7 +263,7 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addSwiftGetVersionCommand(
+    package mutating func addSwiftGetVersionCommand(
         swiftCompilerPath: AbsolutePath,
         swiftVersionFilePath: AbsolutePath
     ) {
@@ -273,14 +273,14 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addWriteInfoPlistCommand(principalClass: String, outputPath: AbsolutePath) {
+    package mutating func addWriteInfoPlistCommand(principalClass: String, outputPath: AbsolutePath) {
         let inputs = WriteAuxiliary.XCTestInfoPlist.computeInputs(principalClass: principalClass)
         let tool = WriteAuxiliaryFile(inputs: inputs, outputFilePath: outputPath)
         let name = outputPath.pathString
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addPkgStructureCmd(
+    package mutating func addPkgStructureCmd(
         name: String,
         inputs: [Node],
         outputs: [Node]
@@ -290,7 +290,7 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addShellCmd(
+    package mutating func addShellCmd(
         name: String,
         description: String,
         inputs: [Node],
@@ -313,7 +313,7 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addSwiftFrontendCmd(
+    package mutating func addSwiftFrontendCmd(
         name: String,
         moduleName: String,
         packageName: String,
@@ -333,7 +333,7 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addClangCmd(
+    package mutating func addClangCmd(
         name: String,
         description: String,
         inputs: [Node],
@@ -352,7 +352,7 @@ public struct LLBuildManifest {
         commands[name] = Command(name: name, tool: tool)
     }
 
-    public mutating func addSwiftCmd(
+    package mutating func addSwiftCmd(
         name: String,
         inputs: [Node],
         outputs: [Node],

--- a/Sources/LLBuildManifest/LLBuildManifestWriter.swift
+++ b/Sources/LLBuildManifest/LLBuildManifestWriter.swift
@@ -14,7 +14,7 @@ import Basics
 
 private let namesToExclude = [".git", ".build"]
 
-public struct LLBuildManifestWriter {
+package struct LLBuildManifestWriter {
     private let manifest: LLBuildManifest
     // FIXME: since JSON is a superset of YAML and we don't need to parse these manifests,
     // we should just use `JSONEncoder` instead.
@@ -38,7 +38,7 @@ public struct LLBuildManifestWriter {
         self.render(commands: manifest.commands)
     }
 
-    public static func write(_ manifest: LLBuildManifest, at path: AbsolutePath, fileSystem: FileSystem) throws {
+    package static func write(_ manifest: LLBuildManifest, at path: AbsolutePath, fileSystem: FileSystem) throws {
         let writer = LLBuildManifestWriter(manifest: manifest)
 
         try fileSystem.writeFileContents(path, string: writer.buffer)
@@ -125,66 +125,66 @@ public struct LLBuildManifestWriter {
     }
 }
 
-public struct ManifestToolStream {
+package struct ManifestToolStream {
     fileprivate var buffer = ""
 
-    public subscript(key: String) -> Int {
+    package subscript(key: String) -> Int {
         get { fatalError() }
         set {
             self.buffer += "    \(key): \(newValue.description.asJSON)\n"
         }
     }
 
-    public subscript(key: String) -> String {
+    package subscript(key: String) -> String {
         get { fatalError() }
         set {
             self.buffer += "    \(key): \(newValue.asJSON)\n"
         }
     }
 
-    public subscript(key: String) -> ToolProtocol {
+    package subscript(key: String) -> ToolProtocol {
         get { fatalError() }
         set {
             self.buffer += "    \(key): \(type(of: newValue).name)\n"
         }
     }
 
-    public subscript(key: String) -> AbsolutePath {
+    package subscript(key: String) -> AbsolutePath {
         get { fatalError() }
         set {
             self.buffer += "    \(key): \(newValue.pathString.asJSON)\n"
         }
     }
 
-    public subscript(key: String) -> [AbsolutePath] {
+    package subscript(key: String) -> [AbsolutePath] {
         get { fatalError() }
         set {
             self.buffer += "    \(key): \(newValue.map(\.pathString).asJSON)\n"
         }
     }
 
-    public subscript(key: String) -> [Node] {
+    package subscript(key: String) -> [Node] {
         get { fatalError() }
         set {
             self.buffer += "    \(key): \(newValue.map(\.encodingName).asJSON)\n"
         }
     }
 
-    public subscript(key: String) -> Bool {
+    package subscript(key: String) -> Bool {
         get { fatalError() }
         set {
             self.buffer += "    \(key): \(newValue.description)\n"
         }
     }
 
-    public subscript(key: String) -> [String] {
+    package subscript(key: String) -> [String] {
         get { fatalError() }
         set {
             self.buffer += "    \(key): \(newValue.asJSON)\n"
         }
     }
 
-    public subscript(key: String) -> [String: String] {
+    package subscript(key: String) -> [String: String] {
         get { fatalError() }
         set {
             self.buffer += "    \(key):\n"

--- a/Sources/LLBuildManifest/Node.swift
+++ b/Sources/LLBuildManifest/Node.swift
@@ -12,8 +12,8 @@
 
 import Basics
 
-public struct Node: Hashable, Codable {
-    public enum Kind: String, Hashable, Codable {
+package struct Node: Hashable, Codable {
+    package enum Kind: String, Hashable, Codable {
         case virtual
         case file
         case directory
@@ -26,10 +26,10 @@ public struct Node: Hashable, Codable {
     }
 
     /// The name used to identify the node.
-    public var name: String
+    package var name: String
 
     /// The kind of node.
-    public var kind: Kind
+    package var kind: Kind
 
     let attributes: Attributes?
 
@@ -40,12 +40,12 @@ public struct Node: Hashable, Codable {
     }
     
     /// Extracts `name` property if this node was constructed as `Node//virtual`.
-    public var extractedVirtualNodeName: String {
+    package var extractedVirtualNodeName: String {
         precondition(kind == .virtual)
         return String(self.name.dropFirst().dropLast())
     }
 
-    public static func virtual(_ name: String, isCommandTimestamp: Bool = false) -> Node {
+    package static func virtual(_ name: String, isCommandTimestamp: Bool = false) -> Node {
         precondition(name.first != "<" && name.last != ">", "<> will be inserted automatically")
         return Node(
             name: "<" + name + ">",
@@ -54,11 +54,11 @@ public struct Node: Hashable, Codable {
         )
     }
 
-    public static func file(_ name: AbsolutePath) -> Node {
+    package static func file(_ name: AbsolutePath) -> Node {
         Node(name: name.pathString, kind: .file)
     }
 
-    public static func file(_ name: AbsolutePath, isMutated: Bool) -> Node {
+    package static func file(_ name: AbsolutePath, isMutated: Bool) -> Node {
         Node(
             name: name.pathString,
             kind: .file,
@@ -66,25 +66,25 @@ public struct Node: Hashable, Codable {
         )
     }
 
-    public static func directory(_ name: AbsolutePath) -> Node {
+    package static func directory(_ name: AbsolutePath) -> Node {
         Node(name: name.pathString, kind: .directory)
     }
 
-    public static func directoryStructure(_ name: AbsolutePath) -> Node {
+    package static func directoryStructure(_ name: AbsolutePath) -> Node {
         Node(name: name.pathString, kind: .directoryStructure)
     }
 }
 
 extension Array where Element == Node {
-    public mutating func append(file path: AbsolutePath) {
+    package mutating func append(file path: AbsolutePath) {
         self.append(.file(path))
     }
 
-    public mutating func append(directory path: AbsolutePath) {
+    package mutating func append(directory path: AbsolutePath) {
         self.append(.directory(path))
     }
 
-    public mutating func append(directoryStructure path: AbsolutePath) {
+    package mutating func append(directoryStructure path: AbsolutePath) {
         self.append(.directoryStructure(path))
     }
 }

--- a/Sources/LLBuildManifest/Target.swift
+++ b/Sources/LLBuildManifest/Target.swift
@@ -10,14 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct Target {
+package struct Target {
     /// The name of the target.
-    public var name: String
+    package var name: String
 
     /// The list of nodes that should be computed to build this target.
-    public var nodes: [Node]
+    package var nodes: [Node]
 
-    public init(name: String, nodes: [Node]) {
+    package init(name: String, nodes: [Node]) {
         self.name = name
         self.nodes = nodes
     }

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -13,7 +13,7 @@
 import Basics
 import class Foundation.ProcessInfo
 
-public protocol ToolProtocol: Codable {
+package protocol ToolProtocol: Codable {
     /// The name of the tool.
     static var name: String { get }
 
@@ -31,16 +31,16 @@ public protocol ToolProtocol: Codable {
 }
 
 extension ToolProtocol {
-    public var alwaysOutOfDate: Bool { return false }
+    package var alwaysOutOfDate: Bool { return false }
 
-    public func write(to stream: inout ManifestToolStream) {}
+    package func write(to stream: inout ManifestToolStream) {}
 }
 
-public struct PhonyTool: ToolProtocol {
-    public static let name: String = "phony"
+package struct PhonyTool: ToolProtocol {
+    package static let name: String = "phony"
 
-    public var inputs: [Node]
-    public var outputs: [Node]
+    package var inputs: [Node]
+    package var outputs: [Node]
 
     init(inputs: [Node], outputs: [Node]) {
         self.inputs = inputs
@@ -48,24 +48,12 @@ public struct PhonyTool: ToolProtocol {
     }
 }
 
-public struct TestDiscoveryTool: ToolProtocol {
-    public static let name: String = "test-discovery-tool"
-    public static let mainFileName: String = "all-discovered-tests.swift"
+package struct TestDiscoveryTool: ToolProtocol {
+    package static let name: String = "test-discovery-tool"
+    package static let mainFileName: String = "all-discovered-tests.swift"
 
-    public var inputs: [Node]
-    public var outputs: [Node]
-
-    init(inputs: [Node], outputs: [Node]) {
-        self.inputs = inputs
-        self.outputs = outputs
-    }
-}
-
-public struct TestEntryPointTool: ToolProtocol {
-    public static let name: String = "test-entry-point-tool"
-
-    public var inputs: [Node]
-    public var outputs: [Node]
+    package var inputs: [Node]
+    package var outputs: [Node]
 
     init(inputs: [Node], outputs: [Node]) {
         self.inputs = inputs
@@ -73,18 +61,30 @@ public struct TestEntryPointTool: ToolProtocol {
     }
 }
 
-public struct CopyTool: ToolProtocol {
-    public static let name: String = "copy-tool"
+package struct TestEntryPointTool: ToolProtocol {
+    package static let name: String = "test-entry-point-tool"
 
-    public var inputs: [Node]
-    public var outputs: [Node]
+    package var inputs: [Node]
+    package var outputs: [Node]
+
+    init(inputs: [Node], outputs: [Node]) {
+        self.inputs = inputs
+        self.outputs = outputs
+    }
+}
+
+package struct CopyTool: ToolProtocol {
+    package static let name: String = "copy-tool"
+
+    package var inputs: [Node]
+    package var outputs: [Node]
 
     init(inputs: [Node], outputs: [Node]) {
         self.inputs = inputs
         self.outputs = outputs
     }
 
-    public func write(to stream: inout ManifestToolStream) {
+    package func write(to stream: inout ManifestToolStream) {
         stream["description"] = "Copying \(inputs[0].name)"
     }
 }
@@ -93,33 +93,33 @@ public struct CopyTool: ToolProtocol {
 /// that requires regenerating the build manifest file. This allows us to skip a lot of
 /// redundant work (package graph loading, build planning, manifest generation) during
 /// incremental builds.
-public struct PackageStructureTool: ToolProtocol {
-    public static let name: String = "package-structure-tool"
+package struct PackageStructureTool: ToolProtocol {
+    package static let name: String = "package-structure-tool"
 
-    public var inputs: [Node]
-    public var outputs: [Node]
+    package var inputs: [Node]
+    package var outputs: [Node]
 
     init(inputs: [Node], outputs: [Node]) {
         self.inputs = inputs
         self.outputs = outputs
     }
 
-    public func write(to stream: inout ManifestToolStream) {
+    package func write(to stream: inout ManifestToolStream) {
         stream["description"] = "Planning build"
         stream["allow-missing-inputs"] = true
     }
 }
 
-public struct ShellTool: ToolProtocol {
-    public static let name: String = "shell"
+package struct ShellTool: ToolProtocol {
+    package static let name: String = "shell"
 
-    public var description: String
-    public var inputs: [Node]
-    public var outputs: [Node]
-    public var arguments: [String]
-    public var environment: EnvironmentVariables
-    public var workingDirectory: String?
-    public var allowMissingInputs: Bool
+    package var description: String
+    package var inputs: [Node]
+    package var outputs: [Node]
+    package var arguments: [String]
+    package var environment: EnvironmentVariables
+    package var workingDirectory: String?
+    package var allowMissingInputs: Bool
 
     init(
         description: String,
@@ -139,7 +139,7 @@ public struct ShellTool: ToolProtocol {
         self.allowMissingInputs = allowMissingInputs
     }
 
-    public func write(to stream: inout ManifestToolStream) {
+    package func write(to stream: inout ManifestToolStream) {
         stream["description"] = description
         stream["args"] = arguments
         if !environment.isEmpty {
@@ -154,36 +154,36 @@ public struct ShellTool: ToolProtocol {
     }
 }
 
-public struct WriteAuxiliaryFile: Equatable, ToolProtocol {
-    public static let name: String = "write-auxiliary-file"
+package struct WriteAuxiliaryFile: Equatable, ToolProtocol {
+    package static let name: String = "write-auxiliary-file"
 
-    public let inputs: [Node]
+    package let inputs: [Node]
     private let outputFilePath: AbsolutePath
-    public let alwaysOutOfDate: Bool
+    package let alwaysOutOfDate: Bool
 
-    public init(inputs: [Node], outputFilePath: AbsolutePath, alwaysOutOfDate: Bool = false) {
+    package init(inputs: [Node], outputFilePath: AbsolutePath, alwaysOutOfDate: Bool = false) {
         self.inputs = inputs
         self.outputFilePath = outputFilePath
         self.alwaysOutOfDate = alwaysOutOfDate
     }
 
-    public var outputs: [Node] {
+    package var outputs: [Node] {
         return [.file(outputFilePath)]
     }
 
-    public func write(to stream: inout ManifestToolStream) {
+    package func write(to stream: inout ManifestToolStream) {
         stream["description"] = "Write auxiliary file \(outputFilePath.pathString)"
     }
 }
 
-public struct ClangTool: ToolProtocol {
-    public static let name: String = "clang"
+package struct ClangTool: ToolProtocol {
+    package static let name: String = "clang"
 
-    public var description: String
-    public var inputs: [Node]
-    public var outputs: [Node]
-    public var arguments: [String]
-    public var dependencies: String?
+    package var description: String
+    package var inputs: [Node]
+    package var outputs: [Node]
+    package var arguments: [String]
+    package var dependencies: String?
 
     init(
         description: String,
@@ -199,7 +199,7 @@ public struct ClangTool: ToolProtocol {
         self.dependencies = dependencies
     }
 
-    public func write(to stream: inout ManifestToolStream) {
+    package func write(to stream: inout ManifestToolStream) {
         stream["description"] = description
         stream["args"] = arguments
         if let dependencies {
@@ -208,11 +208,11 @@ public struct ClangTool: ToolProtocol {
     }
 }
 
-public struct ArchiveTool: ToolProtocol {
-    public static let name: String = "archive"
+package struct ArchiveTool: ToolProtocol {
+    package static let name: String = "archive"
 
-    public var inputs: [Node]
-    public var outputs: [Node]
+    package var inputs: [Node]
+    package var outputs: [Node]
 
     init(inputs: [Node], outputs: [Node]) {
         self.inputs = inputs
@@ -221,14 +221,14 @@ public struct ArchiveTool: ToolProtocol {
 }
 
 /// Swift frontend tool, which maps down to a shell tool.
-public struct SwiftFrontendTool: ToolProtocol {
-    public static let name: String = "shell"
+package struct SwiftFrontendTool: ToolProtocol {
+    package static let name: String = "shell"
 
-    public let moduleName: String
-    public var description: String
-    public var inputs: [Node]
-    public var outputs: [Node]
-    public var arguments: [String]
+    package let moduleName: String
+    package var description: String
+    package var inputs: [Node]
+    package var outputs: [Node]
+    package var arguments: [String]
 
     init(
         moduleName: String,
@@ -244,33 +244,33 @@ public struct SwiftFrontendTool: ToolProtocol {
         self.arguments = arguments
     }
 
-    public func write(to stream: inout ManifestToolStream) {
+    package func write(to stream: inout ManifestToolStream) {
       ShellTool(description: description, inputs: inputs, outputs: outputs, arguments: arguments).write(to: &stream)
     }
 }
 
 /// Swift compiler llbuild tool.
-public struct SwiftCompilerTool: ToolProtocol {
-    public static let name: String = "shell"
+package struct SwiftCompilerTool: ToolProtocol {
+    package static let name: String = "shell"
 
-    public static let numThreads: Int = ProcessInfo.processInfo.activeProcessorCount
+    package static let numThreads: Int = ProcessInfo.processInfo.activeProcessorCount
 
-    public var inputs: [Node]
-    public var outputs: [Node]
+    package var inputs: [Node]
+    package var outputs: [Node]
 
-    public var executable: AbsolutePath
-    public var moduleName: String
-    public var moduleAliases: [String: String]?
-    public var moduleOutputPath: AbsolutePath
-    public var importPath: AbsolutePath
-    public var tempsPath: AbsolutePath
-    public var objects: [AbsolutePath]
-    public var otherArguments: [String]
-    public var sources: [AbsolutePath]
-    public var fileList: AbsolutePath
-    public var isLibrary: Bool
-    public var wholeModuleOptimization: Bool
-    public var outputFileMapPath: AbsolutePath
+    package var executable: AbsolutePath
+    package var moduleName: String
+    package var moduleAliases: [String: String]?
+    package var moduleOutputPath: AbsolutePath
+    package var importPath: AbsolutePath
+    package var tempsPath: AbsolutePath
+    package var objects: [AbsolutePath]
+    package var otherArguments: [String]
+    package var sources: [AbsolutePath]
+    package var fileList: AbsolutePath
+    package var isLibrary: Bool
+    package var wholeModuleOptimization: Bool
+    package var outputFileMapPath: AbsolutePath
 
     init(
         inputs: [Node],
@@ -340,7 +340,7 @@ public struct SwiftCompilerTool: ToolProtocol {
         return arguments
     }
 
-    public func write(to stream: inout ManifestToolStream) {
+    package func write(to stream: inout ManifestToolStream) {
         ShellTool(description: description, inputs: inputs, outputs: outputs, arguments: arguments).write(to: &stream)
     }
 }


### PR DESCRIPTION
These APIs should not be marked `public` to prevent SwiftPM clients from adopting them by accident.