### PR TITLE
Update Swift version to 5.9 in `.swiftformat`

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 ## File options
 
---swiftversion 5.7
+--swiftversion 5.9
 --exclude .build
 
 ## Formatting options


### PR DESCRIPTION
We require Swift 5.9 to build the package, so we can adopt 5.9-specific formatting tweak as well.