### PR TITLE
[6.0] Teach swift package add-target --type test about swift-testing  (#7481)

### DIFF
--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -21,6 +21,8 @@ import TSCBasic
 import TSCUtility
 import Workspace
 
+extension AddTarget.TestHarness: ExpressibleByArgument { }
+
 extension SwiftPackageCommand {
     struct AddTarget: SwiftCommand {
         /// The type of target that can be specified on the command line.
@@ -57,6 +59,9 @@ extension SwiftPackageCommand {
 
         @Option(help: "The checksum for a remote binary target")
         var checksum: String?
+
+        @Option(help: "The testing library to use when generating test targets, which can be one of 'xctest', 'swift-testing', or 'none'")
+        var testingLibrary: PackageModelSyntax.AddTarget.TestHarness = .default
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
             let workspace = try swiftCommandState.getActiveWorkspace()
@@ -110,6 +115,7 @@ extension SwiftPackageCommand {
             let editResult = try PackageModelSyntax.AddTarget.addTarget(
                 target,
                 to: manifestSyntax,
+                configuration: .init(testHarness: testingLibrary),
                 installedSwiftPMConfiguration: swiftCommandState
                   .getHostToolchain()
                   .installedSwiftPMConfiguration

--- a/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
+++ b/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct InstalledSwiftPMConfiguration: Codable {
+public struct InstalledSwiftPMConfiguration {
     public struct Version: Codable, CustomStringConvertible {
         let major: Int
         let minor: Int
@@ -31,6 +31,7 @@ public struct InstalledSwiftPMConfiguration: Codable {
 
     let version: Int
     public let swiftSyntaxVersionForMacroTemplate: Version
+    public let swiftTestingVersionForTestTemplate: Version
 
     public static var `default`: InstalledSwiftPMConfiguration {
         return .init(
@@ -40,7 +41,56 @@ public struct InstalledSwiftPMConfiguration: Codable {
                 minor: 0,
                 patch: 0,
                 prereleaseIdentifier: "latest"
-            )
+            ),
+            swiftTestingVersionForTestTemplate: defaultSwiftTestingVersionForTestTemplate
         )
     }
+
+    private static var defaultSwiftTestingVersionForTestTemplate: Version {
+        .init(
+            major: 0,
+            minor: 8,
+            patch: 0,
+            prereleaseIdentifier: nil
+        )
+    }
+}
+
+extension InstalledSwiftPMConfiguration: Codable {
+    enum CodingKeys: CodingKey {
+        case version
+        case swiftSyntaxVersionForMacroTemplate
+        case swiftTestingVersionForTestTemplate
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.version = try container.decode(
+            Int.self,
+            forKey: CodingKeys.version
+        )
+        self.swiftSyntaxVersionForMacroTemplate = try container.decode(
+            Version.self,
+            forKey: CodingKeys.swiftSyntaxVersionForMacroTemplate
+        )
+        self.swiftTestingVersionForTestTemplate = try container.decodeIfPresent(
+            Version.self,
+            forKey: CodingKeys.swiftTestingVersionForTestTemplate
+        ) ?? InstalledSwiftPMConfiguration.defaultSwiftTestingVersionForTestTemplate
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(self.version, forKey: CodingKeys.version)
+        try container.encode(
+            self.swiftSyntaxVersionForMacroTemplate,
+            forKey: CodingKeys.swiftSyntaxVersionForMacroTemplate
+        )
+        try container.encode(
+            self.swiftTestingVersionForTestTemplate,
+            forKey: CodingKeys.swiftTestingVersionForTestTemplate
+        )
+  }
 }

--- a/Utilities/config.json
+++ b/Utilities/config.json
@@ -1,1 +1,3 @@
-{"version":1,"swiftSyntaxVersionForMacroTemplate":{"major":600,"minor":0,"patch":0, "prereleaseIdentifier":"latest"}}
+{"version":1,
+  "swiftSyntaxVersionForMacroTemplate":{"major":600,"minor":0,"patch":0, "prereleaseIdentifier":"latest"},
+  "swiftTestingVersionForTestTemplate":{"major":0,"minor":8,"patch":0}}


### PR DESCRIPTION
**Explanation**: Introduce a command-line argument `--testing-library` to the new add-target command to specify which test library to generate the test for. This can be 'xctest' (the prior XCTest behavior), 'swift-testing' (to use the new swift-testing library), or 'none' (for no test library at all).
**Original PR**: https://github.com/apple/swift-package-manager/pull/7481
**Risk**: Low. Extends new functionality in a new package command.
**Testing**: New tests.
