### PR TITLE
Set an environment variable in `swift test` to indicate which testing library is in use.

### DIFF
--- a/Fixtures/Miscellaneous/CheckTestLibraryEnvironmentVariable/Package.swift
+++ b/Fixtures/Miscellaneous/CheckTestLibraryEnvironmentVariable/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "CheckTestLibraryEnvironmentVariable",
+    targets: [
+        .testTarget(name: "CheckTestLibraryEnvironmentVariableTests"),
+    ]
+)

--- a/Fixtures/Miscellaneous/CheckTestLibraryEnvironmentVariable/Tests/CheckTestLibraryEnvironmentVariableTests/CheckTestLibraryEnvironmentVariableTests.swift
+++ b/Fixtures/Miscellaneous/CheckTestLibraryEnvironmentVariable/Tests/CheckTestLibraryEnvironmentVariableTests/CheckTestLibraryEnvironmentVariableTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+final class CheckTestLibraryEnvironmentVariableTests: XCTestCase {
+    func testEnviromentVariable() throws {
+        let envvar = ProcessInfo.processInfo.environment["SWIFT_PM_TEST_LIBRARY"]
+        XCTAssertEqual(envvar, "XCTest")
+    }
+}

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -421,7 +421,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         let testEnv = try TestingSupport.constructTestEnvironment(
             toolchain: toolchain,
             destinationBuildParameters: productsBuildParameters,
-            sanitizers: globalOptions.build.sanitizers
+            sanitizers: globalOptions.build.sanitizers,
+            library: library
         )
 
         let runner = TestRunner(
@@ -702,7 +703,8 @@ extension SwiftTestCommand {
             let testEnv = try TestingSupport.constructTestEnvironment(
                 toolchain: toolchain,
                 destinationBuildParameters: productsBuildParameters,
-                sanitizers: globalOptions.build.sanitizers
+                sanitizers: globalOptions.build.sanitizers,
+                library: .swiftTesting
             )
 
             let additionalArguments = ["--list-tests"] + CommandLine.arguments.dropFirst()
@@ -1014,7 +1016,8 @@ final class ParallelTestRunner {
         let testEnv = try TestingSupport.constructTestEnvironment(
             toolchain: self.toolchain,
             destinationBuildParameters: self.productsBuildParameters,
-            sanitizers: self.buildOptions.sanitizers
+            sanitizers: self.buildOptions.sanitizers,
+            library: .xctest // swift-testing does not use ParallelTestRunner
         )
 
         // Enqueue all the tests.

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -236,7 +236,8 @@ final class PluginDelegate: PluginInvocationDelegate {
         let testEnvironment = try TestingSupport.constructTestEnvironment(
             toolchain: toolchain,
             destinationBuildParameters: toolsBuildParameters,
-            sanitizers: swiftCommandState.options.build.sanitizers
+            sanitizers: swiftCommandState.options.build.sanitizers,
+            library: .xctest // FIXME: support both libraries
         )
 
         // Iterate over the tests and run those that match the filter.

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -121,7 +121,8 @@ enum TestingSupport {
                     experimentalTestOutput: experimentalTestOutput,
                     library: .xctest
                 ).productsBuildParameters,
-                sanitizers: sanitizers
+                sanitizers: sanitizers,
+                library: .xctest
             )
 
             try TSCBasic.Process.checkNonZeroExit(arguments: args, environment: env)
@@ -136,7 +137,8 @@ enum TestingSupport {
                 shouldSkipBuilding: shouldSkipBuilding,
                 library: .xctest
             ).productsBuildParameters,
-            sanitizers: sanitizers
+            sanitizers: sanitizers,
+            library: .xctest
         )
         args = [path.description, "--dump-tests-json"]
         let data = try Process.checkNonZeroExit(arguments: args, environment: env)
@@ -149,7 +151,8 @@ enum TestingSupport {
     static func constructTestEnvironment(
         toolchain: UserToolchain,
         destinationBuildParameters buildParameters: BuildParameters,
-        sanitizers: [Sanitizer]
+        sanitizers: [Sanitizer],
+        library: BuildParameters.Testing.Library
     ) throws -> EnvironmentVariables {
         var env = EnvironmentVariables.process()
 
@@ -160,6 +163,10 @@ enum TestingSupport {
         if !stdoutStream.isTTY || !stderrStream.isTTY {
             env["NO_COLOR"] = "1"
         }
+
+        // Set an environment variable to indicate which library's test product
+        // is being executed.
+        env["SWIFT_PM_TEST_LIBRARY"] = String(describing: library)
 
         // Add the code coverage related variables.
         if buildParameters.testingParameters.enableCodeCoverage {

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -304,12 +304,9 @@ final class TestCommandTests: CommandsTestCase {
     }
 #endif
 
-#if false
-    // DISABLED: This test cannot be enabled until the hosting copy of SwiftPM
-    // has started setting this environment variable.
-    func testLibraryEnvironmentVariable() {
-        let envvar = ProcessInfo.processInfo.environment["SWIFT_PM_TEST_LIBRARY"]
-        XCTAssertEqual(envvar, "XCTest")
+    func testLibraryEnvironmentVariable() throws {
+      try fixture(name: "Miscellaneous/CheckTestLibraryEnvironmentVariable") { fixturePath in
+        XCTAssertNoThrow(try SwiftPM.Test.execute(packagePath: fixturePath))
+      }
     }
-#endif
 }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -303,4 +303,9 @@ final class TestCommandTests: CommandsTestCase {
         }
     }
 #endif
+
+    func testLibraryEnvironmentVariable() {
+        let envvar = ProcessInfo.processInfo.environment["SWIFT_PM_TEST_LIBRARY"]
+        XCTAssertEqual(envvar, "XCTest")
+    }
 }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -304,8 +304,12 @@ final class TestCommandTests: CommandsTestCase {
     }
 #endif
 
+#if false
+    // DISABLED: This test cannot be enabled until the hosting copy of SwiftPM
+    // has started setting this environment variable.
     func testLibraryEnvironmentVariable() {
         let envvar = ProcessInfo.processInfo.environment["SWIFT_PM_TEST_LIBRARY"]
         XCTAssertEqual(envvar, "XCTest")
     }
+#endif
 }


### PR DESCRIPTION
This PR sets a new environment variable `"SWIFT_PM_TEST_LIBRARY"` to the name of the active testing library (`"XCTest"` or `"swift-testing"`.) Code in these libraries can then use the presence of this environment variable to adjust their behaviour.

Resolves rdar://128272138.