### PR TITLE
Add two Sendable annotations to enable building SourceKit-LSP in Swift 6 mode

### DIFF
--- a/Sources/PackageLoading/Platform.swift
+++ b/Sources/PackageLoading/Platform.swift
@@ -20,23 +20,21 @@ private func isAndroid() -> Bool {
         (try? localFileSystem.isFile(AbsolutePath(validating: "/system/bin/toybox"))) ?? false
 }
 
-public enum Platform: Equatable {
+public enum Platform: Equatable, Sendable {
     case android
     case darwin
     case linux(LinuxFlavor)
     case windows
 
     /// Recognized flavors of linux.
-    public enum LinuxFlavor: Equatable {
+    public enum LinuxFlavor: Equatable, Sendable {
         case debian
         case fedora
     }
 }
 
 extension Platform {
-    // This is not just a computed property because the ToolchainRegistryTests
-    // change the value.
-    public static var current: Platform? = {
+    public static let current: Platform? = {
         #if os(Windows)
         return .windows
         #else

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -563,7 +563,7 @@ public struct TargetSourcesBuilder {
 }
 
 /// Describes a rule for including a source or resource file in a target.
-public struct FileRuleDescription {
+public struct FileRuleDescription: Sendable {
     /// A rule semantically describes a file/directory in a target.
     ///
     /// It is up to the build system to translate a rule into a build command.


### PR DESCRIPTION
* **Explanation**: Mark `FileRuleDescription` and `Platform` as `Sendable` and make `Platform.current` a constant. This allows us to build SourceKit-LSP in Swift 6 mode
* **Scope**: `FileRuleDescription` and `Platform` if SwiftPM is used as a library
* **Risk**: Very low, adding `Sendable` conformances is safe and I don’t expect anyone to modify `Platform.current`
* **Testing**: Verified that this helps us build SourceKit-LSP in Swift 6 mode
* **Issue**: n/a
* **Reviewer**:  @xedin on https://github.com/apple/swift-package-manager/pull/7553