### PR TITLE
Add VisionOS platform support to `PIF.PlatformFilter`

### DIFF
--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1601,6 +1601,9 @@ extension [PackageCondition] {
             case .openbsd:
                 result += PIF.PlatformFilter.openBSDFilters
 
+            case .visionOS:
+                result += PIF.PlatformFilter.visionOSFilters
+
             default:
                 assertionFailure("Unhandled platform condition: \(condition)")
                 break
@@ -1670,6 +1673,12 @@ extension PIF.PlatformFilter {
     /// WebAssembly platform filters.
     public static let webAssemblyFilters: [PIF.PlatformFilter] = [
         .init(platform: "wasi"),
+    ]
+
+    /// VisionOS platform filters.
+    public static let visionOSFilters: [PIF.PlatformFilter] = [
+        .init(platform: "visionos"),
+        .init(platform: "visionos", environment: "simulator")
     ]
 }
 

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1677,6 +1677,8 @@ extension PIF.PlatformFilter {
 
     /// VisionOS platform filters.
     public static let visionOSFilters: [PIF.PlatformFilter] = [
+        .init(platform: "xros"),
+        .init(platform: "xros", environment: "simulator"),
         .init(platform: "visionos"),
         .init(platform: "visionos", environment: "simulator")
     ]

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1583,6 +1583,9 @@ extension [PackageCondition] {
             case .watchOS:
                 result += PIF.PlatformFilter.watchOSFilters
 
+            case .visionOS:
+                result += PIF.PlatformFilter.visionOSFilters
+
             case .linux:
                 result += PIF.PlatformFilter.linuxFilters
 
@@ -1600,9 +1603,6 @@ extension [PackageCondition] {
 
             case .openbsd:
                 result += PIF.PlatformFilter.openBSDFilters
-
-            case .visionOS:
-                result += PIF.PlatformFilter.visionOSFilters
 
             default:
                 assertionFailure("Unhandled platform condition: \(condition)")


### PR DESCRIPTION
#### Motivation:
In the process of generating PIF, I identified a missing case for VisionOS in the implementation of the `[PackageConditionProtocol].toPlatformFilters()`, which led to assertionFailure when Package's platforms included VisionOS. 

#### Modifications:
- Added a new case `.visionOS` in the switch statement within the `toPlatformFilters()` extension for `[PackageCondition]`. 
- Added a new static property `visionOSFilters` within `PIF.PlatformFilter` to define filters specific to VisionOS.

#### Result:
With these changes, PIFBuilder can now generate PIF without errors for packages that include VisionOS as a target