### PR TITLE
Add Sendable to FileRuleDescription

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -567,7 +567,7 @@ public struct FileRuleDescription: Sendable {
     /// A rule semantically describes a file/directory in a target.
     ///
     /// It is up to the build system to translate a rule into a build command.
-    public enum Rule: Equatable {
+    public enum Rule: Equatable, Sendable {
         /// The compile rule for `sources` in a package.
         case compile
 


### PR DESCRIPTION
### Motivation:

I found that the `FileRuleDescription` doesn't conform to `Sendable`; due to this, some products fail to build for Swift 6.

### Modifications:

Some structs conform to `Sendable`

### Result:

I passed to build on the latest Swift 6.0 snapshot.

```
# swift 6.0 4/30
TOOLCHAINS=org.swift.600202404301a swift build
```
