### PR TITLE
[6.0] NFC: Add `Sendable` annotations to PackageDescription APIs

### DIFF
--- a/Sources/PackageDescription/BuildSettings.swift
+++ b/Sources/PackageDescription/BuildSettings.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The build configuration, such as debug or release.
-public struct BuildConfiguration {
+public struct BuildConfiguration: Sendable {
     /// The configuration of the build. Valid values are `debug` and `release`.
     let config: String
 
@@ -54,7 +54,7 @@ public struct BuildConfiguration {
 ///     ]
 /// ),
 /// ```
-public struct BuildSettingCondition {
+public struct BuildSettingCondition: Sendable {
     /// The applicable platforms for this build setting condition.
     let platforms: [Platform]?
     /// The applicable build configuration for this build setting condition.
@@ -115,7 +115,7 @@ struct BuildSettingData {
 }
 
 /// A C language build setting.
-public struct CSetting {
+public struct CSetting: Sendable {
     /// The abstract build setting data.
     let data: BuildSettingData
 
@@ -185,7 +185,7 @@ public struct CSetting {
 }
 
 /// A CXX-language build setting.
-public struct CXXSetting {
+public struct CXXSetting: Sendable {
     /// The data store for the CXX build setting.
     let data: BuildSettingData
 
@@ -255,7 +255,7 @@ public struct CXXSetting {
 }
 
 /// A Swift language build setting.
-public struct SwiftSetting {
+public struct SwiftSetting: Sendable {
     /// The data store for the Swift build setting.
     let data: BuildSettingData
 
@@ -390,7 +390,7 @@ public struct SwiftSetting {
 }
 
 /// A linker build setting.
-public struct LinkerSetting {
+public struct LinkerSetting: Sendable {
     /// The data store for the Linker setting.
     let data: BuildSettingData
 

--- a/Sources/PackageDescription/Context.swift
+++ b/Sources/PackageDescription/Context.swift
@@ -15,7 +15,7 @@
 /// The context encapsulates states that are known when Swift Package Manager interprets the package manifest,
 /// for example the location in the file system where the current package resides.
 @available(_PackageDescription, introduced: 5.6)
-public struct Context {
+public struct Context: Sendable {
     private static let model = try! ContextModel.decode()
 
     /// The directory that contains `Package.swift`.
@@ -46,7 +46,7 @@ public struct Context {
 
 /// Information about the git status of a given package, if available.
 @available(_PackageDescription, introduced: 6.0)
-public struct GitInformation {
+public struct GitInformation: Sendable {
     public let currentTag: String?
     public let currentCommit: String
     public let hasUncommittedChanges: Bool

--- a/Sources/PackageDescription/Product.swift
+++ b/Sources/PackageDescription/Product.swift
@@ -68,8 +68,7 @@ public class Product {
     }
 
     /// The executable product of a Swift package.
-    public final class Executable: Product {
-
+    public final class Executable: Product, @unchecked Sendable {
         /// The names of the targets in this product.
         public let targets: [String]
 
@@ -80,7 +79,7 @@ public class Product {
     }
 
     /// The library product of a Swift package.
-    public final class Library: Product {
+    public final class Library: Product, @unchecked Sendable {
         /// The different types of a library product.
         public enum LibraryType: String {
             /// A statically linked library.
@@ -106,7 +105,7 @@ public class Product {
     }
 
     /// The plug-in product of a Swift package.
-    public final class Plugin: Product {
+    public final class Plugin: Product, @unchecked Sendable {
         /// The name of the plug-in target to vend as a product.
         public let targets: [String]
 

--- a/Sources/PackageDescription/Resource.swift
+++ b/Sources/PackageDescription/Resource.swift
@@ -33,10 +33,10 @@
 /// To learn more about package resources, see
 /// <doc:bundling-resources-with-a-swift-package>.
 @available(_PackageDescription, introduced: 5.3)
-public struct Resource {
+public struct Resource: Sendable {
 
     /// Defines the explicit type of localization for resources.
-    public enum Localization: String {
+    public enum Localization: String, Sendable {
 
         /// A constant that represents default localization.
         case `default`

--- a/Sources/PackageDescription/SupportedPlatforms.swift
+++ b/Sources/PackageDescription/SupportedPlatforms.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A platform supported by Swift Package Manager.
-public struct Platform: Equatable {
+public struct Platform: Equatable, Sendable {
 
     /// The name of the platform.
     let name: String
@@ -88,7 +88,7 @@ public struct Platform: Equatable {
 /// package's deployment version. The deployment target of a package's
 /// dependencies must be lower than or equal to the top-level package's
 /// deployment target version for a particular platform.
-public struct SupportedPlatform: Equatable {
+public struct SupportedPlatform: Equatable, Sendable {
 
     /// The platform.
     let platform: Platform
@@ -698,7 +698,7 @@ extension SupportedPlatform {
     }
 }
 
-fileprivate protocol AppleOSVersion {
+fileprivate protocol AppleOSVersion: Sendable {
     static var name: String { get }
     static var minimumMajorVersion: Int { get }
     init(uncheckedVersion: String)

--- a/Sources/PackageDescription/Version.swift
+++ b/Sources/PackageDescription/Version.swift
@@ -35,7 +35,7 @@
 /// Increase the third digit of a version, or _patch version_, if you're making
 /// a backward-compatible bug fix. This allows clients to benefit from bugfixes
 /// to your package without incurring any maintenance burden.
-public struct Version {
+public struct Version: Sendable {
 
     /// The major version according to the semantic versioning standard.
     public let major: Int


### PR DESCRIPTION
- Explanation:

In preparation to enable Swift language version 6 when tools version allows we need to proactively annotate `PackageDescription` APIs with `Sendable`.

- Scope: `PackageDescription` APIs.

- Main Branch PRs: https://github.com/apple/swift-package-manager/pull/7475

- Risk: Very Low

- Resolves: N/A

- Reviewed By: @MaxDesiatov 

- Testing: Non-functional changes.
