### PR TITLE
Use `.so` as the default dynamic library extension on unknown OSes

### DIFF
--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -147,7 +147,7 @@ extension Triple {
         case .wasi:
             return ".wasm"
         default:
-            fatalError("Cannot create dynamic libraries for os \"\(os)\".")
+            return ".so"
         }
     }
 


### PR DESCRIPTION

Use `.so` as the default dynamic library extension on unknown OSes

### Motivation:

`fatalError` here can lead to a crash while loading a package manifest containing `.library` products with none-OS targets even though the product won't be used in the build.

### Modifications:

Use `.so` as the default dynamic library extension on unknown OSes
LLVM defaults to `.so` for unknown OSes, so it makes sense to do the same in SwiftPM.

### Result:

Dynamic libraries for Embedded targets will be suffixed with `.so`
