### PR TITLE
Don’t disable Swift 6 mode in swift-syntax

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -744,8 +744,6 @@ def get_swiftpm_env_cmd(args):
         env_cmd.append("SWIFTPM_LLBUILD_FWK=1")
     env_cmd.append("SWIFTCI_USE_LOCAL_DEPS=1")
     env_cmd.append("SWIFTPM_MACOS_DEPLOYMENT_TARGET=%s" % g_macos_deployment_target)
-    # Disable Swift 6 mode in swift-syntax to work around rdar://126952308
-    env_cmd.append("SWIFTSYNTAX_DISABLE_SWIFT_6_MODE=1")
 
     if not '-macosx' in args.build_target and args.command == 'install':
         env_cmd.append("SWIFTCI_INSTALL_RPATH_OS=%s" % args.platform_path.group(2))

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -20,8 +20,6 @@ echo "Current directory is ${PWD}"
 
 CONFIGURATION=debug
 export SWIFTCI_IS_SELF_HOSTED=1
-# Disable Swift 6 mode in swift-syntax to work around rdar://126952308
-export SWIFTSYNTAX_DISABLE_SWIFT_6_MODE=1
 
 set -x
 


### PR DESCRIPTION
* **Explanation**: Remove code that forced swift-syntax to be built in Swift 5 mode because the underlying issue was fixed by https://github.com/apple/swift-package-manager/pull/7504
* **Scope**: Building SwiftPM
* **Risk**: Low, if there are any issues, they will be caught at build time
* **Testing**: Checked that SwiftPM still builds
* **Issue**: n/a
* **Reviewer**:  @bnbarham on https://github.com/apple/swift-package-manager/pull/7545