### PR TITLE
When adding a macro target to a package, create a dependency on swift-syntax

### DIFF
--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -113,7 +113,10 @@ extension SwiftPackageCommand {
 
             let editResult = try PackageModelSyntax.AddTarget.addTarget(
                 target,
-                to: manifestSyntax
+                to: manifestSyntax,
+                installedSwiftPMConfiguration: swiftCommandState
+                  .getHostToolchain()
+                  .installedSwiftPMConfiguration
             )
 
             try editResult.applyEdits(

--- a/Sources/PackageModelSyntax/AddPackageDependency.swift
+++ b/Sources/PackageModelSyntax/AddPackageDependency.swift
@@ -44,12 +44,26 @@ public struct AddPackageDependency {
             throw ManifestEditError.cannotFindPackage
         }
 
-        let edits = try packageCall.appendingToArrayArgument(
+        let newPackageCall = try addPackageDependencyLocal(
+            dependency, to: packageCall
+        )
+
+        return PackageEditResult(
+            manifestEdits: [
+                .replace(packageCall, with: newPackageCall.description)
+            ]
+        )
+    }
+
+    /// Implementation of adding a package dependency to an existing call.
+    static func addPackageDependencyLocal(
+        _ dependency: PackageDependency,
+        to packageCall: FunctionCallExprSyntax
+    ) throws -> FunctionCallExprSyntax {
+        try packageCall.appendingToArrayArgument(
             label: "dependencies",
             trailingLabels: Self.argumentLabelsAfterDependencies,
             newElement: dependency.asSyntax()
         )
-
-        return PackageEditResult(manifestEdits: edits)
     }
 }

--- a/Sources/PackageModelSyntax/AddTarget.swift
+++ b/Sources/PackageModelSyntax/AddTarget.swift
@@ -35,7 +35,8 @@ public struct AddTarget {
     /// new target.
     public static func addTarget(
         _ target: TargetDescription,
-        to manifest: SourceFileSyntax
+        to manifest: SourceFileSyntax,
+        installedSwiftPMConfiguration: InstalledSwiftPMConfiguration = .default
     ) throws -> PackageEditResult {
         // Make sure we have a suitable tools version in the manifest.
         try manifest.checkEditManifestToolsVersion()
@@ -99,7 +100,9 @@ public struct AddTarget {
             if !manifest.description.contains("swift-syntax") {
                 newPackageCall = try AddPackageDependency
                     .addPackageDependencyLocal(
-                        .swiftSyntax,
+                        .swiftSyntax(
+                          configuration: installedSwiftPMConfiguration
+                        ),
                         to: newPackageCall
                     )
 
@@ -279,9 +282,10 @@ fileprivate extension PackageDependency {
     }
 
     /// Package dependency on the swift-syntax package.
-    static var swiftSyntax: PackageDependency {
-        let swiftSyntaxVersionDefault = InstalledSwiftPMConfiguration
-            .default
+    static func swiftSyntax(
+      configuration: InstalledSwiftPMConfiguration
+    ) -> PackageDependency {
+        let swiftSyntaxVersionDefault = configuration
             .swiftSyntaxVersionForMacroTemplate
         let swiftSyntaxVersion = Version(swiftSyntaxVersionDefault.description)!
 

--- a/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
+++ b/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
@@ -465,14 +465,22 @@ class ManifestEditTests: XCTestCase {
     func testAddMacroTarget() throws {
         try assertManifestRefactor("""
             // swift-tools-version: 5.5
+            import PackageDescription
+
             let package = Package(
                 name: "packages"
             )
             """,
             expectedManifest: """
             // swift-tools-version: 5.5
+            import CompilerPluginSupport
+            import PackageDescription
+
             let package = Package(
                 name: "packages",
+                dependencies: [
+                    .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.0-latest"),
+                ],
                 targets: [
                     .macro(
                         name: "MyMacro",


### PR DESCRIPTION
When editing a package manifest to add a new macro target, also create a package dependency on swift-syntax and import CompilerPluginSupport. We need both so that the macro will build.
