### PR TITLE
Opt in to keep existing config of module contents for SwiftPM targets

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -278,6 +278,10 @@ package final class ProductBuildDescription: SPMBuildCore.ProductBuildDescriptio
                 args += ["-enable-experimental-feature", feature]
             }
 
+            if self.package.manifest.allowNonResilientAccessInPackage {
+                args += ["-enable-experimental-feature", "AllowNonResilientAccessInPackage"]
+            }
+
             // Embed the swift stdlib library path inside tests and executables on Darwin.
             let useStdlibRpath: Bool
             switch self.product.type {

--- a/Sources/PackageModel/PackageModel.swift
+++ b/Sources/PackageModel/PackageModel.swift
@@ -137,6 +137,9 @@ extension Manifest {
     public var usePackageNameFlag: Bool {
         return self.toolsVersion >= .v5_9
     }
+    public var allowNonResilientAccessInPackage: Bool {
+        return self.toolsVersion > .v5_10
+    }
 }
 
 extension ObservabilityMetadata {


### PR DESCRIPTION
A .swiftmodule can be configured to only contain exportable decls. Targets in SwiftPM, however, are mostly built from source and contain all contents besides exportable decls unless specified. To continue with the existing configuration, pass a feature flag (AllowNonResilientAccessInPackage) that allows it by default.

rdar://124650423