### PR TITLE
Add `swift build --enable-code-coverage`

### DIFF
--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -664,4 +664,21 @@ final class BuildCommandTests: CommandsTestCase {
         }
     }
 #endif
+
+    func testCodeCoverage() throws {
+        // Test that no codecov directory is created if not specified when building.
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
+            let buildResult = try self.build(["--build-tests"], packagePath: path, cleanAfterward: false)
+            XCTAssertThrowsError(try SwiftPM.Test.execute(["--skip-build", "--enable-code-coverage"], packagePath: path))
+        }
+
+        // Test that enabling code coverage during building produces the expected folder.
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
+            let buildResult = try self.build(["--build-tests", "--enable-code-coverage"], packagePath: path, cleanAfterward: false)
+            try SwiftPM.Test.execute(["--skip-build", "--enable-code-coverage"], packagePath: path)
+            let codeCovPath = buildResult.binPath.appending("codecov")
+            let codeCovFiles = try localFileSystem.getDirectoryContents(codeCovPath)
+            XCTAssertGreaterThan(codeCovFiles.count, 0)
+        }
+    }
 }


### PR DESCRIPTION
This PR adds the `--enable-code-coverage` flag (from `swift test`) to `swift build` so that code coverage can be used in a two-stage build process (build, then execute later.)

Resolves rdar://127309781.