### PR TITLE
PackageModelTests: fix warnings

### DIFF
--- a/Tests/PackageModelTests/MinimumDeploymentTargetTests.swift
+++ b/Tests/PackageModelTests/MinimumDeploymentTargetTests.swift
@@ -22,7 +22,7 @@ class MinimumDeploymentTargetTests: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         let result = ProcessResult(arguments: [],
-                                   environment: [:],
+                                   environmentBlock: [:],
                                    exitStatus: .terminated(code: 0),
                                    output: "".asResult,
                                    stderrOutput: "xcodebuild: error: SDK \"macosx\" cannot be located.".asResult)
@@ -36,7 +36,7 @@ class MinimumDeploymentTargetTests: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         let result = ProcessResult(arguments: [],
-                                   environment: [:],
+                                   environmentBlock: [:],
                                    exitStatus: .terminated(code: 0),
                                    output: "some string".asResult,
                                    stderrOutput: "".asResult)
@@ -50,7 +50,7 @@ class MinimumDeploymentTargetTests: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         let result = ProcessResult(arguments: [],
-                                   environment: [:],
+                                   environmentBlock: [:],
                                    exitStatus: .terminated(code: 0),
                                    output: .failure(DummyError()),
                                    stderrOutput: "".asResult)


### PR DESCRIPTION
Resolve warnings in `Tests/PackageModelTests/MinimumDeploymentTargetTests.swift` .

### Motivation:

3 warnings were displayed indicating that a deprecated function is being used and suggesting the use of an alternative function.

### Modifications:

Following the suggestion, the warning was resolved.

### Result:

The following warnings have been resolved:

> `init(arguments:environment:exitStatus:output:stderrOutput:)` is deprecated: use `init(arguments:environmentBlock:exitStatus:output:stderrOutput:)`


