### PR TITLE
Pass through `--experimental-event-stream-version` to swift-testing.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -164,6 +164,11 @@ struct TestCommandOptions: ParsableArguments {
     @Option(name: .customLong("experimental-event-stream-output"),
             help: .hidden)
     var eventStreamOutputPath: AbsolutePath?
+
+    /// The schema version of swift-testing's JSON input/output.
+    @Option(name: .customLong("experimental-event-stream-version"),
+            help: .hidden)
+    var eventStreamVersion: Int?
 }
 
 /// Tests filtering specifier, which is used to filter tests to run.


### PR DESCRIPTION
Follow-on to #7534. swift-testing has an additional argument specifying the schema version of the JSON being used that we also need to pass through SwiftPM.

See: https://github.com/apple/swift-testing/pull/383