### PR TITLE
NFC: Fix `@Sendable @escaping` order, symbol name typo

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -49,7 +49,7 @@ extension DispatchQueue {
 
 /// Bridges between potentially blocking methods that take a result completion closure and async/await
 public func safe_async<T, ErrorType: Error>(
-    _ body: @Sendable @escaping (@Sendable @escaping (Result<T, ErrorType>) -> Void) -> Void
+    _ body: @escaping @Sendable (@escaping @Sendable (Result<T, ErrorType>) -> Void) -> Void
 ) async throws -> T {
     try await withCheckedThrowingContinuation { continuation in
         // It is possible that body make block indefinitely on a lock, semaphore,

--- a/Sources/Basics/FileSystem/TemporaryFile.swift
+++ b/Sources/Basics/FileSystem/TemporaryFile.swift
@@ -34,7 +34,7 @@ public func withTemporaryDirectory<Result>(
     fileSystem: FileSystem = localFileSystem,
     dir: AbsolutePath? = nil,
     prefix: String = "TemporaryDirectory",
-    _ body: @Sendable @escaping (AbsolutePath, @escaping (AbsolutePath) -> Void) async throws -> Result
+    _ body: @escaping @Sendable (AbsolutePath, @escaping (AbsolutePath) -> Void) async throws -> Result
 ) throws -> Task<Result, Error> {
     let temporaryDirectory = try createTemporaryDirectory(fileSystem: fileSystem, dir: dir, prefix: prefix)
 

--- a/Sources/Basics/Observability.swift
+++ b/Sources/Basics/Observability.swift
@@ -46,8 +46,7 @@ public class ObservabilitySystem {
     private struct SingleDiagnosticsHandler: ObservabilityHandlerProvider, DiagnosticsHandler {
         var diagnosticsHandler: DiagnosticsHandler { self }
 
-        let underlying: @Sendable (ObservabilityScope, Diagnostic)
-            -> Void
+        let underlying: @Sendable (ObservabilityScope, Diagnostic) -> Void
 
         init(_ underlying: @escaping @Sendable (ObservabilityScope, Diagnostic) -> Void) {
             self.underlying = underlying

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -53,7 +53,7 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
             ),
             additionalFileRules: FileRuleDescription.swiftpmFileTypes,
             pkgConfigDirectories: self.swiftCommandState.options.locations.pkgConfigDirectories,
-            dependenciesByRootPackageIdentity: rootPackageInfo.dependecies,
+            dependenciesByRootPackageIdentity: rootPackageInfo.dependencies,
             targetsByRootPackageIdentity: rootPackageInfo.targets,
             outputStream: outputStream ?? self.swiftCommandState.outputStream,
             logLevel: logLevel ?? self.swiftCommandState.logLevel,

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -463,7 +463,7 @@ package final class SwiftCommandState {
         return workspace
     }
 
-    package func getRootPackageInformation() throws -> (dependecies: [PackageIdentity: [PackageIdentity]], targets: [PackageIdentity: [String]]) {
+    package func getRootPackageInformation() throws -> (dependencies: [PackageIdentity: [PackageIdentity]], targets: [PackageIdentity: [String]]) {
         let workspace = try self.getActiveWorkspace()
         let root = try self.getWorkspaceRoot()
         let rootManifests = try temp_await {

--- a/Sources/PackageRegistry/SignatureValidation.swift
+++ b/Sources/PackageRegistry/SignatureValidation.swift
@@ -91,7 +91,7 @@ struct SignatureValidation {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
         guard !self.skipSignatureValidation else {
             return completion(.success(.none))
@@ -138,7 +138,7 @@ struct SignatureValidation {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
         do {
             let versionMetadata = try self.versionMetadataProvider(package, version)
@@ -240,7 +240,7 @@ struct SignatureValidation {
         configuration: RegistryConfiguration.Security.Signing,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
-        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
         Task {
             do {
@@ -353,7 +353,7 @@ struct SignatureValidation {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
         guard !self.skipSignatureValidation else {
             return completion(.success(.none))
@@ -402,7 +402,7 @@ struct SignatureValidation {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
         let manifestName = toolsVersion.map { "Package@swift-\($0).swift" } ?? Manifest.filename
 
@@ -506,7 +506,7 @@ struct SignatureValidation {
         configuration: RegistryConfiguration.Security.Signing,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
-        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
         Task {
             do {
@@ -577,7 +577,7 @@ struct SignatureValidation {
         signatureFormat: SignatureFormat,
         configuration: RegistryConfiguration.Security.Signing,
         fileSystem: FileSystem,
-        completion: @Sendable @escaping (Result<SigningEntity?, Error>) -> Void
+        completion: @escaping @Sendable (Result<SigningEntity?, Error>) -> Void
     ) {
         Task {
             do {


### PR DESCRIPTION
Sticking to `@escaping @Sendable` as a preferred order of attributes.

Also fixed `dependecies` -> `dependencies` typo.
