### PR TITLE
Revert "Remove previously deprecated `--enable-test-discovery`"

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -215,13 +215,19 @@ extension SwiftCommandState {
     ) throws -> BuildParameters {
         var parameters = try self.productsBuildParameters
 
+        var explicitlyEnabledDiscovery = false
         var explicitlySpecifiedPath: AbsolutePath?
-        if case let .entryPointExecutable(explicitlySpecifiedPathValue) = parameters.testingParameters.testProductStyle {
+        if case let .entryPointExecutable(
+            explicitlyEnabledDiscoveryValue,
+            explicitlySpecifiedPathValue
+        ) = parameters.testingParameters.testProductStyle {
+            explicitlyEnabledDiscovery = explicitlyEnabledDiscoveryValue
             explicitlySpecifiedPath = explicitlySpecifiedPathValue
         }
         parameters.testingParameters = .init(
             configuration: parameters.configuration,
             targetTriple: parameters.triple,
+            forceTestDiscovery: explicitlyEnabledDiscovery,
             testEntryPointPath: explicitlySpecifiedPath,
             library: library
         )

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -464,8 +464,13 @@ package struct BuildOptions: ParsableArguments {
         #endif
     }
 
+    /// Whether to enable test discovery on platforms without Objective-C runtime.
+    @Flag(help: .hidden)
+    package var enableTestDiscovery: Bool = false
+
     /// Path of test entry point file to use, instead of synthesizing one or using `XCTMain.swift` in the package (if
     /// present).
+    /// This implies `--enable-test-discovery`
     @Option(
         name: .customLong("experimental-test-entry-point-path"),
         help: .hidden

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -371,6 +371,16 @@ package final class SwiftCommandState {
             observabilityScope.emit(.mutuallyExclusiveArgumentsError(arguments: ["--arch", "--triple"]))
         }
 
+        // --enable-test-discovery should never be called on darwin based platforms
+        #if canImport(Darwin)
+        if options.build.enableTestDiscovery {
+            observabilityScope
+                .emit(
+                    warning: "'--enable-test-discovery' option is deprecated; tests are automatically discovered on all platforms"
+                )
+        }
+        #endif
+
         if options.caching.shouldDisableManifestCaching {
             observabilityScope
                 .emit(
@@ -767,6 +777,7 @@ package final class SwiftCommandState {
             testingParameters: .init(
                 configuration: options.build.configuration,
                 targetTriple: triple,
+                forceTestDiscovery: options.build.enableTestDiscovery, // backwards compatibility, remove with --enable-test-discovery
                 testEntryPointPath: options.build.testEntryPointPath
             )
         )

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -202,6 +202,36 @@ final class TestCommandTests: CommandsTestCase {
         }
     }
 
+    func testEnableTestDiscoveryDeprecation() throws {
+        let compilerDiagnosticFlags = ["-Xswiftc", "-Xfrontend", "-Xswiftc", "-Rmodule-interface-rebuild"]
+        #if canImport(Darwin)
+        // should emit when LinuxMain is present
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
+            XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
+        }
+
+        // should emit when LinuxMain is not present
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
+            let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
+            XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
+        }
+        #else
+        // should emit when LinuxMain is present
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
+            XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
+        }
+        // should not emit when LinuxMain is present
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
+            let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
+            XCTAssertNoMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
+        }
+        #endif
+    }
+
     func testList() throws {
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let (stdout, stderr) = try SwiftPM.Test.execute(["list"], packagePath: fixturePath)

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -88,6 +88,21 @@ class TestDiscoveryTests: XCTestCase {
         }
     }
 
+    func testEntryPointOverrideIgnored() throws {
+        #if os(macOS)
+        try XCTSkipIf(true)
+        #endif
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let manifestPath = fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName)
+            try localFileSystem.writeFileContents(manifestPath, string: "fatalError(\"should not be called\")")
+            let (stdout, stderr) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
+            // in "swift test" build output goes to stderr
+            XCTAssertMatch(stderr, .contains("Build complete!"))
+            // in "swift test" test output goes to stdout
+            XCTAssertNoMatch(stdout, .contains("Executed 1 test"))
+        }
+    }
+
     func testTestExtensions() throws {
         #if os(macOS)
         try XCTSkipIf(true)


### PR DESCRIPTION
Reverts apple/swift-package-manager#7391, which blocks CI as various projects are still using `--enable-test-discovery`.