### PR TITLE
[5.10] Bump `swift-syntax` dependency in template to 510.0.1

### DIFF
--- a/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
+++ b/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
@@ -33,6 +33,6 @@ public struct InstalledSwiftPMConfiguration: Codable {
     public let swiftSyntaxVersionForMacroTemplate: Version
 
     public static var `default`: InstalledSwiftPMConfiguration {
-        return .init(version: 0, swiftSyntaxVersionForMacroTemplate: .init(major: 509, minor: 0, patch: 0))
+        return .init(version: 0, swiftSyntaxVersionForMacroTemplate: .init(major: 510, minor: 0, patch: 1))
     }
 }


### PR DESCRIPTION
Cherry-pick of #7443.

rdar://124160537
