### PR TITLE
🍒[cxx-interop] Propagate interop flag to the test entry point target

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -555,11 +555,11 @@ package final class SwiftTargetBuildDescription {
             args += ["-color-diagnostics"]
         }
 
-        // If this is a generated test discovery target, it might import a test
+        // If this is a generated test discovery target or a test entry point, it might import a test
         // target that is built with C++ interop enabled. In that case, the test
         // discovery target must enable C++ interop as well
         switch testTargetRole {
-        case .discovery:
+        case .discovery, .entryPoint:
             for dependency in try self.target.recursiveTargetDependencies() {
                 let dependencyScope = self.buildParameters.createScope(for: dependency)
                 let dependencySwiftFlags = dependencyScope.evaluate(.OTHER_SWIFT_FLAGS)

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4063,6 +4063,9 @@ final class BuildPlanTests: XCTestCase {
 
             let testDiscovery = try result.target(for: "APackageDiscoveredTests").swiftTarget().compileArguments()
             XCTAssertMatch(testDiscovery, [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++17"])
+
+            let testEntryPoint = try result.target(for: "APackageTests").swiftTarget().compileArguments()
+            XCTAssertMatch(testEntryPoint, [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++17"])
         }
 
         // omit frame pointers explicitly set to true


### PR DESCRIPTION
**Explanation**: Projects that use C++ interop for some of the Swift targets were failing to build in test mode (`swift test`) because the generated test entry point target wasn't being compiled with C++ interop enabled.
**Scope**: Flags that are being passed to the entry point test target.
**Risk**: Low, this only affects projects that explicitly enable C++ interop in the package manifest on non-Darwin platforms only.
**Testing**: Added a build plan test.
**Issue**: rdar://125498997
**Reviewer**: @MaxDesiatov approved https://github.com/apple/swift-package-manager/pull/7428.

(cherry picked from commit f529daef40418e143ed501ff245109e061db190a)
