### PR TITLE
Cover `–-toolchain` argument in `SwiftCommandStateTests`

### DIFF
--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -21,7 +21,6 @@ import class TSCBasic.FileLock
 import enum TSCBasic.FileMode
 import protocol TSCBasic.FileSystem
 import enum TSCBasic.FileSystemAttribute
-import class TSCBasic.InMemoryFileSystem
 import var TSCBasic.localFileSystem
 import protocol TSCBasic.WritableByteStream
 

--- a/Sources/Basics/FileSystem/InMemoryFileSystem.swift
+++ b/Sources/Basics/FileSystem/InMemoryFileSystem.swift
@@ -1,0 +1,496 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import class Foundation.NSLock
+import class Dispatch.DispatchQueue
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
+import class TSCBasic.FileLock
+import enum TSCBasic.FileMode
+import struct TSCBasic.FileSystemError
+
+/// Concrete FileSystem implementation which simulates an empty disk.
+public final class InMemoryFileSystem: FileSystem {
+    /// Private internal representation of a file system node.
+    /// Not thread-safe.
+    private class Node {
+        /// The actual node data.
+        let contents: NodeContents
+        
+        /// Whether the node has executable bit enabled.
+        var isExecutable: Bool
+
+        init(_ contents: NodeContents, isExecutable: Bool = false) {
+            self.contents = contents
+            self.isExecutable = isExecutable
+        }
+
+        /// Creates deep copy of the object.
+        func copy() -> Node {
+            return Node(contents.copy())
+        }
+    }
+
+    /// Private internal representation the contents of a file system node.
+    /// Not thread-safe.
+    private enum NodeContents {
+        case file(ByteString)
+        case directory(DirectoryContents)
+        case symlink(String)
+
+        /// Creates deep copy of the object.
+        func copy() -> NodeContents {
+            switch self {
+            case .file(let bytes):
+                return .file(bytes)
+            case .directory(let contents):
+                return .directory(contents.copy())
+            case .symlink(let path):
+                return .symlink(path)
+            }
+        }
+    }
+
+    /// Private internal representation the contents of a directory.
+    /// Not thread-safe.
+    private final class DirectoryContents {
+        var entries: [String: Node]
+
+        init(entries: [String: Node] = [:]) {
+            self.entries = entries
+        }
+
+        /// Creates deep copy of the object.
+        func copy() -> DirectoryContents {
+            let contents = DirectoryContents()
+            for (key, node) in entries {
+                contents.entries[key] = node.copy()
+            }
+            return contents
+        }
+    }
+
+    /// The root node of the filesystem.
+    private var root: Node
+
+    /// Protects `root` and everything underneath it.
+    /// FIXME: Using a single lock for this is a performance problem, but in
+    /// reality, the only practical use for InMemoryFileSystem is for unit
+    /// tests.
+    private let lock = NSLock()
+    /// A map that keeps weak references to all locked files.
+    private var lockFiles = Dictionary<TSCBasic.AbsolutePath, WeakReference<DispatchQueue>>()
+    /// Used to access lockFiles in a thread safe manner.
+    private let lockFilesLock = NSLock()
+
+    /// Exclusive file system lock vended to clients through `withLock()`.
+    /// Used to ensure that DispatchQueues are released when they are no longer in use.
+    private struct WeakReference<Value: AnyObject> {
+        weak var reference: Value?
+
+        init(_ value: Value?) {
+            self.reference = value
+        }
+    }
+
+    public init() {
+        root = Node(.directory(DirectoryContents()))
+    }
+
+    /// Creates deep copy of the object.
+    public func copy() -> InMemoryFileSystem {
+        return lock.withLock {
+            let fs = InMemoryFileSystem()
+            fs.root = root.copy()
+            return fs
+        }
+    }
+
+    /// Private function to look up the node corresponding to a path.
+    /// Not thread-safe.
+    private func getNode(_ path: TSCBasic.AbsolutePath, followSymlink: Bool = true) throws -> Node? {
+        func getNodeInternal(_ path: TSCBasic.AbsolutePath) throws -> Node? {
+            // If this is the root node, return it.
+            if path.isRoot {
+                return root
+            }
+
+            // Otherwise, get the parent node.
+            guard let parent = try getNodeInternal(path.parentDirectory) else {
+                return nil
+            }
+
+            // If we didn't find a directory, this is an error.
+            guard case .directory(let contents) = parent.contents else {
+                throw FileSystemError(.notDirectory, path.parentDirectory)
+            }
+
+            // Return the directory entry.
+            let node = contents.entries[path.basename]
+
+            switch node?.contents {
+            case .directory, .file:
+                return node
+            case .symlink(let destination):
+                let destination = try TSCBasic.AbsolutePath(validating: destination, relativeTo: path.parentDirectory)
+                return followSymlink ? try getNodeInternal(destination) : node
+            case .none:
+                return nil
+            }
+        }
+
+        // Get the node that corresponds to the path.
+        return try getNodeInternal(path)
+    }
+
+    // MARK: FileSystem Implementation
+
+    public func exists(_ path: TSCBasic.AbsolutePath, followSymlink: Bool) -> Bool {
+        return lock.withLock {
+            do {
+                switch try getNode(path, followSymlink: followSymlink)?.contents {
+                case .file, .directory, .symlink: return true
+                case .none: return false
+                }
+            } catch {
+                return false
+            }
+        }
+    }
+
+    public func isDirectory(_ path: TSCBasic.AbsolutePath) -> Bool {
+        return lock.withLock {
+            do {
+                if case .directory? = try getNode(path)?.contents {
+                    return true
+                }
+                return false
+            } catch {
+                return false
+            }
+        }
+    }
+
+    public func isFile(_ path: TSCBasic.AbsolutePath) -> Bool {
+        return lock.withLock {
+            do {
+                if case .file? = try getNode(path)?.contents {
+                    return true
+                }
+                return false
+            } catch {
+                return false
+            }
+        }
+    }
+
+    public func isSymlink(_ path: TSCBasic.AbsolutePath) -> Bool {
+        return lock.withLock {
+            do {
+                if case .symlink? = try getNode(path, followSymlink: false)?.contents {
+                    return true
+                }
+                return false
+            } catch {
+                return false
+            }
+        }
+    }
+
+    public func isReadable(_ path: TSCBasic.AbsolutePath) -> Bool {
+        self.exists(path)
+    }
+
+    public func isWritable(_ path: TSCBasic.AbsolutePath) -> Bool {
+        self.exists(path)
+    }
+
+    public func isExecutableFile(_ path: TSCBasic.AbsolutePath) -> Bool {
+        (try? self.getNode(path)?.isExecutable) ?? false
+    }
+
+    public func updatePermissions(_ path: AbsolutePath, isExecutable: Bool) throws {
+        try lock.withLock {
+            guard let node = try self.getNode(path.underlying, followSymlink: true) else {
+                throw FileSystemError(.noEntry, path)
+            }
+            node.isExecutable = isExecutable
+        }
+    }
+
+    /// Virtualized current working directory.
+    public var currentWorkingDirectory: TSCBasic.AbsolutePath? {
+        return try? .init(validating: "/")
+    }
+
+    public func changeCurrentWorkingDirectory(to path: TSCBasic.AbsolutePath) throws {
+        throw FileSystemError(.unsupported, path)
+    }
+
+    public var homeDirectory: TSCBasic.AbsolutePath {
+        get throws {
+            // FIXME: Maybe we should allow setting this when creating the fs.
+            return try .init(validating: "/home/user")
+        }
+    }
+
+    public var cachesDirectory: TSCBasic.AbsolutePath? {
+        return try? self.homeDirectory.appending(component: "caches")
+    }
+
+    public var tempDirectory: TSCBasic.AbsolutePath {
+        get throws {
+            return try .init(validating: "/tmp")
+        }
+    }
+
+    public func getDirectoryContents(_ path: TSCBasic.AbsolutePath) throws -> [String] {
+        return try lock.withLock {
+            guard let node = try getNode(path) else {
+                throw FileSystemError(.noEntry, path)
+            }
+            guard case .directory(let contents) = node.contents else {
+                throw FileSystemError(.notDirectory, path)
+            }
+
+            // FIXME: Perhaps we should change the protocol to allow lazy behavior.
+            return [String](contents.entries.keys)
+        }
+    }
+
+    /// Not thread-safe.
+    private func _createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
+        // Ignore if client passes root.
+        guard !path.isRoot else {
+            return
+        }
+        // Get the parent directory node.
+        let parentPath = path.parentDirectory
+        guard let parent = try getNode(parentPath) else {
+            // If the parent doesn't exist, and we are recursive, then attempt
+            // to create the parent and retry.
+            if recursive && path != parentPath {
+                // Attempt to create the parent.
+                try _createDirectory(parentPath, recursive: true)
+
+                // Re-attempt creation, non-recursively.
+                return try _createDirectory(path, recursive: false)
+            } else {
+                // Otherwise, we failed.
+                throw FileSystemError(.noEntry, parentPath)
+            }
+        }
+
+        // Check that the parent is a directory.
+        guard case .directory(let contents) = parent.contents else {
+            // The parent isn't a directory, this is an error.
+            throw FileSystemError(.notDirectory, parentPath)
+        }
+
+        // Check if the node already exists.
+        if let node = contents.entries[path.basename] {
+            // Verify it is a directory.
+            guard case .directory = node.contents else {
+                // The path itself isn't a directory, this is an error.
+                throw FileSystemError(.notDirectory, path)
+            }
+
+            // We are done.
+            return
+        }
+
+        // Otherwise, the node does not exist, create it.
+        contents.entries[path.basename] = Node(.directory(DirectoryContents()))
+    }
+
+    public func createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws {
+        return try lock.withLock {
+            try _createDirectory(path, recursive: recursive)
+        }
+    }
+
+    public func createSymbolicLink(
+        _ path: TSCBasic.AbsolutePath,
+        pointingAt destination: TSCBasic.AbsolutePath,
+        relative: Bool
+    ) throws {
+        return try lock.withLock {
+            // Create directory to destination parent.
+            guard let destinationParent = try getNode(path.parentDirectory) else {
+                throw FileSystemError(.noEntry, path.parentDirectory)
+            }
+
+            // Check that the parent is a directory.
+            guard case .directory(let contents) = destinationParent.contents else {
+                throw FileSystemError(.notDirectory, path.parentDirectory)
+            }
+
+            guard contents.entries[path.basename] == nil else {
+                throw FileSystemError(.alreadyExistsAtDestination, path)
+            }
+
+            let destination = relative ? destination.relative(to: path.parentDirectory).pathString : destination.pathString
+
+            contents.entries[path.basename] = Node(.symlink(destination))
+        }
+    }
+
+    public func readFileContents(_ path: TSCBasic.AbsolutePath) throws -> ByteString {
+        return try lock.withLock {
+            // Get the node.
+            guard let node = try getNode(path) else {
+                throw FileSystemError(.noEntry, path)
+            }
+
+            // Check that the node is a file.
+            guard case .file(let contents) = node.contents else {
+                // The path is a directory, this is an error.
+                throw FileSystemError(.isDirectory, path)
+            }
+
+            // Return the file contents.
+            return contents
+        }
+    }
+
+    public func writeFileContents(_ path: TSCBasic.AbsolutePath, bytes: ByteString) throws {
+        return try lock.withLock {
+            // It is an error if this is the root node.
+            let parentPath = path.parentDirectory
+            guard path != parentPath else {
+                throw FileSystemError(.isDirectory, path)
+            }
+
+            // Get the parent node.
+            guard let parent = try getNode(parentPath) else {
+                throw FileSystemError(.noEntry, parentPath)
+            }
+
+            // Check that the parent is a directory.
+            guard case .directory(let contents) = parent.contents else {
+                // The parent isn't a directory, this is an error.
+                throw FileSystemError(.notDirectory, parentPath)
+            }
+
+            // Check if the node exists.
+            if let node = contents.entries[path.basename] {
+                // Verify it is a file.
+                guard case .file = node.contents else {
+                    // The path is a directory, this is an error.
+                    throw FileSystemError(.isDirectory, path)
+                }
+            }
+
+            // Write the file.
+            contents.entries[path.basename] = Node(.file(bytes))
+        }
+    }
+
+    public func writeFileContents(_ path: TSCBasic.AbsolutePath, bytes: ByteString, atomically: Bool) throws {
+        // In memory file system's writeFileContents is already atomic, so ignore the parameter here
+        // and just call the base implementation.
+        try writeFileContents(path, bytes: bytes)
+    }
+
+    public func removeFileTree(_ path: TSCBasic.AbsolutePath) throws {
+        return lock.withLock {
+            // Ignore root and get the parent node's content if its a directory.
+            guard !path.isRoot,
+                  let parent = try? getNode(path.parentDirectory),
+                  case .directory(let contents) = parent.contents else {
+                      return
+                  }
+            // Set it to nil to release the contents.
+            contents.entries[path.basename] = nil
+        }
+    }
+
+    public func chmod(_ mode: FileMode, path: TSCBasic.AbsolutePath, options: Set<FileMode.Option>) throws {
+        // FIXME: We don't have these semantics in InMemoryFileSystem.
+    }
+
+    /// Private implementation of core copying function.
+    /// Not thread-safe.
+    private func _copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
+        // Get the source node.
+        guard let source = try getNode(sourcePath) else {
+            throw FileSystemError(.noEntry, sourcePath)
+        }
+
+        // Create directory to destination parent.
+        guard let destinationParent = try getNode(destinationPath.parentDirectory) else {
+            throw FileSystemError(.noEntry, destinationPath.parentDirectory)
+        }
+
+        // Check that the parent is a directory.
+        guard case .directory(let contents) = destinationParent.contents else {
+            throw FileSystemError(.notDirectory, destinationPath.parentDirectory)
+        }
+
+        guard contents.entries[destinationPath.basename] == nil else {
+            throw FileSystemError(.alreadyExistsAtDestination, destinationPath)
+        }
+
+        contents.entries[destinationPath.basename] = source
+    }
+
+    public func copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
+        return try lock.withLock {
+            try _copy(from: sourcePath, to: destinationPath)
+        }
+    }
+
+    public func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {
+        return try lock.withLock {
+            // Get the source parent node.
+            guard let sourceParent = try getNode(sourcePath.parentDirectory) else {
+                throw FileSystemError(.noEntry, sourcePath.parentDirectory)
+            }
+
+            // Check that the parent is a directory.
+            guard case .directory(let contents) = sourceParent.contents else {
+                throw FileSystemError(.notDirectory, sourcePath.parentDirectory)
+            }
+
+            try _copy(from: sourcePath, to: destinationPath)
+
+            contents.entries[sourcePath.basename] = nil
+        }
+    }
+
+    public func withLock<T>(
+        on path: TSCBasic.AbsolutePath,
+        type: FileLock.LockType = .exclusive,
+        _ body: () throws -> T
+    ) throws -> T {
+        let resolvedPath: TSCBasic.AbsolutePath = try lock.withLock {
+            if case let .symlink(destination) = try getNode(path)?.contents {
+                return try .init(validating: destination, relativeTo: path.parentDirectory)
+            } else {
+                return path
+            }
+        }
+
+        let fileQueue: DispatchQueue = lockFilesLock.withLock {
+            if let queueReference = lockFiles[resolvedPath], let queue = queueReference.reference {
+                return queue
+            } else {
+                let queue = DispatchQueue(label: "org.swift.swiftpm.in-memory-file-system.file-queue", attributes: .concurrent)
+                lockFiles[resolvedPath] = WeakReference(queue)
+                return queue
+            }
+        }
+
+        return try fileQueue.sync(flags: type == .exclusive ? .barrier : .init() , execute: body)
+    }
+}
+
+// Internal state of `InMemoryFileSystem` is protected with a lock in all of its `public` methods.
+extension InMemoryFileSystem: @unchecked Sendable {}

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -58,6 +58,8 @@ public final class UserToolchain: Toolchain {
         self.swiftCompilerPath.parentDirectory.appending("swift" + hostExecutableSuffix)
     }
 
+    private let fileSystem: any FileSystem
+
     /// The compilation destination object.
     @available(*, deprecated, renamed: "swiftSDK")
     public var destination: SwiftSDK { swiftSDK }
@@ -103,7 +105,7 @@ public final class UserToolchain: Toolchain {
         )
 
         // Ensure that the runtime is present.
-        guard localFileSystem.exists(runtime) else {
+        guard fileSystem.exists(runtime) else {
             throw InvalidToolchainDiagnostic("Missing runtime for \(sanitizer) sanitizer")
         }
 
@@ -120,13 +122,17 @@ public final class UserToolchain: Toolchain {
         lookupExecutablePath(filename: environment[variable], searchPaths: searchPaths)
     }
 
-    private static func getTool(_ name: String, binDirectories: [AbsolutePath]) throws -> AbsolutePath {
+    private static func getTool(
+        _ name: String,
+        binDirectories: [AbsolutePath],
+        fileSystem: any FileSystem
+    ) throws -> AbsolutePath {
         let executableName = "\(name)\(hostExecutableSuffix)"
         var toolPath: AbsolutePath?
 
         for dir in binDirectories {
             let path = dir.appending(component: executableName)
-            guard localFileSystem.isExecutableFile(path) else {
+            guard fileSystem.isExecutableFile(path) else {
                 continue
             }
             toolPath = path
@@ -142,7 +148,8 @@ public final class UserToolchain: Toolchain {
     private static func findTool(
         _ name: String,
         envSearchPaths: [AbsolutePath],
-        useXcrun: Bool
+        useXcrun: Bool,
+        fileSystem: any FileSystem
     ) throws -> AbsolutePath {
         if useXcrun {
             #if os(macOS)
@@ -152,7 +159,7 @@ public final class UserToolchain: Toolchain {
             #endif
         }
 
-        return try getTool(name, binDirectories: envSearchPaths)
+        return try getTool(name, binDirectories: envSearchPaths, fileSystem: fileSystem)
     }
 
     // MARK: - public API
@@ -163,10 +170,9 @@ public final class UserToolchain: Toolchain {
         useXcrun: Bool,
         environment: EnvironmentVariables,
         searchPaths: [AbsolutePath],
-        extraSwiftFlags: [String]
-    ) throws
-        -> AbsolutePath
-    {
+        extraSwiftFlags: [String],
+        fileSystem: any FileSystem
+    ) throws -> AbsolutePath {
         let variable: String = triple.isApple() ? "LIBTOOL" : "AR"
         let tool: String = {
             if triple.isApple() { return "libtool" }
@@ -196,25 +202,25 @@ public final class UserToolchain: Toolchain {
             searchPaths: searchPaths,
             environment: environment
         ) {
-            if localFileSystem.isExecutableFile(librarian) {
+            if fileSystem.isExecutableFile(librarian) {
                 return librarian
             }
         }
 
-        if let librarian = try? UserToolchain.getTool(tool, binDirectories: binDirectories) {
+        if let librarian = try? UserToolchain.getTool(tool, binDirectories: binDirectories, fileSystem: fileSystem) {
             return librarian
         }
         if triple.isApple() || triple.isWindows() {
-            return try UserToolchain.findTool(tool, envSearchPaths: searchPaths, useXcrun: useXcrun)
+            return try UserToolchain.findTool(tool, envSearchPaths: searchPaths, useXcrun: useXcrun, fileSystem: fileSystem)
         } else {
-            if let librarian = try? UserToolchain.findTool(tool, envSearchPaths: searchPaths, useXcrun: false) {
+            if let librarian = try? UserToolchain.findTool(tool, envSearchPaths: searchPaths, useXcrun: false, fileSystem: fileSystem) {
                 return librarian
             }
             // Fall back to looking for binutils `ar` if `llvm-ar` can't be found.
-            if let librarian = try? UserToolchain.getTool("ar", binDirectories: binDirectories) {
+            if let librarian = try? UserToolchain.getTool("ar", binDirectories: binDirectories, fileSystem: fileSystem) {
                 return librarian
             }
-            return try UserToolchain.findTool("ar", envSearchPaths: searchPaths, useXcrun: false)
+            return try UserToolchain.findTool("ar", envSearchPaths: searchPaths, useXcrun: false, fileSystem: fileSystem)
         }
     }
 
@@ -223,11 +229,12 @@ public final class UserToolchain: Toolchain {
         binDirectories: [AbsolutePath],
         useXcrun: Bool,
         environment: EnvironmentVariables,
-        searchPaths: [AbsolutePath]
+        searchPaths: [AbsolutePath],
+        fileSystem: any FileSystem
     ) throws -> SwiftCompilers {
         func validateCompiler(at path: AbsolutePath?) throws {
             guard let path else { return }
-            guard localFileSystem.isExecutableFile(path) else {
+            guard fileSystem.isExecutableFile(path) else {
                 throw InvalidToolchainDiagnostic(
                     "could not find the `swiftc\(hostExecutableSuffix)` at expected path \(path)"
                 )
@@ -248,7 +255,7 @@ public final class UserToolchain: Toolchain {
         let resolvedBinDirCompiler: AbsolutePath
         if let SWIFT_EXEC {
             resolvedBinDirCompiler = SWIFT_EXEC
-        } else if let binDirCompiler = try? UserToolchain.getTool("swiftc", binDirectories: binDirectories) {
+        } else if let binDirCompiler = try? UserToolchain.getTool("swiftc", binDirectories: binDirectories, fileSystem: fileSystem) {
             resolvedBinDirCompiler = binDirCompiler
         } else {
             // Try to lookup swift compiler on the system which is possible when
@@ -256,13 +263,14 @@ public final class UserToolchain: Toolchain {
             resolvedBinDirCompiler = try UserToolchain.findTool(
                 "swiftc",
                 envSearchPaths: searchPaths,
-                useXcrun: useXcrun
+                useXcrun: useXcrun,
+                fileSystem: fileSystem
             )
         }
 
         // The compiler for compilation tasks is SWIFT_EXEC or the bin dir compiler.
         // The compiler for manifest is either SWIFT_EXEC_MANIFEST or the bin dir compiler.
-        return (SWIFT_EXEC ?? resolvedBinDirCompiler, SWIFT_EXEC_MANIFEST ?? resolvedBinDirCompiler)
+        return (compile: SWIFT_EXEC ?? resolvedBinDirCompiler, manifest: SWIFT_EXEC_MANIFEST ?? resolvedBinDirCompiler)
     }
 
     /// Returns the path to clang compiler tool.
@@ -283,15 +291,22 @@ public final class UserToolchain: Toolchain {
         }
 
         // Then, check the toolchain.
-        do {
-            if let toolPath = try? UserToolchain.getTool("clang", binDirectories: self.swiftSDK.toolset.rootPaths) {
-                self._clangCompiler = toolPath
-                return toolPath
-            }
+        if let toolPath = try? UserToolchain.getTool(
+            "clang",
+            binDirectories: self.swiftSDK.toolset.rootPaths,
+            fileSystem: self.fileSystem
+        ) {
+            self._clangCompiler = toolPath
+            return toolPath
         }
 
         // Otherwise, lookup it up on the system.
-        let toolPath = try UserToolchain.findTool("clang", envSearchPaths: self.envSearchPaths, useXcrun: useXcrun)
+        let toolPath = try UserToolchain.findTool(
+            "clang",
+            envSearchPaths: self.envSearchPaths,
+            useXcrun: useXcrun,
+            fileSystem: self.fileSystem
+        )
         self._clangCompiler = toolPath
         return toolPath
     }
@@ -309,21 +324,38 @@ public final class UserToolchain: Toolchain {
     /// Returns the path to lldb.
     public func getLLDB() throws -> AbsolutePath {
         // Look for LLDB next to the compiler first.
-        if let lldbPath = try? UserToolchain.getTool("lldb", binDirectories: [self.swiftCompilerPath.parentDirectory]) {
+        if let lldbPath = try? UserToolchain.getTool(
+            "lldb",
+            binDirectories: [self.swiftCompilerPath.parentDirectory],
+            fileSystem: self.fileSystem
+        ) {
             return lldbPath
         }
         // If that fails, fall back to xcrun, PATH, etc.
-        return try UserToolchain.findTool("lldb", envSearchPaths: self.envSearchPaths, useXcrun: useXcrun)
+        return try UserToolchain.findTool(
+            "lldb",
+            envSearchPaths: self.envSearchPaths,
+            useXcrun: useXcrun,
+            fileSystem: self.fileSystem
+        )
     }
 
     /// Returns the path to llvm-cov tool.
     public func getLLVMCov() throws -> AbsolutePath {
-        try UserToolchain.getTool("llvm-cov", binDirectories: [self.swiftCompilerPath.parentDirectory])
+        try UserToolchain.getTool(
+            "llvm-cov",
+            binDirectories: [self.swiftCompilerPath.parentDirectory],
+            fileSystem: self.fileSystem
+        )
     }
 
     /// Returns the path to llvm-prof tool.
     public func getLLVMProf() throws -> AbsolutePath {
-        try UserToolchain.getTool("llvm-profdata", binDirectories: [self.swiftCompilerPath.parentDirectory])
+        try UserToolchain.getTool(
+            "llvm-profdata",
+            binDirectories: [self.swiftCompilerPath.parentDirectory],
+            fileSystem: self.fileSystem
+        )
     }
 
     public func getSwiftAPIDigester() throws -> AbsolutePath {
@@ -334,7 +366,12 @@ public final class UserToolchain: Toolchain {
         ) {
             return envValue
         }
-        return try UserToolchain.getTool("swift-api-digester", binDirectories: [self.swiftCompilerPath.parentDirectory])
+        return try UserToolchain.getTool(
+            "swift-api-digester",
+            binDirectories: [self.swiftCompilerPath.parentDirectory],
+            fileSystem: self.fileSystem
+
+        )
     }
 
     public func getSymbolGraphExtract() throws -> AbsolutePath {
@@ -345,13 +382,18 @@ public final class UserToolchain: Toolchain {
         ) {
             return envValue
         }
-        return try UserToolchain.getTool("swift-symbolgraph-extract", binDirectories: [self.swiftCompilerPath.parentDirectory])
+        return try UserToolchain.getTool(
+            "swift-symbolgraph-extract",
+            binDirectories: [self.swiftCompilerPath.parentDirectory],
+            fileSystem: self.fileSystem
+        )
     }
 
     internal static func deriveSwiftCFlags(
         triple: Triple,
         swiftSDK: SwiftSDK,
-        environment: EnvironmentVariables
+        environment: EnvironmentVariables,
+        fileSystem: any FileSystem
     ) throws -> [String] {
         var swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
 
@@ -372,7 +414,7 @@ public final class UserToolchain: Toolchain {
                     if let settings = WindowsSDKSettings(
                         reading: sdkroot.appending("SDKSettings.plist"),
                         observabilityScope: nil,
-                        filesystem: localFileSystem
+                        filesystem: fileSystem
                     ) {
                         switch settings.defaults.runtime {
                         case .multithreadedDebugDLL:
@@ -397,7 +439,7 @@ public final class UserToolchain: Toolchain {
                     if let info = WindowsPlatformInfo(
                         reading: platform.appending("Info.plist"),
                         observabilityScope: nil,
-                        filesystem: localFileSystem
+                        filesystem: fileSystem
                     ) {
                         let installation: AbsolutePath =
                             platform.appending("Developer")
@@ -438,7 +480,7 @@ public final class UserToolchain: Toolchain {
                             validating: "usr/lib/swift/windows/XCTest.lib",
                             relativeTo: installation
                         )
-                        if localFileSystem.exists(implib) {
+                        if fileSystem.exists(implib) {
                             xctest.append(contentsOf: ["-L", implib.parentDirectory.pathString])
                         }
 
@@ -477,7 +519,8 @@ public final class UserToolchain: Toolchain {
             swiftSDK: destination,
             environment: environment,
             searchStrategy: searchStrategy,
-            customLibrariesLocation: customLibrariesLocation
+            customLibrariesLocation: customLibrariesLocation,
+            fileSystem: localFileSystem
         )
     }
 
@@ -487,7 +530,8 @@ public final class UserToolchain: Toolchain {
         searchStrategy: SearchStrategy = .default,
         customLibrariesLocation: ToolchainConfiguration.SwiftPMLibrariesLocation? = nil,
         customInstalledSwiftPMConfiguration: InstalledSwiftPMConfiguration? = nil,
-        customProvidedLibraries: [LibraryMetadata]? = nil
+        customProvidedLibraries: [LibraryMetadata]? = nil,
+        fileSystem: any FileSystem = localFileSystem
     ) throws {
         self.swiftSDK = swiftSDK
         self.environment = environment
@@ -497,7 +541,7 @@ public final class UserToolchain: Toolchain {
             // Get the search paths from PATH.
             self.envSearchPaths = getEnvSearchPaths(
                 pathString: environment.path,
-                currentWorkingDirectory: localFileSystem.currentWorkingDirectory
+                currentWorkingDirectory: fileSystem.currentWorkingDirectory
             )
             self.useXcrun = true
         case .custom(let searchPaths, let useXcrun):
@@ -509,7 +553,8 @@ public final class UserToolchain: Toolchain {
             binDirectories: swiftSDK.toolset.rootPaths,
             useXcrun: useXcrun,
             environment: environment,
-            searchPaths: envSearchPaths
+            searchPaths: envSearchPaths,
+            fileSystem: fileSystem
         )
         self.swiftCompilerPath = swiftCompilers.compile
         self.architectures = swiftSDK.architectures
@@ -517,7 +562,7 @@ public final class UserToolchain: Toolchain {
         #if canImport(Darwin)
         let toolchainPlistPath = self.swiftCompilerPath.parentDirectory.parentDirectory.parentDirectory
             .appending(component: "Info.plist")
-        if localFileSystem.exists(toolchainPlistPath), let toolchainPlist = try? NSDictionary(
+        if fileSystem.exists(toolchainPlistPath), let toolchainPlist = try? NSDictionary(
             contentsOf: URL(fileURLWithPath: toolchainPlistPath.pathString),
             error: ()
         ), let overrideBuildSettings = toolchainPlist["OverrideBuildSettings"] as? NSDictionary,
@@ -572,7 +617,9 @@ public final class UserToolchain: Toolchain {
             swiftCompilerFlags: try Self.deriveSwiftCFlags(
                 triple: triple,
                 swiftSDK: swiftSDK,
-                environment: environment),
+                environment: environment,
+                fileSystem: fileSystem
+            ),
             linkerFlags: swiftSDK.toolset.knownTools[.linker]?.extraCLIOptions ?? [],
             xcbuildFlags: swiftSDK.toolset.knownTools[.xcbuild]?.extraCLIOptions ?? [])
 
@@ -585,7 +632,8 @@ public final class UserToolchain: Toolchain {
             useXcrun: useXcrun,
             environment: environment,
             searchPaths: envSearchPaths,
-            extraSwiftFlags: self.extraFlags.swiftCompilerFlags
+            extraSwiftFlags: self.extraFlags.swiftCompilerFlags,
+            fileSystem: fileSystem
         )
 
         if let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath {
@@ -598,7 +646,7 @@ public final class UserToolchain: Toolchain {
                 if let settings = WindowsSDKSettings(
                     reading: root.appending("SDKSettings.plist"),
                     observabilityScope: nil,
-                    filesystem: localFileSystem
+                    filesystem: fileSystem
                 ) {
                     switch settings.defaults.runtime {
                     case .multithreadedDebugDLL:
@@ -634,7 +682,8 @@ public final class UserToolchain: Toolchain {
         let swiftPMLibrariesLocation = try customLibrariesLocation ?? Self.deriveSwiftPMLibrariesLocation(
             swiftCompilerPath: swiftCompilerPath,
             swiftSDK: swiftSDK,
-            environment: environment
+            environment: environment,
+            fileSystem: fileSystem
         )
 
         let xctestPath: AbsolutePath?
@@ -644,7 +693,8 @@ public final class UserToolchain: Toolchain {
             xctestPath = try Self.deriveXCTestPath(
                 swiftSDK: self.swiftSDK,
                 triple: triple,
-                environment: environment
+                environment: environment,
+                fileSystem: fileSystem
             )
         }
 
@@ -657,12 +707,15 @@ public final class UserToolchain: Toolchain {
             sdkRootPath: self.swiftSDK.pathsConfiguration.sdkRootPath,
             xctestPath: xctestPath
         )
+
+        self.fileSystem = fileSystem
     }
 
     private static func deriveSwiftPMLibrariesLocation(
         swiftCompilerPath: AbsolutePath,
         swiftSDK: SwiftSDK,
-        environment: EnvironmentVariables
+        environment: EnvironmentVariables,
+        fileSystem: any FileSystem
     ) throws -> ToolchainConfiguration.SwiftPMLibrariesLocation? {
         // Look for an override in the env.
         if let pathEnvVariable = environment["SWIFTPM_CUSTOM_LIBS_DIR"] ?? environment["SWIFTPM_PD_LIBS"] {
@@ -678,7 +731,7 @@ public final class UserToolchain: Toolchain {
             #endif
             let paths = pathEnvVariable.split(separator: separator).map(String.init)
             for pathString in paths {
-                if let path = try? AbsolutePath(validating: pathString), localFileSystem.exists(path) {
+                if let path = try? AbsolutePath(validating: pathString), fileSystem.exists(path) {
                     // we found the custom one
                     return .init(root: path)
                 }
@@ -697,7 +750,7 @@ public final class UserToolchain: Toolchain {
         for applicationPath in swiftSDK.toolset.rootPaths {
             // this is the normal case when using the toolchain
             let librariesPath = applicationPath.parentDirectory.appending(components: "lib", "swift", "pm")
-            if localFileSystem.exists(librariesPath) {
+            if fileSystem.exists(librariesPath) {
                 return .init(root: librariesPath)
             }
 
@@ -707,7 +760,7 @@ public final class UserToolchain: Toolchain {
                 "PackageDescription.framework"
             )
             let pluginFrameworksPath = applicationPath.appending(components: "PackageFrameworks", "PackagePlugin.framework")
-            if localFileSystem.exists(manifestFrameworksPath), localFileSystem.exists(pluginFrameworksPath) {
+            if fileSystem.exists(manifestFrameworksPath), fileSystem.exists(pluginFrameworksPath) {
                 return .init(
                     manifestLibraryPath: manifestFrameworksPath,
                     pluginLibraryPath: pluginFrameworksPath
@@ -752,7 +805,8 @@ public final class UserToolchain: Toolchain {
     private static func deriveXCTestPath(
         swiftSDK: SwiftSDK,
         triple: Triple,
-        environment: EnvironmentVariables
+        environment: EnvironmentVariables,
+        fileSystem: any FileSystem
     ) throws -> AbsolutePath? {
         if triple.isDarwin() {
             // XCTest is optional on macOS, for example when Xcode is not installed
@@ -784,7 +838,7 @@ public final class UserToolchain: Toolchain {
             if let info = WindowsPlatformInfo(
                 reading: platform.appending("Info.plist"),
                 observabilityScope: nil,
-                filesystem: localFileSystem
+                filesystem: fileSystem
             ) {
                 let xctest: AbsolutePath =
                     platform.appending("Developer")
@@ -804,7 +858,7 @@ public final class UserToolchain: Toolchain {
                     let path: AbsolutePath =
                         xctest.appending("usr")
                             .appending("bin64")
-                    if localFileSystem.exists(path) {
+                    if fileSystem.exists(path) {
                         return path
                     }
 
@@ -812,7 +866,7 @@ public final class UserToolchain: Toolchain {
                     let path: AbsolutePath =
                         xctest.appending("usr")
                             .appending("bin32")
-                    if localFileSystem.exists(path) {
+                    if fileSystem.exists(path) {
                         return path
                     }
 
@@ -820,7 +874,7 @@ public final class UserToolchain: Toolchain {
                     let path: AbsolutePath =
                         xctest.appending("usr")
                             .appending("bin32a")
-                    if localFileSystem.exists(path) {
+                    if fileSystem.exists(path) {
                         return path
                     }
 
@@ -828,7 +882,7 @@ public final class UserToolchain: Toolchain {
                     let path: AbsolutePath =
                         xctest.appending("usr")
                             .appending("bin64a")
-                    if localFileSystem.exists(path) {
+                    if fileSystem.exists(path) {
                         return path
                     }
 

--- a/Sources/SPMTestSupport/Toolchain.swift
+++ b/Sources/SPMTestSupport/Toolchain.swift
@@ -49,7 +49,7 @@ extension SwiftSDK {
 extension UserToolchain {
     package static var `default`: Self {
         get throws {
-            return try .init(swiftSDK: SwiftSDK.default)
+            return try .init(swiftSDK: SwiftSDK.default, fileSystem: localFileSystem)
         }
     }
 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -426,7 +426,7 @@ public class Workspace {
         )
 
         let currentToolsVersion = customToolsVersion ?? ToolsVersion.current
-        let hostToolchain = try customHostToolchain ?? UserToolchain(swiftSDK: .hostSwiftSDK())
+        let hostToolchain = try customHostToolchain ?? UserToolchain(swiftSDK: .hostSwiftSDK(), fileSystem: fileSystem)
         var manifestLoader = customManifestLoader ?? ManifestLoader(
             toolchain: hostToolchain,
             cacheDir: location.sharedManifestsCacheDirectory,


### PR DESCRIPTION
We should prevent possible regressions in how this argument is handled.