### PR TITLE
Generated code for XCTest on non-Darwin needs to be actor-isolated.

### DIFF
--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -293,4 +293,14 @@ final class TestCommandTests: CommandsTestCase {
             }
         }
     }
+
+#if !canImport(Darwin)
+    func testGeneratedMainIsConcurrencySafe_XCTest() throws {
+        let strictConcurrencyFlags = ["-Xswiftc", "-strict-concurrency=complete"]
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try SwiftPM.Test.execute(strictConcurrencyFlags, packagePath: fixturePath)
+            XCTAssertNoMatch(stderr, .contains("is not concurrency-safe"))
+        }
+    }
+#endif
 }


### PR DESCRIPTION
On Linux, Windows, etc. (anywhere that uses swift-corelibs-xctest instead of XCTest.framework), SwiftPM is responsible for generating an entry point function that passes in all tests discovered at compile time. The compiler cannot tell whether the generated code is concurrency-safe. This PR modifies the generated code and makes it main-actor-isolated. Since it's only ever used in the program's main function, this is safe.

Note that `@main func main()` is implicitly main-actor-isolated per [SE-0323](https://github.com/apple/swift-evolution/blob/main/proposals/0323-async-main-semantics.md).

Resolves #7556.