### PR TITLE
[PackageModel] SwiftTarget: Rename `swiftVersion` into `toolsSwiftVersion`

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -148,7 +148,7 @@ package final class SwiftTargetBuildDescription {
 
     /// The swift version for this target.
     var swiftVersion: SwiftLanguageVersion {
-        self.swiftTarget.swiftVersion
+        self.swiftTarget.toolSwiftVersion
     }
 
     /// Describes the purpose of a test target, including any special roles such as containing a list of discovered

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -146,8 +146,8 @@ package final class SwiftTargetBuildDescription {
     /// Any addition flags to be added. These flags are expected to be computed during build planning.
     var additionalFlags: [String] = []
 
-    /// The swift version for this target.
-    var swiftVersion: SwiftLanguageVersion {
+    /// The swift language version that is computed for this target based on tools version of the manifest.
+    var toolsSwiftVersion: SwiftLanguageVersion {
         self.swiftTarget.toolSwiftVersion
     }
 
@@ -577,7 +577,7 @@ package final class SwiftTargetBuildDescription {
 
         // Fallback to package wide setting if there is no target specific version.
         if args.firstIndex(of: "-swift-version") == nil {
-            args += ["-swift-version", self.swiftVersion.rawValue]
+            args += ["-swift-version", self.toolsSwiftVersion.rawValue]
         }
 
         // Add the output for the `.swiftinterface`, if requested or if library evolution has been enabled some other

--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -268,7 +268,7 @@ private extension PackageModel.SwiftTarget {
             sources: sources,
             dependencies: dependencies,
             packageAccess: packageAccess,
-            swiftVersion: .v5,
+            toolsSwiftVersion: .v5,
             usesUnsafeFlags: false
         )
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -997,7 +997,7 @@ public final class PackageBuilder {
                 others: others,
                 dependencies: dependencies,
                 packageAccess: potentialModule.packageAccess,
-                swiftVersion: self.swiftVersion(),
+                toolsSwiftVersion: self.toolsSwiftVersion(),
                 declaredSwiftVersions: self.declaredSwiftVersions(),
                 buildSettings: buildSettings,
                 buildSettingsDescription: manifestTarget.settings,
@@ -1237,7 +1237,7 @@ public final class PackageBuilder {
     }
 
     /// Computes the swift version to use for this manifest.
-    private func swiftVersion() throws -> SwiftLanguageVersion {
+    private func toolsSwiftVersion() throws -> SwiftLanguageVersion {
         if let swiftVersion = self.swiftVersionCache {
             return swiftVersion
         }
@@ -1738,7 +1738,7 @@ extension PackageBuilder {
                     sources: sources,
                     dependencies: dependencies,
                     packageAccess: false,
-                    swiftVersion: self.swiftVersion(),
+                    toolsSwiftVersion: self.toolsSwiftVersion(),
                     buildSettings: buildSettings,
                     buildSettingsDescription: targetDescription.settings,
                     usesUnsafeFlags: false

--- a/Sources/PackageModel/Target/SwiftTarget.swift
+++ b/Sources/PackageModel/Target/SwiftTarget.swift
@@ -23,7 +23,7 @@ public final class SwiftTarget: Target {
     }
 
     public init(name: String, dependencies: [Target.Dependency], packageAccess: Bool, testDiscoverySrc: Sources) {
-        self.swiftVersion = .v5
+        self.toolSwiftVersion = .v5
         self.declaredSwiftVersions = []
 
         super.init(
@@ -40,8 +40,8 @@ public final class SwiftTarget: Target {
         )
     }
 
-    /// The swift version of this target.
-    public let swiftVersion: SwiftLanguageVersion
+    /// The swift language version that is computed for this target based on tools version of the manifest.
+    public let toolSwiftVersion: SwiftLanguageVersion
 
     /// The list of swift versions declared by the manifest.
     public let declaredSwiftVersions: [SwiftLanguageVersion]
@@ -57,14 +57,14 @@ public final class SwiftTarget: Target {
         others: [AbsolutePath] = [],
         dependencies: [Target.Dependency] = [],
         packageAccess: Bool,
-        swiftVersion: SwiftLanguageVersion,
+        toolsSwiftVersion: SwiftLanguageVersion,
         declaredSwiftVersions: [SwiftLanguageVersion] = [],
         buildSettings: BuildSettings.AssignmentTable = .init(),
         buildSettingsDescription: [TargetBuildSettingDescription.Setting] = [],
         pluginUsages: [PluginUsage] = [],
         usesUnsafeFlags: Bool
     ) {
-        self.swiftVersion = swiftVersion
+        self.toolSwiftVersion = toolsSwiftVersion
         self.declaredSwiftVersions = declaredSwiftVersions
         super.init(
             name: name,
@@ -103,8 +103,8 @@ public final class SwiftTarget: Target {
         // We need to select the latest Swift language version that can
         // satisfy the current tools version but there is not a good way to
         // do that currently.
-        self.swiftVersion = swiftTestTarget?
-            .swiftVersion ?? SwiftLanguageVersion(string: String(SwiftVersion.current.major)) ?? .v4
+        self.toolSwiftVersion = swiftTestTarget?
+            .toolSwiftVersion ?? SwiftLanguageVersion(string: String(SwiftVersion.current.major)) ?? .v4
         self.declaredSwiftVersions = []
         let sources = Sources(paths: [testEntryPointPath], root: testEntryPointPath.parentDirectory)
 
@@ -129,14 +129,14 @@ public final class SwiftTarget: Target {
 
     override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.swiftVersion, forKey: .swiftVersion)
+        try container.encode(self.toolSwiftVersion, forKey: .swiftVersion)
         try container.encode(self.declaredSwiftVersions, forKey: .declaredSwiftVersions)
         try super.encode(to: encoder)
     }
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.swiftVersion = try container.decode(SwiftLanguageVersion.self, forKey: .swiftVersion)
+        self.toolSwiftVersion = try container.decode(SwiftLanguageVersion.self, forKey: .swiftVersion)
         self.declaredSwiftVersions = try container.decode([SwiftLanguageVersion].self, forKey: .declaredSwiftVersions)
         try super.init(from: decoder)
     }

--- a/Sources/SPMTestSupport/ResolvedTarget+Mock.swift
+++ b/Sources/SPMTestSupport/ResolvedTarget+Mock.swift
@@ -29,7 +29,7 @@ extension ResolvedModule {
                 sources: Sources(paths: [], root: "/"),
                 dependencies: [],
                 packageAccess: false,
-                swiftVersion: .v4,
+                toolsSwiftVersion: .v4,
                 usesUnsafeFlags: false
             ),
             dependencies: deps.map { .target($0, conditions: conditions) },

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1584,19 +1584,19 @@ extension SwiftTarget {
         })
         // If we were able to determine the list of versions supported by XCBuild, cross-reference with the package's
         // Swift versions in case the preferred version isn't available.
-        if !supportedSwiftVersions.isEmpty, !supportedSwiftVersions.contains(self.swiftVersion) {
+        if !supportedSwiftVersions.isEmpty, !supportedSwiftVersions.contains(self.toolSwiftVersion) {
             let declaredVersions = Array(normalizedDeclaredVersions.intersection(supportedSwiftVersions)).sorted(by: >)
             if let swiftVersion = declaredVersions.first {
                 return swiftVersion
             } else {
                 throw PIFGenerationError.unsupportedSwiftLanguageVersion(
                     targetName: self.name,
-                    version: self.swiftVersion,
+                    version: self.toolSwiftVersion,
                     supportedVersions: supportedSwiftVersions
                 )
             }
         }
-        return self.swiftVersion
+        return self.toolSwiftVersion
     }
 }
 

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -3303,7 +3303,7 @@ final class PackageBuilderTester {
             guard case let swiftTarget as SwiftTarget = target else {
                 return XCTFail("\(target) is not a swift target", file: file, line: line)
             }
-            XCTAssertEqual(SwiftLanguageVersion(string: swiftVersion)!, swiftTarget.swiftVersion, file: file, line: line)
+            XCTAssertEqual(SwiftLanguageVersion(string: swiftVersion)!, swiftTarget.toolSwiftVersion, file: file, line: line)
         }
 
         func check(pluginCapability: PluginCapability, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
### Motivation:

The value of this field is computed based on the tools version of the manifest and is intended to be used as a fallback if there is no swift language version specified in the build settings for a swift target.

### Modifications:

Renamed `SwiftTarget.swiftVersion` field and `PackageBuilder.swiftVersion()` method to `toolsSwiftVersion`.

### Result:

Code better reflects meaning and intended uses of the data.
