### PR TITLE
Add `Sendable` annotations to SwiftVersion

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -16,7 +16,7 @@
 import TSCclibc
 #endif
 
-public struct SwiftVersion {
+public struct SwiftVersion: Sendable {
     /// The version number.
     public var version: (major: Int, minor: Int, patch: Int)
 


### PR DESCRIPTION
<!-- _[One line description of your change]_ -->

### Motivation:
Add `Sendable` annotations to `SwiftVersion`.

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

I fixed warning for preparing Swift 6.

<table>
  <thead>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img src="https://github.com/apple/swift-package-manager/assets/52638834/a851faf4-f3b2-4237-bd7e-a0b16f8dc88c" width="256" />
      </td>
      <td>
        <img src="https://github.com/apple/swift-package-manager/assets/52638834/e4c5d722-d528-478f-ad85-277a794ef101" width="256" />
      </td>
    </tr>
  </tbody>
</table>

<!-- _[Describe the modifications you've done.]_ -->

### Result:

The warning has been corrected.

<!-- _[After your change, what will change.]_ -->
