### PR TITLE
Report whether a target is part of the root package in the sourcekit-lsp API

### DIFF
--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -21,11 +21,13 @@ private import class PackageModel.UserToolchain
 struct PluginTargetBuildDescription: BuildTarget {
     private let target: ResolvedModule
     private let toolsVersion: ToolsVersion
+    let isPartOfRootPackage: Bool
 
-    init(target: ResolvedModule, toolsVersion: ToolsVersion) {
+    init(target: ResolvedModule, toolsVersion: ToolsVersion, isPartOfRootPackage: Bool) {
         assert(target.type == .plugin)
         self.target = target
         self.toolsVersion = toolsVersion
+        self.isPartOfRootPackage = isPartOfRootPackage
     }
 
     var sources: [URL] {

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -63,7 +63,8 @@ class SourceKitLSPAPITests: XCTestCase {
                 "-emit-dependencies",
                 "-emit-module",
                 "-emit-module-path", "/path/to/build/\(buildParameters.triple)/debug/exe.build/exe.swiftmodule"
-            ]
+            ],
+            isPartOfRootPackage: true
         )
         try description.checkArguments(
             for: "lib",
@@ -73,7 +74,8 @@ class SourceKitLSPAPITests: XCTestCase {
                 "-emit-dependencies",
                 "-emit-module",
                 "-emit-module-path", "/path/to/build/\(buildParameters.triple)/debug/Modules/lib.swiftmodule"
-            ]
+            ],
+            isPartOfRootPackage: true
         )
     }
 }
@@ -82,10 +84,11 @@ extension SourceKitLSPAPI.BuildDescription {
     @discardableResult func checkArguments(
         for targetName: String,
         graph: ModulesGraph,
-        partialArguments: [String]
+        partialArguments: [String],
+        isPartOfRootPackage: Bool
     ) throws -> Bool {
         let target = try XCTUnwrap(graph.allTargets.first(where: { $0.name == targetName }))
-        let buildTarget = try XCTUnwrap(self.getBuildTarget(for: target))
+        let buildTarget = try XCTUnwrap(self.getBuildTarget(for: target, in: graph))
 
         guard let file = buildTarget.sources.first else {
             XCTFail("build target \(targetName) contains no files")
@@ -96,6 +99,7 @@ extension SourceKitLSPAPI.BuildDescription {
         let result = arguments.contains(partialArguments)
 
         XCTAssertTrue(result, "could not match \(partialArguments) to actual arguments \(arguments)")
+        XCTAssertEqual(buildTarget.isPartOfRootPackage, isPartOfRootPackage)
         return result
     }
 }


### PR DESCRIPTION
This is used so we don’t search for tests in targets of package dependencies.

Companion of https://github.com/apple/sourcekit-lsp/pull/1201

rdar://126965614
