### PR TITLE
[chore] Update Package.swift in Examples/package-info

### DIFF
--- a/Examples/package-info/Package.swift
+++ b/Examples/package-info/Package.swift
@@ -1,18 +1,18 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 import PackageDescription
 
 let package = Package(
     name: "package-info",
     platforms: [
-        .macOS(.v12),
-        .iOS(.v13)
+        .macOS(.v13),
+        .iOS(.v16)
     ],
     dependencies: [
         // This just points to the SwiftPM at the root of this repository.
         .package(name: "swift-package-manager", path: "../../"),
         // You will want to depend on a stable semantic version instead:
-        // .package(url: "https://github.com/apple/swift-package-manager", .exact("0.4.0"))
+        // .package(url: "https://github.com/apple/swift-package-manager", branch: "swift-5.10-RELEASE")
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Update Package.swift in Examples/package-info.

### Motivation:

I couldn't build `Examples/package-info` in Venture(v13.6.2).
This is because the minimum supported version of `Examples/package-info` is lower than the minimum supported version of `swift-package-manager`.

### Modifications:

I have corrected the minimum supported version of `Examples/package-info` to be the same as the minimum supported version of `swift-package-manager`. ([`Package.swift`](https://github.com/apple/swift-package-manager/blob/main/Package.swift#L91-L94) in swift-pacakge-manger)

### Result:

`Examples/package-info` can be built.
