### PR TITLE
package -> @_spi public due to package exportability rule updates

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -170,7 +170,8 @@ public struct SwiftSDK: Equatable {
     }
 
     /// Whether or not the receiver supports using XCTest.
-    package let xctestSupport: XCTestSupport
+    @_spi(SwiftPMInternal)
+    public let xctestSupport: XCTestSupport
 
     /// Root directory path of the SDK used to compile for the target triple.
     @available(*, deprecated, message: "use `pathsConfiguration.sdkRootPath` instead")


### PR DESCRIPTION
- **Explanation**: Cherry-pick https://github.com/apple/swift/pull/73161 to `releases/6.0` so that SwiftPM 6.0 can be built with a `main` Swift development snapshot
- **Scope**: Changes access level of a member from `package` to SPI
- **Risk**: Very low, just changes the access lavel 
- **Testing**: n/a
- **Issue**: n/a
- **Reviewer**:  @MaxDesiatov and @bnbarham on https://github.com/apple/swift-package-manager/pull/7525