### PR TITLE
[6.0] Handle Swift versions unsupported by XCBuild

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -16,8 +16,8 @@ import OrderedCollections
 import PackageModel
 
 import func TSCBasic.findCycle
-import func TSCBasic.topologicalSort
 import struct TSCBasic.KeyedPair
+import func TSCBasic.topologicalSort
 
 /// An error in the structure or layout of a package.
 public enum ModuleError: Swift.Error {
@@ -162,7 +162,9 @@ extension ModuleError: CustomStringConvertible {
                 targetsDescription += " and \(targets.count - 3) others"
             }
             return """
-            multiple similar targets \(targetsDescription) appear in registry package '\(registryPackage)' and source control package '\(scmPackage)', \
+            multiple similar targets \(targetsDescription) appear in registry package '\(
+                registryPackage
+            )' and source control package '\(scmPackage)', \
             this may indicate that the two packages are the same and can be de-duplicated \
             by activating the automatic source-control to registry replacement, or by using mirrors. \
             if they are not duplicate consider using the `moduleAliases` parameter in manifest to provide unique names
@@ -175,11 +177,11 @@ extension ModuleError.InvalidLayoutType: CustomStringConvertible {
     public var description: String {
         switch self {
         case .multipleSourceRoots(let paths):
-            return "multiple source roots found: " + paths.map(\.description).sorted().joined(separator: ", ")
+            "multiple source roots found: " + paths.map(\.description).sorted().joined(separator: ", ")
         case .modulemapInSources(let path):
-            return "modulemap '\(path)' should be inside the 'include' directory"
+            "modulemap '\(path)' should be inside the 'include' directory"
         case .modulemapMissing(let path):
-            return "missing system target module map at '\(path)'"
+            "missing system target module map at '\(path)'"
         }
     }
 }
@@ -203,9 +205,9 @@ extension Target.Error: CustomStringConvertible {
     var description: String {
         switch self {
         case .invalidName(let path, let problem):
-            return "invalid target name at '\(path)'; \(problem)"
+            "invalid target name at '\(path)'; \(problem)"
         case .mixedSources(let path):
-            return "target at '\(path)' contains mixed language source files; feature not supported"
+            "target at '\(path)' contains mixed language source files; feature not supported"
         }
     }
 }
@@ -214,7 +216,7 @@ extension Target.Error.ModuleNameProblem: CustomStringConvertible {
     var description: String {
         switch self {
         case .emptyName:
-            return "target names can not be empty"
+            "target names can not be empty"
         }
     }
 }
@@ -231,9 +233,9 @@ extension Product.Error: CustomStringConvertible {
     var description: String {
         switch self {
         case .emptyName:
-            return "product names can not be empty"
+            "product names can not be empty"
         case .moduleEmpty(let product, let target):
-            return "target '\(target)' referenced in product '\(product)' is empty"
+            "target '\(target)' referenced in product '\(product)' is empty"
         }
     }
 }
@@ -313,6 +315,10 @@ public final class PackageBuilder {
     // The set of the sources computed so far, used to validate source overlap
     private var allSources = Set<AbsolutePath>()
 
+    // Caches all declared versions for this package.
+    private var declaredSwiftVersionsCache: [SwiftLanguageVersion]? = nil
+
+    // Caches the version we chose to build for.
     private var swiftVersionCache: SwiftLanguageVersion? = nil
 
     /// Create a builder for the given manifest and package `path`.
@@ -497,15 +503,15 @@ public final class PackageBuilder {
         -> (targetDir: String, testTargetDir: String, pluginTargetDir: String)
     {
         let targetDir = PackageBuilder.predefinedSourceDirectories.first(where: {
-            fileSystem.isDirectory(packagePath.appending(component: $0))
+            self.fileSystem.isDirectory(self.packagePath.appending(component: $0))
         }) ?? PackageBuilder.predefinedSourceDirectories[0]
 
         let testTargetDir = PackageBuilder.predefinedTestDirectories.first(where: {
-            fileSystem.isDirectory(packagePath.appending(component: $0))
+            self.fileSystem.isDirectory(self.packagePath.appending(component: $0))
         }) ?? PackageBuilder.predefinedTestDirectories[0]
 
         let pluginTargetDir = PackageBuilder.predefinedPluginDirectories.first(where: {
-            fileSystem.isDirectory(packagePath.appending(component: $0))
+            self.fileSystem.isDirectory(self.packagePath.appending(component: $0))
         }) ?? PackageBuilder.predefinedPluginDirectories[0]
 
         return (targetDir, testTargetDir, pluginTargetDir)
@@ -558,14 +564,13 @@ public final class PackageBuilder {
             }
 
             // Check if target is present in the predefined directory.
-            let predefinedDir: PredefinedTargetDirectory
-            switch target.type {
+            let predefinedDir: PredefinedTargetDirectory = switch target.type {
             case .test:
-                predefinedDir = predefinedTestTargetDirectory
+                predefinedTestTargetDirectory
             case .plugin:
-                predefinedDir = predefinedPluginTargetDirectory
+                predefinedPluginTargetDirectory
             default:
-                predefinedDir = predefinedTargetDirectory
+                predefinedTargetDirectory
             }
             let path = predefinedDir.path.appending(component: target.name)
 
@@ -600,7 +605,12 @@ public final class PackageBuilder {
         let potentialTargets: [PotentialModule]
         potentialTargets = try self.manifest.targetsRequired(for: self.productFilter).map { target in
             let path = try findPath(for: target)
-            return PotentialModule(name: target.name, path: path, type: target.type, packageAccess: target.packageAccess)
+            return PotentialModule(
+                name: target.name,
+                path: path,
+                type: target.type,
+                packageAccess: target.packageAccess
+            )
         }
 
         let targets = try createModules(potentialTargets)
@@ -639,12 +649,13 @@ public final class PackageBuilder {
 
         let products = Dictionary(manifest.products.map { ($0.name, $0) }, uniquingKeysWith: { $1 })
 
-        // If there happens to be a plugin product with the right name in the same package, we want to use that automatically.
+        // If there happens to be a plugin product with the right name in the same package, we want to use that
+        // automatically.
         func pluginTargetName(for productName: String) -> String? {
             if let product = products[productName], product.type == .plugin {
-                return product.targets.first
+                product.targets.first
             } else {
-                return nil
+                nil
             }
         }
 
@@ -659,12 +670,12 @@ public final class PackageBuilder {
                     // Since we already checked above that all referenced targets
                     // has to present, we always expect this target to be present in
                     // potentialModules dictionary.
-                    return potentialModuleMap[name]!
+                    potentialModuleMap[name]!
                 case .product:
-                    return nil
+                    nil
                 case .byName(let name, _):
                     // By name dependency may or may not be a target dependency.
-                    return potentialModuleMap[name]
+                    potentialModuleMap[name]
                 }
             }
             // If there are plugin usages, consider them to be dependencies too.
@@ -672,16 +683,16 @@ public final class PackageBuilder {
                 successors += pluginUsages.compactMap {
                     switch $0 {
                     case .plugin(_, .some(_)):
-                        return nil
+                        nil
                     case .plugin(let name, nil):
                         if let potentialModule = potentialModuleMap[name] {
-                            return potentialModule
+                            potentialModule
                         } else if let targetName = pluginTargetName(for: name),
                                   let potentialModule = potentialModuleMap[targetName]
                         {
-                            return potentialModule
+                            potentialModule
                         } else {
-                            return nil
+                            nil
                         }
                     }
                 }
@@ -885,7 +896,7 @@ public final class PackageBuilder {
 
         // Compute the path to public headers directory.
         let publicHeaderComponent = manifestTarget.publicHeadersPath ?? ClangTarget.defaultPublicHeadersComponent
-        let publicHeadersPath = potentialModule.path.appending(try RelativePath(validating: publicHeaderComponent))
+        let publicHeadersPath = try potentialModule.path.appending(RelativePath(validating: publicHeaderComponent))
         guard publicHeadersPath.isDescendantOfOrEqual(to: potentialModule.path) else {
             throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
         }
@@ -960,7 +971,7 @@ public final class PackageBuilder {
 
         // Create and return the right kind of target depending on what kind of sources we found.
         if sources.hasSwiftSources {
-            return SwiftTarget(
+            return try SwiftTarget(
                 name: potentialModule.name,
                 potentialBundleName: potentialBundleName,
                 type: targetType,
@@ -971,15 +982,18 @@ public final class PackageBuilder {
                 others: others,
                 dependencies: dependencies,
                 packageAccess: potentialModule.packageAccess,
-                swiftVersion: try self.swiftVersion(),
+                swiftVersion: self.swiftVersion(),
+                declaredSwiftVersions: self.declaredSwiftVersions(),
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
                 usesUnsafeFlags: manifestTarget.usesUnsafeFlags
             )
         } else {
-            // It's not a Swift target, so it's a Clang target (those are the only two types of source target currently supported).
+            // It's not a Swift target, so it's a Clang target (those are the only two types of source target currently
+            // supported).
 
-            // First determine the type of module map that will be appropriate for the target based on its header layout.
+            // First determine the type of module map that will be appropriate for the target based on its header
+            // layout.
             let moduleMapType: ModuleMapType
 
             if self.fileSystem.exists(publicHeadersPath) {
@@ -1027,8 +1041,7 @@ public final class PackageBuilder {
         for target: TargetDescription?,
         targetRoot: AbsolutePath,
         cxxLanguageStandard: String? = nil
-    ) throws -> BuildSettings.AssignmentTable
-    {
+    ) throws -> BuildSettings.AssignmentTable {
         var table = BuildSettings.AssignmentTable()
         guard let target else { return table }
 
@@ -1098,7 +1111,8 @@ public final class PackageBuilder {
                 }
 
                 if lang == .Cxx {
-                    values = ["-cxx-interoperability-mode=default"] + (cxxLanguageStandard.flatMap { ["-Xcc", "-std=\($0)"] } ?? [])
+                    values = ["-cxx-interoperability-mode=default"] +
+                        (cxxLanguageStandard.flatMap { ["-Xcc", "-std=\($0)"] } ?? [])
                 } else {
                     values = []
                 }
@@ -1163,16 +1177,37 @@ public final class PackageBuilder {
 
         if let platforms = condition?.platformNames.map({
             if let platform = platformRegistry.platformByName[$0] {
-                return platform
+                platform
             } else {
-                return PackageModel.Platform.custom(name: $0, oldestSupportedVersion: .unknown)
+                PackageModel.Platform.custom(name: $0, oldestSupportedVersion: .unknown)
             }
-        }), !platforms.isEmpty
-        {
+        }), !platforms.isEmpty {
             conditions.append(.init(platforms: platforms))
         }
 
         return conditions
+    }
+
+    private func declaredSwiftVersions() throws -> [SwiftLanguageVersion] {
+        if let versions = self.declaredSwiftVersionsCache {
+            return versions
+        }
+
+        let versions: [SwiftLanguageVersion]
+        if let swiftLanguageVersions = manifest.swiftLanguageVersions {
+            versions = swiftLanguageVersions.sorted(by: >).filter { $0 <= ToolsVersion.current }
+
+            if versions.isEmpty {
+                throw ModuleError.incompatibleToolsVersions(
+                    package: self.identity.description, required: swiftLanguageVersions, current: .current
+                )
+            }
+        } else {
+            versions = []
+        }
+
+        self.declaredSwiftVersionsCache = versions
+        return versions
     }
 
     /// Computes the swift version to use for this manifest.
@@ -1181,20 +1216,13 @@ public final class PackageBuilder {
             return swiftVersion
         }
 
-        let computedSwiftVersion: SwiftLanguageVersion
-
         // Figure out the swift version from declared list in the manifest.
-        if let swiftLanguageVersions = manifest.swiftLanguageVersions {
-            guard let swiftVersion = swiftLanguageVersions.sorted(by: >).first(where: { $0 <= ToolsVersion.current })
-            else {
-                throw ModuleError.incompatibleToolsVersions(
-                    package: self.identity.description, required: swiftLanguageVersions, current: .current
-                )
-            }
-            computedSwiftVersion = swiftVersion
+        let declaredSwiftVersions = try declaredSwiftVersions()
+        let computedSwiftVersion: SwiftLanguageVersion = if let declaredSwiftVersion = declaredSwiftVersions.first {
+            declaredSwiftVersion
         } else {
             // Otherwise, use the version depending on the manifest version.
-            computedSwiftVersion = self.manifest.toolsVersion.swiftLanguageVersion
+            self.manifest.toolsVersion.swiftLanguageVersion
         }
         self.swiftVersionCache = computedSwiftVersion
         return computedSwiftVersion
@@ -1242,9 +1270,9 @@ public final class PackageBuilder {
                 }
                 // If we have already searched this path, skip.
                 if !pathsSearched.contains(searchPath) {
-                    SwiftTarget.testEntryPointNames.forEach { name in
+                    for name in SwiftTarget.testEntryPointNames {
                         let path = searchPath.appending(component: name)
-                        if fileSystem.isFile(path) {
+                        if self.fileSystem.isFile(path) {
                             testEntryPointFiles.insert(path)
                         }
                     }
@@ -1340,12 +1368,11 @@ public final class PackageBuilder {
 
         // First add explicit products.
 
-        let filteredProducts: [ProductDescription]
-        switch self.productFilter {
+        let filteredProducts: [ProductDescription] = switch self.productFilter {
         case .everything:
-            filteredProducts = self.manifest.products
+            self.manifest.products
         case .specific(let set):
-            filteredProducts = self.manifest.products.filter { set.contains($0.name) }
+            self.manifest.products.filter { set.contains($0.name) }
         }
         for product in filteredProducts {
             if product.name.isEmpty {
@@ -1543,11 +1570,11 @@ public final class PackageBuilder {
         // These are static constants, safe to access by index; the first choice is preferred.
         switch type {
         case .test:
-            return self.predefinedTestDirectories[0]
+            self.predefinedTestDirectories[0]
         case .plugin:
-            return self.predefinedPluginDirectories[0]
+            self.predefinedPluginDirectories[0]
         default:
-            return self.predefinedSourceDirectories[0]
+            self.predefinedSourceDirectories[0]
         }
     }
 }
@@ -1591,9 +1618,9 @@ extension Manifest {
             [target.name] + target.dependencies.compactMap {
                 switch $0 {
                 case .target(let name, _):
-                    return name
+                    name
                 case .byName, .product:
-                    return nil
+                    nil
                 }
             }
         }
@@ -1639,9 +1666,9 @@ extension Target.Dependency {
     fileprivate var nameAndType: String {
         switch self {
         case .target:
-            return "target-\(name)"
+            "target-\(name)"
         case .product:
-            return "product-\(name)"
+            "product-\(name)"
         }
     }
 }
@@ -1656,7 +1683,7 @@ extension PackageBuilder {
         }
 
         return try walk(snippetsDirectory, fileSystem: self.fileSystem)
-            .filter { fileSystem.isFile($0) && $0.extension == "swift" }
+            .filter { self.fileSystem.isFile($0) && $0.extension == "swift" }
             .map { sourceFile in
                 let name = sourceFile.basenameWithoutExt
                 let sources = Sources(paths: [sourceFile], root: sourceFile.parentDirectory)
@@ -1678,14 +1705,14 @@ extension PackageBuilder {
                     targetRoot: sourceFile.parentDirectory
                 )
 
-                return SwiftTarget(
+                return try SwiftTarget(
                     name: name,
                     type: .snippet,
                     path: .root,
                     sources: sources,
                     dependencies: dependencies,
                     packageAccess: false,
-                    swiftVersion: try swiftVersion(),
+                    swiftVersion: self.swiftVersion(),
                     buildSettings: buildSettings,
                     buildSettingsDescription: targetDescription.settings,
                     usesUnsafeFlags: false

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -13,8 +13,8 @@
 import Basics
 import Foundation
 import PackageGraph
-@testable import PackageModel
 import PackageLoading
+@testable import PackageModel
 import SPMBuildCore
 import SPMTestSupport
 @testable import XCBuildSupport
@@ -32,13 +32,14 @@ class PIFBuilderTests: XCTestCase {
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
         // Repeat multiple times to detect non-deterministic shuffling due to sets.
-        for _ in 0..<10 {
-            let fs = InMemoryFileSystem(emptyFiles:
-                                            "/A/Sources/A1/main.swift",
-                                        "/A/Sources/A2/lib.swift",
-                                        "/A/Sources/A3/lib.swift",
-                                        "/B/Sources/B1/main.swift",
-                                        "/B/Sources/B2/lib.swift"
+        for _ in 0 ..< 10 {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                "/A/Sources/A1/main.swift",
+                "/A/Sources/A2/lib.swift",
+                "/A/Sources/A3/lib.swift",
+                "/B/Sources/B1/main.swift",
+                "/B/Sources/B2/lib.swift"
             )
 
             let observability = ObservabilitySystem.makeForTesting()
@@ -56,7 +57,8 @@ class PIFBuilderTests: XCTestCase {
                         targets: [
                             .init(name: "B2", dependencies: []),
                             .init(name: "B1", dependencies: ["B2"]),
-                        ]),
+                        ]
+                    ),
                     Manifest.createRootManifest(
                         displayName: "A",
                         path: "/A",
@@ -72,7 +74,8 @@ class PIFBuilderTests: XCTestCase {
                             .init(name: "A1", dependencies: ["A3", "A2", .product(name: "blib", package: "B")]),
                             .init(name: "A2", dependencies: []),
                             .init(name: "A3", dependencies: []),
-                        ]),
+                        ]
+                    ),
                 ],
                 observabilityScope: observability.topScope
             )
@@ -87,18 +90,27 @@ class PIFBuilderTests: XCTestCase {
 
             XCTAssertNoDiagnostics(observability.diagnostics)
 
-            let projectNames = pif.workspace.projects.map({ $0.name })
+            let projectNames = pif.workspace.projects.map(\.name)
             XCTAssertEqual(projectNames, ["A", "B", "Aggregate"])
-            let projectATargetNames = pif.workspace.projects[0].targets.map({ $0.name })
-            XCTAssertEqual(projectATargetNames, ["aexe_79CC9E117_PackageProduct", "alib_79D40CF5C_PackageProduct", "A2", "A3"])
+            let projectATargetNames = pif.workspace.projects[0].targets.map(\.name)
+            XCTAssertEqual(
+                projectATargetNames,
+                ["aexe_79CC9E117_PackageProduct", "alib_79D40CF5C_PackageProduct", "A2", "A3"]
+            )
             let targetAExeDependencies = pif.workspace.projects[0].targets[0].dependencies
-            XCTAssertEqual(targetAExeDependencies.map{ $0.targetGUID }, ["PACKAGE-PRODUCT:blib", "PACKAGE-TARGET:A2", "PACKAGE-TARGET:A3"])
-            let projectBTargetNames = pif.workspace.projects[1].targets.map({ $0.name })
-#if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
+            XCTAssertEqual(
+                targetAExeDependencies.map(\.targetGUID),
+                ["PACKAGE-PRODUCT:blib", "PACKAGE-TARGET:A2", "PACKAGE-TARGET:A3"]
+            )
+            let projectBTargetNames = pif.workspace.projects[1].targets.map(\.name)
+            #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
             XCTAssertEqual(projectBTargetNames, ["blib_7AE74026D_PackageProduct", "B2"])
-#else
-            XCTAssertEqual(projectBTargetNames, ["bexe_7ADFD1428_PackageProduct", "blib_7AE74026D_PackageProduct", "B2"])
-#endif
+            #else
+            XCTAssertEqual(
+                projectBTargetNames,
+                ["bexe_7ADFD1428_PackageProduct", "blib_7AE74026D_PackageProduct", "B2"]
+            )
+            #endif
         }
     }
 
@@ -106,10 +118,11 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Tests/FooTests/tests.swift",
-                                    "/Bar/Sources/BarLib/lib.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Tests/FooTests/tests.swift",
+            "/Bar/Sources/BarLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -128,7 +141,8 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "foo", dependencies: [.product(name: "BarLib", package: "Bar")]),
                         .init(name: "FooTests", type: .test),
-                    ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -145,7 +159,8 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "BarLib"),
                         .init(name: "BarTests", type: .test),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -188,7 +203,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.ENABLE_TESTING_SEARCH_PATHS], "YES")
                         XCTAssertEqual(settings[.ENTITLEMENTS_REQUIRED], "NO")
                         XCTAssertEqual(settings[.GCC_OPTIMIZATION_LEVEL], "0")
-                        XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "SWIFT_PACKAGE", "DEBUG=1"])
+                        XCTAssertEqual(
+                            settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE", "DEBUG=1"]
+                        )
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], "12.0")
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET, for: .macCatalyst], "13.0")
                         XCTAssertEqual(settings[.KEEP_PRIVATE_EXTERNS], "NO")
@@ -200,7 +218,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SDKROOT], "auto")
                         XCTAssertEqual(settings[.SKIP_INSTALL], "YES")
                         XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["$(AVAILABLE_PLATFORMS)"])
-                        XCTAssertEqual(settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS], ["$(inherited)", "SWIFT_PACKAGE", "DEBUG"])
+                        XCTAssertEqual(
+                            settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE", "DEBUG"]
+                        )
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Onone")
@@ -246,7 +267,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SDKROOT], "auto")
                         XCTAssertEqual(settings[.SKIP_INSTALL], "YES")
                         XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["$(AVAILABLE_PLATFORMS)"])
-                        XCTAssertEqual(settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS], ["$(inherited)", "SWIFT_PACKAGE"])
+                        XCTAssertEqual(
+                            settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE"]
+                        )
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Owholemodule")
@@ -292,7 +316,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.ENABLE_TESTING_SEARCH_PATHS], "YES")
                         XCTAssertEqual(settings[.ENTITLEMENTS_REQUIRED], "NO")
                         XCTAssertEqual(settings[.GCC_OPTIMIZATION_LEVEL], "0")
-                        XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "SWIFT_PACKAGE", "DEBUG=1"])
+                        XCTAssertEqual(
+                            settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE", "DEBUG=1"]
+                        )
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], "12.0")
                         XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET, for: .macCatalyst], "13.0")
                         XCTAssertEqual(settings[.KEEP_PRIVATE_EXTERNS], "NO")
@@ -304,7 +331,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SDKROOT], "auto")
                         XCTAssertEqual(settings[.SKIP_INSTALL], "YES")
                         XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["$(AVAILABLE_PLATFORMS)"])
-                        XCTAssertEqual(settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS], ["$(inherited)", "SWIFT_PACKAGE", "DEBUG"])
+                        XCTAssertEqual(
+                            settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE", "DEBUG"]
+                        )
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Onone")
@@ -350,7 +380,10 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.SDKROOT], "auto")
                         XCTAssertEqual(settings[.SKIP_INSTALL], "YES")
                         XCTAssertEqual(settings[.SUPPORTED_PLATFORMS], ["$(AVAILABLE_PLATFORMS)"])
-                        XCTAssertEqual(settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS], ["$(inherited)", "SWIFT_PACKAGE"])
+                        XCTAssertEqual(
+                            settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS],
+                            ["$(inherited)", "SWIFT_PACKAGE"]
+                        )
                         XCTAssertEqual(settings[.SWIFT_INSTALL_OBJC_HEADER], "NO")
                         XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "")
                         XCTAssertEqual(settings[.SWIFT_OPTIMIZATION_LEVEL], "-Owholemodule")
@@ -389,14 +422,15 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/cfoo/main.c",
-                                    "/Foo/Sources/FooLib/lib.swift",
-                                    "/Foo/Sources/SystemLib/module.modulemap",
-                                    "/Bar/Sources/bar/main.swift",
-                                    "/Bar/Sources/cbar/main.c",
-                                    "/Bar/Sources/BarLib/lib.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/cfoo/main.c",
+            "/Foo/Sources/FooLib/lib.swift",
+            "/Foo/Sources/SystemLib/module.modulemap",
+            "/Bar/Sources/bar/main.swift",
+            "/Bar/Sources/cbar/main.c",
+            "/Bar/Sources/BarLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -417,14 +451,15 @@ class PIFBuilderTests: XCTestCase {
                             "SystemLib",
                             "cfoo",
                             .product(name: "bar", package: "Bar"),
-                            .product(name: "cbar", package: "Bar")
+                            .product(name: "cbar", package: "Bar"),
                         ]),
                         .init(name: "cfoo"),
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
                         .init(name: "FooLib", dependencies: [
                             .product(name: "BarLib", package: "Bar"),
-                        ])
-                    ]),
+                        ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -441,13 +476,14 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "bar", dependencies: ["BarLib"]),
                         .init(name: "cbar"),
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -474,7 +510,7 @@ class PIFBuilderTests: XCTestCase {
                         "PACKAGE-PRODUCT:BarLib",
                         "PACKAGE-PRODUCT:cbar",
                         "PACKAGE-TARGET:FooLib",
-                        "PACKAGE-TARGET:SystemLib"
+                        "PACKAGE-TARGET:SystemLib",
                     ])
                     XCTAssertEqual(target.sources, ["/Foo/Sources/foo/main.swift"])
                     XCTAssertEqual(target.frameworks, [
@@ -492,7 +528,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "foo")
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
-                            XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], ["$(inherited)", "@executable_path/../lib"])
+                            XCTAssertEqual(
+                                settings[.LD_RUNPATH_SEARCH_PATHS],
+                                ["$(inherited)", "@executable_path/../lib"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "foo")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "foo")
@@ -504,7 +543,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "foo")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -516,7 +558,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "foo")
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
-                            XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], ["$(inherited)", "@executable_path/../lib"])
+                            XCTAssertEqual(
+                                settings[.LD_RUNPATH_SEARCH_PATHS],
+                                ["$(inherited)", "@executable_path/../lib"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "foo")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "foo")
@@ -528,7 +573,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "foo")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -552,9 +600,15 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "cfoo")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/cfoo/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Foo/Sources/cfoo/include"]
+                            )
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
-                            XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], ["$(inherited)", "@executable_path/../lib"])
+                            XCTAssertEqual(
+                                settings[.LD_RUNPATH_SEARCH_PATHS],
+                                ["$(inherited)", "@executable_path/../lib"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "cfoo")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "cfoo")
@@ -565,7 +619,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_DYNAMIC_LINK_STDLIB], "YES")
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.TARGET_NAME], "cfoo")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -576,9 +633,15 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.CLANG_ENABLE_MODULES], "YES")
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "cfoo")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/cfoo/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Foo/Sources/cfoo/include"]
+                            )
                             XCTAssertEqual(settings[.INSTALL_PATH], "/usr/local/bin")
-                            XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], ["$(inherited)", "@executable_path/../lib"])
+                            XCTAssertEqual(
+                                settings[.LD_RUNPATH_SEARCH_PATHS],
+                                ["$(inherited)", "@executable_path/../lib"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "cfoo")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "cfoo")
@@ -589,7 +652,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_DYNAMIC_LINK_STDLIB], "YES")
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.TARGET_NAME], "cfoo")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -626,7 +692,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "4.2")
                             XCTAssertEqual(settings[.TARGET_NAME], "bar")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -647,7 +716,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "4.2")
                             XCTAssertEqual(settings[.TARGET_NAME], "bar")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -673,7 +745,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "cbar")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/cbar/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Bar/Sources/cbar/include"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "cbar")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "cbar")
@@ -683,7 +758,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_DYNAMIC_LINK_STDLIB], "YES")
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.TARGET_NAME], "cbar")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -696,7 +774,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "cbar")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/cbar/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Bar/Sources/cbar/include"]
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "cbar")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "cbar")
@@ -706,7 +787,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_DYNAMIC_LINK_STDLIB], "YES")
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.TARGET_NAME], "cbar")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -718,19 +802,20 @@ class PIFBuilderTests: XCTestCase {
 
     func testTestProducts() throws {
         #if !os(macOS)
-                try XCTSkipIf(true, "test is only supported on macOS")
+        try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/FooTests/FooTests.swift",
-                                    "/Foo/Sources/CFooTests/CFooTests.m",
-                                    "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/FooLib/lib.swift",
-                                    "/Foo/Sources/SystemLib/module.modulemap",
-                                    "/Bar/Sources/bar/main.swift",
-                                    "/Bar/Sources/BarTests/BarTests.swift",
-                                    "/Bar/Sources/CBarTests/CBarTests.m",
-                                    "/Bar/Sources/BarLib/lib.swift",
-                                    inputsDir.appending("Foo.pc").pathString
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/FooTests/FooTests.swift",
+            "/Foo/Sources/CFooTests/CFooTests.m",
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/FooLib/lib.swift",
+            "/Foo/Sources/SystemLib/module.modulemap",
+            "/Bar/Sources/bar/main.swift",
+            "/Bar/Sources/BarTests/BarTests.swift",
+            "/Bar/Sources/CBarTests/CBarTests.m",
+            "/Bar/Sources/BarLib/lib.swift",
+            inputsDir.appending("Foo.pc").pathString
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -757,8 +842,9 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
                         .init(name: "FooLib", dependencies: [
                             .product(name: "BarLib", package: "Bar"),
-                        ])
-                    ]),
+                        ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -775,14 +861,15 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "BarTests", dependencies: ["BarLib"], type: .test),
                         .init(name: "CBarTests", type: .test),
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -805,7 +892,7 @@ class PIFBuilderTests: XCTestCase {
                         "PACKAGE-PRODUCT:bar",
                         "PACKAGE-PRODUCT:BarLib",
                         "PACKAGE-TARGET:FooLib",
-                        "PACKAGE-TARGET:SystemLib"
+                        "PACKAGE-TARGET:SystemLib",
                     ])
                     XCTAssertEqual(target.sources, ["/Foo/Sources/FooTests/FooTests.swift"])
                     XCTAssertEqual(target.frameworks, [
@@ -825,11 +912,11 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
                                 "@loader_path/Frameworks",
-                                "@loader_path/../Frameworks"
+                                "@loader_path/../Frameworks",
                             ])
                             XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/toolchain/lib/swift/macosx"
+                                "/toolchain/lib/swift/macosx",
                             ])
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooTests")
@@ -839,11 +926,28 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "FooTests")
-                            XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS).versionString)
-                            XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
-                            XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
-                            XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
-                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
+                            XCTAssertEqual(
+                                settings[.WATCHOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS)
+                                    .versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.IPHONEOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.TVOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.MACOSX_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.XROS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS)
+                                    .versionString
+                            )
                         }
                     }
 
@@ -858,11 +962,11 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
                                 "@loader_path/Frameworks",
-                                "@loader_path/../Frameworks"
+                                "@loader_path/../Frameworks",
                             ])
                             XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/toolchain/lib/swift/macosx"
+                                "/toolchain/lib/swift/macosx",
                             ])
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooTests")
@@ -872,11 +976,28 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "FooTests")
-                            XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS).versionString)
-                            XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
-                            XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
-                            XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
-                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
+                            XCTAssertEqual(
+                                settings[.WATCHOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS)
+                                    .versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.IPHONEOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.TVOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.MACOSX_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.XROS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS)
+                                    .versionString
+                            )
                         }
                     }
 
@@ -901,16 +1022,16 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/Foo/Sources/CFooTests/include"
+                                "/Foo/Sources/CFooTests/include",
                             ])
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
                                 "@loader_path/Frameworks",
-                                "@loader_path/../Frameworks"
+                                "@loader_path/../Frameworks",
                             ])
                             XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/toolchain/lib/swift/macosx"
+                                "/toolchain/lib/swift/macosx",
                             ])
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "CFooTests")
@@ -919,11 +1040,28 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_DYNAMIC_LINK_STDLIB], "YES")
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.TARGET_NAME], "CFooTests")
-                            XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS).versionString)
-                            XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
-                            XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
-                            XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
-                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
+                            XCTAssertEqual(
+                                settings[.WATCHOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS)
+                                    .versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.IPHONEOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.TVOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.MACOSX_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.XROS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS)
+                                    .versionString
+                            )
                         }
                     }
 
@@ -937,16 +1075,16 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.GENERATE_INFOPLIST_FILE], "YES")
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/Foo/Sources/CFooTests/include"
+                                "/Foo/Sources/CFooTests/include",
                             ])
                             XCTAssertEqual(settings[.LD_RUNPATH_SEARCH_PATHS], [
                                 "$(inherited)",
                                 "@loader_path/Frameworks",
-                                "@loader_path/../Frameworks"
+                                "@loader_path/../Frameworks",
                             ])
                             XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], [
                                 "$(inherited)",
-                                "/toolchain/lib/swift/macosx"
+                                "/toolchain/lib/swift/macosx",
                             ])
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "CFooTests")
@@ -955,11 +1093,28 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SWIFT_FORCE_DYNAMIC_LINK_STDLIB], "YES")
                             XCTAssertEqual(settings[.SWIFT_FORCE_STATIC_LINK_STDLIB], "NO")
                             XCTAssertEqual(settings[.TARGET_NAME], "CFooTests")
-                            XCTAssertEqual(settings[.WATCHOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS).versionString)
-                            XCTAssertEqual(settings[.IPHONEOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString)
-                            XCTAssertEqual(settings[.TVOS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString)
-                            XCTAssertEqual(settings[.MACOSX_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString)
-                            XCTAssertEqual(settings[.XROS_DEPLOYMENT_TARGET], MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS).versionString)
+                            XCTAssertEqual(
+                                settings[.WATCHOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .watchOS)
+                                    .versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.IPHONEOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .iOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.TVOS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .tvOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.MACOSX_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
+                            )
+                            XCTAssertEqual(
+                                settings[.XROS_DEPLOYMENT_TARGET],
+                                MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .visionOS)
+                                    .versionString
+                            )
                         }
                     }
 
@@ -978,11 +1133,12 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/FooLib1/lib.swift",
-                                    "/Foo/Sources/FooLib2/lib.swift",
-                                    "/Foo/Sources/SystemLib/module.modulemap",
-                                    "/Bar/Sources/BarLib/lib.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/FooLib1/lib.swift",
+            "/Foo/Sources/FooLib2/lib.swift",
+            "/Foo/Sources/SystemLib/module.modulemap",
+            "/Bar/Sources/BarLib/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1007,7 +1163,8 @@ class PIFBuilderTests: XCTestCase {
                             .product(name: "BarLib", package: "Bar"),
                         ]),
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
-                    ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -1020,13 +1177,14 @@ class PIFBuilderTests: XCTestCase {
                     ],
                     targets: [
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1072,7 +1230,7 @@ class PIFBuilderTests: XCTestCase {
                         }
                     }
 
-                    target.checkAllImpartedBuildSettings { settings in
+                    target.checkAllImpartedBuildSettings { _ in
                         // No imparted build settings.
                     }
                 }
@@ -1142,7 +1300,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.SKIP_INSTALL], "NO")
                             XCTAssertEqual(settings[.TARGET_BUILD_DIR], "$(TARGET_BUILD_DIR)/PackageFrameworks")
                             XCTAssertEqual(settings[.TARGET_NAME], "BarLib")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -1166,7 +1327,10 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.TARGET_BUILD_DIR], "$(TARGET_BUILD_DIR)/PackageFrameworks")
                             XCTAssertEqual(settings[.TARGET_NAME], "BarLib")
                             XCTAssertEqual(settings[.USES_SWIFTPM_UNSAFE_FLAGS], "NO")
-                            XCTAssertEqual(settings[.LIBRARY_SEARCH_PATHS], ["$(inherited)", "/toolchain/lib/swift/macosx"])
+                            XCTAssertEqual(
+                                settings[.LIBRARY_SEARCH_PATHS],
+                                ["$(inherited)", "/toolchain/lib/swift/macosx"]
+                            )
                         }
                     }
 
@@ -1180,11 +1344,12 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/FooLib1/lib.swift",
-                                    "/Foo/Sources/FooLib2/lib.cpp",
-                                    "/Foo/Sources/SystemLib/module.modulemap",
-                                    "/Bar/Sources/BarLib/lib.c"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/FooLib1/lib.swift",
+            "/Foo/Sources/FooLib2/lib.cpp",
+            "/Foo/Sources/SystemLib/module.modulemap",
+            "/Bar/Sources/BarLib/lib.c"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1206,7 +1371,8 @@ class PIFBuilderTests: XCTestCase {
                             .product(name: "BarLib", package: "Bar"),
                         ]),
                         .init(name: "SystemLib", type: .system, pkgConfig: "Foo"),
-                    ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -1218,13 +1384,14 @@ class PIFBuilderTests: XCTestCase {
                     ],
                     targets: [
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1261,17 +1428,23 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module FooLib1 {
-                                    header "FooLib1-Swift.h"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap")
+                            module FooLib1 {
+                                header "FooLib1-Swift.h"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooLib1")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "FooLib1")
                             XCTAssertEqual(settings[.PRODUCT_NAME], "FooLib1.o")
-                            XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)")
+                            XCTAssertEqual(
+                                settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)"
+                            )
                             XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "FooLib1-Swift.h")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "FooLib1")
@@ -1289,17 +1462,23 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module FooLib1 {
-                                    header "FooLib1-Swift.h"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap")
+                            module FooLib1 {
+                                header "FooLib1-Swift.h"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooLib1")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "FooLib1")
                             XCTAssertEqual(settings[.PRODUCT_NAME], "FooLib1.o")
-                            XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)")
+                            XCTAssertEqual(
+                                settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)"
+                            )
                             XCTAssertEqual(settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME], "FooLib1-Swift.h")
                             XCTAssertEqual(settings[.SWIFT_VERSION], "5")
                             XCTAssertEqual(settings[.TARGET_NAME], "FooLib1")
@@ -1309,7 +1488,7 @@ class PIFBuilderTests: XCTestCase {
                     target.checkAllImpartedBuildSettings { settings in
                         XCTAssertEqual(settings[.OTHER_CFLAGS], [
                             "$(inherited)",
-                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap"
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib1.modulemap",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-Wl,-no_warn_duplicate_libraries"])
@@ -1334,15 +1513,21 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "FooLib2.o")
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/FooLib2/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Foo/Sources/FooLib2/include"]
+                            )
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module FooLib2 {
-                                    umbrella "/Foo/Sources/FooLib2/include"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap")
+                            module FooLib2 {
+                                umbrella "/Foo/Sources/FooLib2/include"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooLib2")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "FooLib2")
@@ -1361,15 +1546,21 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.DEFINES_MODULE], "YES")
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "FooLib2.o")
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/FooLib2/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Foo/Sources/FooLib2/include"]
+                            )
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module FooLib2 {
-                                    umbrella "/Foo/Sources/FooLib2/include"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap")
+                            module FooLib2 {
+                                umbrella "/Foo/Sources/FooLib2/include"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "FooLib2")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "FooLib2")
@@ -1382,13 +1573,17 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Foo/Sources/FooLib2/include"])
                         XCTAssertEqual(settings[.OTHER_CFLAGS], [
                             "$(inherited)",
-                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap"
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
-                        XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-lc++", "-Wl,-no_warn_duplicate_libraries"])
+                        XCTAssertEqual(
+                            settings[.OTHER_LDFLAGS],
+                            ["$(inherited)", "-lc++", "-Wl,-no_warn_duplicate_libraries"]
+                        )
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], [
                             "$(inherited)",
-                            "-Xcc", "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap"
+                            "-Xcc",
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/FooLib2.modulemap",
                         ])
                     }
                 }
@@ -1413,15 +1608,21 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "BarLib.o")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/BarLib/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Bar/Sources/BarLib/include"]
+                            )
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module BarLib {
-                                    umbrella "/Bar/Sources/BarLib/include"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap")
+                            module BarLib {
+                                umbrella "/Bar/Sources/BarLib/include"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "BarLib")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "BarLib")
@@ -1440,15 +1641,21 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertEqual(settings[.EXECUTABLE_NAME], "BarLib.o")
                             XCTAssertEqual(settings[.GCC_C_LANGUAGE_STANDARD], "c11")
                             XCTAssertEqual(settings[.GENERATE_MASTER_OBJECT_FILE], "NO")
-                            XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/BarLib/include"])
+                            XCTAssertEqual(
+                                settings[.HEADER_SEARCH_PATHS],
+                                ["$(inherited)", "/Bar/Sources/BarLib/include"]
+                            )
                             XCTAssertEqual(settings[.MACH_O_TYPE], "mh_object")
                             XCTAssertEqual(settings[.MODULEMAP_FILE_CONTENTS], """
-                                module BarLib {
-                                    umbrella "/Bar/Sources/BarLib/include"
-                                    export *
-                                }
-                                """)
-                            XCTAssertEqual(settings[.MODULEMAP_PATH], "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap")
+                            module BarLib {
+                                umbrella "/Bar/Sources/BarLib/include"
+                                export *
+                            }
+                            """)
+                            XCTAssertEqual(
+                                settings[.MODULEMAP_PATH],
+                                "$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap"
+                            )
                             XCTAssertEqual(settings[.PACKAGE_RESOURCE_TARGET_KIND], "regular")
                             XCTAssertEqual(settings[.PRODUCT_BUNDLE_IDENTIFIER], "BarLib")
                             XCTAssertEqual(settings[.PRODUCT_MODULE_NAME], "BarLib")
@@ -1461,13 +1668,14 @@ class PIFBuilderTests: XCTestCase {
                         XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], ["$(inherited)", "/Bar/Sources/BarLib/include"])
                         XCTAssertEqual(settings[.OTHER_CFLAGS], [
                             "$(inherited)",
-                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap"
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-Wl,-no_warn_duplicate_libraries"])
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], [
                             "$(inherited)",
-                            "-Xcc", "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap"
+                            "-Xcc",
+                            "-fmodule-map-file=$(OBJROOT)/GeneratedModuleMaps/$(PLATFORM_NAME)/BarLib.modulemap",
                         ])
                     }
                 }
@@ -1479,12 +1687,13 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/App/Sources/App/main.swift",
-                                        "/App/Sources/Logging/lib.swift",
-                                    "/App/Sources/Utils/lib.swift",
-                                    "/Bar/Sources/Lib/lib.swift",
-                                    "/Bar/Sources/Logging/lib.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/App/Sources/App/main.swift",
+            "/App/Sources/Logging/lib.swift",
+            "/App/Sources/Utils/lib.swift",
+            "/Bar/Sources/Lib/lib.swift",
+            "/Bar/Sources/Logging/lib.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1503,7 +1712,8 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "Utils", dependencies: [
                             .product(name: "BarLib", package: "Bar", moduleAliases: ["Logging": "BarLogging"]),
                         ]),
-                    ]),
+                    ]
+                ),
                 Manifest.createLocalSourceControlManifest(
                     displayName: "Bar",
                     path: "/Bar",
@@ -1513,13 +1723,14 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "Lib", dependencies: ["Logging"]),
                         .init(name: "Logging", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1588,7 +1799,6 @@ class PIFBuilderTests: XCTestCase {
                             XCTAssertNil(settings[.SWIFT_MODULE_ALIASES])
                         }
                     }
-
                 }
                 project.checkTarget("PACKAGE-TARGET:Logging") { target in
                     XCTAssertEqual(target.name, "Logging")
@@ -1706,8 +1916,9 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Bar/Sources/BarLib/lib.c"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Bar/Sources/BarLib/lib.c"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1725,13 +1936,14 @@ class PIFBuilderTests: XCTestCase {
                     ],
                     targets: [
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(shouldCreateDylibForDynamicProducts: true),
@@ -1758,9 +1970,10 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Bar/Sources/BarLib/lib.c",
-                                    "/Bar/Sources/BarLib/module.modulemap"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Bar/Sources/BarLib/lib.c",
+            "/Bar/Sources/BarLib/module.modulemap"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1779,13 +1992,14 @@ class PIFBuilderTests: XCTestCase {
                     ],
                     targets: [
                         .init(name: "BarLib"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(shouldCreateDylibForDynamicProducts: true),
@@ -1816,9 +2030,10 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/SystemLib1/module.modulemap",
-                                    "/Foo/Sources/SystemLib2/module.modulemap"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/SystemLib1/module.modulemap",
+            "/Foo/Sources/SystemLib2/module.modulemap"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -1834,13 +2049,14 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "SystemLib1", type: .system),
                         .init(name: "SystemLib2", type: .system, pkgConfig: "Foo"),
-                    ]),
+                    ]
+                ),
             ],
             observabilityScope: observability.topScope
         )
 
         var pif: PIF.TopLevelObject!
-        try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
+        try withCustomEnv(["PKG_CONFIG_PATH": self.inputsDir.pathString]) {
             let builder = PIFBuilder(
                 graph: graph,
                 parameters: .mock(),
@@ -1875,12 +2091,12 @@ class PIFBuilderTests: XCTestCase {
                     target.checkAllImpartedBuildSettings { settings in
                         XCTAssertEqual(settings[.OTHER_CFLAGS], [
                             "$(inherited)",
-                            "-fmodule-map-file=/Foo/Sources/SystemLib1/module.modulemap"
+                            "-fmodule-map-file=/Foo/Sources/SystemLib1/module.modulemap",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], [
                             "$(inherited)",
-                            "-Xcc", "-fmodule-map-file=/Foo/Sources/SystemLib1/module.modulemap"
+                            "-Xcc", "-fmodule-map-file=/Foo/Sources/SystemLib1/module.modulemap",
                         ])
                     }
                 }
@@ -1908,20 +2124,20 @@ class PIFBuilderTests: XCTestCase {
                             "$(inherited)",
                             "-fmodule-map-file=/Foo/Sources/SystemLib2/module.modulemap",
                             "-I/path/to/inc",
-                            "-I\(self.inputsDir)"
+                            "-I\(self.inputsDir)",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDFLAGS], [
                             "$(inherited)",
                             "-L/usr/da/lib",
                             "-lSystemModule",
-                            "-lok"
+                            "-lok",
                         ])
                         XCTAssertEqual(settings[.OTHER_LDRFLAGS], [])
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], [
                             "$(inherited)",
                             "-Xcc", "-fmodule-map-file=/Foo/Sources/SystemLib2/module.modulemap",
                             "-I/path/to/inc",
-                            "-I\(self.inputsDir)"
+                            "-I\(self.inputsDir)",
                         ])
                     }
                 }
@@ -1933,7 +2149,8 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
+        let fs = InMemoryFileSystem(
+            emptyFiles:
             "/Foo/Sources/foo/main.swift",
             "/Foo/Sources/FooLib/lib.swift",
             "/Foo/Sources/FooTests/FooTests.swift",
@@ -1955,13 +2172,14 @@ class PIFBuilderTests: XCTestCase {
                         .init(name: "foo", dependencies: ["BinaryLibrary"]),
                         .init(name: "FooLib", dependencies: ["BinaryLibrary"]),
                         .init(name: "FooTests", dependencies: ["BinaryLibrary"], type: .test),
-                        .init(name: "BinaryLibrary", path: "BinaryLibrary.xcframework", type: .binary)
-                    ]),
+                        .init(name: "BinaryLibrary", path: "BinaryLibrary.xcframework", type: .binary),
+                    ]
+                ),
             ],
             binaryArtifacts: [
                 .plain("foo"): [
-                    "BinaryLibrary": .init(kind: .xcframework, originURL: nil, path: "/Foo/BinaryLibrary.xcframework")
-                ]
+                    "BinaryLibrary": .init(kind: .xcframework, originURL: nil, path: "/Foo/BinaryLibrary.xcframework"),
+                ],
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -2002,16 +2220,17 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/foo/Resources/Data.plist",
-                                    "/Foo/Sources/foo/Resources/Database.xcdatamodel",
-                                    "/Foo/Sources/FooLib/lib.swift",
-                                    "/Foo/Sources/FooLib/Resources/Data.plist",
-                                    "/Foo/Sources/FooLib/Resources/Database.xcdatamodel",
-                                    "/Foo/Sources/FooTests/FooTests.swift",
-                                    "/Foo/Sources/FooTests/Resources/Data.plist",
-                                    "/Foo/Sources/FooTests/Resources/Database.xcdatamodel"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/foo/Resources/Data.plist",
+            "/Foo/Sources/foo/Resources/Database.xcdatamodel",
+            "/Foo/Sources/FooLib/lib.swift",
+            "/Foo/Sources/FooLib/Resources/Data.plist",
+            "/Foo/Sources/FooLib/Resources/Database.xcdatamodel",
+            "/Foo/Sources/FooTests/FooTests.swift",
+            "/Foo/Sources/FooTests/Resources/Data.plist",
+            "/Foo/Sources/FooTests/Resources/Database.xcdatamodel"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2028,15 +2247,16 @@ class PIFBuilderTests: XCTestCase {
                     targets: [
                         .init(name: "foo", resources: [
                             // This is intentionally specific to test that we pick up `.xcdatamodel` implicitly.
-                            .init(rule: .process(localization: .none), path: "Resources/Data.plist")
+                            .init(rule: .process(localization: .none), path: "Resources/Data.plist"),
                         ]),
                         .init(name: "FooLib", resources: [
-                            .init(rule: .process(localization: .none), path: "Resources")
+                            .init(rule: .process(localization: .none), path: "Resources"),
                         ]),
                         .init(name: "FooTests", resources: [
-                            .init(rule: .process(localization: .none), path: "Resources")
+                            .init(rule: .process(localization: .none), path: "Resources"),
                         ], type: .test),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             useXCBuildFileRules: true,
@@ -2224,10 +2444,11 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/FooLib/lib.swift",
-                                    "/Foo/Sources/FooTests/FooTests.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/FooLib/lib.swift",
+            "/Foo/Sources/FooTests/FooTests.swift"
         )
 
         let toolsVersion: ToolsVersion = if isPackageAccessModifierSupported { .v5_9 } else { .v5 }
@@ -2250,54 +2471,66 @@ class PIFBuilderTests: XCTestCase {
                             settings: [
                                 .init(
                                     tool: .c,
-                                    kind: .define("ENABLE_BEST_MODE")),
+                                    kind: .define("ENABLE_BEST_MODE")
+                                ),
                                 .init(
                                     tool: .cxx,
                                     kind: .headerSearchPath("some/path"),
-                                    condition: .init(platformNames: ["macos"])),
+                                    condition: .init(platformNames: ["macos"])
+                                ),
                                 .init(
                                     tool: .linker,
                                     kind: .linkedLibrary("z"),
-                                    condition: .init(config: "debug")),
+                                    condition: .init(config: "debug")
+                                ),
                                 .init(
                                     tool: .swift,
                                     kind: .unsafeFlags(["-secret", "value"]),
-                                    condition: .init(platformNames: ["macos", "linux"], config: "release")),
+                                    condition: .init(platformNames: ["macos", "linux"], config: "release")
+                                ),
                             ]
                         ),
                         .init(name: "FooLib", settings: [
                             .init(
                                 tool: .c,
-                                kind: .define("ENABLE_BEST_MODE")),
+                                kind: .define("ENABLE_BEST_MODE")
+                            ),
                             .init(
                                 tool: .cxx,
                                 kind: .headerSearchPath("some/path"),
-                                condition: .init(platformNames: ["macos"])),
+                                condition: .init(platformNames: ["macos"])
+                            ),
                             .init(
                                 tool: .linker,
                                 kind: .linkedLibrary("z"),
-                                condition: .init(config: "debug")),
+                                condition: .init(config: "debug")
+                            ),
                             .init(
                                 tool: .swift,
                                 kind: .unsafeFlags(["-secret", "value"]),
-                                condition: .init(platformNames: ["macos", "linux"], config: "release")),
+                                condition: .init(platformNames: ["macos", "linux"], config: "release")
+                            ),
                         ]),
                         .init(name: "FooTests", type: .test, settings: [
                             .init(
                                 tool: .c,
-                                kind: .define("ENABLE_BEST_MODE")),
+                                kind: .define("ENABLE_BEST_MODE")
+                            ),
                             .init(
                                 tool: .cxx,
                                 kind: .headerSearchPath("some/path"),
-                                condition: .init(platformNames: ["macos"])),
+                                condition: .init(platformNames: ["macos"])
+                            ),
                             .init(
                                 tool: .linker,
                                 kind: .linkedLibrary("z"),
-                                condition: .init(config: "debug")),
+                                condition: .init(config: "debug")
+                            ),
                             .init(
                                 tool: .swift,
                                 kind: .unsafeFlags(["-secret", "value"]),
-                                condition: .init(platformNames: ["macos", "linux"], config: "release")),
+                                condition: .init(platformNames: ["macos", "linux"], config: "release")
+                            ),
                         ]),
                     ]
                 ),
@@ -2327,11 +2560,14 @@ class PIFBuilderTests: XCTestCase {
                 project.checkTarget("PACKAGE-PRODUCT:foo") { target in
                     target.checkBuildConfiguration("Debug") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/foo/some/path"
+                                "/Foo/Sources/foo/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-lz"])
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
@@ -2340,16 +2576,25 @@ class PIFBuilderTests: XCTestCase {
 
                     target.checkBuildConfiguration("Release") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/foo/some/path"
+                                "/Foo/Sources/foo/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], nil)
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .macOS], ["$(inherited)", "-secret", "value"])
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .linux], ["$(inherited)", "-secret", "value"])
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .macOS],
+                                ["$(inherited)", "-secret", "value"]
+                            )
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .linux],
+                                ["$(inherited)", "-secret", "value"]
+                            )
                         }
                     }
                 }
@@ -2379,11 +2624,14 @@ class PIFBuilderTests: XCTestCase {
                 project.checkTarget("PACKAGE-TARGET:FooLib") { target in
                     target.checkBuildConfiguration("Debug") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/FooLib/some/path"
+                                "/Foo/Sources/FooLib/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-lz"])
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
@@ -2392,23 +2640,35 @@ class PIFBuilderTests: XCTestCase {
 
                     target.checkBuildConfiguration("Release") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/FooLib/some/path"
+                                "/Foo/Sources/FooLib/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], nil)
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .macOS], ["$(inherited)", "-secret", "value"])
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .linux], ["$(inherited)", "-secret", "value"])
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .macOS],
+                                ["$(inherited)", "-secret", "value"]
+                            )
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .linux],
+                                ["$(inherited)", "-secret", "value"]
+                            )
                         }
                     }
 
                     target.checkImpartedBuildSettings { settings in
                         XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], nil)
                         XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
-                        XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-Wl,-no_warn_duplicate_libraries", "-lz"])
+                        XCTAssertEqual(
+                            settings[.OTHER_LDFLAGS],
+                            ["$(inherited)", "-Wl,-no_warn_duplicate_libraries", "-lz"]
+                        )
                         XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], nil)
                     }
                 }
@@ -2416,11 +2676,14 @@ class PIFBuilderTests: XCTestCase {
                 project.checkTarget("PACKAGE-PRODUCT:FooTests") { target in
                     target.checkBuildConfiguration("Debug") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/FooTests/some/path"
+                                "/Foo/Sources/FooTests/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], ["$(inherited)", "-lz"])
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
@@ -2429,16 +2692,25 @@ class PIFBuilderTests: XCTestCase {
 
                     target.checkBuildConfiguration("Release") { configuration in
                         configuration.checkBuildSettings { settings in
-                            XCTAssertEqual(settings[.GCC_PREPROCESSOR_DEFINITIONS], ["$(inherited)", "ENABLE_BEST_MODE"])
+                            XCTAssertEqual(
+                                settings[.GCC_PREPROCESSOR_DEFINITIONS],
+                                ["$(inherited)", "ENABLE_BEST_MODE"]
+                            )
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS], nil)
                             XCTAssertEqual(settings[.HEADER_SEARCH_PATHS, for: .macOS], [
                                 "$(inherited)",
-                                "/Foo/Sources/FooTests/some/path"
+                                "/Foo/Sources/FooTests/some/path",
                             ])
                             XCTAssertEqual(settings[.OTHER_LDFLAGS], nil)
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], packageNameOptions)
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .macOS], ["$(inherited)", "-secret", "value"])
-                            XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS, for: .linux], ["$(inherited)", "-secret", "value"])
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .macOS],
+                                ["$(inherited)", "-secret", "value"]
+                            )
+                            XCTAssertEqual(
+                                settings[.OTHER_SWIFT_FLAGS, for: .linux],
+                                ["$(inherited)", "-secret", "value"]
+                            )
                         }
                     }
                 }
@@ -2447,22 +2719,23 @@ class PIFBuilderTests: XCTestCase {
     }
 
     func testBuildSettings() throws {
-        try buildSettingsTestCase(isPackageAccessModifierSupported: false)
+        try self.buildSettingsTestCase(isPackageAccessModifierSupported: false)
     }
 
     func testBuildSettingsPackageAccess() throws {
-        try buildSettingsTestCase(isPackageAccessModifierSupported: true)
+        try self.buildSettingsTestCase(isPackageAccessModifierSupported: true)
     }
 
     func testConditionalDependencies() throws {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift",
-                                    "/Foo/Sources/FooLib1/lib.swift",
-                                    "/Foo/Sources/FooLib2/lib.swift",
-                                    "/Foo/Sources/FooTests/FooTests.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift",
+            "/Foo/Sources/FooLib1/lib.swift",
+            "/Foo/Sources/FooLib2/lib.swift",
+            "/Foo/Sources/FooTests/FooTests.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2481,7 +2754,8 @@ class PIFBuilderTests: XCTestCase {
                         ]),
                         .init(name: "FooLib1"),
                         .init(name: "FooLib2"),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -2508,18 +2782,28 @@ class PIFBuilderTests: XCTestCase {
                     XCTAssertEqual(target.dependencies, ["PACKAGE-TARGET:FooLib1", "PACKAGE-TARGET:FooLib2"])
                     XCTAssertEqual(target.frameworks, ["PACKAGE-TARGET:FooLib1", "PACKAGE-TARGET:FooLib2"])
 
-                    let dependencyMap = Dictionary(uniqueKeysWithValues: target.baseTarget.dependencies.map{ ($0.targetGUID, $0.platformFilters) })
+                    let dependencyMap = Dictionary(uniqueKeysWithValues: target.baseTarget.dependencies.map { (
+                        $0.targetGUID,
+                        $0.platformFilters
+                    ) })
                     XCTAssertEqual(dependencyMap, expectedFilters)
 
-                    let frameworksBuildFiles = target.baseTarget.buildPhases.first{ $0 is PIF.FrameworksBuildPhase }?.buildFiles ?? []
-                    let frameworksBuildFilesMap = Dictionary(uniqueKeysWithValues: frameworksBuildFiles.compactMap{ file -> (PIF.GUID, [PIF.PlatformFilter])? in
-                        switch file.reference {
-                        case .target(let guid):
-                            return (guid, file.platformFilters)
-                        case .file:
-                            return nil
-                        }
-                    })
+                    let frameworksBuildFiles = target.baseTarget.buildPhases.first { $0 is PIF.FrameworksBuildPhase }?
+                        .buildFiles ?? []
+                    let frameworksBuildFilesMap = Dictionary(
+                        uniqueKeysWithValues: frameworksBuildFiles
+                            .compactMap { file -> (
+                                PIF.GUID,
+                                [PIF.PlatformFilter]
+                            )? in
+                                switch file.reference {
+                                case .target(let guid):
+                                    return (guid, file.platformFilters)
+                                case .file:
+                                    return nil
+                                }
+                            }
+                    )
                     XCTAssertEqual(dependencyMap, frameworksBuildFilesMap)
                 }
             }
@@ -2530,8 +2814,9 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/Foo/Sources/foo/main.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2547,7 +2832,8 @@ class PIFBuilderTests: XCTestCase {
                     toolsVersion: .v5_3,
                     targets: [
                         .init(name: "foo", dependencies: []),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -2580,8 +2866,9 @@ class PIFBuilderTests: XCTestCase {
         #if !os(macOS)
         try XCTSkipIf(true, "test is only supported on macOS")
         #endif
-        let fs = InMemoryFileSystem(emptyFiles:
-                                        "/MyLib/Sources/MyLib/Foo.swift"
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/MyLib/Sources/MyLib/Foo.swift"
         )
 
         let observability = ObservabilitySystem.makeForTesting()
@@ -2600,9 +2887,11 @@ class PIFBuilderTests: XCTestCase {
                             .init(
                                 tool: .swift,
                                 kind: .unsafeFlags(["-enable-library-evolution"]),
-                                condition: .init(config: "release")),
+                                condition: .init(config: "release")
+                            ),
                         ]),
-                    ]),
+                    ]
+                ),
             ],
             shouldCreateMultipleTestProducts: true,
             observabilityScope: observability.topScope
@@ -2630,9 +2919,60 @@ class PIFBuilderTests: XCTestCase {
                     }
                     target.checkBuildConfiguration("Release") { configuration in
                         configuration.checkBuildSettings { settings in
-                            // Check that the `-enable-library-evolution` setting for Release also set SWIFT_EMIT_MODULE_INTERFACE.
+                            // Check that the `-enable-library-evolution` setting for Release also set
+                            // SWIFT_EMIT_MODULE_INTERFACE.
                             XCTAssertEqual(settings[.SWIFT_EMIT_MODULE_INTERFACE], "YES")
                             XCTAssertEqual(settings[.OTHER_SWIFT_FLAGS], ["$(inherited)", "-enable-library-evolution"])
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func testSupportedSwiftVersions() throws {
+        #if !os(macOS)
+        try XCTSkipIf(true, "test is only supported on macOS")
+        #endif
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Foo/Sources/foo/main.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Foo",
+                    path: "/Foo",
+                    toolsVersion: .v5_3,
+                    swiftLanguageVersions: [.v4_2, .v5],
+                    targets: [
+                        .init(name: "foo", dependencies: []),
+                    ]
+                ),
+            ],
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
+        )
+
+        let builder = PIFBuilder(
+            graph: graph,
+            parameters: .mock(supportedSwiftVersions: [.v4_2]),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let pif = try builder.construct()
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        try PIFTester(pif) { workspace in
+            try workspace.checkProject("PACKAGE:/Foo") { project in
+                project.checkTarget("PACKAGE-PRODUCT:foo") { target in
+                    target.checkBuildConfiguration("Debug") { configuration in
+                        configuration.checkBuildSettings { settings in
+                            XCTAssertEqual(settings[.SWIFT_VERSION], "4.2")
                         }
                     }
                 }
@@ -2644,7 +2984,8 @@ class PIFBuilderTests: XCTestCase {
 extension PIFBuilderParameters {
     static func mock(
         isPackageAccessModifierSupported: Bool = false,
-        shouldCreateDylibForDynamicProducts: Bool = false
+        shouldCreateDylibForDynamicProducts: Bool = false,
+        supportedSwiftVersions: [SwiftLanguageVersion] = []
     ) -> Self {
         PIFBuilderParameters(
             isPackageAccessModifierSupported: isPackageAccessModifierSupported,
@@ -2652,7 +2993,8 @@ extension PIFBuilderParameters {
             shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts,
             toolchainLibDir: "/toolchain/lib",
             pkgConfigDirectories: ["/pkg-config"],
-            sdkRootPath: "/some.sdk"
+            sdkRootPath: "/some.sdk",
+            supportedSwiftVersions: supportedSwiftVersions
         )
     }
 }


### PR DESCRIPTION
XCBuild has its own notion of supported Swift versions which can differ from the ones SwiftPM's own build system and the used compiler support. Using a version outside of the supported range prevents building, so we'll try to obtain the list of supported versions and intersect it with the versions supported by a given package to find the best version supported by both.

(cherry picked from commit 3f9587c3930b2b910635ffeab05339d3c5c6c86d)

*Explanation*: XCBuild has its own notion of supported Swift versions that can be different from the toolchain/SwiftPM. To support packages that support multiple language versions, including Swift 6, we need to allow falling back to an older language version if the newest supported one is not supported by XCBuild.
*Scope*: Anyone using XCBuild from existing Xcodes together with a Swift 6 toolchain, specifically we're running into this when adopting Swift 6 in swift-syntax since the macOS toolchain build uses XCBuild to produce universal binaries.
*Issue*: rdar://126952308 (Building a package that supports Swift 6 mode using a Swift 6 toolchain but with a RainbowE Xcode fails with: `SWIFT_VERSION '6' is unsupported, supported versions are: 4.0, 4.2, 5.0`)
*Original PR*: https://github.com/apple/swift-package-manager/pull/7499
*Risk*: Low risk
*Testing*: Manually tested with a few different Xcodes, added a unit test for the specific scenario.
*Reviewer*: @MaxDesiatov 