### PR TITLE
Expose the build triple of a `BuildTarget` in `SourceKitLSPAPI`

### DIFF
--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -23,12 +23,17 @@ import class Build.ClangTargetBuildDescription
 import class Build.SwiftTargetBuildDescription
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ModulesGraph
+import enum PackageGraph.BuildTriple
+
+public typealias BuildTriple = PackageGraph.BuildTriple
 
 public protocol BuildTarget {
     var sources: [URL] { get }
 
     /// The name of the target. It should be possible to build a target by passing this name to `swift build --target`
     var name: String { get }
+
+    var buildTriple: BuildTriple { get }
 
     /// Whether the target is part of the root package that the user opened or if it's part of a package dependency.
     var isPartOfRootPackage: Bool { get }
@@ -53,6 +58,10 @@ private struct WrappedClangTargetBuildDescription: BuildTarget {
         return description.clangTarget.name
     }
 
+    public var buildTriple: BuildTriple {
+        return description.target.buildTriple
+    }
+
     public func compileArguments(for fileURL: URL) throws -> [String] {
         let filePath = try resolveSymlinks(try AbsolutePath(validating: fileURL.path))
         let commandLine = try description.emitCommandLine(for: filePath)
@@ -72,6 +81,10 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
 
     public var name: String {
         return description.target.name
+    }
+
+    public var buildTriple: BuildTriple {
+        return description.target.buildTriple
     }
 
     var sources: [URL] {

--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -17,6 +17,7 @@ import struct PackageGraph.ResolvedModule
 private import class PackageLoading.ManifestLoader
 internal import struct PackageModel.ToolsVersion
 private import class PackageModel.UserToolchain
+import enum PackageGraph.BuildTriple
 
 struct PluginTargetBuildDescription: BuildTarget {
     private let target: ResolvedModule
@@ -36,6 +37,10 @@ struct PluginTargetBuildDescription: BuildTarget {
 
     var name: String {
         return target.name
+    }
+
+    var buildTriple: BuildTriple {
+        return target.buildTriple
     }
 
     func compileArguments(for fileURL: URL) throws -> [String] {


### PR DESCRIPTION
If we have a package like this

```swift
let package = Package(
  name: "MyLibrary",
  targets: [
   .target(name: "Lib"),
   .executableTarget(name: "MyExec", dependencies: ["Lib"]),
   .plugin(
     name: "MyPlugin",
     capability: .command(
       intent: .sourceCodeFormatting(),
       permissions: []
     ),
     dependencies: ["MyExec"]
   )
  ]
)
```

Then the package graph contains two targets for `Lib`. We need to be able to differentiate them in SourceKit-LSP. For that, we need to expose the build triple of a `BuildTarget`.





