### PR TITLE
Handle Swift versions unsupported by XCBuild

### DIFF
--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -10,16 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Basics
-import PackageModel
-import PackageLoading
+import Foundation
 import PackageGraph
+import PackageLoading
+import PackageModel
 
 import SPMBuildCore
 
-import func TSCBasic.topologicalSort
 import func TSCBasic.memoize
+import func TSCBasic.topologicalSort
 
 /// The parameters required by `PIFBuilder`.
 struct PIFBuilderParameters {
@@ -40,11 +40,13 @@ struct PIFBuilderParameters {
 
     /// The toolchain's SDK root path.
     let sdkRootPath: AbsolutePath?
+
+    /// The Swift language versions supported by the XCBuild being used for the buid.
+    let supportedSwiftVersions: [SwiftLanguageVersion]
 }
 
 /// PIF object builder for a package graph.
 public final class PIFBuilder {
-
     /// Name of the PIF target aggregating all targets (excluding tests).
     public static let allExcludingTestsTargetName = "AllExcludingTests"
 
@@ -108,14 +110,15 @@ public final class PIFBuilder {
 
     /// Constructs a `PIF.TopLevelObject` representing the package graph.
     public func construct() throws -> PIF.TopLevelObject {
-        try memoize(to: &pif) {
-            let rootPackage = self.graph.rootPackages[graph.rootPackages.startIndex]
+        try memoize(to: &self.pif) {
+            let rootPackage = self.graph.rootPackages[self.graph.rootPackages.startIndex]
 
-            let sortedPackages = graph.packages.sorted { $0.manifest.displayName < $1.manifest.displayName } // TODO: use identity instead?
+            let sortedPackages = self.graph.packages
+                .sorted { $0.manifest.displayName < $1.manifest.displayName } // TODO: use identity instead?
             var projects: [PIFProjectBuilder] = try sortedPackages.map { package in
                 try PackagePIFProjectBuilder(
                     package: package,
-                    parameters: parameters,
+                    parameters: self.parameters,
                     fileSystem: self.fileSystem,
                     observabilityScope: self.observabilityScope
                 )
@@ -123,11 +126,11 @@ public final class PIFBuilder {
 
             projects.append(AggregatePIFProjectBuilder(projects: projects))
 
-            let workspace = PIF.Workspace(
+            let workspace = try PIF.Workspace(
                 guid: "Workspace:\(rootPackage.path.pathString)",
-                name: rootPackage.manifest.displayName,  // TODO: use identity instead?
+                name: rootPackage.manifest.displayName, // TODO: use identity instead?
                 path: rootPackage.path,
-                projects: try projects.map { try $0.construct() }
+                projects: projects.map { try $0.construct() }
             )
 
             return PIF.TopLevelObject(workspace: workspace)
@@ -142,8 +145,8 @@ public final class PIFBuilder {
         observabilityScope: ObservabilityScope,
         preservePIFModelStructure: Bool
     ) throws -> String {
-        let parameters = PIFBuilderParameters(buildParameters)
-        let builder = Self.init(
+        let parameters = PIFBuilderParameters(buildParameters, supportedSwiftVersions: [])
+        let builder = Self(
             graph: packageGraph,
             parameters: parameters,
             fileSystem: fileSystem,
@@ -170,9 +173,9 @@ class PIFProjectBuilder {
     var developmentRegion: String
 
     fileprivate init() {
-        groupTree = PIFGroupBuilder(path: "")
-        targets = []
-        buildConfigurations = []
+        self.groupTree = PIFGroupBuilder(path: "")
+        self.targets = []
+        self.buildConfigurations = []
     }
 
     /// Creates and adds a new empty build configuration, i.e. one that does not initially have any build settings.
@@ -181,10 +184,15 @@ class PIFProjectBuilder {
     func addBuildConfiguration(
         name: String,
         settings: PIF.BuildSettings = PIF.BuildSettings(),
-        impartedBuildProperties: PIF.ImpartedBuildProperties = PIF.ImpartedBuildProperties(settings: PIF.BuildSettings())
+        impartedBuildProperties: PIF.ImpartedBuildProperties = PIF
+            .ImpartedBuildProperties(settings: PIF.BuildSettings())
     ) -> PIFBuildConfigurationBuilder {
-        let builder = PIFBuildConfigurationBuilder(name: name, settings: settings, impartedBuildProperties: impartedBuildProperties)
-        buildConfigurations.append(builder)
+        let builder = PIFBuildConfigurationBuilder(
+            name: name,
+            settings: settings,
+            impartedBuildProperties: impartedBuildProperties
+        )
+        self.buildConfigurations.append(builder)
         return builder
     }
 
@@ -200,34 +208,34 @@ class PIFProjectBuilder {
         productName: String
     ) -> PIFTargetBuilder {
         let target = PIFTargetBuilder(guid: guid, name: name, productType: productType, productName: productName)
-        targets.append(target)
+        self.targets.append(target)
         return target
     }
 
     @discardableResult
     func addAggregateTarget(guid: PIF.GUID, name: String) -> PIFAggregateTargetBuilder {
         let target = PIFAggregateTargetBuilder(guid: guid, name: name)
-        targets.append(target)
+        self.targets.append(target)
         return target
     }
 
     func construct() throws -> PIF.Project {
         let buildConfigurations = self.buildConfigurations.map { builder -> PIF.BuildConfiguration in
-            builder.guid = "\(guid)::BUILDCONFIG_\(builder.name)"
+            builder.guid = "\(self.guid)::BUILDCONFIG_\(builder.name)"
             return builder.construct()
         }
 
         // Construct group tree before targets to make sure file references have GUIDs.
-        groupTree.guid = "\(guid)::MAINGROUP"
+        groupTree.guid = "\(self.guid)::MAINGROUP"
         let groupTree = self.groupTree.construct() as! PIF.Group
         let targets = try self.targets.map { try $0.construct() }
 
         return PIF.Project(
-            guid: guid,
-            name: name,
-            path: path,
-            projectDirectory: projectDirectory,
-            developmentRegion: developmentRegion,
+            guid: self.guid,
+            name: self.name,
+            path: self.path,
+            projectDirectory: self.projectDirectory,
+            developmentRegion: self.developmentRegion,
             buildConfigurations: buildConfigurations,
             targets: targets,
             groupTree: groupTree
@@ -243,7 +251,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
     private var binaryGroup: PIFGroupBuilder!
     private let executableTargetProductMap: [ResolvedModule.ID: ResolvedProduct]
 
-    var isRootPackage: Bool { package.manifest.packageKind.isRoot }
+    var isRootPackage: Bool { self.package.manifest.packageKind.isRoot }
 
     init(
         package: ResolvedPackage,
@@ -349,24 +357,24 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         addBuildConfiguration(name: "Release", settings: releaseSettings)
 
         for product in package.products.sorted(by: { $0.name < $1.name }) {
-            try addTarget(for: product)
+            try self.addTarget(for: product)
         }
 
         for target in package.targets.sorted(by: { $0.name < $1.name }) {
             try self.addTarget(for: target)
         }
 
-        if binaryGroup.children.isEmpty {
-            groupTree.removeChild(binaryGroup)
+        if self.binaryGroup.children.isEmpty {
+            groupTree.removeChild(self.binaryGroup)
         }
     }
 
     private func addTarget(for product: ResolvedProduct) throws {
         switch product.type {
         case .executable, .snippet, .test:
-            try addMainModuleTarget(for: product)
+            try self.addMainModuleTarget(for: product)
         case .library:
-            addLibraryTarget(for: product)
+            self.addLibraryTarget(for: product)
         case .plugin, .macro:
             return
         }
@@ -395,18 +403,18 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
     }
 
     private func targetName(for product: ResolvedProduct) -> String {
-        return Self.targetName(for: product.name)
+        Self.targetName(for: product.name)
     }
 
     static func targetName(for productName: String) -> String {
-        return "\(productName)_\(String(productName.hash, radix: 16, uppercase: true))_PackageProduct"
+        "\(productName)_\(String(productName.hash, radix: 16, uppercase: true))_PackageProduct"
     }
 
     private func addMainModuleTarget(for product: ResolvedProduct) throws {
         let productType: PIF.Target.ProductType = product.type == .executable ? .executable : .unitTest
-        let pifTarget = addTarget(
+        let pifTarget = self.addTarget(
             guid: product.pifTargetGUID,
-            name: targetName(for: product),
+            name: self.targetName(for: product),
             productType: productType,
             productName: product.name
         )
@@ -414,11 +422,11 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         // We'll be infusing the product's main module target into the one for the product itself.
         let mainTarget = product.mainTarget
 
-        addSources(mainTarget.sources, to: pifTarget)
+        self.addSources(mainTarget.sources, to: pifTarget)
 
         let dependencies = try! topologicalSort(mainTarget.dependencies) { $0.packageDependencies }.sorted()
         for dependency in dependencies {
-            addDependency(to: dependency, in: pifTarget, linkProduct: true)
+            self.addDependency(to: dependency, in: pifTarget, linkProduct: true)
         }
 
         // Configure the target-wide build settings. The details depend on the kind of product we're building, but are
@@ -434,7 +442,10 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.DEFINES_MODULE] = "YES"
 
         if product.type == .executable || product.type == .test {
-            settings[.LIBRARY_SEARCH_PATHS] = ["$(inherited)", "\(parameters.toolchainLibDir.pathString)/swift/macosx"]
+            settings[.LIBRARY_SEARCH_PATHS] = [
+                "$(inherited)",
+                "\(self.parameters.toolchainLibDir.pathString)/swift/macosx",
+            ]
         }
 
         // Tests can have a custom deployment target based on the minimum supported by XCTest.
@@ -452,7 +463,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             settings[.SUPPORTED_PLATFORMS] = ["macosx", "linux"]
 
             // Setup install path for executables if it's in root of a pure Swift package.
-            if isRootPackage {
+            if self.isRootPackage {
                 settings[.SKIP_INSTALL] = "NO"
                 settings[.INSTALL_PATH] = "/usr/local/bin"
                 settings[.LD_RUNPATH_SEARCH_PATHS, default: ["$(inherited)"]].append("@executable_path/../lib")
@@ -471,7 +482,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             settings[.GCC_C_LANGUAGE_STANDARD] = clangTarget.cLanguageStandard
             settings[.CLANG_CXX_LANGUAGE_STANDARD] = clangTarget.cxxLanguageStandard
         } else if let swiftTarget = mainTarget.underlying as? SwiftTarget {
-            settings[.SWIFT_VERSION] = swiftTarget.swiftVersion.description
+            settings[.SWIFT_VERSION] = try swiftTarget
+                .computeEffectiveSwiftVersion(supportedSwiftVersions: self.parameters.supportedSwiftVersions)
+                .description
 
             settings.addCommonSwiftSettings(package: self.package, target: mainTarget, parameters: self.parameters)
         }
@@ -487,7 +500,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         var releaseSettings = settings
 
         var impartedSettings = PIF.BuildSettings()
-        try addManifestBuildSettings(
+        try self.addManifestBuildSettings(
             from: mainTarget.underlying,
             debugSettings: &debugSettings,
             releaseSettings: &releaseSettings,
@@ -495,8 +508,16 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         )
 
         let impartedBuildProperties = PIF.ImpartedBuildProperties(settings: impartedSettings)
-        pifTarget.addBuildConfiguration(name: "Debug", settings: debugSettings, impartedBuildProperties: impartedBuildProperties)
-        pifTarget.addBuildConfiguration(name: "Release", settings: releaseSettings, impartedBuildProperties: impartedBuildProperties)
+        pifTarget.addBuildConfiguration(
+            name: "Debug",
+            settings: debugSettings,
+            impartedBuildProperties: impartedBuildProperties
+        )
+        pifTarget.addBuildConfiguration(
+            name: "Release",
+            settings: releaseSettings,
+            impartedBuildProperties: impartedBuildProperties
+        )
     }
 
     private func addLibraryTarget(for product: ResolvedProduct) {
@@ -525,7 +546,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         // depends.
         let pifTarget = self.addTarget(
             guid: product.pifTargetGUID,
-            name: targetName(for: product),
+            name: self.targetName(for: product),
             productType: productType,
             productName: pifTargetProductName
         )
@@ -537,10 +558,10 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             switch dependency {
             case .target(let target, let conditions):
                 if target.type != .systemModule {
-                    addDependency(to: target, in: pifTarget, conditions: conditions, linkProduct: true)
+                    self.addDependency(to: target, in: pifTarget, conditions: conditions, linkProduct: true)
                 }
             case .product(let product, let conditions):
-                addDependency(to: product, in: pifTarget, conditions: conditions, linkProduct: true)
+                self.addDependency(to: product, in: pifTarget, conditions: conditions, linkProduct: true)
             }
         }
 
@@ -565,9 +586,12 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             settings[.DEFINES_MODULE] = "YES"
             settings[.SKIP_INSTALL] = "NO"
             settings[.INSTALL_PATH] = "/usr/local/lib"
-            settings[.LIBRARY_SEARCH_PATHS] = ["$(inherited)", "\(parameters.toolchainLibDir.pathString)/swift/macosx"]
+            settings[.LIBRARY_SEARCH_PATHS] = [
+                "$(inherited)",
+                "\(self.parameters.toolchainLibDir.pathString)/swift/macosx",
+            ]
 
-            if !parameters.shouldCreateDylibForDynamicProducts {
+            if !self.parameters.shouldCreateDylibForDynamicProducts {
                 settings[.GENERATE_INFOPLIST_FILE] = "YES"
                 // If the built framework is named same as one of the target in the package, it can be picked up
                 // automatically during indexing since the build system always adds a -F flag to the built products dir.
@@ -590,7 +614,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
     }
 
     private func addLibraryTarget(for target: ResolvedModule) throws {
-        let pifTarget = addTarget(
+        let pifTarget = self.addTarget(
             guid: target.pifTargetGUID,
             name: target.name,
             productType: .objectFile,
@@ -612,7 +636,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         // symbols when there are more than one targets that produce .o as their product.
         settings[.CLANG_COVERAGE_MAPPING_LINKER_ARGS] = "NO"
         if let aliases = target.moduleAliases {
-            settings[.SWIFT_MODULE_ALIASES] = aliases.map{ $0.key + "=" + $0.value }
+            settings[.SWIFT_MODULE_ALIASES] = aliases.map { $0.key + "=" + $0.value }
         }
 
         // Create a set of build settings that will be imparted to any target that depends on this one.
@@ -632,16 +656,16 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             // Also propagate this search path to all direct and indirect clients.
             impartedSettings[.HEADER_SEARCH_PATHS, default: ["$(inherited)"]].append(clangTarget.includeDir.pathString)
 
-            if !fileSystem.exists(clangTarget.moduleMapPath) {
+            if !self.fileSystem.exists(clangTarget.moduleMapPath) {
                 impartedSettings[.OTHER_SWIFT_FLAGS, default: ["$(inherited)"]] +=
                     ["-Xcc", "-fmodule-map-file=\(moduleMapFile)"]
 
                 moduleMapFileContents = """
-                    module \(target.c99name) {
-                        umbrella "\(clangTarget.includeDir.pathString)"
-                        export *
-                    }
-                    """
+                module \(target.c99name) {
+                    umbrella "\(clangTarget.includeDir.pathString)"
+                    export *
+                }
+                """
 
                 shouldImpartModuleMap = true
             } else {
@@ -649,7 +673,9 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
                 shouldImpartModuleMap = false
             }
         } else if let swiftTarget = target.underlying as? SwiftTarget {
-            settings[.SWIFT_VERSION] = swiftTarget.swiftVersion.description
+            settings[.SWIFT_VERSION] = try swiftTarget
+                .computeEffectiveSwiftVersion(supportedSwiftVersions: self.parameters.supportedSwiftVersions)
+                .description
             // Generate ObjC compatibility header for Swift library targets.
             settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR] = "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)"
             settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME] = "\(target.name)-Swift.h"
@@ -657,11 +683,11 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             settings.addCommonSwiftSettings(package: self.package, target: target, parameters: self.parameters)
 
             moduleMapFileContents = """
-                module \(target.c99name) {
-                    header "\(target.name)-Swift.h"
-                    export *
-                }
-                """
+            module \(target.c99name) {
+                header "\(target.name)-Swift.h"
+                export *
+            }
+            """
 
             shouldImpartModuleMap = true
         } else {
@@ -686,12 +712,12 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         // radar://112671586 supress unnecessary warnings
         impartedSettings[.OTHER_LDFLAGS, default: ["$(inherited)"]].append("-Wl,-no_warn_duplicate_libraries")
 
-        addSources(target.sources, to: pifTarget)
+        self.addSources(target.sources, to: pifTarget)
 
         // Handle the target's dependencies (but don't link against them).
         let dependencies = try! topologicalSort(target.dependencies) { $0.packageDependencies }.sorted()
         for dependency in dependencies {
-            addDependency(to: dependency, in: pifTarget, linkProduct: false)
+            self.addDependency(to: dependency, in: pifTarget, linkProduct: false)
         }
 
         if let resourceBundle = addResourceBundle(for: target, in: pifTarget) {
@@ -713,8 +739,16 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         )
 
         let impartedBuildProperties = PIF.ImpartedBuildProperties(settings: impartedSettings)
-        pifTarget.addBuildConfiguration(name: "Debug", settings: debugSettings, impartedBuildProperties: impartedBuildProperties)
-        pifTarget.addBuildConfiguration(name: "Release", settings: releaseSettings, impartedBuildProperties: impartedBuildProperties)
+        pifTarget.addBuildConfiguration(
+            name: "Debug",
+            settings: debugSettings,
+            impartedBuildProperties: impartedBuildProperties
+        )
+        pifTarget.addBuildConfiguration(
+            name: "Release",
+            settings: releaseSettings,
+            impartedBuildProperties: impartedBuildProperties
+        )
         pifTarget.impartedBuildSettings = impartedSettings
     }
 
@@ -729,10 +763,10 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         var cFlags: [String] = []
         for result in try pkgConfigArgs(
             for: systemTarget,
-            pkgConfigDirectories: parameters.pkgConfigDirectories,
-            sdkRootPath: parameters.sdkRootPath,
-            fileSystem: fileSystem,
-            observabilityScope: observabilityScope
+            pkgConfigDirectories: self.parameters.pkgConfigDirectories,
+            sdkRootPath: self.parameters.sdkRootPath,
+            fileSystem: self.fileSystem,
+            observabilityScope: self.observabilityScope
         ) {
             if let error = result.error {
                 self.observabilityScope.emit(
@@ -746,14 +780,24 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         }
 
         impartedSettings[.OTHER_LDRFLAGS] = []
-        impartedSettings[.OTHER_CFLAGS, default: ["$(inherited)"]] += ["-fmodule-map-file=\(systemTarget.moduleMapPath)"] + cFlags
-        impartedSettings[.OTHER_SWIFT_FLAGS, default: ["$(inherited)"]] += ["-Xcc", "-fmodule-map-file=\(systemTarget.moduleMapPath)"] + cFlags
+        impartedSettings[.OTHER_CFLAGS, default: ["$(inherited)"]] +=
+            ["-fmodule-map-file=\(systemTarget.moduleMapPath)"] + cFlags
+        impartedSettings[.OTHER_SWIFT_FLAGS, default: ["$(inherited)"]] +=
+            ["-Xcc", "-fmodule-map-file=\(systemTarget.moduleMapPath)"] + cFlags
         let impartedBuildProperties = PIF.ImpartedBuildProperties(settings: impartedSettings)
 
         // Create an aggregate PIF target (which doesn't have an actual product).
         let pifTarget = addAggregateTarget(guid: target.pifTargetGUID, name: target.name)
-        pifTarget.addBuildConfiguration(name: "Debug", settings: PIF.BuildSettings(), impartedBuildProperties: impartedBuildProperties)
-        pifTarget.addBuildConfiguration(name: "Release", settings: PIF.BuildSettings(), impartedBuildProperties: impartedBuildProperties)
+        pifTarget.addBuildConfiguration(
+            name: "Debug",
+            settings: PIF.BuildSettings(),
+            impartedBuildProperties: impartedBuildProperties
+        )
+        pifTarget.addBuildConfiguration(
+            name: "Release",
+            settings: PIF.BuildSettings(),
+            impartedBuildProperties: impartedBuildProperties
+        )
         pifTarget.impartedBuildSettings = impartedSettings
     }
 
@@ -761,7 +805,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         // Create a group for the target's source files.  For now we use an absolute path for it, but we should really
         // make it be container-relative, since it's always inside the package directory.
         let targetGroup = groupTree.addGroup(
-            path: sources.root.relative(to: package.path).pathString,
+            path: sources.root.relative(to: self.package.path).pathString,
             sourceTree: .group
         )
 
@@ -778,14 +822,14 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
     ) {
         switch dependency {
         case .target(let target, let conditions):
-            addDependency(
+            self.addDependency(
                 to: target,
                 in: pifTarget,
                 conditions: conditions,
                 linkProduct: linkProduct
             )
         case .product(let product, let conditions):
-            addDependency(
+            self.addDependency(
                 to: product,
                 in: pifTarget,
                 conditions: conditions,
@@ -802,17 +846,18 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
     ) {
         // Only add the binary target as a library when we want to link against the product.
         if let binaryTarget = target.underlying as? BinaryTarget {
-            let ref = binaryGroup.addFileReference(path: binaryTarget.artifactPath.pathString)
+            let ref = self.binaryGroup.addFileReference(path: binaryTarget.artifactPath.pathString)
             pifTarget.addLibrary(ref, platformFilters: conditions.toPlatformFilters())
         } else {
             // If this is an executable target, the dependency should be to the PIF target created from the its
             // product, as we don't have PIF targets corresponding to executable targets.
-            let targetGUID = executableTargetProductMap[target.id]?.pifTargetGUID ?? target.pifTargetGUID
+            let targetGUID = self.executableTargetProductMap[target.id]?.pifTargetGUID ?? target.pifTargetGUID
             let linkProduct = linkProduct && target.type != .systemModule && target.type != .executable
             pifTarget.addDependency(
                 toTargetWithGUID: targetGUID,
                 platformFilters: conditions.toPlatformFilters(),
-                linkProduct: linkProduct)
+                linkProduct: linkProduct
+            )
         }
     }
 
@@ -835,7 +880,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         }
 
         let bundleName = "\(package.manifest.displayName)_\(target.name)" // TODO: use identity instead?
-        let resourcesTarget = addTarget(
+        let resourcesTarget = self.addTarget(
             guid: target.pifResourceTargetGUID,
             name: bundleName,
             productType: .bundle,
@@ -852,7 +897,8 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         settings[.TARGET_NAME] = bundleName
         settings[.PRODUCT_NAME] = bundleName
         settings[.PRODUCT_MODULE_NAME] = bundleName
-        let bundleIdentifier = "\(package.manifest.displayName).\(target.name).resources".spm_mangledToBundleIdentifier() // TODO: use identity instead?
+        let bundleIdentifier = "\(package.manifest.displayName).\(target.name).resources"
+            .spm_mangledToBundleIdentifier() // TODO: use identity instead?
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = bundleIdentifier
         settings[.GENERATE_INFOPLIST_FILE] = "YES"
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "resource"
@@ -860,7 +906,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         resourcesTarget.addBuildConfiguration(name: "Debug", settings: settings)
         resourcesTarget.addBuildConfiguration(name: "Release", settings: settings)
 
-        let coreDataFileTypes = [XCBuildFileType.xcdatamodeld, .xcdatamodel].flatMap { $0.fileTypes }
+        let coreDataFileTypes = [XCBuildFileType.xcdatamodeld, .xcdatamodel].flatMap(\.fileTypes)
         for resource in target.underlying.resources {
             // FIXME: Handle rules here.
             let resourceFile = groupTree.addFileReference(
@@ -878,7 +924,10 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
         }
 
         let targetGroup = groupTree.addGroup(path: "/", sourceTree: .group)
-        pifTarget.addResourceFile(targetGroup.addFileReference(path: "\(bundleName).bundle", sourceTree: .builtProductsDir))
+        pifTarget.addResourceFile(targetGroup.addFileReference(
+            path: "\(bundleName).bundle",
+            sourceTree: .builtProductsDir
+        ))
 
         return bundleName
     }
@@ -909,7 +958,8 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             for assignment in assignments {
                 var value = assignment.value
                 if setting == .HEADER_SEARCH_PATHS {
-                    value = try value.map { try AbsolutePath(validating: $0, relativeTo: target.sources.root).pathString }
+                    value = try value
+                        .map { try AbsolutePath(validating: $0, relativeTo: target.sources.root).pathString }
                 }
 
                 if let platforms = assignment.platforms {
@@ -918,10 +968,22 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
                             switch configuration {
                             case .debug:
                                 debugSettings[setting, for: platform, default: ["$(inherited)"]] += value
-                                addInferredBuildSettings(for: setting, value: value, platform: platform, configuration: .debug, settings: &debugSettings)
+                                self.addInferredBuildSettings(
+                                    for: setting,
+                                    value: value,
+                                    platform: platform,
+                                    configuration: .debug,
+                                    settings: &debugSettings
+                                )
                             case .release:
                                 releaseSettings[setting, for: platform, default: ["$(inherited)"]] += value
-                                addInferredBuildSettings(for: setting, value: value, platform: platform, configuration: .release, settings: &releaseSettings)
+                                self.addInferredBuildSettings(
+                                    for: setting,
+                                    value: value,
+                                    platform: platform,
+                                    configuration: .release,
+                                    settings: &releaseSettings
+                                )
                             }
                         }
 
@@ -934,10 +996,20 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
                         switch configuration {
                         case .debug:
                             debugSettings[setting, default: ["$(inherited)"]] += value
-                            addInferredBuildSettings(for: setting, value: value, configuration: .debug, settings: &debugSettings)
+                            self.addInferredBuildSettings(
+                                for: setting,
+                                value: value,
+                                configuration: .debug,
+                                settings: &debugSettings
+                            )
                         case .release:
                             releaseSettings[setting, default: ["$(inherited)"]] += value
-                            addInferredBuildSettings(for: setting, value: value, configuration: .release, settings: &releaseSettings)
+                            self.addInferredBuildSettings(
+                                for: setting,
+                                value: value,
+                                configuration: .release,
+                                settings: &releaseSettings
+                            )
                         }
                     }
 
@@ -989,10 +1061,18 @@ final class AggregatePIFProjectBuilder: PIFProjectBuilder {
         for case let project as PackagePIFProjectBuilder in projects where project.isRootPackage {
             for case let target as PIFTargetBuilder in project.targets {
                 if target.productType != .unitTest {
-                    allExcludingTestsTarget.addDependency(toTargetWithGUID: target.guid,  platformFilters: [], linkProduct: false)
+                    allExcludingTestsTarget.addDependency(
+                        toTargetWithGUID: target.guid,
+                        platformFilters: [],
+                        linkProduct: false
+                    )
                 }
 
-                allIncludingTestsTarget.addDependency(toTargetWithGUID: target.guid, platformFilters: [], linkProduct: false)
+                allIncludingTestsTarget.addDependency(
+                    toTargetWithGUID: target.guid,
+                    platformFilters: [],
+                    linkProduct: false
+                )
             }
         }
     }
@@ -1021,12 +1101,12 @@ final class PIFFileReferenceBuilder: PIFReferenceBuilder {
     }
 
     func construct() -> PIF.Reference {
-        return PIF.FileReference(
-            guid: guid,
-            path: path,
-            sourceTree: sourceTree,
-            name: name,
-            fileType: fileType
+        PIF.FileReference(
+            guid: self.guid,
+            path: self.path,
+            sourceTree: self.sourceTree,
+            name: self.name,
+            fileType: self.fileType
         )
     }
 }
@@ -1044,7 +1124,7 @@ final class PIFGroupBuilder: PIFReferenceBuilder {
         self.path = path
         self.sourceTree = sourceTree
         self.name = name
-        children = []
+        self.children = []
     }
 
     /// Creates and appends a new Group to the list of children. The new group is returned so that it can be configured.
@@ -1054,7 +1134,7 @@ final class PIFGroupBuilder: PIFReferenceBuilder {
         name: String? = nil
     ) -> PIFGroupBuilder {
         let group = PIFGroupBuilder(path: path, sourceTree: sourceTree, name: name)
-        children.append(group)
+        self.children.append(group)
         return group
     }
 
@@ -1066,26 +1146,26 @@ final class PIFGroupBuilder: PIFReferenceBuilder {
         fileType: String? = nil
     ) -> PIFFileReferenceBuilder {
         let file = PIFFileReferenceBuilder(path: path, sourceTree: sourceTree, name: name, fileType: fileType)
-        children.append(file)
+        self.children.append(file)
         return file
     }
 
     func removeChild(_ reference: PIFReferenceBuilder) {
-        children.removeAll { $0 === reference }
+        self.children.removeAll { $0 === reference }
     }
 
     func construct() -> PIF.Reference {
         let children = self.children.enumerated().map { kvp -> PIF.Reference in
             let (index, builder) = kvp
-            builder.guid = "\(guid)::REF_\(index)"
+            builder.guid = "\(self.guid)::REF_\(index)"
             return builder.construct()
         }
 
         return PIF.Group(
-            guid: guid,
-            path: path,
-            sourceTree: sourceTree,
-            name: name,
+            guid: self.guid,
+            path: self.path,
+            sourceTree: self.sourceTree,
+            name: self.name,
             children: children
         )
     }
@@ -1115,10 +1195,15 @@ class PIFBaseTargetBuilder {
     public func addBuildConfiguration(
         name: String,
         settings: PIF.BuildSettings = PIF.BuildSettings(),
-        impartedBuildProperties: PIF.ImpartedBuildProperties = PIF.ImpartedBuildProperties(settings: PIF.BuildSettings())
+        impartedBuildProperties: PIF.ImpartedBuildProperties = PIF
+            .ImpartedBuildProperties(settings: PIF.BuildSettings())
     ) -> PIFBuildConfigurationBuilder {
-        let builder = PIFBuildConfigurationBuilder(name: name, settings: settings, impartedBuildProperties: impartedBuildProperties)
-        buildConfigurations.append(builder)
+        let builder = PIFBuildConfigurationBuilder(
+            name: name,
+            settings: settings,
+            impartedBuildProperties: impartedBuildProperties
+        )
+        self.buildConfigurations.append(builder)
         return builder
     }
 
@@ -1131,7 +1216,7 @@ class PIFBaseTargetBuilder {
     @discardableResult
     func addHeadersBuildPhase() -> PIFHeadersBuildPhaseBuilder {
         let buildPhase = PIFHeadersBuildPhaseBuilder()
-        buildPhases.append(buildPhase)
+        self.buildPhases.append(buildPhase)
         return buildPhase
     }
 
@@ -1140,7 +1225,7 @@ class PIFBaseTargetBuilder {
     @discardableResult
     func addSourcesBuildPhase() -> PIFSourcesBuildPhaseBuilder {
         let buildPhase = PIFSourcesBuildPhaseBuilder()
-        buildPhases.append(buildPhase)
+        self.buildPhases.append(buildPhase)
         return buildPhase
     }
 
@@ -1149,14 +1234,14 @@ class PIFBaseTargetBuilder {
     @discardableResult
     func addFrameworksBuildPhase() -> PIFFrameworksBuildPhaseBuilder {
         let buildPhase = PIFFrameworksBuildPhaseBuilder()
-        buildPhases.append(buildPhase)
+        self.buildPhases.append(buildPhase)
         return buildPhase
     }
 
     @discardableResult
     func addResourcesBuildPhase() -> PIFResourcesBuildPhaseBuilder {
         let buildPhase = PIFResourcesBuildPhaseBuilder()
-        buildPhases.append(buildPhase)
+        self.buildPhases.append(buildPhase)
         return buildPhase
     }
 
@@ -1165,52 +1250,60 @@ class PIFBaseTargetBuilder {
     /// true, the receiver will also be configured to link against the product produced by the other target (this
     /// presumes that the product type is one that can be linked against).
     func addDependency(toTargetWithGUID targetGUID: String, platformFilters: [PIF.PlatformFilter], linkProduct: Bool) {
-        dependencies.append(.init(targetGUID: targetGUID, platformFilters: platformFilters))
+        self.dependencies.append(.init(targetGUID: targetGUID, platformFilters: platformFilters))
         if linkProduct {
-            let frameworksPhase = buildPhases.first { $0 is PIFFrameworksBuildPhaseBuilder }
-                ?? addFrameworksBuildPhase()
+            let frameworksPhase = self.buildPhases.first { $0 is PIFFrameworksBuildPhaseBuilder }
+                ?? self.addFrameworksBuildPhase()
             frameworksPhase.addBuildFile(toTargetWithGUID: targetGUID, platformFilters: platformFilters)
         }
     }
 
     /// Convenience function to add a file reference to the Headers build phase, after creating it if needed.
     @discardableResult
-    public func addHeaderFile(_ fileReference: PIFFileReferenceBuilder, headerVisibility: PIF.BuildFile.HeaderVisibility) -> PIFBuildFileBuilder {
-        let headerPhase = buildPhases.first { $0 is PIFHeadersBuildPhaseBuilder } ?? addHeadersBuildPhase()
+    public func addHeaderFile(
+        _ fileReference: PIFFileReferenceBuilder,
+        headerVisibility: PIF.BuildFile.HeaderVisibility
+    ) -> PIFBuildFileBuilder {
+        let headerPhase = self.buildPhases.first { $0 is PIFHeadersBuildPhaseBuilder } ?? self.addHeadersBuildPhase()
         return headerPhase.addBuildFile(to: fileReference, platformFilters: [], headerVisibility: headerVisibility)
     }
 
     /// Convenience function to add a file reference to the Sources build phase, after creating it if needed.
     @discardableResult
     public func addSourceFile(_ fileReference: PIFFileReferenceBuilder) -> PIFBuildFileBuilder {
-        let sourcesPhase = buildPhases.first { $0 is PIFSourcesBuildPhaseBuilder } ?? addSourcesBuildPhase()
+        let sourcesPhase = self.buildPhases.first { $0 is PIFSourcesBuildPhaseBuilder } ?? self.addSourcesBuildPhase()
         return sourcesPhase.addBuildFile(to: fileReference, platformFilters: [])
     }
 
     /// Convenience function to add a file reference to the Frameworks build phase, after creating it if needed.
     @discardableResult
-    public func addLibrary(_ fileReference: PIFFileReferenceBuilder, platformFilters: [PIF.PlatformFilter]) -> PIFBuildFileBuilder {
-        let frameworksPhase = buildPhases.first { $0 is PIFFrameworksBuildPhaseBuilder } ?? addFrameworksBuildPhase()
+    public func addLibrary(
+        _ fileReference: PIFFileReferenceBuilder,
+        platformFilters: [PIF.PlatformFilter]
+    ) -> PIFBuildFileBuilder {
+        let frameworksPhase = self.buildPhases.first { $0 is PIFFrameworksBuildPhaseBuilder } ?? self
+            .addFrameworksBuildPhase()
         return frameworksPhase.addBuildFile(to: fileReference, platformFilters: platformFilters)
     }
 
     @discardableResult
     public func addResourceFile(_ fileReference: PIFFileReferenceBuilder) -> PIFBuildFileBuilder {
-        let resourcesPhase = buildPhases.first { $0 is PIFResourcesBuildPhaseBuilder } ?? addResourcesBuildPhase()
+        let resourcesPhase = self.buildPhases.first { $0 is PIFResourcesBuildPhaseBuilder } ?? self
+            .addResourcesBuildPhase()
         return resourcesPhase.addBuildFile(to: fileReference, platformFilters: [])
     }
 
     fileprivate func constructBuildConfigurations() -> [PIF.BuildConfiguration] {
-        buildConfigurations.map { builder -> PIF.BuildConfiguration in
-            builder.guid = "\(guid)::BUILDCONFIG_\(builder.name)"
+        self.buildConfigurations.map { builder -> PIF.BuildConfiguration in
+            builder.guid = "\(self.guid)::BUILDCONFIG_\(builder.name)"
             return builder.construct()
         }
     }
 
     fileprivate func constructBuildPhases() throws -> [PIF.BuildPhase] {
-        try buildPhases.enumerated().map { kvp in
+        try self.buildPhases.enumerated().map { kvp in
             let (index, builder) = kvp
-            builder.guid = "\(guid)::BUILDPHASE_\(index)"
+            builder.guid = "\(self.guid)::BUILDPHASE_\(index)"
             return try builder.construct()
         }
     }
@@ -1218,11 +1311,11 @@ class PIFBaseTargetBuilder {
 
 final class PIFAggregateTargetBuilder: PIFBaseTargetBuilder {
     override func construct() throws -> PIF.BaseTarget {
-        return PIF.AggregateTarget(
+        try PIF.AggregateTarget(
             guid: guid,
             name: name,
             buildConfigurations: constructBuildConfigurations(),
-            buildPhases: try self.constructBuildPhases(),
+            buildPhases: self.constructBuildPhases(),
             dependencies: dependencies,
             impartedBuildSettings: impartedBuildSettings
         )
@@ -1241,13 +1334,13 @@ final class PIFTargetBuilder: PIFBaseTargetBuilder {
     }
 
     override func construct() throws -> PIF.BaseTarget {
-        return PIF.Target(
+        try PIF.Target(
             guid: guid,
             name: name,
-            productType: productType,
-            productName: productName,
+            productType: self.productType,
+            productName: self.productName,
             buildConfigurations: constructBuildConfigurations(),
-            buildPhases: try self.constructBuildPhases(),
+            buildPhases: self.constructBuildPhases(),
             dependencies: dependencies,
             impartedBuildSettings: impartedBuildSettings
         )
@@ -1261,16 +1354,24 @@ class PIFBuildPhaseBuilder {
     var guid: PIF.GUID
 
     fileprivate init() {
-        buildFiles = []
+        self.buildFiles = []
     }
 
     /// Adds a new build file builder that refers to a file reference.
     /// - Parameters:
     ///   - file: The builder for the file reference.
     @discardableResult
-    func addBuildFile(to file: PIFFileReferenceBuilder, platformFilters: [PIF.PlatformFilter], headerVisibility: PIF.BuildFile.HeaderVisibility? = nil) -> PIFBuildFileBuilder {
-        let builder = PIFBuildFileBuilder(file: file, platformFilters: platformFilters, headerVisibility: headerVisibility)
-        buildFiles.append(builder)
+    func addBuildFile(
+        to file: PIFFileReferenceBuilder,
+        platformFilters: [PIF.PlatformFilter],
+        headerVisibility: PIF.BuildFile.HeaderVisibility? = nil
+    ) -> PIFBuildFileBuilder {
+        let builder = PIFBuildFileBuilder(
+            file: file,
+            platformFilters: platformFilters,
+            headerVisibility: headerVisibility
+        )
+        self.buildFiles.append(builder)
         return builder
     }
 
@@ -1278,9 +1379,12 @@ class PIFBuildPhaseBuilder {
     /// - Parameters:
     ///   - targetGUID: The GIUD referencing the target.
     @discardableResult
-    func addBuildFile(toTargetWithGUID targetGUID: PIF.GUID, platformFilters: [PIF.PlatformFilter]) -> PIFBuildFileBuilder {
+    func addBuildFile(
+        toTargetWithGUID targetGUID: PIF.GUID,
+        platformFilters: [PIF.PlatformFilter]
+    ) -> PIFBuildFileBuilder {
         let builder = PIFBuildFileBuilder(targetGUID: targetGUID, platformFilters: platformFilters)
-        buildFiles.append(builder)
+        self.buildFiles.append(builder)
         return builder
     }
 
@@ -1289,9 +1393,9 @@ class PIFBuildPhaseBuilder {
     }
 
     fileprivate func constructBuildFiles() -> [PIF.BuildFile] {
-        return buildFiles.enumerated().map { kvp -> PIF.BuildFile in
+        self.buildFiles.enumerated().map { kvp -> PIF.BuildFile in
             let (index, builder) = kvp
-            builder.guid = "\(guid)::\(index)"
+            builder.guid = "\(self.guid)::\(index)"
             return builder.construct()
         }
     }
@@ -1329,9 +1433,9 @@ final class PIFBuildFileBuilder {
         var pifReference: PIF.BuildFile.Reference {
             switch self {
             case .file(let builder):
-                return .file(guid: builder.guid)
+                .file(guid: builder.guid)
             case .target(let guid):
-                return .target(guid: guid)
+                .target(guid: guid)
             }
         }
     }
@@ -1345,20 +1449,33 @@ final class PIFBuildFileBuilder {
 
     let headerVisibility: PIF.BuildFile.HeaderVisibility?
 
-    fileprivate init(file: PIFFileReferenceBuilder, platformFilters: [PIF.PlatformFilter], headerVisibility: PIF.BuildFile.HeaderVisibility? = nil) {
-        reference = .file(builder: file)
+    fileprivate init(
+        file: PIFFileReferenceBuilder,
+        platformFilters: [PIF.PlatformFilter],
+        headerVisibility: PIF.BuildFile.HeaderVisibility? = nil
+    ) {
+        self.reference = .file(builder: file)
         self.platformFilters = platformFilters
         self.headerVisibility = headerVisibility
     }
 
-    fileprivate init(targetGUID: PIF.GUID, platformFilters: [PIF.PlatformFilter], headerVisibility: PIF.BuildFile.HeaderVisibility? = nil) {
-        reference = .target(guid: targetGUID)
+    fileprivate init(
+        targetGUID: PIF.GUID,
+        platformFilters: [PIF.PlatformFilter],
+        headerVisibility: PIF.BuildFile.HeaderVisibility? = nil
+    ) {
+        self.reference = .target(guid: targetGUID)
         self.platformFilters = platformFilters
         self.headerVisibility = headerVisibility
     }
 
     func construct() -> PIF.BuildFile {
-        PIF.BuildFile(guid: guid, reference: reference.pifReference, platformFilters: platformFilters, headerVisibility: headerVisibility)
+        PIF.BuildFile(
+            guid: self.guid,
+            reference: self.reference.pifReference,
+            platformFilters: self.platformFilters,
+            headerVisibility: self.headerVisibility
+        )
     }
 }
 
@@ -1378,7 +1495,12 @@ final class PIFBuildConfigurationBuilder {
     }
 
     func construct() -> PIF.BuildConfiguration {
-        PIF.BuildConfiguration(guid: guid, name: name, buildSettings: settings, impartedBuildProperties: impartedBuildProperties)
+        PIF.BuildConfiguration(
+            guid: self.guid,
+            name: self.name,
+            buildSettings: self.settings,
+            impartedBuildProperties: self.impartedBuildProperties
+        )
     }
 }
 
@@ -1404,7 +1526,7 @@ extension ResolvedProduct {
     public func recursivePackageDependencies() -> [ResolvedModule.Dependency] {
         let initialDependencies = targets.map { ResolvedModule.Dependency.target($0, conditions: []) }
         return try! topologicalSort(initialDependencies) { dependency in
-            return dependency.packageDependencies
+            dependency.packageDependencies
         }.sorted()
     }
 }
@@ -1414,20 +1536,19 @@ extension ResolvedModule {
     var pifResourceTargetGUID: PIF.GUID { "PACKAGE-RESOURCE:\(name)" }
 }
 
-extension Array where Element == ResolvedModule.Dependency {
-
+extension [ResolvedModule.Dependency] {
     /// Sorts to get products first, sorted by name, followed by targets, sorted by name.
     func sorted() -> [ResolvedModule.Dependency] {
-        sorted { lhsDependency, rhsDependency in
+        self.sorted { lhsDependency, rhsDependency in
             switch (lhsDependency, rhsDependency) {
             case (.product, .target):
-                return true
+                true
             case (.target, .product):
-                return false
+                false
             case (.product(let lhsProduct, _), .product(let rhsProduct, _)):
-                return lhsProduct.name < rhsProduct.name
+                lhsProduct.name < rhsProduct.name
             case (.target(let lhsTarget, _), .target(let rhsTarget, _)):
-                return lhsTarget.name < rhsTarget.name
+                lhsTarget.name < rhsTarget.name
             }
         }
     }
@@ -1435,13 +1556,13 @@ extension Array where Element == ResolvedModule.Dependency {
 
 extension ResolvedPackage {
     func deploymentTarget(for platform: PackageModel.Platform, usingXCTest: Bool = false) -> String? {
-        return self.getSupportedPlatform(for: platform, usingXCTest: usingXCTest).version.versionString
+        self.getSupportedPlatform(for: platform, usingXCTest: usingXCTest).version.versionString
     }
 }
 
 extension ResolvedModule {
     func deploymentTarget(for platform: PackageModel.Platform, usingXCTest: Bool = false) -> String? {
-        return self.getSupportedPlatform(for: platform, usingXCTest: usingXCTest).version.versionString
+        self.getSupportedPlatform(for: platform, usingXCTest: usingXCTest).version.versionString
     }
 }
 
@@ -1451,21 +1572,46 @@ extension Target {
     }
 }
 
+extension SwiftTarget {
+    func computeEffectiveSwiftVersion(supportedSwiftVersions: [SwiftLanguageVersion]) throws -> SwiftLanguageVersion {
+        // We have to normalize to two component strings to match the results from XCBuild w.r.t. to hashing of
+        // `SwiftLanguageVersion` instances.
+        let normalizedDeclaredVersions = Set(self.declaredSwiftVersions.compactMap {
+            SwiftLanguageVersion(string: "\($0.major).\($0.minor)")
+        })
+        // If we were able to determine the list of versions supported by XCBuild, cross-reference with the package's
+        // Swift versions in case the preferred version isn't available.
+        if !supportedSwiftVersions.isEmpty, !supportedSwiftVersions.contains(self.swiftVersion) {
+            let declaredVersions = Array(normalizedDeclaredVersions.intersection(supportedSwiftVersions)).sorted(by: >)
+            if let swiftVersion = declaredVersions.first {
+                return swiftVersion
+            } else {
+                throw PIFGenerationError.unsupportedSwiftLanguageVersion(
+                    targetName: self.name,
+                    version: self.swiftVersion,
+                    supportedVersions: supportedSwiftVersions
+                )
+            }
+        }
+        return self.swiftVersion
+    }
+}
+
 extension ProductType {
     var targetType: Target.Kind {
         switch self {
         case .executable:
-            return .executable
+            .executable
         case .snippet:
-            return .snippet
+            .snippet
         case .test:
-            return .test
+            .test
         case .library:
-            return .library
+            .library
         case .plugin:
-            return .plugin
+            .plugin
         case .macro:
-            return .macro
+            .macro
         }
     }
 }
@@ -1481,8 +1627,8 @@ private struct PIFBuildSettingAssignment {
     let platforms: [PIF.BuildSettings.Platform]?
 }
 
-private extension BuildSettings.AssignmentTable {
-    var pifAssignments: [PIF.BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] {
+extension BuildSettings.AssignmentTable {
+    fileprivate var pifAssignments: [PIF.BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] {
         var pifAssignments: [PIF.BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] = [:]
 
         for (declaration, assignments) in self.assignments {
@@ -1508,7 +1654,8 @@ private extension BuildSettings.AssignmentTable {
                 let pifAssignment = PIFBuildSettingAssignment(
                     value: value,
                     configurations: assignment.configurations,
-                    platforms: assignment.pifPlatforms)
+                    platforms: assignment.pifPlatforms
+                )
 
                 pifAssignments[setting, default: []].append(pifAssignment)
             }
@@ -1518,20 +1665,20 @@ private extension BuildSettings.AssignmentTable {
     }
 }
 
-private extension BuildSettings.Assignment {
-    var configurations: [BuildConfiguration] {
+extension BuildSettings.Assignment {
+    fileprivate var configurations: [BuildConfiguration] {
         if let configurationCondition = conditions.lazy.compactMap(\.configurationCondition).first {
-            return [configurationCondition.configuration]
+            [configurationCondition.configuration]
         } else {
-            return BuildConfiguration.allCases
+            BuildConfiguration.allCases
         }
     }
 
-    var pifPlatforms: [PIF.BuildSettings.Platform]? {
+    fileprivate var pifPlatforms: [PIF.BuildSettings.Platform]? {
         if let platformsCondition = conditions.lazy.compactMap(\.platformsCondition).first {
-            return platformsCondition.platforms.compactMap { PIF.BuildSettings.Platform(rawValue: $0.name) }
+            platformsCondition.platforms.compactMap { PIF.BuildSettings.Platform(rawValue: $0.name) }
         } else {
-            return nil
+            nil
         }
     }
 }
@@ -1540,8 +1687,7 @@ private extension BuildSettings.Assignment {
 public struct DelayedImmutable<Value> {
     private var _value: Value? = nil
 
-    public init() {
-    }
+    public init() {}
 
     public var wrappedValue: Value {
         get {
@@ -1551,10 +1697,10 @@ public struct DelayedImmutable<Value> {
             return value
         }
         set {
-            if _value != nil {
+            if self._value != nil {
                 fatalError("property initialized twice")
             }
-            _value = newValue
+            self._value = newValue
         }
     }
 }
@@ -1562,7 +1708,7 @@ public struct DelayedImmutable<Value> {
 extension [PackageCondition] {
     func toPlatformFilters() -> [PIF.PlatformFilter] {
         var result: [PIF.PlatformFilter] = []
-        let platformConditions = self.compactMap(\.platformsCondition).flatMap { $0.platforms }
+        let platformConditions = self.compactMap(\.platformsCondition).flatMap(\.platforms)
 
         for condition in platformConditions {
             switch condition {
@@ -1604,7 +1750,6 @@ extension [PackageCondition] {
 
             default:
                 assertionFailure("Unhandled platform condition: \(condition)")
-                break
             }
         }
         return result
@@ -1612,31 +1757,30 @@ extension [PackageCondition] {
 }
 
 extension PIF.PlatformFilter {
-
     /// macOS platform filters.
     public static let macOSFilters: [PIF.PlatformFilter] = [.init(platform: "macos")]
 
     /// Mac Catalyst platform filters.
     public static let macCatalystFilters: [PIF.PlatformFilter] = [
-        .init(platform: "ios", environment: "maccatalyst")
+        .init(platform: "ios", environment: "maccatalyst"),
     ]
 
     /// iOS platform filters.
     public static let iOSFilters: [PIF.PlatformFilter] = [
         .init(platform: "ios"),
-        .init(platform: "ios", environment: "simulator")
+        .init(platform: "ios", environment: "simulator"),
     ]
 
     /// tvOS platform filters.
     public static let tvOSFilters: [PIF.PlatformFilter] = [
         .init(platform: "tvos"),
-        .init(platform: "tvos", environment: "simulator")
+        .init(platform: "tvos", environment: "simulator"),
     ]
 
     /// watchOS platform filters.
     public static let watchOSFilters: [PIF.PlatformFilter] = [
         .init(platform: "watchos"),
-        .init(platform: "watchos", environment: "simulator")
+        .init(platform: "watchos", environment: "simulator"),
     ]
 
     /// DriverKit platform filters.
@@ -1657,11 +1801,9 @@ extension PIF.PlatformFilter {
     ]
 
     /// Common Linux platform filters.
-    public static let linuxFilters: [PIF.PlatformFilter] = {
-        ["", "eabi", "gnu", "gnueabi", "gnueabihf"].map {
-            .init(platform: "linux", environment: $0)
-        }
-    }()
+    public static let linuxFilters: [PIF.PlatformFilter] = ["", "eabi", "gnu", "gnueabi", "gnueabihf"].map {
+        .init(platform: "linux", environment: $0)
+    }
 
     /// OpenBSD filters.
     public static let openBSDFilters: [PIF.PlatformFilter] = [
@@ -1678,12 +1820,12 @@ extension PIF.PlatformFilter {
         .init(platform: "xros"),
         .init(platform: "xros", environment: "simulator"),
         .init(platform: "visionos"),
-        .init(platform: "visionos", environment: "simulator")
+        .init(platform: "visionos", environment: "simulator"),
     ]
 }
 
-private extension PIF.BuildSettings {
-    mutating func addCommonSwiftSettings(
+extension PIF.BuildSettings {
+    fileprivate mutating func addCommonSwiftSettings(
         package: ResolvedPackage,
         target: ResolvedModule,
         parameters: PIFBuilderParameters
@@ -1698,17 +1840,25 @@ private extension PIF.BuildSettings {
     }
 }
 
-private extension PIF.BuildSettings.Platform {
-    static func from(platform: PackageModel.Platform) -> PIF.BuildSettings.Platform? {
+extension PIF.BuildSettings.Platform {
+    fileprivate static func from(platform: PackageModel.Platform) -> PIF.BuildSettings.Platform? {
         switch platform {
-        case .iOS: return .iOS
-        case .linux: return .linux
-        case .macCatalyst: return .macCatalyst
-        case .macOS: return .macOS
-        case .tvOS: return .tvOS
-        case .watchOS: return .watchOS
-        case .driverKit: return .driverKit
-        default: return nil
+        case .iOS: .iOS
+        case .linux: .linux
+        case .macCatalyst: .macCatalyst
+        case .macOS: .macOS
+        case .tvOS: .tvOS
+        case .watchOS: .watchOS
+        case .driverKit: .driverKit
+        default: nil
         }
     }
+}
+
+public enum PIFGenerationError: Error {
+    case unsupportedSwiftLanguageVersion(
+        targetName: String,
+        version: SwiftLanguageVersion,
+        supportedVersions: [SwiftLanguageVersion]
+    )
 }

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -16,8 +16,8 @@ import Foundation
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
 import PackageGraph
 
-@testable import PackageModel
 import PackageLoading
+@testable import PackageModel
 import SPMBuildCore
 import SPMTestSupport
 @testable import XCBuildSupport
@@ -35,13 +35,14 @@ class PIFBuilderTests: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         // Repeat multiple times to detect non-deterministic shuffling due to sets.
-        for _ in 0..<10 {
-            let fs = InMemoryFileSystem(emptyFiles:
-                                            "/A/Sources/A1/main.swift",
-                                        "/A/Sources/A2/lib.swift",
-                                        "/A/Sources/A3/lib.swift",
-                                        "/B/Sources/B1/main.swift",
-                                        "/B/Sources/B2/lib.swift"
+        for _ in 0 ..< 10 {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                "/A/Sources/A1/main.swift",
+                "/A/Sources/A2/lib.swift",
+                "/A/Sources/A3/lib.swift",
+                "/B/Sources/B1/main.swift",
+                "/B/Sources/B2/lib.swift"
             )
 
             let observability = ObservabilitySystem.makeForTesting()
@@ -59,7 +60,8 @@ class PIFBuilderTests: XCTestCase {
                         targets: [
                             .init(name: "B2", dependencies: []),
                             .init(name: "B1", dependencies: ["B2"]),
-                        ]),
+                        ]
+                    ),
                     Manifest.createRootManifest(
                         displayName: "A",
                         path: "/A",
@@ -75,7 +77,8 @@ class PIFBuilderTests: XCTestCase {
                             .init(name: "A1", dependencies: ["A3", "A2", .product(name: "blib", package: "B")]),
                             .init(name: "A2", dependencies: []),
                             .init(name: "A3", dependencies: []),
-                        ]),
+                        ]
+                    ),
                 ],
                 observabilityScope: observability.topScope
             )
@@ -90,18 +93,27 @@ class PIFBuilderTests: XCTestCase {
 
             XCTAssertNoDiagnostics(observability.diagnostics)
 
-            let projectNames = pif.workspace.projects.map({ $0.name })
+            let projectNames = pif.workspace.projects.map(\.name)
             XCTAssertEqual(projectNames, ["A", "B", "Aggregate"])
-            let projectATargetNames = pif.workspace.projects[0].targets.map({ $0.name })
-            XCTAssertEqual(projectATargetNames, ["aexe_79CC9E117_PackageProduct", "alib_79D40CF5C_PackageProduct", "A2", "A3"])
+            let projectATargetNames = pif.workspace.projects[0].targets.map(\.name)
+            XCTAssertEqual(
+                projectATargetNames,
+                ["aexe_79CC9E117_PackageProduct", "alib_79D40CF5C_PackageProduct", "A2", "A3"]
+            )
             let targetAExeDependencies = pif.workspace.projects[0].targets[0].dependencies
-            XCTAssertEqual(targetAExeDependencies.map{ $0.targetGUID }, ["PACKAGE-PRODUCT:blib", "PACKAGE-TARGET:A2", "PACKAGE-TARGET:A3"])
-            let projectBTargetNames = pif.workspace.projects[1].targets.map({ $0.name })
-#if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
+            XCTAssertEqual(
+                targetAExeDependencies.map(\.targetGUID),
+                ["PACKAGE-PRODUCT:blib", "PACKAGE-TARGET:A2", "PACKAGE-TARGET:A3"]
+            )
+            let projectBTargetNames = pif.workspace.projects[1].targets.map(\.name)
+            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             XCTAssertEqual(projectBTargetNames, ["blib_7AE74026D_PackageProduct", "B2"])
-#else
-            XCTAssertEqual(projectBTargetNames, ["bexe_7ADFD1428_PackageProduct", "blib_7AE74026D_PackageProduct", "B2"])
-#endif
+            #else
+            XCTAssertEqual(
+                projectBTargetNames,
+                ["bexe_7ADFD1428_PackageProduct", "blib_7AE74026D_PackageProduct", "B2"]
+            )
+            #endif
         }
     }
 
@@ -109,10 +121,11 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Tests/FooTests/tests.swift",
-                                    "/Bar/Sources/BarLib/lib.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Tests/FooTests/tests.swift",
+            "/Bar/Sources/BarLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -131,7 +144,8 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "foo", dependencies: [.product(name: "BarLib", package: "Bar")]),
                         .init(name: "FooTests", type: .test),
-                    ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -148,7 +162,8 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "BarLib"),
                         .init(name: "BarTests", type: .test),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -191,7 +206,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.ENABLE_TESTING_SEARCH_PATHS], "YES")
                         XCTAssertEqual(settings[.ENTITLEMENTS_REQUIRED], "NO")
                         XCTAssertEqual(settings[.GCC_OPTIMIZATION_LEVEL], "0")
-                        XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "SWIFT_PACKAGE", "DEBUG=1"])
+                        XCTAssertEqual(
+                            settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE", "DEBUG=1"]
+                        )
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], "12.0")
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET, for: .macCatalyst], "13.0")
                         XCTAssertEqual(settings[.KEEP_PRIVATE_EXTERNS], "NO")
@@ -203,7 +221,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SDKROOT], "auto")
                         XCTAssertEqual(settings[.SKIP_INSTALL], "YES")
                         XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["$(AVAILABLE_PLATFORMS)"])
-                        XCTAssertEqual(settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS], ["$(inherited)", "SWIFT_PACKAGE", "DEBUG"])
+                        XCTAssertEqual(
+                            settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE", "DEBUG"]
+                        )
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Onone")
@@ -249,7 +270,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SDKROOT], "auto")
                         XCTAssertEqual(settings[.SKIP_INSTALL], "YES")
                         XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["$(AVAILABLE_PLATFORMS)"])
-                        XCTAssertEqual(settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS], ["$(inherited)", "SWIFT_PACKAGE"])
+                        XCTAssertEqual(
+                            settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE"]
+                        )
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Owholemodule")
@@ -295,7 +319,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.ENABLE_TESTING_SEARCH_PATHS], "YES")
                         XCTAssertEqual(settings[.ENTITLEMENTS_REQUIRED], "NO")
                         XCTAssertEqual(settings[.GCC_OPTIMIZATION_LEVEL], "0")
-                        XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "SWIFT_PACKAGE", "DEBUG=1"])
+                        XCTAssertEqual(
+                            settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE", "DEBUG=1"]
+                        )
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], "12.0")
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET, for: .macCatalyst], "13.0")
                         XCTAssertEqual(settings[.KEEP_PRIVATE_EXTERNS], "NO")
@@ -307,7 +334,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SDKROOT], "auto")
                         XCTAssertEqual(settings[.SKIP_INSTALL], "YES")
                         XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["$(AVAILABLE_PLATFORMS)"])
-                        XCTAssertEqual(settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS], ["$(inherited)", "SWIFT_PACKAGE", "DEBUG"])
+                        XCTAssertEqual(
+                            settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE", "DEBUG"]
+                        )
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Onone")
@@ -353,7 +383,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SDKROOT], "auto")
                         XCTAssertEqual(settings[.SKIP_INSTALL], "YES")
                         XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["$(AVAILABLE_PLATFORMS)"])
-                        XCTAssertEqual(settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS], ["$(inherited)", "SWIFT_PACKAGE"])
+                        XCTAssertEqual(
+                            settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE"]
+                        )
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Owholemodule")
@@ -392,14 +425,15 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/cfoo/main.c",
-                                    "/Foo/Sources/FooLib/lib.swift",
-                                    "/Foo/Sources/SystemLib/module.modulemap",
-                                    "/Bar/Sources/bar/main.swift",
-                                    "/Bar/Sources/cbar/main.c",
-                                    "/Bar/Sources/BarLib/lib.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/cfoo/main.c",
+            "/Foo/Sources/FooLib/lib.swift",
+            "/Foo/Sources/SystemLib/module.modulemap",
+            "/Bar/Sources/bar/main.swift",
+            "/Bar/Sources/cbar/main.c",
+            "/Bar/Sources/BarLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -420,14 +454,15 @@ class PIFBuilderTests: XCTestCase {
                             "SystemLib",
                             "cfoo",
                             .product(name: "bar", package: "Bar"),
-                            .product(name: "cbar", package: "Bar")
+                            .product(name: "cbar", package: "Bar"),
                         ]),
                         .init(name: "cfoo"),
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
                         .init(name: "FooLib", dependencies: [
                             .product(name: "BarLib", package: "Bar"),
-                        ])
-                    ]),
+                        ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -444,13 +479,14 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "bar", dependencies: ["BarLib"]),
                         .init(name: "cbar"),
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -477,7 +513,7 @@ class PIFBuilderTests: XCTestCase {
                         "PACKAGE-PRODUCT:BarLib",
                         "PACKAGE-PRODUCT:cbar",
                         "PACKAGE-TARGET:FooLib",
-                        "PACKAGE-TARGET:SystemLib"
+                        "PACKAGE-TARGET:SystemLib",
                     ])
                     XCTAssertEqual(target.sources, ["/Foo/Sources/foo/main.swift"])
                     XCTAssertEqual(target.frameworks, [
@@ -495,7 +531,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "foo")
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
-                            XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], ["$(inherited)", "@executable_path/../lib"])
+                            XCTAssertEqual(
+                                settings[.LD_RUNPATH_SEARCH_PATHS],
+                                ["$(inherited)", "@executable_path/../lib"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "foo")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "foo")
@@ -505,7 +544,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["macosx", "linux"])
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "foo")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -517,7 +559,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "foo")
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
-                            XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], ["$(inherited)", "@executable_path/../lib"])
+                            XCTAssertEqual(
+                                settings[.LD_RUNPATH_SEARCH_PATHS],
+                                ["$(inherited)", "@executable_path/../lib"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "foo")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "foo")
@@ -527,7 +572,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["macosx", "linux"])
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "foo")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -551,9 +599,15 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "cfoo")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/cfoo/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Foo/Sources/cfoo/include"]
+                            )
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
-                            XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], ["$(inherited)", "@executable_path/../lib"])
+                            XCTAssertEqual(
+                                settings[.LD_RUNPATH_SEARCH_PATHS],
+                                ["$(inherited)", "@executable_path/../lib"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "cfoo")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "cfoo")
@@ -562,7 +616,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SKIP_INSTALL], "NO")
                             XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["macosx", "linux"])
                             XCTAssertEqual(settings[.TARGET_NAME], "cfoo")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -573,9 +630,15 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "cfoo")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/cfoo/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Foo/Sources/cfoo/include"]
+                            )
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
-                            XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], ["$(inherited)", "@executable_path/../lib"])
+                            XCTAssertEqual(
+                                settings[.LD_RUNPATH_SEARCH_PATHS],
+                                ["$(inherited)", "@executable_path/../lib"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "cfoo")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "cfoo")
@@ -584,7 +647,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SKIP_INSTALL], "NO")
                             XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["macosx", "linux"])
                             XCTAssertEqual(settings[.TARGET_NAME], "cfoo")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -619,7 +685,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["macosx", "linux"])
                             XCTAssertEqual(settings[.SWIFT_VERSION], "4.2")
                             XCTAssertEqual(settings[.TARGET_NAME], "bar")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -638,7 +707,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["macosx", "linux"])
                             XCTAssertEqual(settings[.SWIFT_VERSION], "4.2")
                             XCTAssertEqual(settings[.TARGET_NAME], "bar")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -664,7 +736,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "cbar")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/cbar/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Bar/Sources/cbar/include"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "cbar")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "cbar")
@@ -672,7 +747,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SDKROOT], "macosx")
                             XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["macosx", "linux"])
                             XCTAssertEqual(settings[.TARGET_NAME], "cbar")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -685,7 +763,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "cbar")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/cbar/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Bar/Sources/cbar/include"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "cbar")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "cbar")
@@ -693,7 +774,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SDKROOT], "macosx")
                             XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["macosx", "linux"])
                             XCTAssertEqual(settings[.TARGET_NAME], "cbar")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -705,19 +789,20 @@ class PIFBuilderTests: XCTestCase {
 
     func testTestProducts() throws {
         #if !os(macOS)
-                try XCTSkipIf(true, "test is only supported on macOS")
+        try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/FooTests/FooTests.swift",
-                                    "/Foo/Sources/CFooTests/CFooTests.m",
-                                    "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/FooLib/lib.swift",
-                                    "/Foo/Sources/SystemLib/module.modulemap",
-                                    "/Bar/Sources/bar/main.swift",
-                                    "/Bar/Sources/BarTests/BarTests.swift",
-                                    "/Bar/Sources/CBarTests/CBarTests.m",
-                                    "/Bar/Sources/BarLib/lib.swift",
-                                    inputsDir.appending("Foo.pc").pathString
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/FooTests/FooTests.swift",
+            "/Foo/Sources/CFooTests/CFooTests.m",
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/FooLib/lib.swift",
+            "/Foo/Sources/SystemLib/module.modulemap",
+            "/Bar/Sources/bar/main.swift",
+            "/Bar/Sources/BarTests/BarTests.swift",
+            "/Bar/Sources/CBarTests/CBarTests.m",
+            "/Bar/Sources/BarLib/lib.swift",
+            inputsDir.appending("Foo.pc").pathString
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -744,8 +829,9 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
                         .init(name: "FooLib", dependencies: [
                             .product(name: "BarLib", package: "Bar"),
-                        ])
-                    ]),
+                        ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -762,14 +848,15 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "BarTests", dependencies: ["BarLib"], type: .test),
                         .init(name: "CBarTests", type: .test),
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -792,7 +879,7 @@ class PIFBuilderTests: XCTestCase {
                         "PACKAGE-PRODUCT:bar",
                         "PACKAGE-PRODUCT:BarLib",
                         "PACKAGE-TARGET:FooLib",
-                        "PACKAGE-TARGET:SystemLib"
+                        "PACKAGE-TARGET:SystemLib",
                     ])
                     XCTAssertEqual(target.sources, ["/Foo/Sources/FooTests/FooTests.swift"])
                     XCTAssertEqual(target.frameworks, [
@@ -812,11 +899,11 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
                                 "@loader_path/Frameworks",
-                                "@loader_path/../Frameworks"
+                                "@loader_path/../Frameworks",
                             ])
                             XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/toolchain/lib/swift/macosx"
+                                "/toolchain/lib/swift/macosx",
                             ])
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooTests")
@@ -824,11 +911,28 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.PRODUCT_NAME], "FooTests")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "FooTests")
-                            XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS).versionString)
-                            XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
-                            XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
-                            XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
-                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
+                            XCTAssertEqual(
+                                settings[.WATCHOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS)
+                                    .versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.IPHONEOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.TVOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.MACOSX_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.XROS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS)
+                                    .versionString
+                            )
                         }
                     }
 
@@ -843,11 +947,11 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
                                 "@loader_path/Frameworks",
-                                "@loader_path/../Frameworks"
+                                "@loader_path/../Frameworks",
                             ])
                             XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/toolchain/lib/swift/macosx"
+                                "/toolchain/lib/swift/macosx",
                             ])
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooTests")
@@ -855,11 +959,28 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.PRODUCT_NAME], "FooTests")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "FooTests")
-                            XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS).versionString)
-                            XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
-                            XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
-                            XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
-                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
+                            XCTAssertEqual(
+                                settings[.WATCHOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS)
+                                    .versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.IPHONEOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.TVOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.MACOSX_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.XROS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS)
+                                    .versionString
+                            )
                         }
                     }
 
@@ -884,27 +1005,44 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/Foo/Sources/CFooTests/include"
+                                "/Foo/Sources/CFooTests/include",
                             ])
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
                                 "@loader_path/Frameworks",
-                                "@loader_path/../Frameworks"
+                                "@loader_path/../Frameworks",
                             ])
                             XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/toolchain/lib/swift/macosx"
+                                "/toolchain/lib/swift/macosx",
                             ])
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "CFooTests")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "CFooTests")
                             XCTAssertEqual(settings[.PRODUCT_NAME], "CFooTests")
                             XCTAssertEqual(settings[.TARGET_NAME], "CFooTests")
-                            XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS).versionString)
-                            XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
-                            XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
-                            XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
-                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
+                            XCTAssertEqual(
+                                settings[.WATCHOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS)
+                                    .versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.IPHONEOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.TVOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.MACOSX_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.XROS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS)
+                                    .versionString
+                            )
                         }
                     }
 
@@ -918,27 +1056,44 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/Foo/Sources/CFooTests/include"
+                                "/Foo/Sources/CFooTests/include",
                             ])
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
                                 "@loader_path/Frameworks",
-                                "@loader_path/../Frameworks"
+                                "@loader_path/../Frameworks",
                             ])
                             XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/toolchain/lib/swift/macosx"
+                                "/toolchain/lib/swift/macosx",
                             ])
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "CFooTests")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "CFooTests")
                             XCTAssertEqual(settings[.PRODUCT_NAME], "CFooTests")
                             XCTAssertEqual(settings[.TARGET_NAME], "CFooTests")
-                            XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS).versionString)
-                            XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
-                            XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
-                            XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
-                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
+                            XCTAssertEqual(
+                                settings[.WATCHOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS)
+                                    .versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.IPHONEOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.TVOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.MACOSX_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.XROS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS)
+                                    .versionString
+                            )
                         }
                     }
 
@@ -957,11 +1112,12 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/FooLib1/lib.swift",
-                                    "/Foo/Sources/FooLib2/lib.swift",
-                                    "/Foo/Sources/SystemLib/module.modulemap",
-                                    "/Bar/Sources/BarLib/lib.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/FooLib1/lib.swift",
+            "/Foo/Sources/FooLib2/lib.swift",
+            "/Foo/Sources/SystemLib/module.modulemap",
+            "/Bar/Sources/BarLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -986,7 +1142,8 @@ class PIFBuilderTests: XCTestCase {
                             .product(name: "BarLib", package: "Bar"),
                         ]),
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
-                    ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -999,13 +1156,14 @@ class PIFBuilderTests: XCTestCase {
                     ],
                     targets: [
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1051,7 +1209,7 @@ class PIFBuilderTests: XCTestCase {
                         }
                     }
 
-                    target.checkAllImpartedBuildSettings { settings in
+                    target.checkAllImpartedBuildSettings { _ in
                         // No imparted build settings.
                     }
                 }
@@ -1121,7 +1279,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SKIP_INSTALL], "NO")
                             XCTAssertEqual(settings[.TARGET_BUILD_DIR], "$(TARGET_BUILD_DIR)/PackageFrameworks")
                             XCTAssertEqual(settings[.TARGET_NAME], "BarLib")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -1145,7 +1306,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.TARGET_BUILD_DIR], "$(TARGET_BUILD_DIR)/PackageFrameworks")
                             XCTAssertEqual(settings[.TARGET_NAME], "BarLib")
                             XCTAssertEqual(settings[.USES_SWIFTPM_UNSAFE_FLAGS], "NO")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -1159,11 +1323,12 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/FooLib1/lib.swift",
-                                    "/Foo/Sources/FooLib2/lib.cpp",
-                                    "/Foo/Sources/SystemLib/module.modulemap",
-                                    "/Bar/Sources/BarLib/lib.c"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/FooLib1/lib.swift",
+            "/Foo/Sources/FooLib2/lib.cpp",
+            "/Foo/Sources/SystemLib/module.modulemap",
+            "/Bar/Sources/BarLib/lib.c"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1185,7 +1350,8 @@ class PIFBuilderTests: XCTestCase {
                             .product(name: "BarLib", package: "Bar"),
                         ]),
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
-                    ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -1197,13 +1363,14 @@ class PIFBuilderTests: XCTestCase {
                     ],
                     targets: [
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1240,17 +1407,23 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module FooLib1 {
-                                    header "FooLib1-Swift.h"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap")
+                            module FooLib1 {
+                                header "FooLib1-Swift.h"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooLib1")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "FooLib1")
                             XCTAssertEqual(settings[.PRODUCT_NAME], "FooLib1.o")
-                            XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)")
+                            XCTAssertEqual(
+                                settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)"
+                            )
                             XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "FooLib1-Swift.h")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "FooLib1")
@@ -1268,17 +1441,23 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module FooLib1 {
-                                    header "FooLib1-Swift.h"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap")
+                            module FooLib1 {
+                                header "FooLib1-Swift.h"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooLib1")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "FooLib1")
                             XCTAssertEqual(settings[.PRODUCT_NAME], "FooLib1.o")
-                            XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)")
+                            XCTAssertEqual(
+                                settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)"
+                            )
                             XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "FooLib1-Swift.h")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "FooLib1")
@@ -1288,7 +1467,7 @@ class PIFBuilderTests: XCTestCase {
                     target.checkAllImpartedBuildSettings { settings in
                         XCTAssertEqual(settings[.OTHER_CFLAGS], [
                             "$(inherited)",
-                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap"
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-Wl,-no_warn_duplicate_libraries"])
@@ -1313,15 +1492,21 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "FooLib2.o")
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/FooLib2/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Foo/Sources/FooLib2/include"]
+                            )
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module FooLib2 {
-                                    umbrella "/Foo/Sources/FooLib2/include"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap")
+                            module FooLib2 {
+                                umbrella "/Foo/Sources/FooLib2/include"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooLib2")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "FooLib2")
@@ -1340,15 +1525,21 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "FooLib2.o")
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/FooLib2/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Foo/Sources/FooLib2/include"]
+                            )
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module FooLib2 {
-                                    umbrella "/Foo/Sources/FooLib2/include"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap")
+                            module FooLib2 {
+                                umbrella "/Foo/Sources/FooLib2/include"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooLib2")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "FooLib2")
@@ -1361,13 +1552,17 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/FooLib2/include"])
                         XCTAssertEqual(settings[.OTHER_CFLAGS], [
                             "$(inherited)",
-                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap"
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
-                        XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-lc++", "-Wl,-no_warn_duplicate_libraries"])
+                        XCTAssertEqual(
+                            settings[.OTHER_LDFLAGS],
+                            ["$(inherited)", "-lc++", "-Wl,-no_warn_duplicate_libraries"]
+                        )
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], [
                             "$(inherited)",
-                            "-Xcc", "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap"
+                            "-Xcc",
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap",
                         ])
                     }
                 }
@@ -1392,15 +1587,21 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "BarLib.o")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/BarLib/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Bar/Sources/BarLib/include"]
+                            )
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module BarLib {
-                                    umbrella "/Bar/Sources/BarLib/include"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap")
+                            module BarLib {
+                                umbrella "/Bar/Sources/BarLib/include"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "BarLib")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "BarLib")
@@ -1419,15 +1620,21 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "BarLib.o")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/BarLib/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Bar/Sources/BarLib/include"]
+                            )
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module BarLib {
-                                    umbrella "/Bar/Sources/BarLib/include"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap")
+                            module BarLib {
+                                umbrella "/Bar/Sources/BarLib/include"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "BarLib")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "BarLib")
@@ -1440,13 +1647,14 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/BarLib/include"])
                         XCTAssertEqual(settings[.OTHER_CFLAGS], [
                             "$(inherited)",
-                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap"
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-Wl,-no_warn_duplicate_libraries"])
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], [
                             "$(inherited)",
-                            "-Xcc", "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap"
+                            "-Xcc",
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap",
                         ])
                     }
                 }
@@ -1458,12 +1666,13 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/App/Sources/App/main.swift",
-                                        "/App/Sources/Logging/lib.swift",
-                                    "/App/Sources/Utils/lib.swift",
-                                    "/Bar/Sources/Lib/lib.swift",
-                                    "/Bar/Sources/Logging/lib.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/App/Sources/App/main.swift",
+            "/App/Sources/Logging/lib.swift",
+            "/App/Sources/Utils/lib.swift",
+            "/Bar/Sources/Lib/lib.swift",
+            "/Bar/Sources/Logging/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1482,7 +1691,8 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "Utils", dependencies: [
                             .product(name: "BarLib", package: "Bar", moduleAliases: ["Logging": "BarLogging"]),
                         ]),
-                    ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -1492,13 +1702,14 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "Lib", dependencies: ["Logging"]),
                         .init(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1567,7 +1778,6 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertNil(settings[.SWIFT_MODULE_ALIASES])
                         }
                     }
-
                 }
                 project.checkTarget("PACKAGE-TARGET:Logging") { target in
                     XCTAssertEqual(target.name, "Logging")
@@ -1685,8 +1895,9 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Bar/Sources/BarLib/lib.c"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Bar/Sources/BarLib/lib.c"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1704,13 +1915,14 @@ class PIFBuilderTests: XCTestCase {
                     ],
                     targets: [
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(shouldCreateDylibForDynamicProducts: true),
@@ -1737,9 +1949,10 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Bar/Sources/BarLib/lib.c",
-                                    "/Bar/Sources/BarLib/module.modulemap"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Bar/Sources/BarLib/lib.c",
+            "/Bar/Sources/BarLib/module.modulemap"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1758,13 +1971,14 @@ class PIFBuilderTests: XCTestCase {
                     ],
                     targets: [
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(shouldCreateDylibForDynamicProducts: true),
@@ -1795,9 +2009,10 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/SystemLib1/module.modulemap",
-                                    "/Foo/Sources/SystemLib2/module.modulemap"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/SystemLib1/module.modulemap",
+            "/Foo/Sources/SystemLib2/module.modulemap"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1813,13 +2028,14 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "SystemLib1", type: .system),
                         .init(name: "SystemLib2", type: .system, pkgConfig: "Foo"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1854,12 +2070,12 @@ class PIFBuilderTests: XCTestCase {
                     target.checkAllImpartedBuildSettings { settings in
                         XCTAssertEqual(settings[.OTHER_CFLAGS], [
                             "$(inherited)",
-                            "-fmodule-map-file=/Foo/Sources/SystemLib1/module.modulemap"
+                            "-fmodule-map-file=/Foo/Sources/SystemLib1/module.modulemap",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], [
                             "$(inherited)",
-                            "-Xcc", "-fmodule-map-file=/Foo/Sources/SystemLib1/module.modulemap"
+                            "-Xcc", "-fmodule-map-file=/Foo/Sources/SystemLib1/module.modulemap",
                         ])
                     }
                 }
@@ -1887,20 +2103,20 @@ class PIFBuilderTests: XCTestCase {
                             "$(inherited)",
                             "-fmodule-map-file=/Foo/Sources/SystemLib2/module.modulemap",
                             "-I/path/to/inc",
-                            "-I\(self.inputsDir)"
+                            "-I\(self.inputsDir)",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDFLAGS], [
                             "$(inherited)",
                             "-L/usr/da/lib",
                             "-lSystemModule",
-                            "-lok"
+                            "-lok",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], [
                             "$(inherited)",
                             "-Xcc", "-fmodule-map-file=/Foo/Sources/SystemLib2/module.modulemap",
                             "-I/path/to/inc",
-                            "-I\(self.inputsDir)"
+                            "-I\(self.inputsDir)",
                         ])
                     }
                 }
@@ -1912,7 +2128,8 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
+        let fs = InMemoryFileSystem(
+            emptyFiles:
             "/Foo/Sources/foo/main.swift",
             "/Foo/Sources/FooLib/lib.swift",
             "/Foo/Sources/FooTests/FooTests.swift",
@@ -1934,13 +2151,14 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "foo", dependencies: ["BinaryLibrary"]),
                         .init(name: "FooLib", dependencies: ["BinaryLibrary"]),
                         .init(name: "FooTests", dependencies: ["BinaryLibrary"], type: .test),
-                        .init(name: "BinaryLibrary", path: "BinaryLibrary.xcframework", type: .binary)
-                    ]),
+                        .init(name: "BinaryLibrary", path: "BinaryLibrary.xcframework", type: .binary),
+                    ]
+                ),
             ],
             binaryArtifacts: [
                 .plain("foo"): [
-                    "BinaryLibrary": .init(kind: .xcframework, originURL: nil, path: "/Foo/BinaryLibrary.xcframework")
-                ]
+                    "BinaryLibrary": .init(kind: .xcframework, originURL: nil, path: "/Foo/BinaryLibrary.xcframework"),
+                ],
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -1981,16 +2199,17 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/foo/Resources/Data.plist",
-                                    "/Foo/Sources/foo/Resources/Database.xcdatamodel",
-                                    "/Foo/Sources/FooLib/lib.swift",
-                                    "/Foo/Sources/FooLib/Resources/Data.plist",
-                                    "/Foo/Sources/FooLib/Resources/Database.xcdatamodel",
-                                    "/Foo/Sources/FooTests/FooTests.swift",
-                                    "/Foo/Sources/FooTests/Resources/Data.plist",
-                                    "/Foo/Sources/FooTests/Resources/Database.xcdatamodel"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/foo/Resources/Data.plist",
+            "/Foo/Sources/foo/Resources/Database.xcdatamodel",
+            "/Foo/Sources/FooLib/lib.swift",
+            "/Foo/Sources/FooLib/Resources/Data.plist",
+            "/Foo/Sources/FooLib/Resources/Database.xcdatamodel",
+            "/Foo/Sources/FooTests/FooTests.swift",
+            "/Foo/Sources/FooTests/Resources/Data.plist",
+            "/Foo/Sources/FooTests/Resources/Database.xcdatamodel"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2007,15 +2226,16 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "foo", resources: [
                             // This is intentionally specific to test that we pick up `.xcdatamodel` implicitly.
-                            .init(rule: .process(localization: .none), path: "Resources/Data.plist")
+                            .init(rule: .process(localization: .none), path: "Resources/Data.plist"),
                         ]),
                         .init(name: "FooLib", resources: [
-                            .init(rule: .process(localization: .none), path: "Resources")
+                            .init(rule: .process(localization: .none), path: "Resources"),
                         ]),
                         .init(name: "FooTests", resources: [
-                            .init(rule: .process(localization: .none), path: "Resources")
+                            .init(rule: .process(localization: .none), path: "Resources"),
                         ], type: .test),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             useXCBuildFileRules: true,
@@ -2203,10 +2423,11 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/FooLib/lib.swift",
-                                    "/Foo/Sources/FooTests/FooTests.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/FooLib/lib.swift",
+            "/Foo/Sources/FooTests/FooTests.swift"
         )
 
         let toolsVersion: ToolsVersion = if isPackageAccessModifierSupported { .v5_9 } else { .v5 }
@@ -2229,54 +2450,66 @@ class PIFBuilderTests: XCTestCase {
                             settings: [
                                 .init(
                                     tool: .c,
-                                    kind: .define("ENABLE_BEST_MODE")),
+                                    kind: .define("ENABLE_BEST_MODE")
+                                ),
                                 .init(
                                     tool: .cxx,
                                     kind: .headerSearchPath("some/path"),
-                                    condition: .init(platformNames: ["macos"])),
+                                    condition: .init(platformNames: ["macos"])
+                                ),
                                 .init(
                                     tool: .linker,
                                     kind: .linkedLibrary("z"),
-                                    condition: .init(config: "debug")),
+                                    condition: .init(config: "debug")
+                                ),
                                 .init(
                                     tool: .swift,
                                     kind: .unsafeFlags(["-secret", "value"]),
-                                    condition: .init(platformNames: ["macos", "linux"], config: "release")),
+                                    condition: .init(platformNames: ["macos", "linux"], config: "release")
+                                ),
                             ]
                         ),
                         .init(name: "FooLib", settings: [
                             .init(
                                 tool: .c,
-                                kind: .define("ENABLE_BEST_MODE")),
+                                kind: .define("ENABLE_BEST_MODE")
+                            ),
                             .init(
                                 tool: .cxx,
                                 kind: .headerSearchPath("some/path"),
-                                condition: .init(platformNames: ["macos"])),
+                                condition: .init(platformNames: ["macos"])
+                            ),
                             .init(
                                 tool: .linker,
                                 kind: .linkedLibrary("z"),
-                                condition: .init(config: "debug")),
+                                condition: .init(config: "debug")
+                            ),
                             .init(
                                 tool: .swift,
                                 kind: .unsafeFlags(["-secret", "value"]),
-                                condition: .init(platformNames: ["macos", "linux"], config: "release")),
+                                condition: .init(platformNames: ["macos", "linux"], config: "release")
+                            ),
                         ]),
                         .init(name: "FooTests", type: .test, settings: [
                             .init(
                                 tool: .c,
-                                kind: .define("ENABLE_BEST_MODE")),
+                                kind: .define("ENABLE_BEST_MODE")
+                            ),
                             .init(
                                 tool: .cxx,
                                 kind: .headerSearchPath("some/path"),
-                                condition: .init(platformNames: ["macos"])),
+                                condition: .init(platformNames: ["macos"])
+                            ),
                             .init(
                                 tool: .linker,
                                 kind: .linkedLibrary("z"),
-                                condition: .init(config: "debug")),
+                                condition: .init(config: "debug")
+                            ),
                             .init(
                                 tool: .swift,
                                 kind: .unsafeFlags(["-secret", "value"]),
-                                condition: .init(platformNames: ["macos", "linux"], config: "release")),
+                                condition: .init(platformNames: ["macos", "linux"], config: "release")
+                            ),
                         ]),
                     ]
                 ),
@@ -2306,11 +2539,14 @@ class PIFBuilderTests: XCTestCase {
                 project.checkTarget("PACKAGE-PRODUCT:foo") { target in
                     target.checkBuildConfiguration("Debug") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/foo/some/path"
+                                "/Foo/Sources/foo/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-lz"])
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
@@ -2319,16 +2555,25 @@ class PIFBuilderTests: XCTestCase {
 
                     target.checkBuildConfiguration("Release") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/foo/some/path"
+                                "/Foo/Sources/foo/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], nil)
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .macOS], ["$(inherited)", "-secret", "value"])
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .linux], ["$(inherited)", "-secret", "value"])
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .macOS],
+                                ["$(inherited)", "-secret", "value"]
+                            )
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .linux],
+                                ["$(inherited)", "-secret", "value"]
+                            )
                         }
                     }
                 }
@@ -2358,11 +2603,14 @@ class PIFBuilderTests: XCTestCase {
                 project.checkTarget("PACKAGE-TARGET:FooLib") { target in
                     target.checkBuildConfiguration("Debug") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/FooLib/some/path"
+                                "/Foo/Sources/FooLib/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-lz"])
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
@@ -2371,23 +2619,35 @@ class PIFBuilderTests: XCTestCase {
 
                     target.checkBuildConfiguration("Release") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/FooLib/some/path"
+                                "/Foo/Sources/FooLib/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], nil)
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .macOS], ["$(inherited)", "-secret", "value"])
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .linux], ["$(inherited)", "-secret", "value"])
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .macOS],
+                                ["$(inherited)", "-secret", "value"]
+                            )
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .linux],
+                                ["$(inherited)", "-secret", "value"]
+                            )
                         }
                     }
 
                     target.checkImpartedBuildSettings { settings in
                         XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], nil)
                         XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
-                        XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-Wl,-no_warn_duplicate_libraries", "-lz"])
+                        XCTAssertEqual(
+                            settings[.OTHER_LDFLAGS],
+                            ["$(inherited)", "-Wl,-no_warn_duplicate_libraries", "-lz"]
+                        )
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], nil)
                     }
                 }
@@ -2395,11 +2655,14 @@ class PIFBuilderTests: XCTestCase {
                 project.checkTarget("PACKAGE-PRODUCT:FooTests") { target in
                     target.checkBuildConfiguration("Debug") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/FooTests/some/path"
+                                "/Foo/Sources/FooTests/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-lz"])
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
@@ -2408,16 +2671,25 @@ class PIFBuilderTests: XCTestCase {
 
                     target.checkBuildConfiguration("Release") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/FooTests/some/path"
+                                "/Foo/Sources/FooTests/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], nil)
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .macOS], ["$(inherited)", "-secret", "value"])
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .linux], ["$(inherited)", "-secret", "value"])
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .macOS],
+                                ["$(inherited)", "-secret", "value"]
+                            )
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .linux],
+                                ["$(inherited)", "-secret", "value"]
+                            )
                         }
                     }
                 }
@@ -2426,22 +2698,23 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testBuildSettings() throws {
-        try buildSettingsTestCase(isPackageAccessModifierSupported: false)
+        try self.buildSettingsTestCase(isPackageAccessModifierSupported: false)
     }
 
     func testBuildSettingsPackageAccess() throws {
-        try buildSettingsTestCase(isPackageAccessModifierSupported: true)
+        try self.buildSettingsTestCase(isPackageAccessModifierSupported: true)
     }
 
     func testConditionalDependencies() throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/FooLib1/lib.swift",
-                                    "/Foo/Sources/FooLib2/lib.swift",
-                                    "/Foo/Sources/FooTests/FooTests.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/FooLib1/lib.swift",
+            "/Foo/Sources/FooLib2/lib.swift",
+            "/Foo/Sources/FooTests/FooTests.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2460,7 +2733,8 @@ class PIFBuilderTests: XCTestCase {
                         ]),
                         .init(name: "FooLib1"),
                         .init(name: "FooLib2"),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -2487,18 +2761,28 @@ class PIFBuilderTests: XCTestCase {
                     XCTAssertEqual(target.dependencies, ["PACKAGE-TARGET:FooLib1", "PACKAGE-TARGET:FooLib2"])
                     XCTAssertEqual(target.frameworks, ["PACKAGE-TARGET:FooLib1", "PACKAGE-TARGET:FooLib2"])
 
-                    let dependencyMap = Dictionary(uniqueKeysWithValues: target.baseTarget.dependencies.map{ ($0.targetGUID, $0.platformFilters) })
+                    let dependencyMap = Dictionary(uniqueKeysWithValues: target.baseTarget.dependencies.map { (
+                        $0.targetGUID,
+                        $0.platformFilters
+                    ) })
                     XCTAssertEqual(dependencyMap, expectedFilters)
 
-                    let frameworksBuildFiles = target.baseTarget.buildPhases.first{ $0 is PIF.FrameworksBuildPhase }?.buildFiles ?? []
-                    let frameworksBuildFilesMap = Dictionary(uniqueKeysWithValues: frameworksBuildFiles.compactMap{ file -> (PIF.GUID, [PIF.PlatformFilter])? in
-                        switch file.reference {
-                        case .target(let guid):
-                            return (guid, file.platformFilters)
-                        case .file:
-                            return nil
-                        }
-                    })
+                    let frameworksBuildFiles = target.baseTarget.buildPhases.first { $0 is PIF.FrameworksBuildPhase }?
+                        .buildFiles ?? []
+                    let frameworksBuildFilesMap = Dictionary(
+                        uniqueKeysWithValues: frameworksBuildFiles
+                            .compactMap { file -> (
+                                PIF.GUID,
+                                [PIF.PlatformFilter]
+                            )? in
+                                switch file.reference {
+                                case .target(let guid):
+                                    return (guid, file.platformFilters)
+                                case .file:
+                                    return nil
+                                }
+                            }
+                    )
                     XCTAssertEqual(dependencyMap, frameworksBuildFilesMap)
                 }
             }
@@ -2509,8 +2793,9 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2526,7 +2811,8 @@ class PIFBuilderTests: XCTestCase {
                     toolsVersion: .v5_3,
                     targets: [
                         .init(name: "foo", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -2559,8 +2845,9 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/MyLib/Sources/MyLib/Foo.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/MyLib/Sources/MyLib/Foo.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2579,9 +2866,11 @@ class PIFBuilderTests: XCTestCase {
                             .init(
                                 tool: .swift,
                                 kind: .unsafeFlags(["-enable-library-evolution"]),
-                                condition: .init(config: "release")),
+                                condition: .init(config: "release")
+                            ),
                         ]),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -2609,9 +2898,60 @@ class PIFBuilderTests: XCTestCase {
                     }
                     target.checkBuildConfiguration("Release") { configuration in
                         configuration.checkBuildSettings { settings in
-                            // Check that the `-enable-library-evolution` setting for Release also set SWIFT_EMIT_MODULE_INTERFACE.
+                            // Check that the `-enable-library-evolution` setting for Release also set
+                            // SWIFT_EMIT_MODULE_INTERFACE.
                             XCTAssertEqual(settings[.SWIFT_EMIT_MODULE_INTERFACE], "YES")
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], ["$(inherited)", "-enable-library-evolution"])
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func testSupportedSwiftVersions() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Foo",
+                    path: "/Foo",
+                    toolsVersion: .v5_3,
+                    swiftLanguageVersions: [.v4_2, .v5],
+                    targets: [
+                        .init(name: "foo", dependencies: []),
+                    ]
+                ),
+            ],
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
+        )
+
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(supportedSwiftVersions: [.v4_2]),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let pif = try builder.construct()
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
+                project.checkTarget("PACKAGE-PRODUCT:foo") { target in
+                    target.checkBuildConfiguration("Debug") { configuration in
+                        configuration.checkBuildSettings { settings in
+                            XCTAssertEqual(settings[.SWIFT_VERSION], "4.2")
                         }
                     }
                 }
@@ -2623,7 +2963,8 @@ class PIFBuilderTests: XCTestCase {
 extension PIFBuilderParameters {
     static func mock(
         isPackageAccessModifierSupported: Bool = false,
-        shouldCreateDylibForDynamicProducts: Bool = false
+        shouldCreateDylibForDynamicProducts: Bool = false,
+        supportedSwiftVersions: [SwiftLanguageVersion] = []
     ) -> Self {
         PIFBuilderParameters(
             isPackageAccessModifierSupported: isPackageAccessModifierSupported,
@@ -2631,7 +2972,8 @@ extension PIFBuilderParameters {
             shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts,
             toolchainLibDir: "/toolchain/lib",
             pkgConfigDirectories: ["/pkg-config"],
-            sdkRootPath: "/some.sdk"
+            sdkRootPath: "/some.sdk",
+            supportedSwiftVersions: supportedSwiftVersions
         )
     }
 }


### PR DESCRIPTION
XCBuild has its own notion of supported Swift versions which can differ from the ones SwiftPM's own build system and the used compiler support. Using a version outside of the supported range prevents building, so we'll try to obtain the list of supported versions and intersect it with the versions supported by a given package to find the best version supported by both.