### PR TITLE
Pass all arguments when initing testing parameters in `swift build`

### DIFF
--- a/Fixtures/Miscellaneous/TestDiscovery/IgnoresLinuxMain/Package.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/IgnoresLinuxMain/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package = Package(
+    name: "IgnoresLinuxMain",
+    targets: [
+        .testTarget(name: "IgnoresLinuxMainTests"),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestDiscovery/IgnoresLinuxMain/Tests/IgnoresLinuxMainTests/SomeTest.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/IgnoresLinuxMain/Tests/IgnoresLinuxMainTests/SomeTest.swift
@@ -1,0 +1,5 @@
+import XCTest
+
+final class SomeTests: XCTestCase {
+    func testSomething() {}
+}

--- a/Fixtures/Miscellaneous/TestDiscovery/IgnoresLinuxMain/Tests/LinuxMain.swift
+++ b/Fixtures/Miscellaneous/TestDiscovery/IgnoresLinuxMain/Tests/LinuxMain.swift
@@ -1,0 +1,1 @@
+fatalError("Should not use the contents of LinuxMain.swift")

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -154,6 +154,11 @@ package struct SwiftBuildCommand: AsyncSwiftCommand {
                 buildParameters.testingParameters = .init(
                     configuration: buildParameters.configuration,
                     targetTriple: buildParameters.triple,
+                    enableCodeCoverage: buildParameters.testingParameters.enableCodeCoverage,
+                    enableTestability: buildParameters.testingParameters.enableTestability,
+                    experimentalTestOutput: buildParameters.testingParameters.experimentalTestOutput,
+                    forceTestDiscovery: globalOptions.build.enableTestDiscovery,
+                    testEntryPointPath: globalOptions.build.testEntryPointPath,
                     library: library
                 )
                 try build(swiftCommandState, subset: subset, buildParameters: buildParameters)


### PR DESCRIPTION
Ensures that a fully-initialized `TestingParameters` structure is used with `swift build --build-tests` instead of using any default parameters (which will tend us toward the wrong output with packages that use `--enable-test-discovery` and still have LinuxMain.swift files.)

Tested with swift-numerics on Ubuntu 22.04 aarch64; before the change, we'd hit the `fatalError()` call in that package's LinuxMain.swift file. After the change, we correctly run XCTest-based tests.

Resolves #7389.