### PR TITLE
Replace getdtablesize() on Android

### DIFF
--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -297,9 +297,15 @@ package struct SwiftRunCommand: AsyncSwiftCommand {
         var sig_set_all = sigset_t()
         sigfillset(&sig_set_all)
         sigprocmask(SIG_UNBLOCK, &sig_set_all, nil)
+
+        #if os(Android)
+        let number_fds = Int32(sysconf(_SC_OPEN_MAX))
+        #else
+        let number_fds = getdtablesize()
+        #endif
         
         // 2. close all file descriptors.
-        for i in 3..<getdtablesize() {
+        for i in 3..<number_fds {
             close(i)
         }
         #endif


### PR DESCRIPTION
I've had to make this change on my Android CI since #7369 was merged a couple weeks ago, finagolfin/swift-android-sdk@c5828e4, as Bionic doesn't have this function. I found that [Chromium had switched to this years ago](https://codereview.chromium.org/349323003), can replace `getdtablesize()` altogether instead if wanted.

@MaxDesiatov, let me know what you think.