### PR TITLE
On Darwin, allow XCTest to be missing if we're only building swift-testing tests.

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -178,11 +178,12 @@ enum TestingSupport {
         #endif
         return env
         #else
-        // Add the sdk platform path if we have it. If this is not present, we might always end up failing.
-        let sdkPlatformFrameworksPath = try SwiftSDK.sdkPlatformFrameworkPaths()
-        // appending since we prefer the user setting (if set) to the one we inject
-        env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
-        env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)
+        // Add the sdk platform path if we have it.
+        if let sdkPlatformFrameworksPath = try? SwiftSDK.sdkPlatformFrameworkPaths() {
+            // appending since we prefer the user setting (if set) to the one we inject
+            env.appendPath("DYLD_FRAMEWORK_PATH", value: sdkPlatformFrameworksPath.fwk.pathString)
+            env.appendPath("DYLD_LIBRARY_PATH", value: sdkPlatformFrameworksPath.lib.pathString)
+        }
 
         // Fast path when no sanitizers are enabled.
         if sanitizers.isEmpty {

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -156,7 +156,7 @@ public struct SwiftSDK: Equatable {
     }
 
     /// Whether or not the receiver supports testing using XCTest.
-    public enum XCTestSupport: Sendable, Equatable {
+    package enum XCTestSupport: Sendable, Equatable {
         /// XCTest is supported.
         case supported
 
@@ -169,7 +169,7 @@ public struct SwiftSDK: Equatable {
     }
 
     /// Whether or not the receiver supports using XCTest.
-    public let xctestSupport: XCTestSupport
+    package let xctestSupport: XCTestSupport
 
     /// Root directory path of the SDK used to compile for the target triple.
     @available(*, deprecated, message: "use `pathsConfiguration.sdkRootPath` instead")
@@ -465,7 +465,7 @@ public struct SwiftSDK: Equatable {
     }
 
     /// Creates a Swift SDK with the specified properties.
-    public init(
+    package init(
         hostTriple: Triple? = nil,
         targetTriple: Triple? = nil,
         toolset: Toolset,


### PR DESCRIPTION
This PR removes the constraint on Darwin that XCTest.framework must be present in order to build tests using swift-testing. On Darwin, XCTest is included as a framework inside Xcode, but if a developer installs the Xcode Command Line Tools instead of the full IDE, XCTest is not included. They then get a diagnostic of the form:

> error: XCTest not available: terminated(1): /usr/bin/xcrun --sdk macosx --show-sdk-platform-path output:
>    xcrun: error: unable to lookup item 'PlatformPath' from command line tools installation
>    xcrun: error: unable to lookup item 'PlatformPath' in SDK '/Library/Developer/CommandLineTools/SDKs/MacOSX14.0.sdk'

Which is a poor experience if they aren't even using XCTest.

This change, as a (positive) side effect, suppresses the same diagnostic when running commands that are not usually dependent on the presence of XCTest such as `swift build`.

Note that swift-corelibs-xctest is not supported on Darwin, so installing the Xcode Command Line Tools and adding an explicit dependency on swift-corelibs-xctest will not produce a functional test target bundle. Supporting swift-corelibs-xctest on Darwin is a potential future direction.

Automated testing for this change is difficult because it relies on a build environment that is not supported in CI (namely the presence of the CL tools but not Xcode nor XCTest.framework.) I have manually tested the change against swift-testing's own test target.

A separate PR will be necessary in swift-testing to remove some remaining XCTest dependencies. Those changes are not covered by this PR.

Resolves rdar://125372431.