### PR TITLE
pkgconfig: Apply PKG_CONFIG_SYSROOTDIR when generating paths

### DIFF
--- a/Tests/PackageLoadingTests/pkgconfigInputs/case_insensitive.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/case_insensitive.pc
@@ -2,6 +2,9 @@ prefix=/usr/local/bin
 exec_prefix=${prefix}
 
 #some comment
+Name: case_insensitive
+Version: 1
+Description: Demonstrate that pkgconfig keys are case-insensitive
 
 # upstream pkg-config parser allows Cflags & CFlags as key
 CFlags: -I/usr/local/include

--- a/Tests/PackageLoadingTests/pkgconfigInputs/deps_variable.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/deps_variable.pc
@@ -2,6 +2,9 @@ prefix=/usr/local/bin
 exec_prefix=${prefix}
 my_dep=atk
 #some comment
+Name: deps_variable
+Version: 1
+Description: Demonstrate use of a locally-defined variable
 
 Requires: gdk-3.0 >= 1.0.0 ${my_dep}
 Libs: -L${prefix} -lgtk-3 

--- a/Tests/PackageLoadingTests/pkgconfigInputs/double_sysroot.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/double_sysroot.pc
@@ -1,0 +1,7 @@
+prefix=/usr
+datarootdir=${prefix}/share
+pkgdatadir=${pc_sysrootdir}/${datarootdir}/pkgdata
+
+Name: double_sysroot
+Description: Demonstrate double-prefixing of pc_sysrootdir (https://github.com/pkgconf/pkgconf/issues/123)
+Version: 1

--- a/Tests/PackageLoadingTests/pkgconfigInputs/dummy_dependency.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/dummy_dependency.pc
@@ -2,6 +2,9 @@ prefix=/usr/local/bin
 exec_prefix=${prefix}
 
 #some comment
+Name: dummy_dependency
+Version: 1
+Description: Demonstrate a blank dependency entry
 
 Requires: pango, , fontconfig >=  2.13.0
 Libs:-L${prefix} -lpangoft2-1.0

--- a/Tests/PackageLoadingTests/pkgconfigInputs/empty_cflags.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/empty_cflags.pc
@@ -2,6 +2,9 @@ prefix=/usr/local/bin
 exec_prefix=${prefix}
 
 #some comment
+Name: empty_cflags
+Version: 1
+Description: Demonstrate an empty cflags list
 
 Requires: gdk-3.0 atk
 Libs:-L${prefix} -lgtk-3 

--- a/Tests/PackageLoadingTests/pkgconfigInputs/escaped_spaces.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/escaped_spaces.pc
@@ -2,6 +2,9 @@ prefix=/usr/local/bin
 exec_prefix=${prefix}
 my_dep=atk
 #some comment
+Name: escaped_spaces
+Version: 1
+Description: Demonstrate use of escape characters in flag values
 
 Requires: gdk-3.0 >= 1.0.0 ${my_dep}
 Libs: -L"${prefix}" -l"gtk 3" -wantareal\\here -one\\ -two

--- a/Tests/PackageLoadingTests/pkgconfigInputs/failure_case.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/failure_case.pc
@@ -2,6 +2,9 @@ prefix=/usr/local/bin
 exec_prefix=${prefix}
 
 #some comment
+Name: failure_case
+Version: 1
+Description: Demonstrate failure caused by use of an undefined variable
 
 Requires: gdk-3.0 >= 1.0.0
 Libs: -L${prefix} -lgtk-3 ${my_dep}

--- a/Tests/PackageLoadingTests/pkgconfigInputs/not_double_sysroot.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/not_double_sysroot.pc
@@ -1,0 +1,6 @@
+prefix=/usr
+datarootdir=${prefix}/share
+pkgdatadir=${pc_sysrootdir}/filler/${datarootdir}/pkgdata
+
+Name: double_sysroot
+Description: Demonstrate pc_sysrootdir appearing elsewhere in a path - this is not a double prefix and should not be removed

--- a/Tests/PackageLoadingTests/pkgconfigInputs/quotes_failure.pc
+++ b/Tests/PackageLoadingTests/pkgconfigInputs/quotes_failure.pc
@@ -2,6 +2,9 @@ prefix=/usr/local/bin
 exec_prefix=${prefix}
 my_dep=atk
 #some comment
+Name: quotes_failure
+Version: 1
+Description: Demonstrate failure due to unbalanced quotes
 
 Requires: gdk-3.0 >= 1.0.0 ${my_dep}
 Libs: -L"${prefix}" -l"gt"k3" -wantareal\\here -one\\ -two


### PR DESCRIPTION
pkgconfig: Apply PKG_CONFIG_SYSROOTDIR when generating paths

### Motivation:

SwiftPM's pkg-config implementation sets the 'pc_sysrootdir' variable,
but most .pc files do not use this variable directly.  Instead, they rely on
the pkg-config tool rewriting the generated paths to include the sysroot
prefix when necessary.   SwiftPM does not do this, so it does not generate
the correct compiler flags to use libraries from a sysroot.

https://github.com/apple/swift-package-manager/issues/7409

### Modifications:

There are two major pkg-config implementations which handle sysroot
differently:

  *  `pkg-config` (the original freedesktop.org implementation) prepends
     sysroot after variable expansion, when in creates the compiler flag
     lists

  *  `pkgconf` (a newer implementation) prepends sysroot to variables
     when they are defined, so sysroot is included when they are
     expanded

pkg-config's method skips single character compiler flags, such as '-I'
and '-L', and has special cases for longer options. It does not handle
spaces between the flags and their values properly, and prepends sysroot
multiple times in some cases, such as when the .pc file uses the
sysroot_dir variable directly or has been rewritten to hard-code the
sysroot prefix.

pkgconf's method handles spaces correctly, although it also makes
extra checks to ensure that sysroot is not applied more than once.

In 2024 pkg-config is the more popular option according to Homebrew
installation statistics, but the major Linux distributions
 have generally switched to pkgconf.

We will use pkgconf's method here as it seems more robust than
pkg-config's, and pkgconf's greater popularity on Linux means libraries
developed there may depend on the specific way it handles .pc files.

### Result:

SwiftPM will now apply the sysroot prefix to compiler flags, such as 
include (`-I`) and library (`-L`) search paths.

sysroot is only applied when the `PKG_CONFIG_SYSROOT_DIR` is set;
a future commit could apply it automatically when `--experimental-swift-sdk`
is used.