### PR TITLE
[ModulesGraph] Fix association between `.tools` targets and their pac…

### DIFF
--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -207,7 +207,8 @@ public struct ModulesGraph {
                         switch dependency {
                         case .target(let targetDependency, _):
                             allTargets.insert(targetDependency)
-                            modulesToPackages[targetDependency.id] = package
+                            modulesToPackages[targetDependency.id] =
+                                identitiesToPackages[targetDependency.packageIdentity]
                         case .product(let productDependency, _):
                             allProducts.insert(productDependency)
                             productsToPackages[productDependency.id] =

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -150,6 +150,20 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
 
                 XCTAssertEqual(results.filter({ $0.target.buildTriple == .tools }).count, 1)
                 XCTAssertEqual(results.filter({ $0.target.buildTriple == .destination }).count, 1)
+
+                for result in results {
+                    XCTAssertEqual(result.target.packageIdentity, .plain("swift-syntax"))
+                    XCTAssertEqual(graph.package(for: result.target)?.identity, .plain("swift-syntax"))
+                }
+            }
+
+            result.checkTargets("SwiftCompilerPlugin") { results in
+                XCTAssertEqual(results.count, 2)
+
+                for result in results {
+                    XCTAssertEqual(result.target.packageIdentity, .plain("swift-syntax"))
+                    XCTAssertEqual(graph.package(for: result.target)?.identity, .plain("swift-syntax"))
+                }
             }
         }
     }


### PR DESCRIPTION
…kages

While inserting updated `.tools` targets to `modulesToPackages` the logic 
should use the package where the target resides instead of the package where it's referenced.

Resolves: rdar://127369576