### PR TITLE
[6.0] Add `--enable-code-coverage` to `swift build`

### DIFF
--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -664,4 +664,21 @@ final class BuildCommandTests: CommandsTestCase {
         }
     }
 #endif
+
+    func testCodeCoverage() throws {
+        // Test that no codecov directory is created if not specified when building.
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
+            let buildResult = try self.build(["--build-tests"], packagePath: path, cleanAfterward: false)
+            XCTAssertThrowsError(try SwiftPM.Test.execute(["--skip-build", "--enable-code-coverage"], packagePath: path))
+        }
+
+        // Test that enabling code coverage during building produces the expected folder.
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
+            let buildResult = try self.build(["--build-tests", "--enable-code-coverage"], packagePath: path, cleanAfterward: false)
+            try SwiftPM.Test.execute(["--skip-build", "--enable-code-coverage"], packagePath: path)
+            let codeCovPath = buildResult.binPath.appending("codecov")
+            let codeCovFiles = try localFileSystem.getDirectoryContents(codeCovPath)
+            XCTAssertGreaterThan(codeCovFiles.count, 0)
+        }
+    }
 }


### PR DESCRIPTION
Explanation: Add `--enable-code-coverage` to `swift build`. This flag allows enabling code coverage when splitting a test run between `swift build` and `swift test --skip-build`.
Scope: New option for the `swift build` command.
Original PR: #7508 (partial), #7518
Risk: Low. Behaviour is identical for `swift build` without the new flag, and the new flag must be explicitly specified.
Testing: Ran `swift build` unit tests at desk and in CI.
Reviewer: @bnbarham, @MaxDesiatov, @stmontgomery