### PR TITLE
[6.0] `swift sdk`: print warnings on stderr instead of stdout

### DIFF
--- a/Sources/swift-experimental-sdk/Entrypoint.swift
+++ b/Sources/swift-experimental-sdk/Entrypoint.swift
@@ -11,11 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSDKCommand
+import Foundation
 
 @main
 struct Entrypoint {
     static func main() async {
-        print("warning: `swift experimental-sdk` command is deprecated and will be removed in a future version of SwiftPM. Use `swift sdk` instead.")
+        fputs("warning: `swift experimental-sdk` command is deprecated and will be removed in a future version of SwiftPM. Use `swift sdk` instead.", stderr)
         await SwiftSDKCommand.main()
     }
 }

--- a/Sources/swift-package-manager/SwiftPM.swift
+++ b/Sources/swift-package-manager/SwiftPM.swift
@@ -13,7 +13,7 @@
 import Basics
 
 import Commands
-
+import Foundation
 import SwiftSDKCommand
 import PackageCollectionsCommand
 import PackageRegistryCommand
@@ -42,7 +42,7 @@ struct SwiftPM {
         case "swift-build":
             await SwiftBuildCommand.main()
         case "swift-experimental-sdk":
-            print("warning: `swift experimental-sdk` command is deprecated and will be removed in a future version of SwiftPM. Use `swift sdk` instead.")
+            fputs("warning: `swift experimental-sdk` command is deprecated and will be removed in a future version of SwiftPM. Use `swift sdk` instead.", stderr)
             fallthrough
         case "swift-sdk":
             await SwiftSDKCommand.main()

--- a/Tests/CommandsTests/SDKCommandTests.swift
+++ b/Tests/CommandsTests/SDKCommandTests.swift
@@ -48,7 +48,8 @@ final class SDKCommandTests: CommandsTestCase {
                     )
 
                     if command == .experimentalSDK {
-                        XCTAssertMatch(stdout, .contains(deprecationWarning))
+                        XCTAssertMatch(stderr, .contains(deprecationWarning))
+                        XCTAssertNoMatch(stdout, .contains(deprecationWarning))
                     }
 
                     // We only expect tool's output on the stdout stream.
@@ -57,18 +58,16 @@ final class SDKCommandTests: CommandsTestCase {
                         .contains("\(bundle)` successfully installed as test-sdk.artifactbundle.")
                     )
 
-                    XCTAssertEqual(stderr.count, 0)
-
                     (stdout, stderr) = try command.execute(
                         ["list", "--swift-sdks-path", fixturePath.pathString])
 
                     if command == .experimentalSDK {
-                        XCTAssertMatch(stdout, .contains(deprecationWarning))
+                        XCTAssertMatch(stderr, .contains(deprecationWarning))
+                        XCTAssertNoMatch(stdout, .contains(deprecationWarning))
                     }
 
                     // We only expect tool's output on the stdout stream.
                     XCTAssertMatch(stdout, .contains("test-artifact"))
-                    XCTAssertEqual(stderr.count, 0)
 
                     XCTAssertThrowsError(try command.execute(
                         [
@@ -91,30 +90,30 @@ final class SDKCommandTests: CommandsTestCase {
                     }
 
                     if command == .experimentalSDK {
-                        XCTAssertMatch(stdout, .contains(deprecationWarning))
+                        XCTAssertMatch(stderr, .contains(deprecationWarning))
                     }
 
                     (stdout, stderr) = try command.execute(
                         ["remove", "--swift-sdks-path", fixturePath.pathString, "test-artifact"])
 
                     if command == .experimentalSDK {
-                        XCTAssertMatch(stdout, .contains(deprecationWarning))
+                        XCTAssertMatch(stderr, .contains(deprecationWarning))
+                        XCTAssertNoMatch(stdout, .contains(deprecationWarning))
                     }
 
                     // We only expect tool's output on the stdout stream.
                     XCTAssertMatch(stdout, .contains("test-sdk.artifactbundle` was successfully removed from the file system."))
-                    XCTAssertEqual(stderr.count, 0)
 
                     (stdout, stderr) = try command.execute(
                         ["list", "--swift-sdks-path", fixturePath.pathString])
 
                     if command == .experimentalSDK {
-                        XCTAssertMatch(stdout, .contains(deprecationWarning))
+                        XCTAssertMatch(stderr, .contains(deprecationWarning))
+                        XCTAssertNoMatch(stdout, .contains(deprecationWarning))
                     }
 
                     // We only expect tool's output on the stdout stream.
                     XCTAssertNoMatch(stdout, .contains("test-artifact"))
-                    XCTAssertEqual(stderr.count, 0)
                 }
             }
         }


### PR DESCRIPTION
Cherry-pick of #7532.

**Explanation**: Tools and scripts may rely on command output to remain parseable, so printing these warnings on `stdout` can break such workflows. We should output these warnings on `stderr` instead.

As these warnings are emitted before any logging is available, we're using `fputs` for output on `stderr`

**Scope**: Isolated to `swift sdk` command and subcommands.
**Risk**: Low, the actual change is only 4 lines touching `print` and `import`, code coverage for those is present.
**Testing**: End-to-end test cases present in `Tests/CommandsTests/SDKCommandTests.swift`
**Issue**: N/A
**Reviewer**: @bnbarham 
