### PR TITLE
Set environment variable to disable building swift-syntax in Swift 6 mode

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -745,6 +745,8 @@ def get_swiftpm_env_cmd(args):
         env_cmd.append("SWIFTPM_LLBUILD_FWK=1")
     env_cmd.append("SWIFTCI_USE_LOCAL_DEPS=1")
     env_cmd.append("SWIFTPM_MACOS_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
+    # Disable Swift 6 mode in swift-syntax to work around rdar://126952308
+    env_cmd.append("SWIFTSYNTAX_DISABLE_SWIFT_6_MODE=1")
 
     if not '-macosx' in args.build_target and args.command == 'install':
         env_cmd.append("SWIFTCI_INSTALL_RPATH_OS=%s" % args.platform_path.group(2))

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -20,6 +20,8 @@ echo "Current directory is ${PWD}"
 
 CONFIGURATION=debug
 export SWIFTCI_IS_SELF_HOSTED=1
+# Disable Swift 6 mode in swift-syntax to work around rdar://126952308
+export SWIFTSYNTAX_DISABLE_SWIFT_6_MODE=1
 
 set -x
 


### PR DESCRIPTION
This allows us to work around the following issue in CI: The self-hosted SwiftPM job has Xcode 15.3 (Swift 5.10) installed and builds a Swift 6 SwiftPM from source. It then tries to build itself as a fat binary using the just-built Swift 6 SwiftPM, which uses xcbuild from Xcode as the build system. But the xcbuild in the installed Xcode is too old and doesn't know about Swift 6 mode, so it fails with: SWIFT_VERSION '6' is unsupported, supported versions are: 4.0, 4.2, 5.0 (rdar://126952308). This is fixed by setting `SWIFTSYNTAX_DISABLE_SWIFT_6_MODE` in `build-using-self`.

The source compat suite is seeing the same issue, just by using `bootstrap`, so set it there as well.

Accompanies https://github.com/apple/swift-syntax/pull/2621