### PR TITLE
NFC: Updates to code owners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,4 +26,4 @@
 
 Sources/XCBuildSupport/* @jakepetroules
 
-* @bnbarham @MaxDesiatov @tomerd
+* @bnbarham @MaxDesiatov 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,4 +26,4 @@
 
 Sources/XCBuildSupport/* @jakepetroules
 
-* @bnbarham @MaxDesiatov 
+* @bnbarham @MaxDesiatov @jakepetroules @francescomikulis


### PR DESCRIPTION
- Removes Tom Doron
- Adds Jake Petroules and Francesco Mikulis-Borsoi