### PR TITLE
Fix sendability warnings in `URLSessionHTTPClient`

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -17,8 +17,7 @@ import struct Foundation.URL
 import Security
 #endif
 
-public protocol AuthorizationProvider {
-    @Sendable
+public protocol AuthorizationProvider: Sendable {
     func authentication(for url: URL) -> (user: String, password: String)?
 }
 
@@ -80,7 +79,7 @@ extension AuthorizationProvider {
 
 // MARK: - netrc
 
-public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWriter {
+public final class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWriter {
     // marked internal for testing
     internal let path: AbsolutePath
     private let fileSystem: FileSystem
@@ -202,7 +201,7 @@ public class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWri
 // MARK: - Keychain
 
 #if canImport(Security)
-public class KeychainAuthorizationProvider: AuthorizationProvider, AuthorizationWriter {
+public final class KeychainAuthorizationProvider: AuthorizationProvider, AuthorizationWriter {
     private let observabilityScope: ObservabilityScope
 
     private let cache = ThreadSafeKeyValueStore<String, (user: String, password: String)>()

--- a/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
@@ -26,8 +26,8 @@ public final class LegacyHTTPClient: Cancellable {
     public typealias Request = LegacyHTTPClientRequest
     public typealias Response = HTTPClientResponse
     public typealias Handler = (Request, ProgressHandler?, @escaping (Result<Response, Error>) -> Void) -> Void
-    public typealias ProgressHandler = (_ bytesReceived: Int64, _ totalBytes: Int64?) throws -> Void
-    public typealias CompletionHandler = (Result<HTTPClientResponse, Error>) -> Void
+    public typealias ProgressHandler = @Sendable (_ bytesReceived: Int64, _ totalBytes: Int64?) throws -> Void
+    public typealias CompletionHandler = @Sendable (Result<HTTPClientResponse, Error>) -> Void
 
     public var configuration: LegacyHTTPClientConfiguration
     private let underlying: Handler
@@ -121,7 +121,7 @@ public final class LegacyHTTPClient: Cancellable {
             requestNumber: 0,
             observabilityScope: observabilityScope,
             progress: progress.map { handler in
-                { received, expected in
+                { @Sendable received, expected in
                     // call back on the requested queue
                     callbackQueue.async {
                         do {
@@ -312,7 +312,7 @@ extension LegacyHTTPClient {
         headers: HTTPClientHeaders = .init(),
         options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none,
-        completion: @escaping (Result<Response, Error>) -> Void
+        completion: @Sendable @escaping (Result<Response, Error>) -> Void
     ) {
         self.execute(
             Request(method: .head, url: url, headers: headers, body: nil, options: options),
@@ -326,7 +326,7 @@ extension LegacyHTTPClient {
         headers: HTTPClientHeaders = .init(),
         options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none,
-        completion: @escaping (Result<Response, Error>) -> Void
+        completion: @Sendable @escaping (Result<Response, Error>) -> Void
     ) {
         self.execute(
             Request(method: .get, url: url, headers: headers, body: nil, options: options),
@@ -341,7 +341,7 @@ extension LegacyHTTPClient {
         headers: HTTPClientHeaders = .init(),
         options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none,
-        completion: @escaping (Result<Response, Error>) -> Void
+        completion: @Sendable @escaping (Result<Response, Error>) -> Void
     ) {
         self.execute(
             Request(method: .put, url: url, headers: headers, body: body, options: options),
@@ -356,7 +356,7 @@ extension LegacyHTTPClient {
         headers: HTTPClientHeaders = .init(),
         options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none,
-        completion: @escaping (Result<Response, Error>) -> Void
+        completion: @Sendable @escaping (Result<Response, Error>) -> Void
     ) {
         self.execute(
             Request(method: .post, url: url, headers: headers, body: body, options: options),
@@ -370,7 +370,7 @@ extension LegacyHTTPClient {
         headers: HTTPClientHeaders = .init(),
         options: Request.Options = .init(),
         observabilityScope: ObservabilityScope? = .none,
-        completion: @escaping (Result<Response, Error>) -> Void
+        completion: @Sendable @escaping (Result<Response, Error>) -> Void
     ) {
         self.execute(
             Request(method: .delete, url: url, headers: headers, body: nil, options: options),
@@ -383,7 +383,7 @@ extension LegacyHTTPClient {
 // MARK: - LegacyHTTPClientConfiguration
 
 public struct LegacyHTTPClientConfiguration {
-    public typealias AuthorizationProvider = (URL) -> String?
+    public typealias AuthorizationProvider = @Sendable (URL) -> String?
 
     public var requestHeaders: HTTPClientHeaders?
     public var requestTimeout: DispatchTimeInterval?

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -12,8 +12,6 @@
 
 import Basics
 
-import Build
-
 import LLBuildManifest
 import PackageGraph
 import PackageLoading

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -1651,7 +1651,7 @@ public final class RegistryClient: Cancellable {
                 result.tryMap { response in
                     observabilityScope
                         .emit(
-                            debug: "server response for \(request.url): \(response.statusCode) in \(start.distance(to: .now()).descriptionInSeconds)"
+                            debug: "server response for \(url): \(response.statusCode) in \(start.distance(to: .now()).descriptionInSeconds)"
                         )
                     switch response.statusCode {
                     case 201:


### PR DESCRIPTION
Converted `DownloadTask` and `DataTask` to value types and added more `Sendable` annotations where needed.
