### PR TITLE
[PackageModel] Associated swift version build setting with `SWIFT_VER…

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -820,6 +820,9 @@ package final class SwiftTargetBuildDescription {
         let scope = self.defaultBuildParameters.createScope(for: self.target)
         var flags: [String] = []
 
+        // A custom swift version.
+        flags += scope.evaluate(.SWIFT_VERSION).flatMap { ["-swift-version", $0] }
+
         // Swift defines.
         let swiftDefines = scope.evaluate(.SWIFT_ACTIVE_COMPILATION_CONDITIONS)
         flags += swiftDefines.map { "-D" + $0 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1176,10 +1176,10 @@ public final class PackageBuilder {
                     throw InternalError("only Swift supports swift language version")
 
                 case .swift:
-                    decl = .OTHER_SWIFT_FLAGS
+                    decl = .SWIFT_VERSION
                 }
 
-                values = ["-swift-version", version.rawValue]
+                values = [version.rawValue]
             }
 
             // Create an assignment for this setting.

--- a/Sources/PackageModel/BuildSettings.swift
+++ b/Sources/PackageModel/BuildSettings.swift
@@ -18,6 +18,7 @@ public enum BuildSettings {
         // Swift.
         public static let SWIFT_ACTIVE_COMPILATION_CONDITIONS: Declaration = .init("SWIFT_ACTIVE_COMPILATION_CONDITIONS")
         public static let OTHER_SWIFT_FLAGS: Declaration = .init("OTHER_SWIFT_FLAGS")
+        public static let SWIFT_VERSION: Declaration = .init("SWIFT_VERSION")
 
         // C family.
         public static let GCC_PREPROCESSOR_DEFINITIONS: Declaration = .init("GCC_PREPROCESSOR_DEFINITIONS")

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4083,7 +4083,7 @@ final class BuildPlanTests: XCTestCase {
             )
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-            XCTAssertMatch(exe, [.anySequence, "-DFOO", "-swift-version", "5", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
+            XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
 
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
             XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-Ilfoo", "-L", "lbar", "-g", .end])
@@ -4149,7 +4149,7 @@ final class BuildPlanTests: XCTestCase {
             )
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-            XCTAssertMatch(exe, [.anySequence, "-DFOO", "-swift-version", "5", "-g", "-Xcc", "-g", "-Xcc", "-fomit-frame-pointer", .end])
+            XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-g", "-Xcc", "-g", "-Xcc", "-fomit-frame-pointer", .end])
         }
 
         // omit frame pointers explicitly set to false
@@ -4206,7 +4206,7 @@ final class BuildPlanTests: XCTestCase {
             )
 
             let exe = try result.target(for: "exe").swiftTarget().compileArguments()
-            XCTAssertMatch(exe, [.anySequence, "-DFOO", "-swift-version", "5", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
+            XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
         }
 
         do {
@@ -4253,10 +4253,10 @@ final class BuildPlanTests: XCTestCase {
                 exe,
                 [
                     .anySequence,
+                    "-swift-version", "4",
                     "-DFOO",
                     "-cxx-interoperability-mode=default",
                     "-Xcc", "-std=c++17",
-                    "-swift-version", "4",
                     "-g",
                     "-Xcc", "-g",
                     .end,

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -3055,13 +3055,13 @@ final class PackageBuilderTests: XCTestCase {
                     package.target.buildSettings,
                     environment: BuildEnvironment(platform: .macOS, configuration: .debug)
                 )
-                XCTAssertEqual(macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS), ["-swift-version", "5"])
+                XCTAssertEqual(macosDebugScope.evaluate(.SWIFT_VERSION), ["5"])
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
                     environment: BuildEnvironment(platform: .macOS, configuration: .release)
                 )
-                XCTAssertEqual(macosReleaseScope.evaluate(.OTHER_SWIFT_FLAGS), ["-swift-version", "5"])
+                XCTAssertEqual(macosReleaseScope.evaluate(.SWIFT_VERSION), ["5"])
             }
 
             package.checkModule("bar") { package in
@@ -3069,19 +3069,19 @@ final class PackageBuilderTests: XCTestCase {
                     package.target.buildSettings,
                     environment: BuildEnvironment(platform: .linux, configuration: .debug)
                 )
-                XCTAssertEqual(linuxDebugScope.evaluate(.OTHER_SWIFT_FLAGS), ["-swift-version", "3"])
+                XCTAssertEqual(linuxDebugScope.evaluate(.SWIFT_VERSION), ["3"])
 
                 let macosDebugScope = BuildSettings.Scope(
                     package.target.buildSettings,
                     environment: BuildEnvironment(platform: .macOS, configuration: .debug)
                 )
-                XCTAssertEqual(macosDebugScope.evaluate(.OTHER_SWIFT_FLAGS), ["-swift-version", "4"])
+                XCTAssertEqual(macosDebugScope.evaluate(.SWIFT_VERSION), ["4"])
 
                 let macosReleaseScope = BuildSettings.Scope(
                     package.target.buildSettings,
                     environment: BuildEnvironment(platform: .macOS, configuration: .release)
                 )
-                XCTAssertEqual(macosReleaseScope.evaluate(.OTHER_SWIFT_FLAGS), [])
+                XCTAssertEqual(macosReleaseScope.evaluate(.SWIFT_VERSION), [])
             }
         }
     }


### PR DESCRIPTION
…SION` declaration

Instead of putting it into `OTHER_SWIFT_FLAGS`, let's introduce a dedicated declaration scope - `SWIFT_VERSION` to ease handling and discovery.

Resolves: rdar://127883018
