### PR TITLE
[6.0] Make `supportedTriples` optional in artifactbundle metadata

### DIFF
--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -52,9 +52,9 @@ public struct ArtifactsArchiveMetadata: Equatable {
 
     public struct Variant: Equatable {
         public let path: RelativePath
-        public let supportedTriples: [Triple]
+        public let supportedTriples: [Triple]?
 
-        public init(path: RelativePath, supportedTriples: [Triple]) {
+        public init(path: RelativePath, supportedTriples: [Triple]?) {
             self.path = path
             self.supportedTriples = supportedTriples
         }
@@ -121,7 +121,7 @@ extension ArtifactsArchiveMetadata.Variant: Decodable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.supportedTriples = try container.decode([String].self, forKey: .supportedTriples).map { try Triple($0) }
+        self.supportedTriples = try container.decodeIfPresent([String].self, forKey: .supportedTriples)?.map { try Triple($0) }
         self.path = try RelativePath(validating: container.decode(String.self, forKey: .path))
     }
 }

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -69,7 +69,10 @@ extension BinaryTarget {
             // Filter supported triples with versionLessTriple and pass into
             // ExecutableInfo; empty if non matching triples found.
             try entry.value.variants.map {
-                let filteredSupportedTriples = try $0.supportedTriples
+                guard let supportedTriples = $0.supportedTriples else {
+                    throw StringError("No \"supportedTriples\" found in the artifact metadata for \(entry.key) in \(self.artifactPath)")
+                }
+                let filteredSupportedTriples = try supportedTriples
                     .filter { try $0.withoutVersion() == versionLessTriple }
                 return ExecutableInfo(
                     name: entry.key,

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -21,6 +21,7 @@ private let bundleRootPath = try! AbsolutePath(validating: "/tmp/cross-toolchain
 private let toolchainBinDir = RelativePath("swift.xctoolchain/usr/bin")
 private let sdkRootDir = RelativePath("ubuntu-jammy.sdk")
 private let hostTriple = try! Triple("arm64-apple-darwin22.1.0")
+private let olderHostTriple = try! Triple("arm64-apple-darwin20.1.0")
 private let linuxGNUTargetTriple = try! Triple("x86_64-unknown-linux-gnu")
 private let linuxMuslTargetTriple = try! Triple("x86_64-unknown-linux-musl")
 private let extraFlags = BuildFlags(
@@ -291,6 +292,12 @@ private let parsedDestinationV2Musl = SwiftSDK(
     pathsConfiguration: .init(sdkRootPath: sdkRootAbsolutePath)
 )
 
+private let parsedDestinationForOlderHost = SwiftSDK(
+    targetTriple: linuxMuslTargetTriple,
+    toolset: .init(toolchainBinDir: toolchainBinAbsolutePath, buildFlags: extraFlags),
+    pathsConfiguration: .init(sdkRootPath: sdkRootAbsolutePath)
+)
+
 private let parsedToolsetNoRootDestination = SwiftSDK(
     targetTriple: linuxGNUTargetTriple,
     toolset: .init(
@@ -520,6 +527,24 @@ final class DestinationTests: XCTestCase {
                             swiftSDKs: [parsedDestinationV2Musl]
                         ),
                     ],
+                    "id4": [
+                        .init(
+                            metadata: .init(
+                                path: "id4",
+                                supportedTriples: [olderHostTriple]
+                            ),
+                            swiftSDKs: [parsedDestinationForOlderHost]
+                        ),
+                    ],
+                    "id5": [
+                        .init(
+                            metadata: .init(
+                                path: "id5",
+                                supportedTriples: nil
+                            ),
+                            swiftSDKs: [parsedDestinationV2GNU]
+                        ),
+                    ],
                 ]
             ),
         ]
@@ -552,6 +577,42 @@ final class DestinationTests: XCTestCase {
                 observabilityScope: system.topScope
             ),
             parsedDestinationV2Musl
+        )
+
+        // Newer hostTriple should match with older supportedTriples
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                id: "id4",
+                hostTriple: hostTriple,
+                targetTriple: linuxMuslTargetTriple
+            ),
+            parsedDestinationForOlderHost
+        )
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                matching: "id4",
+                hostTriple: hostTriple,
+                observabilityScope: system.topScope
+            ),
+            parsedDestinationForOlderHost
+        )
+
+        // nil supportedTriples should match with any hostTriple
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                id: "id5",
+                hostTriple: hostTriple,
+                targetTriple: linuxGNUTargetTriple
+            ),
+            parsedDestinationV2GNU
+        )
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                matching: "id5",
+                hostTriple: hostTriple,
+                observabilityScope: system.topScope
+            ),
+            parsedDestinationV2GNU
         )
     }
 }

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -65,4 +65,61 @@ final class ArtifactsArchiveMetadataTests: XCTestCase {
             ]
         ))
     }
+    func testParseMetadataWithoutSupportedTriple() throws {
+        let fileSystem = InMemoryFileSystem()
+        try fileSystem.writeFileContents(
+            "/info.json",
+            string: """
+            {
+                "schemaVersion": "1.0",
+                "artifacts": {
+                    "protocol-buffer-compiler": {
+                        "type": "executable",
+                        "version": "3.5.1",
+                        "variants": [
+                            {
+                                "path": "x86_64-apple-macosx/protoc"
+                            },
+                            {
+                                "path": "x86_64-unknown-linux-gnu/protoc",
+                                "supportedTriples": null
+                            }
+                        ]
+                    }
+                }
+            }
+            """
+        )
+
+        let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
+        XCTAssertEqual(metadata, ArtifactsArchiveMetadata(
+            schemaVersion: "1.0",
+            artifacts: [
+                "protocol-buffer-compiler": ArtifactsArchiveMetadata.Artifact(
+                    type: .executable,
+                    version: "3.5.1",
+                    variants: [
+                        ArtifactsArchiveMetadata.Variant(
+                            path: "x86_64-apple-macosx/protoc",
+                            supportedTriples: nil
+                        ),
+                        ArtifactsArchiveMetadata.Variant(
+                            path: "x86_64-unknown-linux-gnu/protoc",
+                            supportedTriples: nil
+                        ),
+                    ]
+                ),
+            ]
+        ))
+
+        let binaryTarget = BinaryTarget(
+            name: "protoc", kind: .artifactsArchive, path: .root, origin: .local
+        )
+        // No supportedTriples with binaryTarget should be rejected
+        XCTAssertThrowsError(
+            try binaryTarget.parseArtifactArchives(
+                for: Triple("x86_64-apple-macosx"), fileSystem: fileSystem
+            )
+        )
+    }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/7432.

**Explanation**:  We don't have a good way to express a Swift SDK that can be used on any host platform except for listing up all possible platforms.  This change allows `supportedTriples` field to be null or missing to express that the SDK is universally usable. Also this fixes a minor issue around `swift experimental-sdk configuration`, that did not take care of runtime compatibility of OS version in host triples.
**Scope**: Isolated to Swift SDKs.
**Risk**: Low due to limited scope. Incubated on the `main` branch for 30 days with no known regressions.
**Testing**: Automated. New test cases to `ArtifactsArchiveMetadataTests.swift` and `SwiftSDKTests.swift`.
**Issue**: N/A
**Reviewer**: @MaxDesiatov on the original PR. @kateinoigakukun and @bnbarham on the cherry-pick PR.