### PR TITLE
Stop adding '-external-plugin-path' to Xcode toolchain

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -451,25 +451,6 @@ package final class SwiftTargetBuildDescription {
         }
         #endif
 
-        // If we're using an OSS toolchain, add the required arguments bringing in the plugin server from the default toolchain if available.
-        if self.defaultBuildParameters.toolchain.isSwiftDevelopmentToolchain, 
-            DriverSupport.checkSupportedFrontendFlags(
-                flags: ["-external-plugin-path"],
-                toolchain: self.defaultBuildParameters.toolchain,
-                fileSystem: self.fileSystem
-            ), 
-            let pluginServer = try self.defaultBuildParameters.toolchain.swiftPluginServerPath
-        {
-            let toolchainUsrPath = pluginServer.parentDirectory.parentDirectory
-            let pluginPathComponents = ["lib", "swift", "host", "plugins"]
-
-            let pluginPath = toolchainUsrPath.appending(components: pluginPathComponents)
-            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(pluginPath)#\(pluginServer.pathString)"]
-
-            let localPluginPath = toolchainUsrPath.appending(components: ["local"] + pluginPathComponents)
-            args += ["-Xfrontend", "-external-plugin-path", "-Xfrontend", "\(localPluginPath)#\(pluginServer.pathString)"]
-        }
-
         if self.shouldDisableSandbox {
             let toolchainSupportsDisablingSandbox = DriverSupport.checkSupportedFrontendFlags(
                 flags: ["-disable-sandbox"],


### PR DESCRIPTION
In development toolchains. Apple macro plugins are not in .xctoolchain anymore, these flags are useless and harmful.
