### PR TITLE
Allow `swift-corelibs-foundation` to use unsafeFlags when used as a d…

### DIFF
--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -141,9 +141,16 @@ extension Workspace {
                 let dependency = dependency.dependency
                 switch dependency.state {
                 case .sourceControlCheckout(let checkout):
-                    if checkout.isBranchOrRevisionBased {
-                        result.insert(dependency.packageRef)
+                    let packageRef = dependency.packageRef
+
+                    if checkout.isBranchOrRevisionBased
+                      // FIXME: Remove this once we have a general mechanism
+                      //        for passing "safe" flags.
+                      || packageRef.identity == .plain("swift-corelibs-foundation")
+                    {
+                      result.insert(packageRef)
                     }
+
                 case .registryDownload, .edited, .custom:
                     continue
                 case .fileSystem:


### PR DESCRIPTION
…ependency

Tagged dependencies don't currently allow use of `unsafeFlags` but we need to temporarily
lift that requirement for `swift-corelibs-foundation` that depends on C flags. In the future this
would be removed in favor of a more general mechanism for "safe" flags.
