### PR TITLE
[6.0] Mark `buildSettingsDescription` as `@_spi` in `Target.swift`

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -13,6 +13,7 @@
 import Basics
 import PackageGraph
 
+@_spi(SwiftPMInternal)
 import PackageModel
 
 import OrderedCollections

--- a/Sources/PackageModel/Target/Target.swift
+++ b/Sources/PackageModel/Target/Target.swift
@@ -233,7 +233,8 @@ public class Target: PolymorphicCodableProtocol {
     /// The build settings assignments of this target.
     public let buildSettings: BuildSettings.AssignmentTable
 
-    package let buildSettingsDescription: [TargetBuildSettingDescription.Setting]
+    @_spi(SwiftPMInternal)
+    public let buildSettingsDescription: [TargetBuildSettingDescription.Setting]
 
     /// The usages of package plugins by this target.
     public let pluginUsages: [PluginUsage]


### PR DESCRIPTION
**Explanation**: `buildSettingsDescription` needs to be accessed in SwiftPM client code.
**Scope**: a single property of `PackageModel.Target`.
**Risk**: none, change is NFC and builds successfully.
**Testing**: NFC.
**Issue**: rdar://127782783
**Reviewer**: @bnbarham 