### PR TITLE
Replace `ProcessEnv.vars` with `block` w/o API breakage

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -20,7 +20,7 @@ import func TSCBasic.tsc_await
 
 public enum Concurrency {
     public static var maxOperations: Int {
-        ProcessEnv.vars["SWIFTPM_MAX_CONCURRENT_OPERATIONS"].flatMap(Int.init) ?? ProcessInfo.processInfo
+        ProcessEnv.block["SWIFTPM_MAX_CONCURRENT_OPERATIONS"].flatMap(Int.init) ?? ProcessInfo.processInfo
             .activeProcessorCount
     }
 }

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -288,7 +288,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope.makeChildScope(description: "Build Plan")
 
-        var productMap = [ResolvedProduct.ID: (product: ResolvedProduct, buildDescription: ProductBuildDescription)]()
+        var productMap: [ResolvedProduct.ID: (product: ResolvedProduct, buildDescription: ProductBuildDescription)] = [:]
         // Create product description for each product we have in the package graph that is eligible.
         for product in graph.allProducts where product.shouldCreateProductDescription {
             let buildParameters: BuildParameters
@@ -447,7 +447,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 var derivedTestTargets = [item.entryPointTargetBuildDescription.target]
 
                 targetMap[item.entryPointTargetBuildDescription.target.id] = 
-                    .swift(item .entryPointTargetBuildDescription)
+                    .swift(item.entryPointTargetBuildDescription)
 
                 if let discoveryTargetBuildDescription = item.discoveryTargetBuildDescription {
                     targetMap[discoveryTargetBuildDescription.target.id] = .swift(discoveryTargetBuildDescription)

--- a/Sources/Commands/PackageCommands/Format.swift
+++ b/Sources/Commands/PackageCommands/Format.swift
@@ -37,7 +37,7 @@ extension SwiftPackageCommand {
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             // Look for swift-format binary.
             // FIXME: This should be moved to user toolchain.
-            let swiftFormatInEnv = lookupExecutablePath(filename: ProcessEnv.vars["SWIFT_FORMAT"])
+            let swiftFormatInEnv = lookupExecutablePath(filename: ProcessEnv.block["SWIFT_FORMAT"])
             guard let swiftFormat = swiftFormatInEnv ?? Process.findExecutable("swift-format").flatMap(AbsolutePath.init) else {
                 swiftCommandState.observabilityScope.emit(error: "Could not find swift-format in PATH or SWIFT_FORMAT")
                 throw TSCUtility.Diagnostics.fatalError

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -933,7 +933,7 @@ final class ParallelTestRunner {
 
         // command's result output goes on stdout
         // ie "swift test" should output to stdout
-        if ProcessEnv.vars["SWIFTPM_TEST_RUNNER_PROGRESS_BAR"] == "lit" {
+        if ProcessEnv.block["SWIFTPM_TEST_RUNNER_PROGRESS_BAR"] == "lit" {
             self.progressAnimation = ProgressAnimation.percent(
                 stream: TSCBasic.stdoutStream,
                 verbose: false,
@@ -1292,7 +1292,7 @@ extension TestCommandOptions {
 
     /// Returns the test case specifier if overridden in the env.
     private func skippedTestsOverride(fileSystem: FileSystem) -> TestCaseSpecifier? {
-        guard let override = ProcessEnv.vars["_SWIFTPM_SKIP_TESTS_LIST"] else {
+        guard let override = ProcessEnv.block["_SWIFTPM_SKIP_TESTS_LIST"] else {
             return nil
         }
 

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -857,7 +857,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
         // FIXME: Workaround for the module cache bug that's been haunting Swift CI
         // <rdar://problem/48443680>
-        let moduleCachePath = try (ProcessEnv.vars["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"]).flatMap{ try AbsolutePath(validating: $0) }
+        let moduleCachePath = try (
+            ProcessEnv.block["SWIFTPM_MODULECACHE_OVERRIDE"] ??
+            ProcessEnv.block["SWIFTPM_TESTS_MODULECACHE"]).flatMap { try AbsolutePath(validating: $0) }
 
         var cmd: [String] = []
         cmd += [self.toolchain.swiftCompilerPathForManifests.pathString]
@@ -955,7 +957,11 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                     evaluationResult.compilerCommandLine = cmd
 
                     // Compile the manifest.
-                    TSCBasic.Process.popen(arguments: cmd, environment: self.toolchain.swiftCompilerEnvironment, queue: callbackQueue) { result in
+                    TSCBasic.Process.popen(
+                        arguments: cmd,
+                        environment: self.toolchain.swiftCompilerEnvironment,
+                        queue: callbackQueue
+                    ) { result in
                         dispatchPrecondition(condition: .onQueue(callbackQueue))
 
                         var cleanupIfError = DelayableAction(target: tmpDir, action: cleanupTmpDir)
@@ -1054,7 +1060,11 @@ public final class ManifestLoader: ManifestLoaderProtocol {
                         #endif
 
                         let cleanupAfterRunning = cleanupIfError.delay()
-                        TSCBasic.Process.popen(arguments: cmd, environment: environment, queue: callbackQueue) { result in
+                        TSCBasic.Process.popen(
+                            arguments: cmd,
+                            environment: environment,
+                            queue: callbackQueue
+                        ) { result in
                             dispatchPrecondition(condition: .onQueue(callbackQueue))
 
                             defer { cleanupAfterRunning.perform() }

--- a/Sources/PackageLoading/PkgConfig.swift
+++ b/Sources/PackageLoading/PkgConfig.swift
@@ -126,7 +126,7 @@ public struct PkgConfig {
 
     private static var envSearchPaths: [AbsolutePath] {
         get throws {
-            if let configPath = ProcessEnv.vars["PKG_CONFIG_PATH"] {
+            if let configPath = ProcessEnv.block["PKG_CONFIG_PATH"] {
                 #if os(Windows)
                 return try configPath.split(separator: ";").map({ try AbsolutePath(validating: String($0)) })
                 #else
@@ -183,7 +183,7 @@ internal struct PkgConfigParser {
         variables["pcfiledir"] = pcFile.parentDirectory.pathString
 
         // Add pc_sysrootdir variable. This is the path of the sysroot directory for pc files.
-        variables["pc_sysrootdir"] = ProcessEnv.vars["PKG_CONFIG_SYSROOT_DIR"] ?? AbsolutePath.root.pathString
+        variables["pc_sysrootdir"] = ProcessEnv.block["PKG_CONFIG_SYSROOT_DIR"] ?? AbsolutePath.root.pathString
 
         let fileContents: String = try fileSystem.readFileContents(pcFile)
         for line in fileContents.components(separatedBy: "\n") {

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -465,10 +465,10 @@ public struct SwiftSDK: Equatable {
     ) throws -> SwiftSDK {
         let originalWorkingDirectory = originalWorkingDirectory ?? localFileSystem.currentWorkingDirectory
         // Select the correct binDir.
-        if ProcessEnv.vars["SWIFTPM_CUSTOM_BINDIR"] != nil {
+        if ProcessEnv.block["SWIFTPM_CUSTOM_BINDIR"] != nil {
             print("SWIFTPM_CUSTOM_BINDIR was deprecated in favor of SWIFTPM_CUSTOM_BIN_DIR")
         }
-        let customBinDir = (ProcessEnv.vars["SWIFTPM_CUSTOM_BIN_DIR"] ?? ProcessEnv.vars["SWIFTPM_CUSTOM_BINDIR"])
+        let customBinDir = (ProcessEnv.block["SWIFTPM_CUSTOM_BIN_DIR"] ?? ProcessEnv.block["SWIFTPM_CUSTOM_BINDIR"])
             .flatMap { try? AbsolutePath(validating: $0) }
         let binDir = try customBinDir ?? binDir ?? SwiftSDK.hostBinDir(
             fileSystem: localFileSystem,
@@ -478,7 +478,7 @@ public struct SwiftSDK: Equatable {
         let sdkPath: AbsolutePath?
         #if os(macOS)
         // Get the SDK.
-        if let value = ProcessEnv.vars["SDKROOT"] {
+        if let value = ProcessEnv.block["SDKROOT"] {
             sdkPath = try AbsolutePath(validating: value)
         } else {
             // No value in env, so search for it.

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -175,8 +175,8 @@ package enum BuildSystemUtilities {
     /// Returns the build path from the environment, if present.
     public static func getEnvBuildPath(workingDir: AbsolutePath) throws -> AbsolutePath? {
         // Don't rely on build path from env for SwiftPM's own tests.
-        guard ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"] == nil else { return nil }
-        guard let env = ProcessEnv.vars["SWIFTPM_BUILD_DIR"] else { return nil }
+        guard ProcessEnv.block["SWIFTPM_TESTS_MODULECACHE"] == nil else { return nil }
+        guard let env = ProcessEnv.block["SWIFTPM_BUILD_DIR"] else { return nil }
         return try AbsolutePath(validating: env, relativeTo: workingDir)
     }
 }

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -331,7 +331,7 @@ public class RepositoryManager: Cancellable {
         }
         
         // We are expecting handle.repository.url to always be a resolved absolute path.
-        let shouldCacheLocalPackages = ProcessEnv.vars["SWIFTPM_TESTS_PACKAGECACHE"] == "1" || cacheLocalPackages
+        let shouldCacheLocalPackages = ProcessEnv.block["SWIFTPM_TESTS_PACKAGECACHE"] == "1" || cacheLocalPackages
 
         if let cachePath, !(handle.repository.isLocal && !shouldCacheLocalPackages) {
             let cachedRepositoryPath = try cachePath.appending(handle.repository.storagePath())

--- a/Sources/Workspace/DefaultPluginScriptRunner.swift
+++ b/Sources/Workspace/DefaultPluginScriptRunner.swift
@@ -209,7 +209,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         #endif
 
         // Honor any module cache override that's set in the environment.
-        let moduleCachePath = ProcessEnv.vars["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.vars["SWIFTPM_TESTS_MODULECACHE"]
+        let moduleCachePath = ProcessEnv.block["SWIFTPM_MODULECACHE_OVERRIDE"] ?? ProcessEnv.block["SWIFTPM_TESTS_MODULECACHE"]
         if let moduleCachePath {
             commandLine += ["-module-cache-path", moduleCachePath]
         }

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -89,7 +89,7 @@ extension Workspace {
         public var localMirrorsConfigurationFile: AbsolutePath {
             get throws {
                 // backwards compatibility
-                if let customPath = ProcessEnv.vars["SWIFTPM_MIRROR_CONFIG"] {
+                if let customPath = ProcessEnv.block["SWIFTPM_MIRROR_CONFIG"] {
                     return try AbsolutePath(validating: customPath)
                 }
                 return DefaultLocations.mirrorsConfigurationFile(at: self.localConfigurationDirectory)

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -90,7 +90,7 @@ package final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope.makeChildScope(description: "Xcode Build System")
 
-        if let xcbuildTool = ProcessEnv.vars["XCBUILD_TOOL"] {
+        if let xcbuildTool = ProcessEnv.block["XCBUILD_TOOL"] {
             xcbuildPath = try AbsolutePath(validating: xcbuildTool)
         } else {
             let xcodeSelectOutput = try TSCBasic.Process.popen(args: "xcode-select", "-p").utf8Output().spm_chomp()

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -42,7 +42,7 @@ final class APIDiffTests: CommandsTestCase {
         try skipIfApiDigesterUnsupported()
         // The following is added to separate out the integration point testing of the API
         // diff digester with SwiftPM from the functionality tests of the digester itself
-        guard ProcessEnv.vars["SWIFTPM_TEST_API_DIFF_OUTPUT"] == "1" else {
+        guard ProcessEnv.block["SWIFTPM_TEST_API_DIFF_OUTPUT"] == "1" else {
             throw XCTSkip("Env var SWIFTPM_TEST_API_DIFF_OUTPUT must be set to test the output")
         }
     }

--- a/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionsTests/GitHubPackageMetadataProviderTests.swift
@@ -339,7 +339,7 @@ class GitHubPackageMetadataProviderTests: XCTestCase {
         httpClient.configuration.requestHeaders = .init()
         httpClient.configuration.requestHeaders!.add(name: "Cache-Control", value: "no-cache")
         var configuration = GitHubPackageMetadataProvider.Configuration(disableCache: true) // Disable cache so we hit the API
-        if let token = ProcessEnv.vars["GITHUB_API_TOKEN"] {
+        if let token = ProcessEnv.block["GITHUB_API_TOKEN"] {
             configuration.authTokens = { [.github("github.com"): token] }
         }
         configuration.apiLimitWarningThreshold = 50


### PR DESCRIPTION
This fixes some `ProcessEnv.vars` warnings without more intrusive breaking changes for SwiftPM clients, as previously attempted in https://github.com/apple/swift-package-manager/pull/7364.

Also fixed some formatting inconsistencies.
