### PR TITLE
[6.0] Update -swift-version to default to 6 for swift-tools-version 6

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/DependentPlugins/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/DependentPlugins/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     targets: [
         .executableTarget(name: "MyExecutable"),
         .executableTarget(name: "MyExecutable2"),
-        
+
         .plugin(
             name: "MyPlugin",
             capability: .buildTool(),
@@ -18,7 +18,7 @@ let package = Package(
                 "MyExecutable"
             ]
         ),
-        
+
         .plugin(
             name: "MyPlugin2",
             capability: .buildTool(),
@@ -34,5 +34,6 @@ let package = Package(
                 "MyPlugin2",
             ]
         ),
-    ]
+    ],
+    swiftLanguageVersions: [.v5]
 )

--- a/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MySourceGenBuildTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Sources/MySourceGenBuildTool/main.swift
@@ -13,6 +13,6 @@ let variableName = URL(fileURLWithPath: inputFile).deletingPathExtension().lastP
 
 let inputData = FileManager.default.contents(atPath: inputFile) ?? Data()
 let dataAsHex = inputData.map { String(format: "%02hhx", $0) }.joined()
-let outputString = "public var \(variableName) = \(dataAsHex.quotedForSourceCode)\n"
+let outputString = "public let \(variableName) = \(dataAsHex.quotedForSourceCode)\n"
 let outputData = outputString.data(using: .utf8)
 FileManager.default.createFile(atPath: outputFile, contents: outputData)

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Sources/MySourceGenBuildTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Sources/MySourceGenBuildTool/main.swift
@@ -13,6 +13,6 @@ let variableName = URL(fileURLWithPath: inputFile).deletingPathExtension().lastP
 
 let inputData = FileManager.default.contents(atPath: inputFile) ?? Data()
 let dataAsHex = inputData.map { String(format: "%02hhx", $0) }.joined()
-let outputString = "public var \(variableName) = \(dataAsHex.quotedForSourceCode)\n"
+let outputString = "public let \(variableName) = \(dataAsHex.quotedForSourceCode)\n"
 let outputData = outputString.data(using: .utf8)
 FileManager.default.createFile(atPath: outputFile, contents: outputData)

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI/Sources/MySourceGenBuildTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI/Sources/MySourceGenBuildTool/main.swift
@@ -13,6 +13,6 @@ let variableName = URL(fileURLWithPath: inputFile).deletingPathExtension().lastP
 
 let inputData = FileManager.default.contents(atPath: inputFile) ?? Data()
 let dataAsHex = inputData.map { String(format: "%02hhx", $0) }.joined()
-let outputString = "public var \(variableName) = \(dataAsHex.quotedForSourceCode)\n"
+let outputString = "public let \(variableName) = \(dataAsHex.quotedForSourceCode)\n"
 let outputData = outputString.data(using: .utf8)
 FileManager.default.createFile(atPath: outputFile, contents: outputData)

--- a/Fixtures/Miscellaneous/Plugins/PluginWithInternalExecutable/Sources/PluginExecutable/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginWithInternalExecutable/Sources/PluginExecutable/main.swift
@@ -12,6 +12,6 @@ let variableName = URL(fileURLWithPath: inputFile).deletingPathExtension().lastP
 
 let inputData = FileManager.default.contents(atPath: inputFile) ?? Data()
 let dataAsHex = inputData.map { String(format: "%02hhx", $0) }.joined()
-let outputString = "public var \(variableName) = \(dataAsHex.quotedForSourceCode)\n"
+let outputString = "public let \(variableName) = \(dataAsHex.quotedForSourceCode)\n"
 let outputData = outputString.data(using: .utf8)
 FileManager.default.createFile(atPath: outputFile, contents: outputData)

--- a/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/BasicTests.swift
@@ -19,6 +19,7 @@ final class BasicTests: XCTestCase {
 
     func testExamplePackageDealer() throws {
         try XCTSkipIf(isSelfHosted, "These packages don't use the latest runtime library, which doesn't work with self-hosted builds.")
+        try skipUnlessAtLeastSwift6()
 
         try withTemporaryDirectory { tempDir in
             let packagePath = tempDir.appending(component: "dealer")
@@ -93,9 +94,7 @@ final class BasicTests: XCTestCase {
     }
 
     func testSwiftPackageInitExec() throws {
-        #if swift(<5.5)
-        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
-        #endif
+        try skipUnlessAtLeastSwift6()
 
         try withTemporaryDirectory { tempDir in
             // Create a new package with an executable target.
@@ -122,9 +121,7 @@ final class BasicTests: XCTestCase {
     }
 
     func testSwiftPackageInitExecTests() throws {
-        #if swift(<5.5)
-        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
-        #endif
+        try skipUnlessAtLeastSwift6()
 
         try XCTSkip("FIXME: swift-test invocations are timing out in Xcode and self-hosted CI")
 
@@ -149,6 +146,8 @@ final class BasicTests: XCTestCase {
     }
 
     func testSwiftPackageInitLib() throws {
+        try skipUnlessAtLeastSwift6()
+
         try withTemporaryDirectory { tempDir in
             // Create a new package with an executable target.
             let packagePath = tempDir.appending(component: "Project")
@@ -167,6 +166,8 @@ final class BasicTests: XCTestCase {
     }
 
     func testSwiftPackageLibsTests() throws {
+        try skipUnlessAtLeastSwift6()
+
         try XCTSkip("FIXME: swift-test invocations are timing out in Xcode and self-hosted CI")
 
         try withTemporaryDirectory { tempDir in
@@ -225,9 +226,7 @@ final class BasicTests: XCTestCase {
     }
 
     func testSwiftRun() throws {
-        #if swift(<5.5)
-        try XCTSkipIf(true, "skipping because host compiler doesn't support '-entry-point-function-name'")
-        #endif
+        try skipUnlessAtLeastSwift6()
 
         try withTemporaryDirectory { tempDir in
             let packagePath = tempDir.appending(component: "secho")
@@ -256,6 +255,8 @@ final class BasicTests: XCTestCase {
     }
 
     func testSwiftTest() throws {
+        try skipUnlessAtLeastSwift6()
+
         try XCTSkip("FIXME: swift-test invocations are timing out in Xcode and self-hosted CI")
 
         try withTemporaryDirectory { tempDir in
@@ -376,4 +377,10 @@ private extension Character {
             return false
         }
     }
+}
+
+private func skipUnlessAtLeastSwift6() throws {
+    #if compiler(<6.0)
+    try XCTSkipIf(true, "Skipping because test requires at least Swift 6.0")
+    #endif
 }

--- a/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/SwiftPMTests.swift
@@ -53,6 +53,9 @@ final class SwiftPMTests: XCTestCase {
         #if !os(macOS)
         try XCTSkip("Test requires macOS")
         #endif
+        #if swift(<6.0)
+        try XCTSkipIf(true, "Skipping because test requires at least Swift 6.0")
+        #endif
 
         try withTemporaryDirectory { tmpDir in
             let packagePath = tmpDir.appending(component: "foo")

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -389,6 +389,11 @@ public final class SwiftTargetBuildDescription {
             """
             import Foundation
 
+            #if compiler(>=6.0)
+            extension Foundation.Bundle: @unchecked @retroactive Sendable {}
+            #else
+            extension Foundation.Bundle: @unchecked Sendable {}
+            #endif
             extension Foundation.Bundle {
                 static let module: Bundle = {
                     let mainPath = \(mainPathSubstitution)

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -882,23 +882,6 @@ public final class SwiftCommandState {
             }
 
             var extraManifestFlags = self.options.build.manifestFlags
-            // Disable the implicit concurrency import if the compiler in use supports it to avoid warnings if we are building against an older SDK that does not contain a Concurrency module.
-            if DriverSupport.checkSupportedFrontendFlags(
-                flags: ["disable-implicit-concurrency-module-import"],
-                toolchain: try self.toolsBuildParameters.toolchain,
-                fileSystem: self.fileSystem
-            ) {
-                extraManifestFlags += ["-Xfrontend", "-disable-implicit-concurrency-module-import"]
-            }
-            // Disable the implicit string processing import if the compiler in use supports it to avoid warnings if we are building against an older SDK that does not contain a StringProcessing module.
-            if DriverSupport.checkSupportedFrontendFlags(
-                flags: ["disable-implicit-string-processing-module-import"],
-                toolchain: try self.toolsBuildParameters.toolchain,
-                fileSystem: self.fileSystem
-            ) {
-                extraManifestFlags += ["-Xfrontend", "-disable-implicit-string-processing-module-import"]
-            }
-
             if self.logLevel <= .info {
                 extraManifestFlags.append("-v")
             }

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -182,10 +182,11 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
 
             // Otherwise, use 4.2
             return .v4_2
-
-        default:
-            // Anything above 4 major version uses version 5.
+        case 5:
             return .v5
+        default:
+            // Anything above 5 major version uses version 6.
+            return .v6
         }
     }
 }

--- a/Sources/SPMTestSupport/XCTSkipHelpers.swift
+++ b/Sources/SPMTestSupport/XCTSkipHelpers.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageModel
+import XCTest
+
+import class TSCBasic.Process
+import struct TSCBasic.StringError
+
+extension Toolchain {
+    package func skipUnlessAtLeastSwift6(
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws {
+        #if compiler(<6.0)
+        try XCTSkipIf(true, "Skipping because test requires at least Swift 6.0")
+        #endif
+    }
+}

--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -17,7 +17,8 @@ import XCTest
 import var TSCBasic.localFileSystem
 
 final class BuildSystemDelegateTests: XCTestCase {
-    func testDoNotFilterLinkerDiagnostics() throws {
+    func testDoNotFilterLinkerDiagnostics() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
         try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
         try fixture(name: "Miscellaneous/DoNotFilterLinkerDiagnostics") { fixturePath in
             #if !os(macOS)

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -177,7 +177,9 @@ class PluginTests: XCTestCase {
         }
     }
 
-    func testBuildToolWithoutOutputs() throws {
+    func testBuildToolWithoutOutputs() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
@@ -1158,7 +1160,9 @@ class PluginTests: XCTestCase {
         }
     }
 
-    func testURLBasedPluginAPI() throws {
+    func testURLBasedPluginAPI() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
@@ -1168,7 +1172,9 @@ class PluginTests: XCTestCase {
         }
     }
 
-    func testDependentPlugins() throws {
+    func testDependentPlugins() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
         try fixture(name: "Miscellaneous/Plugins/DependentPlugins") { fixturePath in

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import PackageModel
 import SPMTestSupport
 import XCTest
 
@@ -126,7 +127,9 @@ class ResourcesTests: XCTestCase {
         }
     }
 
-    func testResourcesOutsideOfTargetCanBeIncluded() throws {
+    func testResourcesOutsideOfTargetCanBeIncluded() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try testWithTemporaryDirectory { tmpPath in
             let packageDir = tmpPath.appending(components: "MyPackage")
 

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -22,7 +22,10 @@ import func TSCTestSupport.withCustomEnv
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class ManifestLoaderCacheTests: XCTestCase {
+
     func testDBCaching() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try await testWithTemporaryDirectory { path in
             let fileSystem = localFileSystem
             let observability = ObservabilitySystem.makeForTesting()
@@ -117,6 +120,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
     }
 
     func testInMemoryCaching() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         let fileSystem = InMemoryFileSystem()
         let observability = ObservabilitySystem.makeForTesting()
 
@@ -206,6 +211,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
     }
 
     func testContentBasedCaching() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try await testWithTemporaryDirectory { path in
             let manifest = """
                 import PackageDescription
@@ -265,6 +272,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
     }
 
     func testCacheInvalidationOnEnv() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try await testWithTemporaryDirectory { path in
             let fileSystem = InMemoryFileSystem()
             let observability = ObservabilitySystem.makeForTesting()
@@ -330,6 +339,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
     }
 
     func testCacheDoNotInvalidationExpectedEnv() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try await testWithTemporaryDirectory { path in
             let fileSystem = InMemoryFileSystem()
             let observability = ObservabilitySystem.makeForTesting()
@@ -415,6 +426,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
     }
 
     func testInMemoryCacheHappyCase() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         let content = """
             import PackageDescription
             let package = Package(

--- a/Tests/PackageLoadingTests/PD_6_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_6_0_LoadingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -16,12 +16,14 @@ import SourceControl
 import SPMTestSupport
 import XCTest
 
-class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
+final class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v6_0
     }
 
     func testPackageContextGitStatus() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         let content = """
                 import PackageDescription
                 let package = Package(name: "\\(Context.gitInformation?.hasUncommittedChanges == true)")
@@ -34,6 +36,8 @@ class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testPackageContextGitTag() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         let content = """
                 import PackageDescription
                 let package = Package(name: "\\(Context.gitInformation?.currentTag ?? "")")
@@ -46,6 +50,8 @@ class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     func testPackageContextGitCommit() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         let content = """
                 import PackageDescription
                 let package = Package(name: "\\(Context.gitInformation?.currentCommit ?? "")")

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -3027,7 +3027,7 @@ final class PackageBuilderTests: XCTestCase {
         }
     }
 
-    func testSwiftLanguageVesionPerTarget() throws {
+    func testSwiftLanguageVersionPerTarget() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/foo/foo.swift",
             "/Sources/bar/bar.swift"

--- a/Tests/PackageModelTests/ToolsVersionTests.swift
+++ b/Tests/PackageModelTests/ToolsVersionTests.swift
@@ -91,8 +91,12 @@ class ToolsVersionTests: XCTestCase {
             XCTAssertEqual(ToolsVersion(string: version)?.swiftLanguageVersion.description, "4.2")
         }
 
-        for version in ["5.0.0", "5.1.9", "6.0.0", "7.0.0"] {
+        for version in ["5.0.0", "5.1.9"] {
             XCTAssertEqual(ToolsVersion(string: version)?.swiftLanguageVersion.description, "5")
+        }
+
+        for version in ["6.0.0", "7.0.0"] {
+            XCTAssertEqual(ToolsVersion(string: version)?.swiftLanguageVersion.description, "6")
         }
     }
 }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -16,7 +16,7 @@ import PackageModel
 import Workspace
 import XCTest
 
-class InitTests: XCTestCase {
+final class InitTests: XCTestCase {
 
     // MARK: TSCBasic package creation for each package type.
     
@@ -53,8 +53,10 @@ class InitTests: XCTestCase {
             XCTAssertMatch(manifestContents, .contains(packageWithNameOnly(named: name)))
         }
     }
-    
-    func testInitPackageExecutable() throws {
+
+    func testInitPackageExecutable() async throws  {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
@@ -98,7 +100,9 @@ class InitTests: XCTestCase {
         }
     }
 
-    func testInitPackageLibraryWithXCTestOnly() throws {
+    func testInitPackageLibraryWithXCTestOnly() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
@@ -148,7 +152,7 @@ class InitTests: XCTestCase {
             XCTAssertFileExists(path.appending(components: ".build", triple.platformBuildPathComponent, "debug", "Modules", "Foo.swiftmodule"))
         }
     }
-        
+
     func testInitPackageLibraryWithSwiftTestingOnly() throws {
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
@@ -235,7 +239,9 @@ class InitTests: XCTestCase {
         }
     }
 
-    func testInitPackageLibraryWithNoTests() throws {
+    func testInitPackageLibraryWithNoTests() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try testWithTemporaryDirectory { tmpPath in
             let fs = localFileSystem
             let path = tmpPath.appending("Foo")
@@ -339,8 +345,9 @@ class InitTests: XCTestCase {
     }
 
     // MARK: Special case testing
-    
-    func testInitPackageNonc99Directory() throws {
+
+    func testInitPackageNonc99Directory() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             XCTAssertDirectoryExists(tempDirPath)
             
@@ -367,7 +374,9 @@ class InitTests: XCTestCase {
         }
     }
     
-    func testNonC99NameExecutablePackage() throws {
+    func testNonC99NameExecutablePackage() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
             XCTAssertDirectoryExists(tempDirPath)
             

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -33,8 +33,7 @@ extension String {
     }
 }
 
-class ManifestSourceGenerationTests: XCTestCase {
-
+final class ManifestSourceGenerationTests: XCTestCase {
     /// Private function that writes the contents of a package manifest to a temporary package directory and then loads it, then serializes the loaded manifest back out again and loads it once again, after which it compares that no information was lost. Return the source of the newly generated manifest.
     @discardableResult
     private func testManifestWritingRoundTrip(
@@ -591,6 +590,7 @@ class ManifestSourceGenerationTests: XCTestCase {
     }
 
     func testManifestGenerationWithSwiftLanguageVersion() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
         let manifest = Manifest.createRootManifest(
             displayName: "pkg",
             path: "/pkg",

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -155,7 +155,7 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
-    func testInterpreterFlags() throws {
+    func testInterpreterFlags() async throws {
         let fs = localFileSystem
 
         try testWithTemporaryDirectory { path in
@@ -214,7 +214,7 @@ final class WorkspaceTests: XCTestCase {
                     """
                 )
 
-                XCTAssertMatch(ws.interpreterFlags(for: foo), [.equal("-swift-version"), .equal("5")])
+                XCTAssertMatch(ws.interpreterFlags(for: foo), [.equal("-swift-version"), .equal("6")])
             }
         }
     }
@@ -5252,6 +5252,8 @@ final class WorkspaceTests: XCTestCase {
 
     // This verifies that the simplest possible loading APIs are available for package clients.
     func testSimpleAPI() async throws {
+        try await UserToolchain.default.skipUnlessAtLeastSwift6()
+
         try await testWithTemporaryDirectory { path in
             // Create a temporary package as a test case.
             let packagePath = path.appending("MyPkg")


### PR DESCRIPTION
**Explanation**: Changes packages to default to swift version 6 when `swift-tools-version` is set `>= 6.0`. Without this change, all packages will be swift version 5 unless otherwise specified via `swiftLanguageVersions`. Packages default to `swift-tools-version: 6.0` with `swift package init`. Users can opt-out via specifying `swiftLanguageVersions: [.v5]`.
**Scope**: New packages/those updated to 6.0.
**Risk**: Medium. There's inherent risk due to the language mode bump. The change also removes disabling implicit imports for concurrency and string processing in manifest files, which hasn't been widely tested outside of ...
**Testing**: New regression tests. Source compatibility suite run.
**Original PR**: https://github.com/apple/swift-package-manager/pull/7469