### PR TITLE
Remove outdated doc comment in `Workspace+State.swift`

### DIFF
--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -76,7 +76,6 @@ public final class WorkspaceState {
         self.storage.fileExists()
     }
 
-    /// Returns true if the state file exists on the filesystem.
     func reload() throws {
         let storedState = try self.storage.load()
         self.dependencies = storedState.dependencies


### PR DESCRIPTION
This "Returns true if the state file exists on the filesystem" doc comment was copy-pasted from a function above and is clearly wrong: `reload()` function doesn't return any values.