### PR TITLE
Use SwiftSyntax:: prefix for SwiftSyntax

### DIFF
--- a/BuildSupport/SwiftSyntax/CMakeLists.txt
+++ b/BuildSupport/SwiftSyntax/CMakeLists.txt
@@ -1,7 +1,5 @@
 include(FetchContent)
 
-set(BUILD_SHARED_LIBS OFF)
-
 if(DEFINED SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE)
   file(TO_CMAKE_PATH "${SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE}" swift_syntax_path)
   FetchContent_Declare(SwiftSyntax

--- a/Sources/PackageModelSyntax/CMakeLists.txt
+++ b/Sources/PackageModelSyntax/CMakeLists.txt
@@ -52,6 +52,6 @@ set(SWIFT_SYNTAX_MODULES
   SwiftIDEUtils
 )
 export(TARGETS ${SWIFT_SYNTAX_MODULES}
-       NAMESPACE SPMSwiftSyntax::
+       NAMESPACE SwiftSyntax::
        FILE ${CMAKE_BINARY_DIR}/cmake/modules/SwiftSyntaxConfig.cmake
        EXPORT_LINK_INTERFACE_LIBRARIES)


### PR DESCRIPTION
We actually want it to be the same as other clients that might use both SwiftSyntax and SwiftPM, such as SourceKit-LSP.
