### PR TITLE
[6.0]  Suppress warnings for remote Clang targets

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -311,6 +311,15 @@ package final class ClangTargetBuildDescription {
             args += ["-I", includeSearchPath.pathString]
         }
 
+        // suppress warnings if the package is remote
+        if self.package.isRemote {
+            args += ["-w"]
+            // `-w` (suppress warnings) and `-Werror` (warnings as errors) flags are mutually exclusive
+            if let index = args.firstIndex(of: "-Werror") {
+                args.remove(at: index)
+            }
+        }
+
         return args
     }
 

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import PackageGraph
 import PackageLoading
 import PackageModel
 import struct PackageGraph.ModulesGraph
@@ -23,6 +24,9 @@ import enum TSCBasic.ProcessEnv
 
 /// Target description for a Clang target i.e. C language family target.
 package final class ClangTargetBuildDescription {
+    /// The package this target belongs to.
+    package let package: ResolvedPackage
+
     /// The target described by this target.
     package let target: ResolvedTarget
 
@@ -109,6 +113,7 @@ package final class ClangTargetBuildDescription {
 
     /// Create a new target description with target and build parameters.
     init(
+        package: ResolvedPackage,
         target: ResolvedTarget,
         toolsVersion: ToolsVersion,
         additionalFileRules: [FileRuleDescription] = [],
@@ -122,6 +127,7 @@ package final class ClangTargetBuildDescription {
             throw InternalError("underlying target type mismatch \(target)")
         }
 
+        self.package = package
         self.clangTarget = clangTarget
         self.fileSystem = fileSystem
         self.target = target

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -394,8 +394,13 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                     )
                 )
             case is ClangTarget:
+                guard let package = graph.package(for: target) else {
+                    throw InternalError("package not found for \(target)")
+                }
+
                 targetMap[target.id] = try .clang(
                     ClangTargetBuildDescription(
+                        package: package,
                         target: target,
                         toolsVersion: toolsVersion,
                         additionalFileRules: additionalFileRules,

--- a/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
@@ -49,8 +49,33 @@ final class ClangTargetBuildDescriptionTests: XCTestCase {
 
     private func makeTargetBuildDescription() throws -> ClangTargetBuildDescription {
         let observability = ObservabilitySystem.makeForTesting(verbose: false)
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "dummy",
+            toolsVersion: .v5,
+            targets: [try TargetDescription(name: "dummy")]
+        )
+
+        let target = try makeResolvedTarget()
+
+        let package = Package(identity: .plain("dummy"),
+                              manifest: manifest,
+                              path: .root,
+                              targets: [target.underlying],
+                              products: [],
+                              targetSearchPath: .root,
+                              testTargetSearchPath: .root)
+
         return try ClangTargetBuildDescription(
-            target: try makeResolvedTarget(),
+            package: .init(underlying: package,
+                           defaultLocalization: nil,
+                           supportedPlatforms: [],
+                           dependencies: [],
+                           targets: [target],
+                           products: [],
+                           registryMetadata: nil,
+                           platformVersionProvider: .init(implementation: .minimumDeploymentTargetDefault)),
+            target: target,
             toolsVersion: .current,
             buildParameters: mockBuildParameters(
                 toolchain: try UserToolchain.default,


### PR DESCRIPTION
- Explanation:

This mirrors behavior of remote swift targets which suppress warnings as well. Remote package warnings are generally not addressible anyway at the moment.

- Scope: Remote class targets.

- Main Branch PRs: https://github.com/apple/swift-package-manager/pull/7423

- Risk: Very Low

- Reviewed By: @bnbarham @MaxDesiatov   

- Testing: Added test-cases to the test suite.

