### PR TITLE
Fix empty token on swift package-registry login (Issue #7453)

### DIFF
--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -71,12 +71,13 @@ private func readpassword(_ prompt: String) throws -> String {
 
     #if canImport(Darwin)
     var buffer = [CChar](repeating: 0, count: PackageRegistryCommand.Login.passwordBufferSize)
+    password = try withExtendedLifetime(buffer) {
+        guard let passwordPtr = readpassphrase(prompt, &buffer, buffer.count, 0) else {
+            throw StringError("unable to read input")
+        }
 
-    guard let passwordPtr = readpassphrase(prompt, &buffer, buffer.count, 0) else {
-        throw StringError("unable to read input")
+        return String(cString: passwordPtr)
     }
-
-    password = String(cString: passwordPtr)
     #else
     // GNU C implementation of getpass has no limit on the password length
     // (https://man7.org/linux/man-pages/man3/getpass.3.html)


### PR DESCRIPTION
Fix empty token when adding a new package-registry and adding token interactively on release builds

### Motivation:

When executing swift package-registry login it asks for a token but fails to retrieve it properly. It sends an empty string to the registry server and login therefore fails. (see https://github.com/apple/swift-package-manager/issues/7453)

### Modifications:

I've debugged the code a bit and found out, that somehow `buffer` and `passwordPtr` don't seem to be holding correct values after the `readpassphrase` call.

- An easy quick fix is to make sure that `buffer` doesn't get deallocated by adding smth like `_ = buffer` after the String init. This works but is not nice.
- My first try was to use `buffer` instead of  `passwordPtr`  to create the string. These works, but I remember reading somewhere that `&` can be quite nasty sometimes.
- I also tried `buffer.withUnsafeMutablePointer`. However `readpassphrase` seems to not only change the content of `buffer` but move it. This leads to a runtime failure `Fatal error: Array withUnsafeMutableBufferPointer: replacing the buffer is not allowed` 

### Result:
The buffer is retained, the token is properly parsed and sent to the server.


