### PR TITLE
Remove the addition of external-plugin-path for dev toolchains

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -451,25 +451,6 @@ package final class SwiftTargetBuildDescription {
         }
         #endif
 
-        // If we're using an OSS toolchain, add the required arguments bringing in the plugin server from the default toolchain if available.
-        if self.defaultBuildParameters.toolchain.isSwiftDevelopmentToolchain, 
-            DriverSupport.checkSupportedFrontendFlags(
-                flags: ["-external-plugin-path"],
-                toolchain: self.defaultBuildParameters.toolchain,
-                fileSystem: self.fileSystem
-            ), 
-            let pluginServer = try self.defaultBuildParameters.toolchain.swiftPluginServerPath
-        {
-            let toolchainUsrPath = pluginServer.parentDirectory.parentDirectory
-            let pluginPathComponents = ["lib", "swift", "host", "plugins"]
-
-            let pluginPath = toolchainUsrPath.appending(components: pluginPathComponents)
-            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(pluginPath)#\(pluginServer.pathString)"]
-
-            let localPluginPath = toolchainUsrPath.appending(components: ["local"] + pluginPathComponents)
-            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(localPluginPath)#\(pluginServer.pathString)"]
-        }
-
         if self.shouldDisableSandbox {
             let toolchainSupportsDisablingSandbox = DriverSupport.checkSupportedFrontendFlags(
                 flags: ["-disable-sandbox"],

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -25,12 +25,6 @@ public protocol Toolchain {
     /// Path to `lib/swift_static`
     var swiftStaticResourcesPath: AbsolutePath? { get }
 
-    /// Whether the used compiler is from a open source development toolchain.
-    var isSwiftDevelopmentToolchain: Bool { get }
-
-    /// Path to the Swift plugin server utility.
-    var swiftPluginServerPath: AbsolutePath? { get throws }
-
     /// Path containing the macOS Swift stdlib.
     var macosSwiftStdlib: AbsolutePath { get throws }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -84,8 +84,6 @@ public final class UserToolchain: Toolchain {
 
     private let environment: EnvironmentVariables
 
-    public let isSwiftDevelopmentToolchain: Bool
-
     public let installedSwiftPMConfiguration: InstalledSwiftPMConfiguration
 
     public let providedLibraries: [ProvidedLibrary]
@@ -514,22 +512,6 @@ public final class UserToolchain: Toolchain {
         self.swiftCompilerPath = swiftCompilers.compile
         self.architectures = swiftSDK.architectures
 
-        #if canImport(Darwin)
-        let toolchainPlistPath = self.swiftCompilerPath.parentDirectory.parentDirectory.parentDirectory
-            .appending(component: "Info.plist")
-        if localFileSystem.exists(toolchainPlistPath), let toolchainPlist = try? NSDictionary(
-            contentsOf: URL(fileURLWithPath: toolchainPlistPath.pathString),
-            error: ()
-        ), let overrideBuildSettings = toolchainPlist["OverrideBuildSettings"] as? NSDictionary,
-        let isSwiftDevelopmentToolchainStringValue = overrideBuildSettings["SWIFT_DEVELOPMENT_TOOLCHAIN"] as? String {
-            self.isSwiftDevelopmentToolchain = isSwiftDevelopmentToolchainStringValue == "YES"
-        } else {
-            self.isSwiftDevelopmentToolchain = false
-        }
-        #else
-        self.isSwiftDevelopmentToolchain = false
-        #endif
-
         if let customInstalledSwiftPMConfiguration {
             self.installedSwiftPMConfiguration = customInstalledSwiftPMConfiguration
         } else {
@@ -877,16 +859,6 @@ public final class UserToolchain: Toolchain {
 
     public var xctestPath: AbsolutePath? {
         configuration.xctestPath
-    }
-
-    private let _swiftPluginServerPath = ThreadSafeBox<AbsolutePath?>()
-
-    public var swiftPluginServerPath: AbsolutePath? {
-        get throws {
-            try _swiftPluginServerPath.memoize {
-                return try Self.derivePluginServerPath(triple: self.targetTriple)
-            }
-        }
     }
 
     private static func loadJSONResource<T: Decodable>(

--- a/Sources/SPMTestSupport/MockBuildTestHelper.swift
+++ b/Sources/SPMTestSupport/MockBuildTestHelper.swift
@@ -34,9 +34,7 @@ package struct MockToolchain: PackageModel.Toolchain {
     package let librarySearchPaths = [AbsolutePath]()
     package let swiftResourcesPath: AbsolutePath?
     package let swiftStaticResourcesPath: AbsolutePath? = nil
-    package let isSwiftDevelopmentToolchain = false
     package let sdkRootPath: AbsolutePath? = nil
-    package let swiftPluginServerPath: AbsolutePath? = nil
     package let extraFlags = PackageModel.BuildFlags()
     package let installedSwiftPMConfiguration = InstalledSwiftPMConfiguration.default
     package let providedLibraries = [ProvidedLibrary]()


### PR DESCRIPTION
SDK macro plugins are now provided within
`Platforms/<Platform>.platform/Developer/usr/lib/swift/host/plugins` now, which is always added by the driver.