### PR TITLE
[6.0] Pass through experimental swift-testing flags

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -164,6 +164,11 @@ struct TestCommandOptions: ParsableArguments {
     @Option(name: .customLong("experimental-event-stream-output"),
             help: .hidden)
     var eventStreamOutputPath: AbsolutePath?
+
+    /// The schema version of swift-testing's JSON input/output.
+    @Option(name: .customLong("experimental-event-stream-version"),
+            help: .hidden)
+    var eventStreamVersion: Int?
 }
 
 /// Tests filtering specifier, which is used to filter tests to run.

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -154,6 +154,16 @@ struct TestCommandOptions: ParsableArguments {
     var enableExperimentalTestOutput: Bool {
         return testOutput == .experimentalSummary
     }
+
+    /// Path where swift-testing's JSON configuration should be read.
+    @Option(name: .customLong("experimental-configuration-path"),
+            help: .hidden)
+    var configurationPath: AbsolutePath?
+
+    /// Path where swift-testing's JSON output should be written.
+    @Option(name: .customLong("experimental-event-stream-output"),
+            help: .hidden)
+    var eventStreamOutputPath: AbsolutePath?
 }
 
 /// Tests filtering specifier, which is used to filter tests to run.
@@ -682,9 +692,10 @@ extension SwiftTestCommand {
                 sanitizers: globalOptions.build.sanitizers
             )
 
+            let additionalArguments = ["--list-tests"] + CommandLine.arguments.dropFirst()
             let runner = TestRunner(
                 bundlePaths: testProducts.map(\.binaryPath),
-                additionalArguments: ["--list-tests"],
+                additionalArguments: additionalArguments,
                 cancellator: swiftCommandState.cancellator,
                 toolchain: toolchain,
                 testEnv: testEnv,


### PR DESCRIPTION
Explanation: Pass through `--experimental-configuration-path`, `--experimental-event-stream-output`, and `--experimental-event-stream-version` as used by swift-testing. These flags are needed for continued experimental support of swift-testing when using the Swift 6 toolchain.
Scope: Hidden flags in `swift test`.
Original PR: #7534, #7551
Risk: No obvious risk. These flags have no effect on `swift test` itself and are simply passed through verbatim to the swift-testing test executable.
Testing: Tested at-desk that the flags are seen by swift-testing with an appropriate toolchain.
Reviewer: @bnbarham, @MaxDesiatov, @stmontgomery