### PR TITLE
Make `supportedTriples` optional in artifactbundle metadata

### DIFF
--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -52,9 +52,9 @@ public struct ArtifactsArchiveMetadata: Equatable {
 
     public struct Variant: Equatable {
         public let path: RelativePath
-        public let supportedTriples: [Triple]
+        public let supportedTriples: [Triple]?
 
-        public init(path: RelativePath, supportedTriples: [Triple]) {
+        public init(path: RelativePath, supportedTriples: [Triple]?) {
             self.path = path
             self.supportedTriples = supportedTriples
         }
@@ -121,7 +121,7 @@ extension ArtifactsArchiveMetadata.Variant: Decodable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.supportedTriples = try container.decode([String].self, forKey: .supportedTriples).map { try Triple($0) }
+        self.supportedTriples = try container.decodeIfPresent([String].self, forKey: .supportedTriples)?.map { try Triple($0) }
         self.path = try RelativePath(validating: container.decode(String.self, forKey: .path))
     }
 }

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
@@ -36,6 +36,10 @@ public struct SwiftSDKBundle {
 extension SwiftSDKBundle.Variant {
     /// Whether the given host triple is supported by this SDK variant
     internal func isSupporting(hostTriple: Triple) -> Bool {
+        guard let supportedTriples = metadata.supportedTriples else {
+            // No supportedTriples means the SDK can be universally usable
+            return true
+        }
         return supportedTriples.contains(where: { variantTriple in
             hostTriple.isRuntimeCompatible(with: variantTriple)
         })

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
@@ -33,6 +33,15 @@ public struct SwiftSDKBundle {
     public var name: String { path.basename }
 }
 
+extension SwiftSDKBundle.Variant {
+    /// Whether the given host triple is supported by this SDK variant
+    internal func isSupporting(hostTriple: Triple) -> Bool {
+        return supportedTriples.contains(where: { variantTriple in
+            hostTriple.isRuntimeCompatible(with: variantTriple)
+        })
+    }
+}
+
 extension [SwiftSDKBundle] {
     /// Select a Swift SDK with a given artifact ID from a `self` array of available Swift SDKs.
     /// - Parameters:
@@ -48,7 +57,7 @@ extension [SwiftSDKBundle] {
                 }
 
                 for variant in variants {
-                    guard variant.metadata.supportedTriples.contains(hostTriple) else {
+                    guard variant.isSupporting(hostTriple: hostTriple) else {
                         continue
                     }
 
@@ -77,11 +86,7 @@ extension [SwiftSDKBundle] {
         for bundle in self {
             for (artifactID, variants) in bundle.artifacts {
                 for variant in variants {
-                    guard variant.metadata.supportedTriples.contains(where: { variantTriple in
-                        hostTriple.isRuntimeCompatible(with: variantTriple)
-                    }) else {
-                        continue
-                    }
+                    guard variant.isSupporting(hostTriple: hostTriple) else { continue }
 
                     for swiftSDK in variant.swiftSDKs {
                         if artifactID == selector {

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -69,7 +69,10 @@ extension BinaryTarget {
             // Filter supported triples with versionLessTriple and pass into
             // ExecutableInfo; empty if non matching triples found.
             try entry.value.variants.map {
-                let filteredSupportedTriples = try $0.supportedTriples
+                guard let supportedTriples = $0.supportedTriples else {
+                    throw StringError("No \"supportedTriples\" found in the artifact metadata for \(entry.key) in \(self.artifactPath)")
+                }
+                let filteredSupportedTriples = try supportedTriples
                     .filter { try $0.withoutVersion() == versionLessTriple }
                 return ExecutableInfo(
                     name: entry.key,

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -536,6 +536,15 @@ final class DestinationTests: XCTestCase {
                             swiftSDKs: [parsedDestinationForOlderHost]
                         ),
                     ],
+                    "id5": [
+                        .init(
+                            metadata: .init(
+                                path: "id5",
+                                supportedTriples: nil
+                            ),
+                            swiftSDKs: [parsedDestinationV2GNU]
+                        ),
+                    ],
                 ]
             ),
         ]
@@ -586,6 +595,24 @@ final class DestinationTests: XCTestCase {
                 observabilityScope: system.topScope
             ),
             parsedDestinationForOlderHost
+        )
+
+        // nil supportedTriples should match with any hostTriple
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                id: "id5",
+                hostTriple: hostTriple,
+                targetTriple: linuxGNUTargetTriple
+            ),
+            parsedDestinationV2GNU
+        )
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                matching: "id5",
+                hostTriple: hostTriple,
+                observabilityScope: system.topScope
+            ),
+            parsedDestinationV2GNU
         )
     }
 }

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -65,4 +65,61 @@ final class ArtifactsArchiveMetadataTests: XCTestCase {
             ]
         ))
     }
+    func testParseMetadataWithoutSupportedTriple() throws {
+        let fileSystem = InMemoryFileSystem()
+        try fileSystem.writeFileContents(
+            "/info.json",
+            string: """
+            {
+                "schemaVersion": "1.0",
+                "artifacts": {
+                    "protocol-buffer-compiler": {
+                        "type": "executable",
+                        "version": "3.5.1",
+                        "variants": [
+                            {
+                                "path": "x86_64-apple-macosx/protoc"
+                            },
+                            {
+                                "path": "x86_64-unknown-linux-gnu/protoc",
+                                "supportedTriples": null
+                            }
+                        ]
+                    }
+                }
+            }
+            """
+        )
+
+        let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
+        XCTAssertEqual(metadata, ArtifactsArchiveMetadata(
+            schemaVersion: "1.0",
+            artifacts: [
+                "protocol-buffer-compiler": ArtifactsArchiveMetadata.Artifact(
+                    type: .executable,
+                    version: "3.5.1",
+                    variants: [
+                        ArtifactsArchiveMetadata.Variant(
+                            path: "x86_64-apple-macosx/protoc",
+                            supportedTriples: nil
+                        ),
+                        ArtifactsArchiveMetadata.Variant(
+                            path: "x86_64-unknown-linux-gnu/protoc",
+                            supportedTriples: nil
+                        ),
+                    ]
+                ),
+            ]
+        ))
+
+        let binaryTarget = BinaryTarget(
+            name: "protoc", kind: .artifactsArchive, path: .root, origin: .local
+        )
+        // No supportedTriples with binaryTarget should be rejected
+        XCTAssertThrowsError(
+            try binaryTarget.parseArtifactArchives(
+                for: Triple("x86_64-apple-macosx"), fileSystem: fileSystem
+            )
+        )
+    }
 }


### PR DESCRIPTION
Make `supportedTriples` optional in artifactbundle metadata

### Motivation:

We don't have a good way to express a Swift SDK that can be used on any host platform except for listing up all possible platforms.

### Modifications:

This change allows `supportedTriples` field to be null or missing to express that the SDK is universally usable.
Also this fixes a minor issue around `swift experimental-sdk configuration`, that did not take care of runtime compatibility of OS version in host triples.

### Result:

SwiftPM now accepts host-platform independent Swift SDK
