### PR TITLE
[6.0] Bump `swift-syntax` in template to `600.0.0-latest`

### DIFF
--- a/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
+++ b/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
@@ -39,7 +39,7 @@ public struct InstalledSwiftPMConfiguration: Codable {
                 major: 600,
                 minor: 0,
                 patch: 0,
-                prereleaseIdentifier: "prerelease-2024-04-02"
+                prereleaseIdentifier: "latest"
             )
         )
     }

--- a/Utilities/config.json
+++ b/Utilities/config.json
@@ -1,1 +1,1 @@
-{"version":1,"swiftSyntaxVersionForMacroTemplate":{"major":510,"minor":0,"patch":0, "prereleaseIdentifier":"latest"}}
+{"version":1,"swiftSyntaxVersionForMacroTemplate":{"major":600,"minor":0,"patch":0, "prereleaseIdentifier":"latest"}}


### PR DESCRIPTION
Cherry-pick of #7443.

**Explanation**: `swift package init --type macro` template is outdated.
**Scope**: Limited to `swift package init`.
**Risk**: No risks.
**Testing**: Manually verified that `swift package init --type macro` with freshly built `swift-package` binary creates a package with correct versions.
**Issues**: 
rdar://124160537
rdar://112626159

**Reviewer**: @ahoppen and @bnbarham 



