### PR TITLE
Add API needed for background indexing in SourceKit-LSP

### DIFF
--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -74,6 +74,14 @@ public struct ModulesGraph {
     /// Returns all the targets in the graph, regardless if they are reachable from the root targets or not.
     public let allTargets: IdentifiableSet<ResolvedTarget>
 
+    /// Returns all targets within the module graph in topological order, starting with low-level targets (that have no
+    /// dependencies).
+    package var allTargetsInTopologicalOrder: [ResolvedTarget] {
+        get throws {
+            try topologicalSort(Array(allTargets)) { $0.dependencies.compactMap { $0.target } }.reversed()
+        }
+    }
+
     /// Returns all the products in the graph, regardless if they are reachable from the root targets or not.
 
     public let allProducts: IdentifiableSet<ResolvedProduct>

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -121,4 +121,12 @@ public struct BuildDescription {
             return nil
         }
     }
+
+    /// Returns all targets within the module graph in topological order, starting with low-level targets (that have no
+    /// dependencies).
+    public func allTargetsInTopologicalOrder(in modulesGraph: ModulesGraph) throws -> [BuildTarget] {
+        try modulesGraph.allTargetsInTopologicalOrder.compactMap {
+            getBuildTarget(for: $0, in: modulesGraph)
+        }
+    }
 }

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -23,12 +23,17 @@ import class Build.ClangTargetBuildDescription
 import class Build.SwiftTargetBuildDescription
 import struct PackageGraph.ResolvedTarget
 import struct PackageGraph.ModulesGraph
+import enum PackageGraph.BuildTriple
+
+public typealias BuildTriple = PackageGraph.BuildTriple
 
 public protocol BuildTarget {
     var sources: [URL] { get }
 
     /// The name of the target. It should be possible to build a target by passing this name to `swift build --target`
     var name: String { get }
+
+    var buildTriple: BuildTriple { get }
 
     /// Whether the target is part of the root package that the user opened or if it's part of a package dependency.
     var isPartOfRootPackage: Bool { get }
@@ -53,6 +58,10 @@ private struct WrappedClangTargetBuildDescription: BuildTarget {
         return description.clangTarget.name
     }
 
+    public var buildTriple: BuildTriple {
+        return description.target.buildTriple
+    }
+
     public func compileArguments(for fileURL: URL) throws -> [String] {
         let filePath = try resolveSymlinks(try AbsolutePath(validating: fileURL.path))
         let commandLine = try description.emitCommandLine(for: filePath)
@@ -72,6 +81,10 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
 
     public var name: String {
         return description.target.name
+    }
+
+    public var buildTriple: BuildTriple {
+        return description.target.buildTriple
     }
 
     var sources: [URL] {

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -27,6 +27,9 @@ import struct PackageGraph.ModulesGraph
 public protocol BuildTarget {
     var sources: [URL] { get }
 
+    /// The name of the target. It should be possible to build a target by passing this name to `swift build --target`
+    var name: String { get }
+
     /// Whether the target is part of the root package that the user opened or if it's part of a package dependency.
     var isPartOfRootPackage: Bool { get }
 
@@ -46,6 +49,10 @@ private struct WrappedClangTargetBuildDescription: BuildTarget {
         return (try? description.compilePaths().map { URL(fileURLWithPath: $0.source.pathString) }) ?? []
     }
 
+    public var name: String {
+        return description.clangTarget.name
+    }
+
     public func compileArguments(for fileURL: URL) throws -> [String] {
         let filePath = try resolveSymlinks(try AbsolutePath(validating: fileURL.path))
         let commandLine = try description.emitCommandLine(for: filePath)
@@ -61,6 +68,10 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
     init(description: SwiftTargetBuildDescription, isPartOfRootPackage: Bool) {
         self.description = description
         self.isPartOfRootPackage = isPartOfRootPackage
+    }
+
+    public var name: String {
+        return description.target.name
     }
 
     var sources: [URL] {

--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -34,6 +34,10 @@ struct PluginTargetBuildDescription: BuildTarget {
         return target.sources.paths.map { URL(fileURLWithPath: $0.pathString) }
     }
 
+    var name: String {
+        return target.name
+    }
+
     func compileArguments(for fileURL: URL) throws -> [String] {
         // FIXME: This is very odd and we should clean this up by merging `ManifestLoader` and `DefaultPluginScriptRunner` again.
         let loader = ManifestLoader(toolchain: try UserToolchain(swiftSDK: .hostSwiftSDK()))

--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -17,6 +17,7 @@ import struct PackageGraph.ResolvedTarget
 private import class PackageLoading.ManifestLoader
 internal import struct PackageModel.ToolsVersion
 private import class PackageModel.UserToolchain
+import enum PackageGraph.BuildTriple
 
 struct PluginTargetBuildDescription: BuildTarget {
     private let target: ResolvedTarget
@@ -36,6 +37,10 @@ struct PluginTargetBuildDescription: BuildTarget {
 
     var name: String {
         return target.name
+    }
+
+    var buildTriple: BuildTriple {
+        return target.buildTriple
     }
 
     func compileArguments(for fileURL: URL) throws -> [String] {


### PR DESCRIPTION
- **Explanation**: Adds a couple of APIs to the `SourceKitLSPAPI` module that are needed for background indexing in SourceKit-LSP
- **Scope**: Purely additive API
- **Risk**: Very low, just adds new API
- **Testing**: n/a
- **Issue**: n/a
- **Reviewer**: @MaxDesiatov and @bnbarham on https://github.com/apple/swift-package-manager/pull/7540 https://github.com/apple/swift-package-manager/pull/7555 respectively