### PR TITLE
[SwiftSyntax] Add _SwiftSyntaxCShims target to the export list

### DIFF
--- a/Sources/PackageModelSyntax/CMakeLists.txt
+++ b/Sources/PackageModelSyntax/CMakeLists.txt
@@ -43,6 +43,7 @@ install(TARGETS PackageModelSyntax
 set_property(GLOBAL APPEND PROPERTY SwiftPM_EXPORTS PackageModelSyntax)
 
 set(SWIFT_SYNTAX_MODULES
+  _SwiftSyntaxCShims
   SwiftBasicFormat
   SwiftParser
   SwiftParserDiagnostics


### PR DESCRIPTION
SwiftSyntax module is going to depend on it (https://github.com/apple/swift-syntax/pull/2618)