### PR TITLE
[6.0] Generated code for XCTest on non-Darwin needs to be actor-isolated.

### DIFF
--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -293,4 +293,14 @@ final class TestCommandTests: CommandsTestCase {
             }
         }
     }
+
+#if !canImport(Darwin)
+    func testGeneratedMainIsConcurrencySafe_XCTest() throws {
+        let strictConcurrencyFlags = ["-Xswiftc", "-strict-concurrency=complete"]
+        try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+            let (_, stderr) = try SwiftPM.Test.execute(strictConcurrencyFlags, packagePath: fixturePath)
+            XCTAssertNoMatch(stderr, .contains("is not concurrency-safe"))
+        }
+    }
+#endif
 }


### PR DESCRIPTION
Explanation: Ensure that the synthesized entry point for swift-corelibs-xctest is concurrency-safe by marking it `@MainActor`.
Scope: All XCTest-based tests built/run on non-Darwin platforms.
Original PR: #7566
Risk: Low. The change is necessary to suppress a concurrency diagnostic. The synthesized `main()` function is implicitly main-actor-isolated.
Testing: Added unit test to check for the diagnostic, verified it did not occur anymore with the change in place.
Reviewer: @bnbarham, @MaxDesiatov, @stmontgomery, @briancroom