### PR TITLE
[6.0] plugins: Pass correct dependency origin information to plugins

### DIFF
--- a/Sources/PackagePlugin/PluginContextDeserializer.swift
+++ b/Sources/PackagePlugin/PluginContextDeserializer.swift
@@ -251,12 +251,22 @@ internal struct PluginContextDeserializer {
         }
         let products = try wirePackage.productIds.map { try self.product(for: $0) }
         let targets = try wirePackage.targetIds.map { try self.target(for: $0) }
+        let origin : PackageOrigin = switch wirePackage.origin {
+            case .root:
+                .root
+            case .local(let pathId):
+                try .local(path: url(for: pathId).path)
+            case .repository(let url, let displayVersion, let scmRevision):
+                .repository(url: url, displayVersion: displayVersion, scmRevision: scmRevision)
+            case .registry(let identity, let displayVersion):
+                .registry(identity: identity, displayVersion: displayVersion)
+        }
         let package = Package(
             id: wirePackage.identity,
             displayName: wirePackage.displayName,
             directory: Path(url: directory),
             directoryURL: directory,
-            origin: .root,
+            origin:  origin,
             toolsVersion: toolsVersion,
             dependencies: dependencies,
             products: products,

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1879,6 +1879,11 @@ final class PackageCommandTests: CommandsTestCase {
                                 print("  \\(file.path): \\(file.type)")
                             }
                         }
+
+                        // Print out the dependencies so that we can check them.
+                        for dependency in context.package.dependencies {
+                            print("  dependency \\(dependency.package.displayName): \\(dependency.package.origin)")
+                        }
                     }
                 }
                 """
@@ -1957,6 +1962,12 @@ final class PackageCommandTests: CommandsTestCase {
                 let workingDirectory = FileManager.default.currentDirectoryPath
                 let (stdout, _) = try SwiftPM.Package.execute(["mycmd"], packagePath: packageDir)
                 XCTAssertMatch(stdout, .contains("Initial working directory: \(workingDirectory)"))
+            }
+
+            // Check that information about the dependencies was properly sent to the plugin.
+            do {
+                let (stdout, _) = try SwiftPM.Package.execute(["mycmd", "--target", "MyLibrary"], packagePath: packageDir)
+                XCTAssertMatch(stdout, .contains("dependency HelperPackage: local"))
             }
         }
     }


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift-package-manager/pull/7506

**Explanation**: SwiftPM sends information about the origin of each package dependency to the plugin process, but the `PluginContext` passed to the plugin function incorrectly shows all origins as `root`.
**Scope**: Isolated to `PackagePlugin/PluginContextDeserializer.swift`
**Risk**: Low, isolated to plugins.
**Testing**: Existing end-to-end automated test was modified to cover the fix.
**Issue**: rdar://127104161
**Reviewer**: @MaxDesiatov 

### Modifications:

The necessary information is included correctly in the serialized structure sent to the plugin by SwiftPM.    The startup wrapper code in the plugin process correctly deserializes it but does not copy it into the final `PluginContext` struct which is passed to the plugin function; instead, `origin` is hard-coded to `.root`.

This change copies the dependency information into the final context struct.

### Result:

Plugins receive correct information about package dependencies - `local`, with a local path, or `repository` with a URL, version number and revision hash.