### PR TITLE
[6.0] NFC: Rename `ResolvedTarget` to `ResolvedModule`

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -15,7 +15,7 @@ import PackageGraph
 import PackageLoading
 import PackageModel
 import struct PackageGraph.ModulesGraph
-import struct PackageGraph.ResolvedTarget
+import struct PackageGraph.ResolvedModule
 import struct SPMBuildCore.BuildParameters
 import struct SPMBuildCore.BuildToolPluginInvocationResult
 import struct SPMBuildCore.PrebuildCommandResult
@@ -28,7 +28,7 @@ public final class ClangTargetBuildDescription {
     public let package: ResolvedPackage
 
     /// The target described by this target.
-    public let target: ResolvedTarget
+    public let target: ResolvedModule
 
     /// The underlying clang target.
     public let clangTarget: ClangTarget
@@ -114,7 +114,7 @@ public final class ClangTargetBuildDescription {
     /// Create a new target description with target and build parameters.
     init(
         package: ResolvedPackage,
-        target: ResolvedTarget,
+        target: ResolvedModule,
         toolsVersion: ToolsVersion,
         additionalFileRules: [FileRuleDescription] = [],
         buildParameters: BuildParameters,

--- a/Sources/Build/BuildDescription/PluginDescription.swift
+++ b/Sources/Build/BuildDescription/PluginDescription.swift
@@ -43,7 +43,7 @@ public final class PluginDescription: Codable {
     /// Initialize a new plugin target description. The target is expected to be
     /// a `PluginTarget`.
     init(
-        target: ResolvedTarget,
+        target: ResolvedModule,
         products: [ResolvedProduct],
         package: ResolvedPackage,
         toolsVersion: ToolsVersion,

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -50,7 +50,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     var additionalFlags: [String] = []
 
     /// The list of targets that are going to be linked statically in this product.
-    var staticTargets: [ResolvedTarget] = []
+    var staticTargets: [ResolvedModule] = []
 
     /// The list of Swift modules that should be passed to the linker. This is required for debugging to work.
     var swiftASTs: SortedArray<AbsolutePath> = .init()

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -34,7 +34,7 @@ public final class SwiftTargetBuildDescription {
     public let package: ResolvedPackage
 
     /// The target described by this target.
-    public let target: ResolvedTarget
+    public let target: ResolvedModule
 
     private let swiftTarget: SwiftTarget
 
@@ -244,7 +244,7 @@ public final class SwiftTargetBuildDescription {
     /// Create a new target description with target and build parameters.
     init(
         package: ResolvedPackage,
-        target: ResolvedTarget,
+        target: ResolvedModule,
         toolsVersion: ToolsVersion,
         additionalFileRules: [FileRuleDescription] = [],
         buildParameters: BuildParameters,

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import struct PackageGraph.ResolvedTarget
+import struct PackageGraph.ResolvedModule
 import struct PackageModel.Resource
 import struct PackageModel.ToolsVersion
 import struct SPMBuildCore.BuildToolPluginInvocationResult
@@ -61,7 +61,7 @@ public enum TargetBuildDescription {
         }
     }
 
-    var target: ResolvedTarget {
+    var target: ResolvedModule {
         switch self {
         case .swift(let target):
             return target.target

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
@@ -14,7 +14,7 @@ import struct LLBuildManifest.Node
 import struct Basics.AbsolutePath
 import struct Basics.InternalError
 import class Basics.ObservabilityScope
-import struct PackageGraph.ResolvedTarget
+import struct PackageGraph.ResolvedModule
 import PackageModel
 
 extension LLBuildManifestBuilder {
@@ -32,7 +32,7 @@ extension LLBuildManifestBuilder {
             inputs.append(resourcesNode)
         }
 
-        func addStaticTargetInputs(_ target: ResolvedTarget) {
+        func addStaticTargetInputs(_ target: ResolvedModule) {
             if case .swift(let desc)? = self.plan.targetMap[target.id], target.type == .library {
                 inputs.append(file: desc.moduleOutputPath)
             }

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -17,7 +17,7 @@ import struct Basics.TSCAbsolutePath
 import struct LLBuildManifest.Node
 import struct LLBuildManifest.LLBuildManifest
 import struct SPMBuildCore.BuildParameters
-import struct PackageGraph.ResolvedTarget
+import struct PackageGraph.ResolvedModule
 import protocol TSCBasic.FileSystem
 import enum TSCBasic.ProcessEnv
 import func TSCBasic.topologicalSort
@@ -191,9 +191,9 @@ extension LLBuildManifestBuilder {
     public func addTargetsToExplicitBuildManifest() throws {
         // Sort the product targets in topological order in order to collect and "bubble up"
         // their respective dependency graphs to the depending targets.
-        let nodes: [ResolvedTarget.Dependency] = try self.plan.targetMap.keys.compactMap {
+        let nodes: [ResolvedModule.Dependency] = try self.plan.targetMap.keys.compactMap {
             guard let target = self.plan.graph.allTargets[$0] else { throw InternalError("unknown target \($0)") }
-            return ResolvedTarget.Dependency.target(target, conditions: [])
+            return ResolvedModule.Dependency.target(target, conditions: [])
         }
         let allPackageDependencies = try topologicalSort(nodes, successors: { $0.dependencies })
         // Instantiate the inter-module dependency oracle which will cache commonly-scanned
@@ -415,7 +415,7 @@ extension LLBuildManifestBuilder {
             inputs.append(resourcesNode)
         }
 
-        func addStaticTargetInputs(_ target: ResolvedTarget) throws {
+        func addStaticTargetInputs(_ target: ResolvedModule) throws {
             // Ignore C Modules.
             if target.underlying is SystemLibraryTarget { return }
             // Ignore Binary Modules.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -316,7 +316,7 @@ extension TargetBuildDescription {
     }
 }
 
-extension ResolvedTarget {
+extension ResolvedModule {
     public func getCommandName(config: String) -> String {
         "C." + self.getLLBuildTargetName(config: config)
     }

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -533,8 +533,8 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     private func plan(subset: BuildSubset? = nil) throws -> (description: BuildDescription, manifest: LLBuildManifest) {
         // Load the package graph.
         let graph = try getPackageGraph()
-        let buildToolPluginInvocationResults: [ResolvedTarget.ID: (target: ResolvedTarget, results: [BuildToolPluginInvocationResult])]
-        let prebuildCommandResults: [ResolvedTarget.ID: [PrebuildCommandResult]]
+        let buildToolPluginInvocationResults: [ResolvedModule.ID: (target: ResolvedModule, results: [BuildToolPluginInvocationResult])]
+        let prebuildCommandResults: [ResolvedModule.ID: [PrebuildCommandResult]]
         // Invoke any build tool plugins in the graph to generate prebuild commands and build commands.
         if let pluginConfiguration, !self.productsBuildParameters.shouldSkipBuilding {
             // Hacky workaround for rdar://120560817, but it replicates precisely enough the original behavior before
@@ -877,7 +877,7 @@ extension BuildDescription {
 }
 
 extension BuildSubset {
-    func recursiveDependencies(for graph: ModulesGraph, observabilityScope: ObservabilityScope) throws -> [ResolvedTarget]? {
+    func recursiveDependencies(for graph: ModulesGraph, observabilityScope: ObservabilityScope) throws -> [ResolvedModule]? {
         switch self {
         case .allIncludingTests:
             return Array(graph.reachableTargets)

--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -14,7 +14,7 @@ import struct Basics.AbsolutePath
 import struct Basics.Triple
 import struct Basics.InternalError
 import struct PackageGraph.ResolvedProduct
-import struct PackageGraph.ResolvedTarget
+import struct PackageGraph.ResolvedModule
 import class PackageModel.BinaryTarget
 import class PackageModel.ClangTarget
 
@@ -125,8 +125,8 @@ extension BuildPlan {
         buildParameters: BuildParameters
     ) throws -> (
         dylibs: [ResolvedProduct],
-        staticTargets: [ResolvedTarget],
-        systemModules: [ResolvedTarget],
+        staticTargets: [ResolvedModule],
+        systemModules: [ResolvedModule],
         libraryBinaryPaths: Set<AbsolutePath>,
         availableTools: [String: AbsolutePath]
     ) {
@@ -161,7 +161,7 @@ extension BuildPlan {
         }
 
         // Sort the product targets in topological order.
-        let nodes: [ResolvedTarget.Dependency] = product.targets.map { .target($0, conditions: []) }
+        let nodes: [ResolvedModule.Dependency] = product.targets.map { .target($0, conditions: []) }
         let allTargets = try topologicalSort(nodes, successors: { dependency in
             switch dependency {
             // Include all the dependencies of a target.
@@ -186,7 +186,7 @@ extension BuildPlan {
                     return []
                 }
 
-                let productDependencies: [ResolvedTarget.Dependency] = product.targets.map { .target($0, conditions: []) }
+                let productDependencies: [ResolvedModule.Dependency] = product.targets.map { .target($0, conditions: []) }
                 switch product.type {
                 case .library(.automatic), .library(.static):
                     return productDependencies
@@ -202,8 +202,8 @@ extension BuildPlan {
 
         // Create empty arrays to collect our results.
         var linkLibraries = [ResolvedProduct]()
-        var staticTargets = [ResolvedTarget]()
-        var systemModules = [ResolvedTarget]()
+        var staticTargets = [ResolvedModule]()
+        var systemModules = [ResolvedModule]()
         var libraryBinaryPaths: Set<AbsolutePath> = []
         var availableTools = [String: AbsolutePath]()
 

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -103,7 +103,7 @@ extension BuildParameters {
     }
 
     /// Returns the compiler arguments for the index store, if enabled.
-    func indexStoreArguments(for target: ResolvedTarget) -> [String] {
+    func indexStoreArguments(for target: ResolvedModule) -> [String] {
         let addIndexStoreArguments: Bool
         switch indexStoreMode {
         case .on:
@@ -128,7 +128,7 @@ extension BuildParameters {
     }
 
     /// Computes the target triple arguments for a given resolved target.
-    public func targetTripleArgs(for target: ResolvedTarget) throws -> [String] {
+    public func targetTripleArgs(for target: ResolvedModule) throws -> [String] {
         var args = ["-target"]
 
         // Compute the triple string for Darwin platform using the platform version.
@@ -144,7 +144,7 @@ extension BuildParameters {
 
     /// Computes the linker flags to use in order to rename a module-named main function to 'main' for the target
     /// platform, or nil if the linker doesn't support it for the platform.
-    func linkerFlagsForRenamingMainFunction(of target: ResolvedTarget) -> [String]? {
+    func linkerFlagsForRenamingMainFunction(of target: ResolvedModule) -> [String]? {
         let args: [String]
         if self.triple.isApple() {
             args = ["-alias", "_\(target.c99name)_main", "_main"]
@@ -157,7 +157,7 @@ extension BuildParameters {
     }
 
     /// Returns the scoped view of build settings for a given target.
-    func createScope(for target: ResolvedTarget) -> BuildSettings.Scope {
+    func createScope(for target: ResolvedModule) -> BuildSettings.Scope {
         BuildSettings.Scope(target.underlying.buildSettings, environment: buildEnvironment)
     }
 }
@@ -186,7 +186,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     public let toolsBuildParameters: BuildParameters
 
     /// Triple for which this target is compiled.
-    private func buildTriple(for target: ResolvedTarget) -> Basics.Triple {
+    private func buildTriple(for target: ResolvedModule) -> Basics.Triple {
         self.buildParameters(for: target).triple
     }
 
@@ -199,7 +199,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     public let graph: ModulesGraph
 
     /// The target build description map.
-    public let targetMap: [ResolvedTarget.ID: TargetBuildDescription]
+    public let targetMap: [ResolvedModule.ID: TargetBuildDescription]
 
     /// The product build description map.
     public let productMap: [ResolvedProduct.ID: ProductBuildDescription]
@@ -219,14 +219,14 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     }
 
     /// The results of invoking any build tool plugins used by targets in this build.
-    public let buildToolPluginInvocationResults: [ResolvedTarget.ID: [BuildToolPluginInvocationResult]]
+    public let buildToolPluginInvocationResults: [ResolvedModule.ID: [BuildToolPluginInvocationResult]]
 
     /// The results of running any prebuild commands for the targets in this build.  This includes any derived
     /// source files as well as directories to which any changes should cause us to reevaluate the build plan.
-    public let prebuildCommandResults: [ResolvedTarget.ID: [PrebuildCommandResult]]
+    public let prebuildCommandResults: [ResolvedModule.ID: [PrebuildCommandResult]]
 
     @_spi(SwiftPMInternal)
-    public private(set) var derivedTestTargetsMap: [ResolvedProduct.ID: [ResolvedTarget]] = [:]
+    public private(set) var derivedTestTargetsMap: [ResolvedProduct.ID: [ResolvedModule]] = [:]
 
     /// Cache for pkgConfig flags.
     private var pkgConfigCache = [SystemLibraryTarget: (cFlags: [String], libs: [String])]()
@@ -274,8 +274,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         toolsBuildParameters: BuildParameters,
         graph: ModulesGraph,
         additionalFileRules: [FileRuleDescription] = [],
-        buildToolPluginInvocationResults: [ResolvedTarget.ID: [BuildToolPluginInvocationResult]] = [:],
-        prebuildCommandResults: [ResolvedTarget.ID: [PrebuildCommandResult]] = [:],
+        buildToolPluginInvocationResults: [ResolvedModule.ID: [BuildToolPluginInvocationResult]] = [:],
+        prebuildCommandResults: [ResolvedModule.ID: [PrebuildCommandResult]] = [:],
         disableSandbox: Bool = false,
         fileSystem: any FileSystem,
         observabilityScope: ObservabilityScope
@@ -316,7 +316,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
             ))
         }
         let macroProductsByTarget = productMap.values.filter { $0.product.type == .macro }
-            .reduce(into: [ResolvedTarget.ID: ResolvedProduct]()) {
+            .reduce(into: [ResolvedModule.ID: ResolvedProduct]()) {
                 if let target = $1.product.targets.first {
                     $0[target.id] = $1.product
                 }
@@ -326,7 +326,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         // Plugin targets are noted, since they need to be compiled, but they do
         // not get directly incorporated into the build description that will be
         // given to LLBuild.
-        var targetMap = [ResolvedTarget.ID: TargetBuildDescription]()
+        var targetMap = [ResolvedModule.ID: TargetBuildDescription]()
         var pluginDescriptions = [PluginDescription]()
         var shouldGenerateTestObservation = true
         for target in graph.allTargets.sorted(by: { $0.name < $1.name }) {
@@ -474,7 +474,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
 
     static func validateDeploymentVersionOfProductDependency(
         product: ResolvedProduct,
-        forTarget target: ResolvedTarget,
+        forTarget target: ResolvedModule,
         buildEnvironment: BuildEnvironment,
         observabilityScope: ObservabilityScope
     ) throws {
@@ -662,7 +662,7 @@ extension Basics.Diagnostic {
     }
 
     static func productRequiresHigherPlatformVersion(
-        target: ResolvedTarget,
+        target: ResolvedModule,
         targetPlatform: SupportedPlatform,
         product: String,
         productPlatform: SupportedPlatform
@@ -694,7 +694,7 @@ extension BuildParameters {
 /// Generate the resource bundle Info.plist.
 func generateResourceInfoPlist(
     fileSystem: FileSystem,
-    target: ResolvedTarget,
+    target: ResolvedModule,
     path: AbsolutePath
 ) throws -> Bool {
     guard let defaultLocalization = target.defaultLocalization else {

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -70,7 +70,7 @@ struct DumpSymbolGraph: SwiftCommand {
         for target in targets {
             print("-- Emitting symbol graph for", target.name)
             let result = try symbolGraphExtractor.extractSymbolGraph(
-                target: target,
+                module: target,
                 buildPlan: buildPlan,
                 outputRedirection: .collect(redirectStderr: true),
                 outputDirectory: symbolGraphDirectory,

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -427,7 +427,7 @@ final class PluginDelegate: PluginInvocationDelegate {
 
         // Run the symbol graph extractor on the target.
         let result = try symbolGraphExtractor.extractSymbolGraph(
-            target: target,
+            module: target,
             buildPlan: try buildSystem.buildPlan,
             outputRedirection: .collect,
             outputDirectory: outputDir,

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -50,23 +50,23 @@ public struct SymbolGraphExtract {
         case json(pretty: Bool)
     }
     
-    /// Creates a symbol graph for `target` in `outputDirectory` using the build information from `buildPlan`.
+    /// Creates a symbol graph for `module` in `outputDirectory` using the build information from `buildPlan`.
     /// The `outputDirection` determines how the output from the tool subprocess is handled, and `verbosity` specifies
     /// how much console output to ask the tool to emit.
     public func extractSymbolGraph(
-        target: ResolvedTarget,
+        module: ResolvedModule,
         buildPlan: BuildPlan,
         outputRedirection: TSCBasic.Process.OutputRedirection = .none,
         outputDirectory: AbsolutePath,
         verboseOutput: Bool
     ) throws -> ProcessResult {
-        let buildParameters = buildPlan.buildParameters(for: target)
+        let buildParameters = buildPlan.buildParameters(for: module)
         try self.fileSystem.createDirectory(outputDirectory, recursive: true)
 
         // Construct arguments for extracting symbols for a single target.
         var commandLine = [self.tool.pathString]
-        commandLine += ["-module-name", target.c99name]
-        commandLine += try buildParameters.targetTripleArgs(for: target)
+        commandLine += ["-module-name", module.c99name]
+        commandLine += try buildParameters.targetTripleArgs(for: module)
         commandLine += try buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)
         commandLine += ["-module-cache-path", try buildParameters.moduleCache.pathString]
         if verboseOutput {

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -878,7 +878,7 @@ private final class ResolvedProductBuilder: ResolvedBuilder<ResolvedProduct> {
 }
 
 /// Builder for resolved target.
-private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
+private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedModule> {
     /// Enumeration to represent target dependencies.
     enum Dependency {
 
@@ -919,14 +919,14 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedTarget> {
         self.platformVersionProvider = platformVersionProvider
     }
 
-    override func constructImpl() throws -> ResolvedTarget {
+    override func constructImpl() throws -> ResolvedModule {
         let diagnosticsEmitter = self.observabilityScope.makeDiagnosticsEmitter() {
             var metadata = ObservabilityMetadata()
             metadata.targetName = target.name
             return metadata
         }
 
-        let dependencies = try self.dependencies.map { dependency -> ResolvedTarget.Dependency in
+        let dependencies = try self.dependencies.map { dependency -> ResolvedModule.Dependency in
             switch dependency {
             case .target(let targetBuilder, let conditions):
                 return .target(try targetBuilder.construct(), conditions: conditions)

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -66,13 +66,13 @@ public struct ModulesGraph {
     public let packages: [ResolvedPackage]
 
     /// The list of all targets reachable from root targets.
-    public let reachableTargets: IdentifiableSet<ResolvedTarget>
+    public let reachableTargets: IdentifiableSet<ResolvedModule>
 
     /// The list of all products reachable from root targets.
     public let reachableProducts: IdentifiableSet<ResolvedProduct>
 
     /// Returns all the targets in the graph, regardless if they are reachable from the root targets or not.
-    public let allTargets: IdentifiableSet<ResolvedTarget>
+    public let allTargets: IdentifiableSet<ResolvedModule>
 
     /// Returns all targets within the module graph in topological order, starting with low-level targets (that have no
     /// dependencies).
@@ -93,12 +93,12 @@ public struct ModulesGraph {
     public let requiredDependencies: [PackageReference]
 
     /// Returns true if a given target is present in root packages and is not excluded for the given build environment.
-    public func isInRootPackages(_ target: ResolvedTarget, satisfying buildEnvironment: BuildEnvironment) -> Bool {
+    public func isInRootPackages(_ target: ResolvedModule, satisfying buildEnvironment: BuildEnvironment) -> Bool {
         // FIXME: This can be easily cached.
-        return rootPackages.reduce(into: IdentifiableSet<ResolvedTarget>()) { (accumulator: inout IdentifiableSet<ResolvedTarget>, package: ResolvedPackage) in
+        return rootPackages.reduce(into: IdentifiableSet<ResolvedModule>()) { (accumulator: inout IdentifiableSet<ResolvedModule>, package: ResolvedPackage) in
             let allDependencies = package.targets.flatMap { $0.dependencies }
             let unsatisfiedDependencies = allDependencies.filter { !$0.satisfies(buildEnvironment) }
-            let unsatisfiedDependencyTargets = unsatisfiedDependencies.compactMap { (dep: ResolvedTarget.Dependency) -> ResolvedTarget? in
+            let unsatisfiedDependencyTargets = unsatisfiedDependencies.compactMap { (dep: ResolvedModule.Dependency) -> ResolvedModule? in
                 switch dep {
                 case .target(let target, _):
                     return target
@@ -116,10 +116,10 @@ public struct ModulesGraph {
         return self.rootPackages.contains(id: package.id)
     }
 
-    private let targetsToPackages: [ResolvedTarget.ID: ResolvedPackage]
-    /// Returns the package that contains the target, or nil if the target isn't in the graph.
-    public func package(for target: ResolvedTarget) -> ResolvedPackage? {
-        return self.targetsToPackages[target.id]
+    private let modulesToPackages: [ResolvedModule.ID: ResolvedPackage]
+    /// Returns the package that contains the module, or nil if the module isn't in the graph.
+    public func package(for module: ResolvedModule) -> ResolvedPackage? {
+        return self.modulesToPackages[module.id]
     }
 
 
@@ -151,11 +151,11 @@ public struct ModulesGraph {
         // Create a mapping from targets to the packages that define them.  Here
         // we include all targets, including tests in non-root packages, since
         // this is intended for lookup and not traversal.
-        self.targetsToPackages = packages.reduce(into: [:], { partial, package in
+        self.modulesToPackages = packages.reduce(into: [:], { partial, package in
             package.targets.forEach{ partial[$0.id] = package }
         })
 
-        let allTargets = IdentifiableSet(packages.flatMap({ package -> [ResolvedTarget] in
+        let allTargets = IdentifiableSet(packages.flatMap({ package -> [ResolvedModule] in
             if rootPackages.contains(id: package.id) {
                 return package.targets
             } else {
@@ -195,13 +195,13 @@ public struct ModulesGraph {
     }
 
     /// Computes a map from each executable target in any of the root packages to the corresponding test targets.
-    func computeTestTargetsForExecutableTargets() throws -> [ResolvedTarget.ID: [ResolvedTarget]] {
-        var result = [ResolvedTarget.ID: [ResolvedTarget]]()
+    func computeTestTargetsForExecutableTargets() throws -> [ResolvedModule.ID: [ResolvedModule]] {
+        var result = [ResolvedModule.ID: [ResolvedModule]]()
 
         let rootTargets = IdentifiableSet(rootPackages.flatMap { $0.targets })
 
         // Create map of test target to set of its direct dependencies.
-        let testTargetDepMap: [ResolvedTarget.ID: IdentifiableSet<ResolvedTarget>] = try {
+        let testTargetDepMap: [ResolvedModule.ID: IdentifiableSet<ResolvedModule>] = try {
             let testTargetDeps = rootTargets.filter({ $0.type == .test }).map({
                 ($0.id, IdentifiableSet($0.dependencies.compactMap { $0.target }.filter { $0.type != .plugin }))
             })

--- a/Sources/PackageGraph/Resolution/PlatformVersionProvider.swift
+++ b/Sources/PackageGraph/Resolution/PlatformVersionProvider.swift
@@ -32,7 +32,7 @@ func merge(into partial: inout [SupportedPlatform], platforms: [SupportedPlatfor
 
 public struct PlatformVersionProvider: Hashable {
     public enum Implementation: Hashable {
-        case mergingFromTargets(IdentifiableSet<ResolvedTarget>)
+        case mergingFromTargets(IdentifiableSet<ResolvedModule>)
         case customXCTestMinimumDeploymentTargets([PackageModel.Platform: PlatformVersion])
         case minimumDeploymentTargetDefault
     }

--- a/Sources/PackageGraph/Resolution/ResolvedPackage.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedPackage.swift
@@ -34,7 +34,7 @@ public struct ResolvedPackage {
     public let underlying: Package
 
     /// The targets contained in the package.
-    public let targets: [ResolvedTarget]
+    public let targets: [ResolvedModule]
 
     /// The products produced by the package.
     public let products: [ResolvedProduct]
@@ -58,7 +58,7 @@ public struct ResolvedPackage {
         defaultLocalization: String?,
         supportedPlatforms: [SupportedPlatform],
         dependencies: [ResolvedPackage],
-        targets: [ResolvedTarget],
+        targets: [ResolvedModule],
         products: [ResolvedProduct],
         registryMetadata: RegistryReleaseMetadata?,
         platformVersionProvider: PlatformVersionProvider

--- a/Sources/PackageGraph/Resolution/ResolvedTarget.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedTarget.swift
@@ -12,17 +12,20 @@
 
 import PackageModel
 
-/// Represents a fully resolved target. All the dependencies for this target are also stored as resolved.
-public struct ResolvedTarget {
+@available(*, deprecated, renamed: "ResolvedModule")
+public typealias ResolvedTarget = ResolvedModule
+
+/// Represents a fully resolved module. All the dependencies for this module are also stored as resolved.
+public struct ResolvedModule {
     /// Represents dependency of a resolved target.
     public enum Dependency {
         /// Direct dependency of the target. This target is in the same package and should be statically linked.
-        case target(_ target: ResolvedTarget, conditions: [PackageCondition])
+        case target(_ target: ResolvedModule, conditions: [PackageCondition])
 
         /// The target depends on this product.
         case product(_ product: ResolvedProduct, conditions: [PackageCondition])
 
-        public var target: ResolvedTarget? {
+        public var target: ResolvedModule? {
             switch self {
             case .target(let target, _): return target
             case .product: return nil
@@ -44,7 +47,7 @@ public struct ResolvedTarget {
         }
 
         /// Returns the direct dependencies of the underlying dependency, across the package graph.
-        public var dependencies: [ResolvedTarget.Dependency] {
+        public var dependencies: [ResolvedModule.Dependency] {
             switch self {
             case .target(let target, _):
                 return target.dependencies
@@ -54,7 +57,7 @@ public struct ResolvedTarget {
         }
 
         /// Returns the direct dependencies of the underlying dependency, limited to the target's package.
-        public var packageDependencies: [ResolvedTarget.Dependency] {
+        public var packageDependencies: [ResolvedModule.Dependency] {
             switch self {
             case .target(let target, _):
                 return target.dependencies
@@ -86,7 +89,7 @@ public struct ResolvedTarget {
     }
 
     /// Returns the recursive target dependencies, across the whole package-graph.
-    public func recursiveTargetDependencies() throws -> [ResolvedTarget] {
+    public func recursiveTargetDependencies() throws -> [ResolvedModule] {
         try topologicalSort(self.dependencies) { $0.dependencies }.compactMap { $0.target }
     }
 
@@ -150,7 +153,7 @@ public struct ResolvedTarget {
     public init(
         packageIdentity: PackageIdentity,
         underlying: Target,
-        dependencies: [ResolvedTarget.Dependency],
+        dependencies: [ResolvedModule.Dependency],
         defaultLocalization: String? = nil,
         supportedPlatforms: [SupportedPlatform],
         platformVersionProvider: PlatformVersionProvider
@@ -173,13 +176,13 @@ public struct ResolvedTarget {
     }
 }
 
-extension ResolvedTarget: CustomStringConvertible {
+extension ResolvedModule: CustomStringConvertible {
     public var description: String {
         return "<ResolvedTarget: \(name)>"
     }
 }
 
-extension ResolvedTarget.Dependency: CustomStringConvertible {
+extension ResolvedModule.Dependency: CustomStringConvertible {
     public var description: String {
         var str = "<ResolvedTarget.Dependency: "
         switch self {
@@ -193,11 +196,14 @@ extension ResolvedTarget.Dependency: CustomStringConvertible {
     }
 }
 
-extension ResolvedTarget.Dependency: Identifiable {
+extension ResolvedModule.Dependency: Identifiable {
     public struct ID: Hashable {
         enum Kind: Hashable {
-            case target
+            case module
             case product
+
+            @available(*, deprecated, renamed: "module")
+            public static let target: Kind = .module
         }
 
         let kind: Kind
@@ -208,15 +214,15 @@ extension ResolvedTarget.Dependency: Identifiable {
     public var id: ID {
         switch self {
         case .target(let target, _):
-            return .init(kind: .target, packageIdentity: target.packageIdentity, name: target.name)
+            return .init(kind: .module, packageIdentity: target.packageIdentity, name: target.name)
         case .product(let product, _):
             return .init(kind: .product, packageIdentity: product.packageIdentity, name: product.name)
         }
     }
 }
 
-extension ResolvedTarget.Dependency: Equatable {
-    public static func == (lhs: ResolvedTarget.Dependency, rhs: ResolvedTarget.Dependency) -> Bool {
+extension ResolvedModule.Dependency: Equatable {
+    public static func == (lhs: ResolvedModule.Dependency, rhs: ResolvedModule.Dependency) -> Bool {
         switch (lhs, rhs) {
         case (.target(let lhsTarget, _), .target(let rhsTarget, _)):
             return lhsTarget.id == rhsTarget.id
@@ -228,7 +234,7 @@ extension ResolvedTarget.Dependency: Equatable {
     }
 }
 
-extension ResolvedTarget.Dependency: Hashable {
+extension ResolvedModule.Dependency: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch self {
         case .target(let target, _):
@@ -239,7 +245,7 @@ extension ResolvedTarget.Dependency: Hashable {
     }
 }
 
-extension ResolvedTarget: Identifiable {
+extension ResolvedModule: Identifiable {
     /// Resolved target identity that uniquely identifies it in a resolution graph.
     public struct ID: Hashable {
         public let targetName: String

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -94,7 +94,7 @@ public protocol BuildPlan {
 
 extension BuildPlan {
     /// Parameters used for building a given target.
-    public func buildParameters(for target: ResolvedTarget) -> BuildParameters {
+    public func buildParameters(for target: ResolvedModule) -> BuildParameters {
         switch target.buildTriple {
         case .tools:
             return self.toolsBuildParameters

--- a/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginContextSerializer.swift
@@ -28,7 +28,7 @@ internal struct PluginContextSerializer {
     var paths: [WireInput.URL] = []
     var pathsToIds: [AbsolutePath: WireInput.URL.Id] = [:]
     var targets: [WireInput.Target] = []
-    var targetsToWireIDs: [ResolvedTarget.ID: WireInput.Target.Id] = [:]
+    var targetsToWireIDs: [ResolvedModule.ID: WireInput.Target.Id] = [:]
     var products: [WireInput.Product] = []
     var productsToWireIDs: [ResolvedProduct.ID: WireInput.Product.Id] = [:]
     var packages: [WireInput.Package] = []

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -21,7 +21,7 @@ import protocol TSCBasic.DiagnosticLocation
 public enum PluginAction {
     case createBuildToolCommands(
         package: ResolvedPackage,
-        target: ResolvedTarget,
+        target: ResolvedModule,
         pluginGeneratedSources: [AbsolutePath],
         pluginGeneratedResources: [AbsolutePath]
     )

--- a/Sources/SPMBuildCore/ResolvedPackage+Extensions.swift
+++ b/Sources/SPMBuildCore/ResolvedPackage+Extensions.swift
@@ -11,11 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 import struct PackageGraph.ResolvedPackage
-import struct PackageGraph.ResolvedTarget
+import struct PackageGraph.ResolvedModule
 
 extension ResolvedPackage {
     @_spi(SwiftPMInternal)
-    public func packageNameArgument(target: ResolvedTarget, isPackageNameSupported: Bool) -> [String] {
+    public func packageNameArgument(target: ResolvedModule, isPackageNameSupported: Bool) -> [String] {
         if self.manifest.usePackageNameFlag, target.packageAccess {
             ["-package-name", self.identity.description.spm_mangledToC99ExtendedIdentifier()]
         } else {

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -21,7 +21,8 @@ private import SPMBuildCore
 import class Build.BuildPlan
 import class Build.ClangTargetBuildDescription
 import class Build.SwiftTargetBuildDescription
-import struct PackageGraph.ResolvedTarget
+
+import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ModulesGraph
 import enum PackageGraph.BuildTriple
 
@@ -109,7 +110,7 @@ public struct BuildDescription {
     }
 
     // FIXME: should not use `ResolvedTarget` in the public interface
-    public func getBuildTarget(for target: ResolvedTarget, in modulesGraph: ModulesGraph) -> BuildTarget? {
+    public func getBuildTarget(for target: ResolvedModule, in modulesGraph: ModulesGraph) -> BuildTarget? {
         if let description = buildPlan.targetMap[target.id] {
             switch description {
             case .clang(let description):

--- a/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/PluginTargetBuildDescription.swift
@@ -12,7 +12,7 @@
 
 import struct Foundation.URL
 
-import struct PackageGraph.ResolvedTarget
+import struct PackageGraph.ResolvedModule
 
 private import class PackageLoading.ManifestLoader
 internal import struct PackageModel.ToolsVersion
@@ -20,11 +20,11 @@ private import class PackageModel.UserToolchain
 import enum PackageGraph.BuildTriple
 
 struct PluginTargetBuildDescription: BuildTarget {
-    private let target: ResolvedTarget
+    private let target: ResolvedModule
     private let toolsVersion: ToolsVersion
     let isPartOfRootPackage: Bool
 
-    init(target: ResolvedTarget, toolsVersion: ToolsVersion, isPartOfRootPackage: Bool) {
+    init(target: ResolvedModule, toolsVersion: ToolsVersion, isPartOfRootPackage: Bool) {
         assert(target.type == .plugin)
         self.target = target
         self.toolsVersion = toolsVersion


### PR DESCRIPTION
- Explanation:

  With host/target triples separation in the SwiftPM codebase, it gets very confusing whether at a given moment "target" refers to a module, a triple, or a low level build system target.

  Renamed `ResolvedTarget` to `ResolvedModule`. Added a deprecated `typealias ResolvedTarget = ResolvedModule` to allow graceful migration for users of this type.

  Confusion between target triples and package targets is reduced.

  This has no impact on how these concepts are named in user-visible APIs like `PackageDescription` and `PackagePlugin`, target there can stay as "target" for as long as needed.

  Remaining internal uses of "target" outside of "target triple" context, like `*TargetBuildDescription` will be renamed in future PRs.

- Scope: NFC change

- Main Branch PRs: https://github.com/apple/swift-package-manager/pull/7459

- Risk: Very Low

- Reviewed By: @bnbarham  

- Testing: No new tests are necessary


(cherry picked from commit 27996b8ae75df9f35d45c6cc1929a7456c2dcb60)
