### PR TITLE
[6.0] Remove the addition of external-plugin-path for dev toolchains

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -439,25 +439,6 @@ package final class SwiftTargetBuildDescription {
         }
         #endif
 
-        // If we're using an OSS toolchain, add the required arguments bringing in the plugin server from the default toolchain if available.
-        if self.buildParameters.toolchain.isSwiftDevelopmentToolchain, 
-            DriverSupport.checkSupportedFrontendFlags(
-                flags: ["-external-plugin-path"],
-                toolchain: self.buildParameters.toolchain,
-                fileSystem: self.fileSystem
-            ), 
-            let pluginServer = try self.buildParameters.toolchain.swiftPluginServerPath
-        {
-            let toolchainUsrPath = pluginServer.parentDirectory.parentDirectory
-            let pluginPathComponents = ["lib", "swift", "host", "plugins"]
-
-            let pluginPath = toolchainUsrPath.appending(components: pluginPathComponents)
-            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(pluginPath)#\(pluginServer.pathString)"]
-
-            let localPluginPath = toolchainUsrPath.appending(components: ["local"] + pluginPathComponents)
-            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(localPluginPath)#\(pluginServer.pathString)"]
-        }
-
         if self.disableSandbox {
             let toolchainSupportsDisablingSandbox = DriverSupport.checkSupportedFrontendFlags(flags: ["-disable-sandbox"], toolchain: self.buildParameters.toolchain, fileSystem: fileSystem)
             if toolchainSupportsDisablingSandbox {

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -25,12 +25,6 @@ public protocol Toolchain {
     /// Path to `lib/swift_static`
     var swiftStaticResourcesPath: AbsolutePath? { get }
 
-    /// Whether the used compiler is from a open source development toolchain.
-    var isSwiftDevelopmentToolchain: Bool { get }
-
-    /// Path to the Swift plugin server utility.
-    var swiftPluginServerPath: AbsolutePath? { get throws }
-
     /// Path containing the macOS Swift stdlib.
     var macosSwiftStdlib: AbsolutePath { get throws }
 

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -84,8 +84,6 @@ public final class UserToolchain: Toolchain {
 
     private let environment: EnvironmentVariables
 
-    public let isSwiftDevelopmentToolchain: Bool
-
     public let installedSwiftPMConfiguration: InstalledSwiftPMConfiguration
 
     public let providedLibraries: [LibraryMetadata]
@@ -514,22 +512,6 @@ public final class UserToolchain: Toolchain {
         self.swiftCompilerPath = swiftCompilers.compile
         self.architectures = swiftSDK.architectures
 
-        #if canImport(Darwin)
-        let toolchainPlistPath = self.swiftCompilerPath.parentDirectory.parentDirectory.parentDirectory
-            .appending(component: "Info.plist")
-        if localFileSystem.exists(toolchainPlistPath), let toolchainPlist = try? NSDictionary(
-            contentsOf: URL(fileURLWithPath: toolchainPlistPath.pathString),
-            error: ()
-        ), let overrideBuildSettings = toolchainPlist["OverrideBuildSettings"] as? NSDictionary,
-        let isSwiftDevelopmentToolchainStringValue = overrideBuildSettings["SWIFT_DEVELOPMENT_TOOLCHAIN"] as? String {
-            self.isSwiftDevelopmentToolchain = isSwiftDevelopmentToolchainStringValue == "YES"
-        } else {
-            self.isSwiftDevelopmentToolchain = false
-        }
-        #else
-        self.isSwiftDevelopmentToolchain = false
-        #endif
-
         if let customInstalledSwiftPMConfiguration {
             self.installedSwiftPMConfiguration = customInstalledSwiftPMConfiguration
         } else {
@@ -884,15 +866,5 @@ public final class UserToolchain: Toolchain {
 
     public var xctestPath: AbsolutePath? {
         configuration.xctestPath
-    }
-
-    private let _swiftPluginServerPath = ThreadSafeBox<AbsolutePath?>()
-
-    public var swiftPluginServerPath: AbsolutePath? {
-        get throws {
-            try _swiftPluginServerPath.memoize {
-                return try Self.derivePluginServerPath(triple: self.targetTriple)
-            }
-        }
     }
 }

--- a/Sources/SPMTestSupport/MockBuildTestHelper.swift
+++ b/Sources/SPMTestSupport/MockBuildTestHelper.swift
@@ -32,9 +32,7 @@ package struct MockToolchain: PackageModel.Toolchain {
     package let librarySearchPaths = [AbsolutePath]()
     package let swiftResourcesPath: AbsolutePath? = nil
     package let swiftStaticResourcesPath: AbsolutePath? = nil
-    package let isSwiftDevelopmentToolchain = false
     package let sdkRootPath: AbsolutePath? = nil
-    package let swiftPluginServerPath: AbsolutePath? = nil
     package let extraFlags = PackageModel.BuildFlags()
     package let installedSwiftPMConfiguration = InstalledSwiftPMConfiguration.default
     package let providedLibraries = [LibraryMetadata]()


### PR DESCRIPTION
**Explanation**:  SDK macro plugins are now provided within `Platforms` and are added by default. There's no need to add an additional path to the toolchain. Doing so prevents the macros in the dev toolchain from being picked up.
**Scope**: Macros
**Risk**: Low, this path was added prior to macros moving into `Platforms`.
**Testing**: Source compat suite passes (which has various macro projects). We could theoretically test we're not adding the argument, but seems a bit weird to do so.
**Original PR**: https://github.com/apple/swift-package-manager/pull/7524
**Reviewer**: @MaxDesiatov