### PR TITLE
[SE-0301] Add swift package add-product command and supporting library

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_library(Commands
   PackageCommands/AddDependency.swift
+  PackageCommands/AddProduct.swift 
   PackageCommands/AddTarget.swift
   PackageCommands/APIDiff.swift
   PackageCommands/ArchiveSource.swift

--- a/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
+++ b/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
@@ -36,6 +36,7 @@ package struct SwiftPackageCommand: AsyncParsableCommand {
         version: SwiftVersion.current.completeDisplayString,
         subcommands: [
             AddDependency.self,
+            AddProduct.self,
             AddTarget.self,
             Clean.self,
             PurgeCache.self,

--- a/Sources/PackageModelSyntax/AddProduct.swift
+++ b/Sources/PackageModelSyntax/AddProduct.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import PackageModel
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+/// Add a product to the manifest's source code.
+public struct AddProduct {
+    /// The set of argument labels that can occur after the "products"
+    /// argument in the Package initializers.
+    ///
+    /// TODO: Could we generate this from the the PackageDescription module, so
+    /// we don't have keep it up-to-date manually?
+    private static let argumentLabelsAfterProducts: Set<String> = [
+        "dependencies",
+        "targets",
+        "swiftLanguageVersions",
+        "cLanguageStandard",
+        "cxxLanguageStandard"
+    ]
+
+    /// Produce the set of source edits needed to add the given package
+    /// dependency to the given manifest file.
+    public static func addProduct(
+        _ product: ProductDescription,
+        to manifest: SourceFileSyntax
+    ) throws -> PackageEditResult {
+        // Make sure we have a suitable tools version in the manifest.
+        try manifest.checkEditManifestToolsVersion()
+
+        guard let packageCall = manifest.findCall(calleeName: "Package") else {
+            throw ManifestEditError.cannotFindPackage
+        }
+
+        let newPackageCall = try packageCall.appendingToArrayArgument(
+            label: "products",
+            trailingLabels: argumentLabelsAfterProducts,
+            newElement: product.asSyntax()
+        )
+
+        return PackageEditResult(
+            manifestEdits: [
+                .replace(packageCall, with: newPackageCall.description)
+            ]
+        )
+    }
+}

--- a/Sources/PackageModelSyntax/CMakeLists.txt
+++ b/Sources/PackageModelSyntax/CMakeLists.txt
@@ -8,11 +8,13 @@
 
 add_library(PackageModelSyntax
   AddPackageDependency.swift
+  AddProduct.swift
   AddTarget.swift
   ManifestEditError.swift
   ManifestSyntaxRepresentable.swift
   PackageDependency+Syntax.swift
   PackageEditResult.swift
+  ProductDescription+Syntax.swift
   SyntaxEditUtils.swift
   TargetDescription+Syntax.swift
 )

--- a/Sources/PackageModelSyntax/ProductDescription+Syntax.swift
+++ b/Sources/PackageModelSyntax/ProductDescription+Syntax.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageModel
+import SwiftSyntax
+import SwiftParser
+
+extension ProductDescription: ManifestSyntaxRepresentable {
+    /// The function name in the package manifest.
+    ///
+    /// Some of these are actually invalid, but it's up to the caller
+    /// to check the precondition.
+    private var functionName: String {
+        switch type {
+        case .executable: "executable"
+        case .library(_): "library"
+        case .macro: "macro"
+        case .plugin: "plugin"
+        case .snippet: "snippet"
+        case .test: "test"
+        }
+    }
+
+    func asSyntax() -> ExprSyntax {
+        var arguments: [LabeledExprSyntax] = []
+        arguments.append(label: "name", stringLiteral: name)
+
+        // Libraries have a type.
+        if case .library(let libraryType) = type {
+            switch libraryType {
+            case .automatic:
+                break
+
+            case .dynamic, .static:
+                arguments.append(
+                    label: "type",
+                    expression: ".\(raw: libraryType.rawValue)"
+                )
+            }
+        }
+
+        arguments.appendIfNonEmpty(
+            label: "targets",
+            arrayLiteral: targets
+        )
+
+        let separateParen: String = arguments.count > 1 ? "\n" : ""
+        let argumentsSyntax = LabeledExprListSyntax(arguments)
+        return ".\(raw: functionName)(\(argumentsSyntax)\(raw: separateParen))"
+    }
+}

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -851,6 +851,36 @@ final class PackageCommandTests: CommandsTestCase {
         }
     }
 
+    func testPackageAddProduct() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("PackageB")
+            try fs.createDirectory(path)
+
+            try fs.writeFileContents(path.appending("Package.swift"), string:
+                """
+                // swift-tools-version: 5.9
+                import PackageDescription
+                let package = Package(
+                    name: "client"
+                )
+                """
+            )
+
+            _ = try execute(["add-product", "MyLib", "--targets", "MyLib", "--type", "static-library"], packagePath: path)
+
+            let manifest = path.appending("Package.swift")
+            XCTAssertFileExists(manifest)
+            let contents: String = try fs.readFileContents(manifest)
+
+            XCTAssertMatch(contents, .contains(#"products:"#))
+            XCTAssertMatch(contents, .contains(#".library"#))
+            XCTAssertMatch(contents, .contains(#"name: "MyLib""#))
+            XCTAssertMatch(contents, .contains(#"type: .static"#))
+            XCTAssertMatch(contents, .contains(#"targets:"#))
+            XCTAssertMatch(contents, .contains(#""MyLib""#))
+        }
+    }
     func testPackageEditAndUnedit() throws {
         try fixture(name: "Miscellaneous/PackageEdit") { fixturePath in
             let fooPath = fixturePath.appending("foo")

--- a/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
+++ b/Tests/PackageModelSyntaxTests/ManifestEditTests.swift
@@ -335,6 +335,43 @@ class ManifestEditTests: XCTestCase {
         }
     }
 
+    func testAddLibraryProduct() throws {
+        try assertManifestRefactor("""
+            // swift-tools-version: 5.5
+            let package = Package(
+                name: "packages",
+                targets: [
+                    .target(name: "MyLib"),
+                ],
+            )
+            """,
+            expectedManifest: """
+            // swift-tools-version: 5.5
+            let package = Package(
+                name: "packages",
+                products: [
+                    .library(
+                        name: "MyLib",
+                        type: .dynamic,
+                        targets: [ "MyLib" ]
+                    ),
+                ],
+                targets: [
+                    .target(name: "MyLib"),
+                ],
+            )
+            """) { manifest in
+            try AddProduct.addProduct(
+                ProductDescription(
+                    name: "MyLib",
+                    type: .library(.dynamic),
+                    targets: [ "MyLib" ]
+                ),
+                to: manifest
+            )
+        }
+    }
+
     func testAddLibraryTarget() throws {
         try assertManifestRefactor("""
             // swift-tools-version: 5.5
@@ -412,6 +449,7 @@ class ManifestEditTests: XCTestCase {
             let package = Package(
                 name: "packages",
                 targets: [
+                    // These are the targets
                     .target(name: "MyLib")
                 ]
             )
@@ -421,6 +459,7 @@ class ManifestEditTests: XCTestCase {
             let package = Package(
                 name: "packages",
                 targets: [
+                    // These are the targets
                     .target(name: "MyLib"),
                     .executableTarget(
                         name: "MyProgram",


### PR DESCRIPTION
Introduce support for adding a new product to the package manifest,
both programmatically (via PackageModelSyntax) and via the
`swift package add-product` command. Help for this command is:

    OVERVIEW: Add a new product to the manifest

    USAGE: swift package add-product <name> [--type <type>] [--targets <targets> ...] [--url <url>] [--path <path>] [--checksum <checksum>]

    ARGUMENTS:
      <name>                  The name of the new product

    OPTIONS:
      --type <type>           The type of target to add, which can be one of
                              'executable', 'library', 'static-library',
                              'dynamic-library', or 'plugin' (default: library)
      --targets <targets>     A list of targets that are part of this product
      --url <url>             The URL for a remote binary target
      --path <path>           The path to a local binary target
      --checksum <checksum>   The checksum for a remote binary target
      --version               Show the version.
      -h, -help, --help       Show help information.