### PR TITLE
Write output-file-map.json atomically

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -779,7 +779,8 @@ package final class SwiftTargetBuildDescription {
 
         content += "}\n"
 
-        try self.fileSystem.writeFileContents(path, string: content)
+        try fileSystem.createDirectory(path.parentDirectory, recursive: true)
+        try self.fileSystem.writeFileContents(path, bytes: .init(encodingAsUTF8: content), atomically: true)
         return path
     }
 


### PR DESCRIPTION
There are two subtle changes in behavior here:
- This call will fail if the file system doesn’t support atomic operations. I’m not sure if we need to support file systems that don’t allow atomic operations here.

rdar://124727242
