### PR TITLE
Use `arguments` instead of `argumentList` in the macro template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -836,7 +836,7 @@ public final class InitPackage {
                         of node: some FreestandingMacroExpansionSyntax,
                         in context: some MacroExpansionContext
                     ) -> ExprSyntax {
-                        guard let argument = node.argumentList.first?.expression else {
+                        guard let argument = node.arguments.first?.expression else {
                             fatalError("compiler bug: the macro does not have any arguments")
                         }
 


### PR DESCRIPTION
* **Explanation**: `argumentList` has been deprecated. The Swift macro template should use `arguments` instead.
* **Scope**: The Swift macro template
* **Risk**: Very low
* **Testing**: Made the same modification in a macro package that was freshly generated from the template and verified that it builds without warnings
* **Issue**: n/a
* **Reviewer**: @MaxDesiatov on https://github.com/apple/swift-package-manager/pull/7422  
