### PR TITLE
build: remove the requirement to checkout swift-syntax

### DIFF
--- a/BuildSupport/SwiftSyntax/CMakeLists.txt
+++ b/BuildSupport/SwiftSyntax/CMakeLists.txt
@@ -1,17 +1,14 @@
-SET(SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE ${CMAKE_SOURCE_DIR}/../swift-syntax)
-message(STATUS "swift-syntax path: ${SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE}")
-
 include(FetchContent)
 
-if(NOT EXISTS "${SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE}")
-  message(SEND_ERROR "swift-syntax is required to build SwiftPM. Please run update-checkout or specify SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE")
-  return()
-endif()
-
-# Build swift-syntax libraries with FetchContent.
-# set(CMAKE_Swift_COMPILER_TARGET ${SWIFT_HOST_TRIPLE})
 set(BUILD_SHARED_LIBS OFF)
 
-file(TO_CMAKE_PATH "${SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE}" swift_syntax_path)
-FetchContent_Declare(SwiftSyntax SOURCE_DIR "${swift_syntax_path}")
+if(DEFINED SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE)
+  file(TO_CMAKE_PATH "${SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE}" swift_syntax_path)
+  FetchContent_Declare(SwiftSyntax
+    SOURCE_DIR "${swift_syntax_path}")
+else()
+  FetchContent_Declare(SwiftSyntax
+    GIT_REPOSITORY https://github.com/apple/swift-syntax
+    GIT_TAG main)
+endif()
 FetchContent_MakeAvailable(SwiftSyntax)

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -202,6 +202,7 @@ def parse_global_args(args):
     args.source_dirs["swift-collections"]     = os.path.join(args.project_root, "..", "swift-collections")
     args.source_dirs["swift-certificates"]    = os.path.join(args.project_root, "..", "swift-certificates")
     args.source_dirs["swift-asn1"]            = os.path.join(args.project_root, "..", "swift-asn1")
+    args.source_dirs["swift-syntax"]          = os.path.join(args.project_root, "..", "swift-syntax")
     args.source_root                          = os.path.join(args.project_root, "Sources")
 
     if platform.system() == 'Darwin':
@@ -608,6 +609,7 @@ def build_swiftpm_with_cmake(args):
         "-DSwiftCrypto_DIR="       + os.path.join(args.build_dirs["swift-crypto"],          "cmake/modules"),
         "-DSwiftASN1_DIR="         + os.path.join(args.build_dirs["swift-asn1"],            "cmake/modules"),
         "-DSwiftCertificates_DIR=" + os.path.join(args.build_dirs["swift-certificates"],    "cmake/modules"),
+        "-DSWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE=" + args.source_dirs["swift-syntax"],
     ]
 
     if platform.system() == 'Darwin':


### PR DESCRIPTION
In the case that a shared copy of swift-syntax is being used to build, allow the sources to be unavailable. If the user specifies `SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE`, that will be preferred, otherwise, we fallback to the upstream git repository.