### PR TITLE
Add a `swift-corelibs-foundation` specific workaround

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -311,6 +311,18 @@ package final class ClangTargetBuildDescription {
             args += ["-I", includeSearchPath.pathString]
         }
 
+        // FIXME: Remove this once it becomes possible to express this dependency in a package manifest.
+        //
+        // On Linux/Android swift-corelibs-foundation depends on dispatch library which is
+        // currently shipped with the Swift toolchain.
+        if (triple.isLinux() || triple.isAndroid()) && self.package.id == .plain("swift-corelibs-foundation") {
+            let swiftCompilerPath = self.buildParameters.toolchain.swiftCompilerPath
+            let toolchainResourcesPath = swiftCompilerPath.parentDirectory
+                                                          .parentDirectory
+                                                          .appending(components: ["lib", "swift"])
+            args += ["-I", toolchainResourcesPath.pathString]
+        }
+
         return args
     }
 

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import PackageGraph
 import PackageLoading
 import PackageModel
 import struct PackageGraph.ModulesGraph
@@ -23,6 +24,9 @@ import enum TSCBasic.ProcessEnv
 
 /// Target description for a Clang target i.e. C language family target.
 package final class ClangTargetBuildDescription {
+    /// The package this target belongs to.
+    package let package: ResolvedPackage
+
     /// The target described by this target.
     package let target: ResolvedTarget
 
@@ -109,6 +113,7 @@ package final class ClangTargetBuildDescription {
 
     /// Create a new target description with target and build parameters.
     init(
+        package: ResolvedPackage,
         target: ResolvedTarget,
         toolsVersion: ToolsVersion,
         additionalFileRules: [FileRuleDescription] = [],
@@ -122,6 +127,7 @@ package final class ClangTargetBuildDescription {
             throw InternalError("underlying target type mismatch \(target)")
         }
 
+        self.package = package
         self.clangTarget = clangTarget
         self.fileSystem = fileSystem
         self.target = target

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -394,8 +394,13 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     )
                 )
             case is ClangTarget:
+                guard let package = graph.package(for: target) else {
+                    throw InternalError("package not found for \(target)")
+                }
+
                 targetMap[target.id] = try .clang(
                     ClangTargetBuildDescription(
+                        package: package,
                         target: target,
                         toolsVersion: toolsVersion,
                         additionalFileRules: additionalFileRules,

--- a/Sources/SPMTestSupport/MockBuildTestHelper.swift
+++ b/Sources/SPMTestSupport/MockBuildTestHelper.swift
@@ -30,7 +30,7 @@ package struct MockToolchain: PackageModel.Toolchain {
     package let swiftCompilerPath = AbsolutePath("/fake/path/to/swiftc")
     package let includeSearchPaths = [AbsolutePath]()
     package let librarySearchPaths = [AbsolutePath]()
-    package let swiftResourcesPath: AbsolutePath? = nil
+    package let swiftResourcesPath: AbsolutePath?
     package let swiftStaticResourcesPath: AbsolutePath? = nil
     package let isSwiftDevelopmentToolchain = false
     package let sdkRootPath: AbsolutePath? = nil
@@ -51,7 +51,9 @@ package struct MockToolchain: PackageModel.Toolchain {
         #endif
     }
 
-    package init() {}
+    package init(swiftResourcesPath: AbsolutePath? = nil) {
+        self.swiftResourcesPath = swiftResourcesPath
+    }
 }
 
 extension Basics.Triple {

--- a/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
@@ -49,8 +49,33 @@ final class ClangTargetBuildDescriptionTests: XCTestCase {
 
     private func makeTargetBuildDescription() throws -> ClangTargetBuildDescription {
         let observability = ObservabilitySystem.makeForTesting(verbose: false)
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "dummy",
+            toolsVersion: .v5,
+            targets: [try TargetDescription(name: "dummy")]
+        )
+
+        let target = try makeResolvedTarget()
+
+        let package = Package(identity: .plain("dummy"),
+                              manifest: manifest,
+                              path: .root,
+                              targets: [target.underlying],
+                              products: [],
+                              targetSearchPath: .root,
+                              testTargetSearchPath: .root)
+
         return try ClangTargetBuildDescription(
-            target: try makeResolvedTarget(),
+            package: .init(underlying: package,
+                           defaultLocalization: nil,
+                           supportedPlatforms: [],
+                           dependencies: [],
+                           targets: [target],
+                           products: [],
+                           registryMetadata: nil,
+                           platformVersionProvider: .init(implementation: .minimumDeploymentTargetDefault)),
+            target: target,
             toolsVersion: .current,
             buildParameters: mockBuildParameters(
                 toolchain: try UserToolchain.default,

--- a/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
@@ -25,15 +25,11 @@ final class ClangTargetBuildDescriptionTests: XCTestCase {
     }
 
     func testSwiftCorelibsFoundationIncludeWorkaround() throws {
-        let macosParameters = mockBuildParameters(
-            toolchain: try UserToolchain.default,
-            targetTriple: .macOS)
-        let linuxParameters = mockBuildParameters(
-            toolchain: try UserToolchain.default,
-            targetTriple: .arm64Linux)
-        let androidParameters = mockBuildParameters(
-            toolchain: try UserToolchain.default,
-            targetTriple: .arm64Android)
+        let toolchain = MockToolchain(swiftResourcesPath: AbsolutePath("/fake/path/lib/swift"))
+
+        let macosParameters = mockBuildParameters(toolchain: toolchain, targetTriple: .macOS)
+        let linuxParameters = mockBuildParameters(toolchain: toolchain, targetTriple: .arm64Linux)
+        let androidParameters = mockBuildParameters(toolchain: toolchain, targetTriple: .arm64Android)
 
         let macDescription = try makeTargetBuildDescription("swift-corelibs-foundation",
                                                             buildParameters: macosParameters)
@@ -41,6 +37,7 @@ final class ClangTargetBuildDescriptionTests: XCTestCase {
 
         let linuxDescription = try makeTargetBuildDescription("swift-corelibs-foundation",
                                                               buildParameters: linuxParameters)
+        print(try linuxDescription.basicArguments())
         XCTAssertTrue(try linuxDescription.basicArguments().contains("\(linuxParameters.toolchain.swiftResourcesPath!)"))
 
         let androidDescription = try makeTargetBuildDescription("swift-corelibs-foundation",


### PR DESCRIPTION
CoreFoundation depends on dispatch, this dependency is implicit
and dispatch itself is bundled with swift toolchains. Let's add
a package specific workaround for Linux/Android targets to add
toolchain resources directory to search paths of clang build targets.

This is also a prerequisite for https://github.com/apple/swift-package-manager/pull/7423