### PR TITLE
[Package/ModuleGraph] Allow cyclic package dependencies if they don't introduce a cycle in a build graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Note: This is in reverse chronological order, so newer entries are added to the top.
 
+* [#7530]
+
+  Makes it possible for packages to depend on each other if such dependency doesn't form any target-level cycles. For example,
+  package `A` can depend on `B` and `B` on `A` unless targets in `B` depend on products of `A` that depend on some of the same
+  targets from `B` and vice versa.
+
 Swift 6.0
 -----------
 

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(Basics
   FileSystem/VFSOverlay.swift
   Graph/AdjacencyMatrix.swift
   Graph/DirectedGraph.swift
+  Graph/GraphAlgorithms.swift
   Graph/UndirectedGraph.swift
   SourceControlURL.swift
   HTTPClient/HTTPClient.swift

--- a/Sources/Basics/Graph/GraphAlgorithms.swift
+++ b/Sources/Basics/Graph/GraphAlgorithms.swift
@@ -49,7 +49,7 @@ public func DFS<T: Hashable>(
                 continue
             }
 
-            for succ in try successors(curr).reversed() {
+            for succ in try successors(curr) {
                 stack.append(succ)
             }
         }

--- a/Sources/Basics/Graph/GraphAlgorithms.swift
+++ b/Sources/Basics/Graph/GraphAlgorithms.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2015-2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct OrderedCollections.OrderedSet
+
+/// Implements a pre-order depth-first search.
+///
+/// The cycles are handled by skipping cycle points but it should be possible to
+/// to extend this in the future to provide a callback for every cycle.
+///
+/// - Parameters:
+///   - nodes: The list of input nodes to sort.
+///   - successors: A closure for fetching the successors of a particular node.
+///   - onUnique: A callback to indicate the the given node is being processed for the first time.
+///   - onDuplicate: A callback to indicate that the node was already processed at least once.
+///
+/// - Complexity: O(v + e) where (v, e) are the number of vertices and edges
+/// reachable from the input nodes via the relation.
+public func DFS<T: Hashable>(
+    _ nodes: [T],
+    successors: (T) throws -> [T],
+    onUnique: (T) -> Void,
+    onDuplicate: (T, T) -> Void
+) rethrows {
+    var stack = OrderedSet<T>()
+    var visited = Set<T>()
+
+    for node in nodes {
+        precondition(stack.isEmpty)
+        stack.append(node)
+
+        while !stack.isEmpty {
+            let curr = stack.removeLast()
+
+            let visitResult = visited.insert(curr)
+            if visitResult.inserted {
+                onUnique(curr)
+            } else {
+                onDuplicate(visitResult.memberAfterInsert, curr)
+                continue
+            }
+
+            for succ in try successors(curr).reversed() {
+                stack.append(succ)
+            }
+        }
+    }
+}

--- a/Sources/Basics/Graph/GraphAlgorithms.swift
+++ b/Sources/Basics/Graph/GraphAlgorithms.swift
@@ -25,7 +25,7 @@ import struct OrderedCollections.OrderedSet
 ///
 /// - Complexity: O(v + e) where (v, e) are the number of vertices and edges
 /// reachable from the input nodes via the relation.
-public func DFS<T: Hashable>(
+public func depthFirstSearch<T: Hashable>(
     _ nodes: [T],
     successors: (T) throws -> [T],
     onUnique: (T) -> Void,

--- a/Sources/Commands/PackageCommands/CompletionCommand.swift
+++ b/Sources/Commands/PackageCommands/CompletionCommand.swift
@@ -68,6 +68,7 @@ extension SwiftPackageCommand {
                 // command's result output goes on stdout
                 // ie "swift package list-dependencies" should output to stdout
                 ShowDependencies.dumpDependenciesOf(
+                    graph: graph,
                     rootPackage: graph.rootPackages[graph.rootPackages.startIndex],
                     mode: .flatlist,
                     on: TSCBasic.stdoutStream

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -371,6 +371,7 @@ struct PluginCommand: SwiftCommand {
             pkgConfigDirectories: swiftCommandState.options.locations.pkgConfigDirectories,
             sdkRootPath: buildParameters.toolchain.sdkRootPath,
             fileSystem: swiftCommandState.fileSystem,
+            modulesGraph: packageGraph,
             observabilityScope: swiftCommandState.observabilityScope,
             callbackQueue: delegateQueue,
             delegate: pluginDelegate,

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -383,10 +383,17 @@ struct PluginCommand: SwiftCommand {
 
     static func availableCommandPlugins(in graph: ModulesGraph, limitedTo packageIdentity: String?) -> [PluginTarget] {
         // All targets from plugin products of direct dependencies are "available".
-        let directDependencyPackages = graph.rootPackages.flatMap { $0.dependencies }.filter { $0.matching(identity: packageIdentity) }
+        let directDependencyPackages = graph.rootPackages.flatMap {
+            $0.dependencies
+        }.filter {
+            $0.matching(identity: packageIdentity)
+        }.compactMap {
+            graph.package(for: $0)
+        }
+
         let directDependencyPluginTargets = directDependencyPackages.flatMap { $0.products.filter { $0.type == .plugin } }.flatMap { $0.targets }
         // As well as any plugin targets in root packages.
-        let rootPackageTargets = graph.rootPackages.filter { $0.matching(identity: packageIdentity) }.flatMap { $0.targets }
+        let rootPackageTargets = graph.rootPackages.filter { $0.identity.matching(identity: packageIdentity) }.flatMap { $0.targets }
         return (directDependencyPluginTargets + rootPackageTargets).compactMap { $0.underlying as? PluginTarget }.filter {
             switch $0.capability {
             case .buildTool: return false
@@ -470,10 +477,10 @@ extension SandboxNetworkPermission {
     }
 }
 
-extension ResolvedPackage {
+extension PackageIdentity {
     fileprivate func matching(identity: String?) -> Bool {
         if let identity {
-            return self.identity == .plain(identity)
+            return self == .plain(identity)
         } else {
             return true
         }

--- a/Sources/Commands/PackageCommands/ShowDependencies.swift
+++ b/Sources/Commands/PackageCommands/ShowDependencies.swift
@@ -43,13 +43,19 @@ extension SwiftPackageCommand {
             // ie "swift package show-dependencies" should output to stdout
             let stream: OutputByteStream = try outputPath.map { try LocalFileOutputByteStream($0) } ?? TSCBasic.stdoutStream
             Self.dumpDependenciesOf(
+                graph: graph,
                 rootPackage: graph.rootPackages[graph.rootPackages.startIndex],
                 mode: format,
                 on: stream
             )
         }
 
-        static func dumpDependenciesOf(rootPackage: ResolvedPackage, mode: ShowDependenciesMode, on stream: OutputByteStream) {
+        static func dumpDependenciesOf(
+            graph: ModulesGraph,
+            rootPackage: ResolvedPackage,
+            mode: ShowDependenciesMode,
+            on stream: OutputByteStream
+        ) {
             let dumper: DependenciesDumper
             switch mode {
             case .text:
@@ -61,7 +67,7 @@ extension SwiftPackageCommand {
             case .flatlist:
                 dumper = FlatListDumper()
             }
-            dumper.dump(dependenciesOf: rootPackage, on: stream)
+            dumper.dump(graph: graph, dependenciesOf: rootPackage, on: stream)
             stream.flush()
         }
 

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -100,8 +100,6 @@ extension ModulesGraph {
                 flattenedManifests[node.identity] = node
             }
         }
-        // sort by identity
-        allNodes = flattenedManifests.keys.sorted().map { flattenedManifests[$0]! } // force unwrap fine since we are iterating on keys
 
         // Create the packages.
         var manifestToPackage: [Manifest: Package] = [:]
@@ -169,6 +167,7 @@ extension ModulesGraph {
         return try ModulesGraph(
             rootPackages: rootPackages,
             rootDependencies: resolvedPackages.filter { rootDependencies.contains($0.manifest) },
+            packages: resolvedPackages,
             dependencies: requiredDependencies,
             binaryArtifacts: binaryArtifacts
         )

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -69,7 +69,7 @@ extension ModulesGraph {
         var allNodes = [GraphLoadingNode]()
 
         // Cycles in dependencies don't matter as long as there are no target cycles between packages.
-        DFS(inputManifests.map { KeyedPair($0, key: $0.id) }) {
+        depthFirstSearch(inputManifests.map { KeyedPair($0, key: $0.id) }) {
             $0.item.requiredDependencies.compactMap { dependency in
                 manifestMap[dependency.identity].map { (manifest, fileSystem) in
                     KeyedPair(

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -162,6 +162,7 @@ public struct ModulesGraph {
     public init(
         rootPackages: [ResolvedPackage],
         rootDependencies: [ResolvedPackage] = [],
+        packages: [ResolvedPackage],
         dependencies requiredDependencies: [PackageReference],
         binaryArtifacts: [PackageIdentity: [String: BinaryArtifact]]
     ) throws {
@@ -169,7 +170,7 @@ public struct ModulesGraph {
         self.requiredDependencies = requiredDependencies
         self.inputPackages = rootPackages + rootDependencies
         self.binaryArtifacts = binaryArtifacts
-        self.packages = try topologicalSort(inputPackages, successors: { $0.dependencies })
+        self.packages = packages
         let identitiesToPackages = self.packages.spm_createDictionary { ($0.identity, $0) }
 
         // Create a mapping from targets to the packages that define them.  Here

--- a/Sources/PackageGraph/Resolution/ResolvedPackage.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedPackage.swift
@@ -40,7 +40,7 @@ public struct ResolvedPackage {
     public let products: [ResolvedProduct]
 
     /// The dependencies of the package.
-    public let dependencies: [ResolvedPackage]
+    public let dependencies: [PackageIdentity]
 
     /// The default localization for resources.
     public let defaultLocalization: String?
@@ -57,7 +57,7 @@ public struct ResolvedPackage {
         underlying: Package,
         defaultLocalization: String?,
         supportedPlatforms: [SupportedPlatform],
-        dependencies: [ResolvedPackage],
+        dependencies: [PackageIdentity],
         targets: IdentifiableSet<ResolvedModule>,
         products: [ResolvedProduct],
         registryMetadata: RegistryReleaseMetadata?,

--- a/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
@@ -22,6 +22,7 @@ typealias WireInput = HostToPluginMessage.InputContext
 /// the input information to a plugin.
 internal struct PluginContextSerializer {
     let fileSystem: FileSystem
+    let modulesGraph: ModulesGraph
     let buildEnvironment: BuildEnvironment
     let pkgConfigDirectories: [AbsolutePath]
     let sdkRootPath: AbsolutePath?

--- a/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
@@ -245,7 +245,7 @@ internal struct PluginContextSerializer {
         }
 
         // Serialize the dependencies. It is important to do this before the `let id = package.count` below so the correct wire ID gets assigned.
-        let dependencies = try package.dependencies.map {
+        let dependencies = try modulesGraph.directDependencies(for: package).map {
             WireInput.Package.Dependency(packageId: try serialize(package: $0))
         }
 

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -43,6 +43,7 @@ extension PluginTarget {
         pkgConfigDirectories: [AbsolutePath],
         sdkRootPath: AbsolutePath?,
         fileSystem: FileSystem,
+        modulesGraph: ModulesGraph,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
         delegate: PluginInvocationDelegate
@@ -62,6 +63,7 @@ extension PluginTarget {
                 pkgConfigDirectories: pkgConfigDirectories,
                 sdkRootPath: sdkRootPath,
                 fileSystem: fileSystem,
+                modulesGraph: modulesGraph,
                 observabilityScope: observabilityScope,
                 callbackQueue: callbackQueue,
                 delegate: delegate,
@@ -107,6 +109,7 @@ extension PluginTarget {
         pkgConfigDirectories: [AbsolutePath],
         sdkRootPath: AbsolutePath?,
         fileSystem: FileSystem,
+        modulesGraph: ModulesGraph,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
         delegate: PluginInvocationDelegate,
@@ -125,6 +128,7 @@ extension PluginTarget {
         do {
             var serializer = PluginContextSerializer(
                 fileSystem: fileSystem,
+                modulesGraph: modulesGraph,
                 buildEnvironment: buildEnvironment,
                 pkgConfigDirectories: pkgConfigDirectories,
                 sdkRootPath: sdkRootPath
@@ -571,6 +575,7 @@ extension ModulesGraph {
                     pkgConfigDirectories: pkgConfigDirectories,
                     sdkRootPath: buildParameters.toolchain.sdkRootPath,
                     fileSystem: fileSystem,
+                    modulesGraph: self,
                     observabilityScope: observabilityScope,
                     callbackQueue: delegateQueue,
                     delegate: delegate,

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -147,7 +147,7 @@ package final class PackageGraphResult {
     }
 
     package func find(package: PackageIdentity) -> ResolvedPackage? {
-        return graph.packages.first(where: { $0.identity == package })
+        return graph.package(for: package)
     }
 
     private func reachableBuildTargets(in environment: BuildEnvironment) throws -> IdentifiableSet<ResolvedModule> {

--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -16,7 +16,7 @@ import struct Basics.InternalError
 import class Basics.ObservabilityScope
 import struct Basics.SwiftVersion
 import func Basics.temp_await
-import func Basics.DFS
+import func Basics.depthFirstSearch
 import class Basics.ThreadSafeKeyValueStore
 import class Dispatch.DispatchGroup
 import struct Dispatch.DispatchTime
@@ -533,7 +533,7 @@ extension Workspace {
             }
 
             var deduplication = [PackageIdentity: Int]()
-            try DFS(
+            try depthFirstSearch(
                 manifestGraphRoots,
                 successors: successorManifests
             ) { pair in

--- a/Sources/Workspace/Workspace+Signing.swift
+++ b/Sources/Workspace/Workspace+Signing.swift
@@ -46,7 +46,7 @@ extension Workspace {
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity]
     ) throws {
         try expectedSigningEntities.forEach { identity, expectedSigningEntity in
-            if let package = packageGraph.packages.first(where: { $0.identity == identity }) {
+            if let package = packageGraph.package(for: identity) {
                 guard let actualSigningEntity = package.registryMetadata?.signature?.signedBy else {
                     throw SigningError.unsigned(package: identity, expected: expectedSigningEntity)
                 }
@@ -68,7 +68,7 @@ extension Workspace {
                         expected: expectedSigningEntity
                     )
                 }
-                guard let package = packageGraph.packages.first(where: { $0.identity == mirroredIdentity }) else {
+                guard let package = packageGraph.package(for: mirroredIdentity) else {
                     // Unsure if this case is reachable in practice.
                     throw SigningError.expectedIdentityNotFound(package: identity)
                 }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1150,7 +1150,7 @@ extension Workspace {
         observabilityScope: ObservabilityScope,
         completion: @escaping (Result<Package, Error>) -> Void
     ) {
-        guard let previousPackage = packageGraph.packages.first(where: { $0.identity == identity }) else {
+        guard let previousPackage = packageGraph.package(for: identity) else {
             return completion(.failure(StringError("could not find package with identity \(identity)")))
         }
 

--- a/Tests/CommandsTests/MermaidPackageSerializerTests.swift
+++ b/Tests/CommandsTests/MermaidPackageSerializerTests.swift
@@ -110,7 +110,7 @@ final class MermaidPackageSerializerTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         XCTAssertEqual(graph.packages.count, 2)
-        let package = try XCTUnwrap(graph.packages.first)
+        let package = try XCTUnwrap(graph.package(for: .plain("A")))
         let serializer = MermaidPackageSerializer(package: package.underlying)
         XCTAssertEqual(
             serializer.renderedMarkdown,
@@ -169,7 +169,7 @@ final class MermaidPackageSerializerTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         XCTAssertEqual(graph.packages.count, 2)
-        let package = try XCTUnwrap(graph.packages.first)
+        let package = try XCTUnwrap(graph.package(for: .plain("A")))
         let serializer = MermaidPackageSerializer(package: package.underlying)
         XCTAssertEqual(
             serializer.renderedMarkdown,

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -647,6 +647,7 @@ final class PackageCommandTests: CommandsTestCase {
 
         let output = BufferedOutputByteStream()
         SwiftPackageCommand.ShowDependencies.dumpDependenciesOf(
+            graph: graph,
             rootPackage: graph.rootPackages[graph.rootPackages.startIndex],
             mode: .dot,
             on: output

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -548,6 +548,7 @@ final class PluginTests: XCTestCase {
                         pkgConfigDirectories: [],
                         sdkRootPath: nil,
                         fileSystem: localFileSystem,
+                        modulesGraph: packageGraph,
                         observabilityScope: observability.topScope,
                         callbackQueue: delegateQueue,
                         delegate: delegate,
@@ -825,6 +826,7 @@ final class PluginTests: XCTestCase {
                             pkgConfigDirectories: [],
                             sdkRootPath: try UserToolchain.default.sdkRootPath,
                             fileSystem: localFileSystem,
+                            modulesGraph: packageGraph,
                             observabilityScope: observability.topScope,
                             callbackQueue: delegateQueue,
                             delegate: delegate

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -83,12 +83,12 @@ final class ModulesGraphTests: XCTestCase {
             result.checkTarget("Baz") { result in result.check(dependencies: "Bar") }
         }
 
-        let fooPackage = try XCTUnwrap(g.packages.first{ $0.identity == .plain("Foo") })
+        let fooPackage = try XCTUnwrap(g.package(for: .plain("Foo")))
         let fooTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "Foo" })
         let fooDepTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "FooDep" })
         XCTAssertEqual(g.package(for: fooTarget)?.id, fooPackage.id)
         XCTAssertEqual(g.package(for: fooDepTarget)?.id, fooPackage.id)
-        let barPackage = try XCTUnwrap(g.packages.first{ $0.identity == .plain("Bar") })
+        let barPackage = try XCTUnwrap(g.package(for: .plain("Bar")))
         let barTarget = try XCTUnwrap(g.allTargets.first{ $0.name == "Bar" })
         XCTAssertEqual(g.package(for: barTarget)?.id, barPackage.id)
     }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1971,7 +1971,7 @@ final class WorkspaceTests: XCTestCase {
             // Ensure that the order of the manifests is stable.
             XCTAssertEqual(
                 manifests.allDependencyManifests.map(\.value.manifest.displayName),
-                ["Foo", "Baz", "Bam", "Bar"]
+                ["Foo", "Bar", "Baz", "Bam"]
             )
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -12111,15 +12111,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
-                    diagnostic: .regex("cyclic dependency declaration found: root[1|2] -> *"),
-                    severity: .error
-                )
-                result.check(
-                    diagnostic: """
-                    exhausted attempts to resolve the dependencies graph, with the following dependencies unresolved:
-                    * 'bar' from http://scm.com/org/bar
-                    * 'foo' from http://scm.com/org/foo
-                    """,
+                    diagnostic: .regex("cyclic dependency declaration found: Root[1|2] -> *"),
                     severity: .error
                 )
             }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1971,7 +1971,7 @@ final class WorkspaceTests: XCTestCase {
             // Ensure that the order of the manifests is stable.
             XCTAssertEqual(
                 manifests.allDependencyManifests.map(\.value.manifest.displayName),
-                ["Foo", "Bar", "Baz", "Bam"]
+                ["Bam", "Baz", "Bar", "Foo"]
             )
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -11123,7 +11123,7 @@ final class WorkspaceTests: XCTestCase {
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
                 result.check(
-                    diagnostic: "cyclic dependency declaration found: Root -> FooUtilityPackage -> BarPackage -> FooUtilityPackage",
+                    diagnostic: "'bar' dependency on '/tmp/ws/pkgs/other/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'",
                     severity: .error
                 )
             }
@@ -11207,7 +11207,11 @@ final class WorkspaceTests: XCTestCase {
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
                 result.check(
-                    diagnostic: "cyclic dependency declaration found: Root -> FooUtilityPackage -> BarPackage -> FooUtilityPackage",
+                    diagnostic: "'bar' dependency on '/tmp/ws/pkgs/other/utility' conflicts with dependency on '/tmp/ws/pkgs/foo/utility' which has the same identity 'utility'. this will be escalated to an error in future versions of SwiftPM.",
+                    severity: .warning
+                )
+                result.check(
+                    diagnostic: "product 'OtherUtilityProduct' required by package 'bar' target 'BarTarget' not found in package 'OtherUtilityPackage'.",
                     severity: .error
                 )
             }
@@ -11282,7 +11286,7 @@ final class WorkspaceTests: XCTestCase {
                 // FIXME: rdar://72940946
                 // we need to improve this situation or diagnostics when working on identity
                 result.check(
-                    diagnostic: "cyclic dependency declaration found: Root -> BarPackage -> Root",
+                    diagnostic: "product 'FooProduct' required by package 'bar' target 'BarTarget' not found in package 'FooPackage'.",
                     severity: .error
                 )
             }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -12019,7 +12019,7 @@ final class WorkspaceTests: XCTestCase {
                     targets: [
                         .init(name: "Root1Target", dependencies: [
                             .product(name: "FooProduct", package: "foo"),
-                            .product(name: "Root2Target", package: "Root2")
+                            .product(name: "Root2Product", package: "Root2")
                         ]),
                     ],
                     products: [
@@ -12115,7 +12115,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(roots: ["Root1", "Root2"]) { _, diagnostics in
             testDiagnostics(diagnostics) { result in
                 result.check(
-                    diagnostic: .regex("cyclic dependency declaration found: Root[1|2] -> *"),
+                    diagnostic: .regex("cyclic dependency declaration found: Root[1|2]Target -> *"),
                     severity: .error
                 )
             }


### PR DESCRIPTION
### Motivation:

It should be possible for packages to depend on each other if such dependence doesn't introduce cycles in the build graph.

### Modifications:

- Introduced a new DFS method to walk over graphs that breaks cycles.
- Replaces use of `findCycle` + `topologicalSort` with `DFS` while building manifest and package graphs. This allows cycles in dependencies to be modeled correctly.
- Removes some of the redundant data transformations from modules graph.
- Modifies `ResolvedPackage` to carry identities of its dependencies instead of resolved dependencies themselves. This helps to simplify logic in `createResolvedPackages`.
- Adds detection of target cycles across packages.

### Result:

Makes it possible for package A to depend on package B and B to depend on A if their targets don't form a cycle.
