### PR TITLE
Make `SwiftSDK.init` available via `@_spi`

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2015-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2015-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -19,6 +19,8 @@ import CoreCommands
 import Dispatch
 import Foundation
 import PackageGraph
+
+@_spi(SwiftPMInternal)
 import PackageModel
 
 import SPMBuildCore

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -156,7 +156,8 @@ public struct SwiftSDK: Equatable {
     }
 
     /// Whether or not the receiver supports testing using XCTest.
-    package enum XCTestSupport: Sendable, Equatable {
+    @_spi(SwiftPMInternal)
+    public enum XCTestSupport: Sendable, Equatable {
         /// XCTest is supported.
         case supported
 
@@ -465,7 +466,8 @@ public struct SwiftSDK: Equatable {
     }
 
     /// Creates a Swift SDK with the specified properties.
-    package init(
+    @_spi(SwiftPMInternal)
+    public init(
         hostTriple: Triple? = nil,
         targetTriple: Triple? = nil,
         toolset: Toolset,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -20,7 +20,10 @@ import DriverSupport
 @testable import PackageGraph
 
 import PackageLoading
+
+@_spi(SwiftPMInternal)
 @testable import PackageModel
+
 import SPMBuildCore
 import SPMTestSupport
 import SwiftDriver

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,7 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+
+@_spi(SwiftPMInternal)
 @testable import PackageModel
+
 import func TSCBasic.withTemporaryFile
 import XCTest
 

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -11,7 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Basics
+
+@_spi(SwiftPMInternal)
 @testable import PackageModel
+
 @testable import SPMBuildCore
 import XCTest
 

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -16,7 +16,10 @@ import Basics
 @testable import PackageGraph
 
 import PackageLoading
+
+@_spi(SwiftPMInternal)
 import PackageModel
+
 @testable import SPMBuildCore
 import SPMTestSupport
 import Workspace
@@ -26,7 +29,7 @@ import class TSCBasic.InMemoryFileSystem
 
 import struct TSCUtility.SerializedDiagnostics
 
-class PluginInvocationTests: XCTestCase {
+final class PluginInvocationTests: XCTestCase {
 
     func testBasics() throws {
         // Construct a canned file system and package graph with a single package and a library that uses a build tool plugin that invokes a tool.


### PR DESCRIPTION
This initializer is an internal implementation detail that should only be available via `@_spi`.
