### PR TITLE
Pass through swift-testing's experimental JSON streams from `swift test`

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -154,6 +154,16 @@ struct TestCommandOptions: ParsableArguments {
     var enableExperimentalTestOutput: Bool {
         return testOutput == .experimentalSummary
     }
+
+    /// Path where swift-testing's JSON configuration should be read.
+    @Option(name: .customLong("experimental-configuration-path"),
+            help: ArgumentHelp("", visibility: .hidden))
+    var configurationPath: AbsolutePath?
+
+    /// Path where swift-testing's JSON output should be written.
+    @Option(name: .customLong("experimental-event-stream-output"),
+            help: ArgumentHelp("", visibility: .hidden))
+    var eventStreamOutputPath: AbsolutePath?
 }
 
 /// Tests filtering specifier, which is used to filter tests to run.
@@ -688,9 +698,10 @@ extension SwiftTestCommand {
                 sanitizers: globalOptions.build.sanitizers
             )
 
+            let additionalArguments = ["--list-tests"] + CommandLine.arguments.dropFirst()
             let runner = TestRunner(
                 bundlePaths: testProducts.map(\.binaryPath),
-                additionalArguments: ["--list-tests"],
+                additionalArguments: additionalArguments,
                 cancellator: swiftCommandState.cancellator,
                 toolchain: toolchain,
                 testEnv: testEnv,

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -162,7 +162,7 @@ struct TestCommandOptions: ParsableArguments {
 
     /// Path where swift-testing's JSON output should be written.
     @Option(name: .customLong("experimental-event-stream-output"),
-            help: ArgumentHelp("", visibility: .hidden))
+            help: .hidden)
     var eventStreamOutputPath: AbsolutePath?
 }
 

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -157,7 +157,7 @@ struct TestCommandOptions: ParsableArguments {
 
     /// Path where swift-testing's JSON configuration should be read.
     @Option(name: .customLong("experimental-configuration-path"),
-            help: ArgumentHelp("", visibility: .hidden))
+            help: .hidden)
     var configurationPath: AbsolutePath?
 
     /// Path where swift-testing's JSON output should be written.


### PR DESCRIPTION
This PR adds two undocumented/unsupported experimental options to `swift test` to allow passing through JSON files/streams for input and output. These streams are still under development in swift-testing, so these options are not yet supported, but this change will allow interested coders to experiment with them.