### PR TITLE
[6.0] Write output-file-map.json atomically

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -779,7 +779,8 @@ package final class SwiftTargetBuildDescription {
 
         content += "}\n"
 
-        try self.fileSystem.writeFileContents(path, string: content)
+        try fileSystem.createDirectory(path.parentDirectory, recursive: true)
+        try self.fileSystem.writeFileContents(path, bytes: .init(encodingAsUTF8: content), atomically: true)
         return path
     }
 


### PR DESCRIPTION
* **Explanation**: When using sourcekit-lsp with VS Code it often happens that sourcekitd is trying to read the `output-file-map.json` while SwiftPM is writing it non-atomically. This results in a buffer in sourcekitd that is not null-terminated. To fix this issue, generate the output file map atomically. 
* **Scope**: Generation of `output-file-map.json`
* **Risk**: This could fail if the `FileSystem` subclass in SwiftPM does not support atomic write operations. But I think we only really care about the local file system here, which does support atomic operations
* **Testing**: Tests continue passing. I will verify that this fixes the sourcekitd crashes when a new toolchain is released with the fix
* **Issue**:  rdar://124727242
* **Reviewer**:  @MaxDesiatov  on https://github.com/apple/swift-package-manager/pull/7406