### PR TITLE
package -> @_spi public due to package exportability rule updates

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -170,7 +170,8 @@ public struct SwiftSDK: Equatable {
     }
 
     /// Whether or not the receiver supports using XCTest.
-    package let xctestSupport: XCTestSupport
+    @_spi(SwiftPMInternal)
+    public let xctestSupport: XCTestSupport
 
     /// Root directory path of the SDK used to compile for the target triple.
     @available(*, deprecated, message: "use `pathsConfiguration.sdkRootPath` instead")


### PR DESCRIPTION
The exportability rules around `package` access level are updated in a way that an `@_spi public` can't be bound to a `package` var, similar to how `@_spi public` can't be bound to a `public` var.  For reference, see https://github.com/apple/swift/pull/73161. 
This PR corrects such use case. 
 