### PR TITLE
Add prepare for index experimental build argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Package.resolved
 .docc-build
 .vscode
 Utilities/InstalledSwiftPMConfiguration/config.json
+.devcontainer

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -246,6 +246,12 @@ public final class SwiftTargetBuildDescription {
     /// Whether to disable sandboxing (e.g. for macros).
     private let shouldDisableSandbox: Bool
 
+    /// Whether to build preparing for indexing
+    public var prepareForIndexing: Bool {
+        // Do full build for tools
+        defaultBuildParameters.prepareForIndexing && target.buildTriple != .tools
+    }
+
     /// Create a new target description with target and build parameters.
     init(
         package: ResolvedPackage,
@@ -580,6 +586,14 @@ public final class SwiftTargetBuildDescription {
         // way.
         if self.defaultBuildParameters.driverParameters.enableParseableModuleInterfaces || args.contains("-enable-library-evolution") {
             args += ["-emit-module-interface-path", self.parseableModuleInterfaceOutputPath.pathString]
+        }
+
+        if self.prepareForIndexing {
+            args += [
+                "-Xfrontend", "-experimental-skip-all-function-bodies",
+                "-Xfrontend", "-experimental-allow-module-with-compiler-errors",
+                "-Xfrontend", "-empty-abi-descriptor"
+            ]
         }
 
         args += self.defaultBuildParameters.toolchain.extraFlags.swiftCompilerFlags

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -246,12 +246,6 @@ public final class SwiftTargetBuildDescription {
     /// Whether to disable sandboxing (e.g. for macros).
     private let shouldDisableSandbox: Bool
 
-    /// Whether to build preparing for indexing
-    public var prepareForIndexing: Bool {
-        // Do full build for tools
-        defaultBuildParameters.prepareForIndexing && target.buildTriple != .tools
-    }
-
     /// Create a new target description with target and build parameters.
     init(
         package: ResolvedPackage,
@@ -588,9 +582,12 @@ public final class SwiftTargetBuildDescription {
             args += ["-emit-module-interface-path", self.parseableModuleInterfaceOutputPath.pathString]
         }
 
-        if self.prepareForIndexing {
+        if self.defaultBuildParameters.prepareForIndexing {
             args += [
+                "-Xfrontend", "-enable-library-evolution",
                 "-Xfrontend", "-experimental-skip-all-function-bodies",
+                "-Xfrontend", "-experimental-lazy-typecheck",
+                "-Xfrontend", "-experimental-skip-non-exportable-decls",
                 "-Xfrontend", "-experimental-allow-module-with-compiler-errors",
                 "-Xfrontend", "-empty-abi-descriptor"
             ]

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -537,7 +537,7 @@ extension LLBuildManifestBuilder {
 
     private func addModuleWrapCmd(_ target: SwiftTargetBuildDescription) throws {
         // Add commands to perform the module wrapping Swift modules when debugging strategy is `modulewrap`.
-        guard target.defaultBuildParameters.debuggingStrategy == .modulewrap else { return }
+        guard target.defaultBuildParameters.debuggingStrategy == .modulewrap, !target.prepareForIndexing else { return }
         var moduleWrapArgs = [
             target.defaultBuildParameters.toolchain.swiftCompilerPath.pathString,
             "-modulewrap", target.moduleOutputPath.pathString,

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -41,15 +41,9 @@ extension LLBuildManifestBuilder {
         let inputs = try self.computeSwiftCompileCmdInputs(target)
 
         // Outputs.
-        let objectNodes = try target.objects.map(Node.file)
+        let objectNodes = target.defaultBuildParameters.prepareForIndexing ? [] : try target.objects.map(Node.file)
         let moduleNode = Node.file(target.moduleOutputPath)
-        let cmdOutputs: [Node]
-        if target.defaultBuildParameters.prepareForIndexing {
-            // Don't include the object nodes on prepare builds
-            cmdOutputs = [moduleNode]
-        } else {
-            cmdOutputs = objectNodes + [moduleNode]
-        }
+        let cmdOutputs = objectNodes + [moduleNode]
 
         if target.defaultBuildParameters.driverParameters.useIntegratedSwiftDriver {
             try self.addSwiftCmdsViaIntegratedDriver(

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -150,8 +150,11 @@ public class LLBuildManifestBuilder {
 
         for (_, description) in self.plan.productMap {
             // Need to generate macro products
-            if description.product.type == .macro {
+            switch description.product.type {
+            case .macro, .plugin:
                 try self.createProductCommand(description)
+            default:
+                break
             }
         }
 

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -851,7 +851,9 @@ extension BuildDescription {
     ) throws -> (BuildDescription, LLBuildManifest) {
         // Generate the llbuild manifest.
         let llbuild = LLBuildManifestBuilder(plan, disableSandboxForPluginCommands: disableSandboxForPluginCommands, fileSystem: fileSystem, observabilityScope: observabilityScope)
-        let buildManifest = try llbuild.generateManifest(at: plan.destinationBuildParameters.llbuildManifest)
+        let buildManifest = plan.destinationBuildParameters.prepareForIndexing
+            ? try llbuild.generatePrepareManifest(at: plan.destinationBuildParameters.llbuildManifest)
+            : try llbuild.generateManifest(at: plan.destinationBuildParameters.llbuildManifest)
 
         let swiftCommands = llbuild.manifest.getCmdToolMap(kind: SwiftCompilerTool.self)
         let swiftFrontendCommands = llbuild.manifest.getCmdToolMap(kind: SwiftFrontendTool.self)

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -437,7 +437,7 @@ public struct BuildOptions: ParsableArguments {
     @Flag(help: "Enable or disable indexing-while-building feature")
     public var indexStoreMode: StoreMode = .autoIndexStore
 
-    @Flag(name: .customLong("experimental-prepare-for-indexing"))
+    @Flag(name: .customLong("experimental-prepare-for-indexing"), help: .hidden)
     var prepareForIndexing: Bool = false
 
     /// Whether to enable generation of `.swiftinterface`s alongside `.swiftmodule`s.

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -437,6 +437,9 @@ public struct BuildOptions: ParsableArguments {
     @Flag(help: "Enable or disable indexing-while-building feature")
     public var indexStoreMode: StoreMode = .autoIndexStore
 
+    @Flag(name: .customLong("experimental-prepare-for-indexing"))
+    var prepareForIndexing: Bool = false
+
     /// Whether to enable generation of `.swiftinterface`s alongside `.swiftmodule`s.
     @Flag(name: .customLong("enable-parseable-module-interfaces"))
     public var shouldEnableParseableModuleInterfaces: Bool = false

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -725,7 +725,7 @@ public final class SwiftCommandState {
     when building on macOS.
     """
 
-    private func _buildParams(toolchain: UserToolchain) throws -> BuildParameters {
+    private func _buildParams(toolchain: UserToolchain, prepareForIndexing: Bool? = nil) throws -> BuildParameters {
         let triple = toolchain.targetTriple
 
         let dataPath = self.scratchDirectory.appending(
@@ -748,7 +748,7 @@ public final class SwiftCommandState {
             sanitizers: options.build.enabledSanitizers,
             indexStoreMode: options.build.indexStoreMode.buildParameter,
             isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
-            prepareForIndexing: options.build.prepareForIndexing,
+            prepareForIndexing: prepareForIndexing ?? options.build.prepareForIndexing,
             debuggingParameters: .init(
                 debugInfoFormat: options.build.debugInfoFormat.buildParameter,
                 triple: triple,
@@ -797,7 +797,8 @@ public final class SwiftCommandState {
 
     private lazy var _toolsBuildParameters: Result<BuildParameters, Swift.Error> = {
         Result(catching: {
-            try _buildParams(toolchain: self.getHostToolchain())
+            // Ensure prepare for indexing is disable for tools
+            try _buildParams(toolchain: self.getHostToolchain(), prepareForIndexing: false)
         })
     }()
 

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -748,6 +748,7 @@ public final class SwiftCommandState {
             sanitizers: options.build.enabledSanitizers,
             indexStoreMode: options.build.indexStoreMode.buildParameter,
             isXcodeBuildSystemEnabled: options.build.buildSystem == .xcode,
+            prepareForIndexing: options.build.prepareForIndexing,
             debuggingParameters: .init(
                 debugInfoFormat: options.build.debugInfoFormat.buildParameter,
                 triple: triple,

--- a/Sources/LLBuildManifest/LLBuildManifest.swift
+++ b/Sources/LLBuildManifest/LLBuildManifest.swift
@@ -368,7 +368,8 @@ public struct LLBuildManifest {
         fileList: AbsolutePath,
         isLibrary: Bool,
         wholeModuleOptimization: Bool,
-        outputFileMapPath: AbsolutePath
+        outputFileMapPath: AbsolutePath,
+        prepareForIndexing: Bool
     ) {
         assert(commands[name] == nil, "already had a command named '\(name)'")
         let tool = SwiftCompilerTool(
@@ -386,7 +387,8 @@ public struct LLBuildManifest {
             fileList: fileList,
             isLibrary: isLibrary,
             wholeModuleOptimization: wholeModuleOptimization,
-            outputFileMapPath: outputFileMapPath
+            outputFileMapPath: outputFileMapPath,
+            prepareForIndexing: prepareForIndexing
         )
         commands[name] = Command(name: name, tool: tool)
     }

--- a/Sources/LLBuildManifest/Tools.swift
+++ b/Sources/LLBuildManifest/Tools.swift
@@ -271,6 +271,7 @@ public struct SwiftCompilerTool: ToolProtocol {
     public var isLibrary: Bool
     public var wholeModuleOptimization: Bool
     public var outputFileMapPath: AbsolutePath
+    public var prepareForIndexing: Bool
 
     init(
         inputs: [Node],
@@ -287,7 +288,8 @@ public struct SwiftCompilerTool: ToolProtocol {
         fileList: AbsolutePath,
         isLibrary: Bool,
         wholeModuleOptimization: Bool,
-        outputFileMapPath: AbsolutePath
+        outputFileMapPath: AbsolutePath,
+        prepareForIndexing: Bool
     ) {
         self.inputs = inputs
         self.outputs = outputs
@@ -304,6 +306,7 @@ public struct SwiftCompilerTool: ToolProtocol {
         self.isLibrary = isLibrary
         self.wholeModuleOptimization = wholeModuleOptimization
         self.outputFileMapPath = outputFileMapPath
+        self.prepareForIndexing = prepareForIndexing
     }
 
     var description: String {
@@ -334,7 +337,10 @@ public struct SwiftCompilerTool: ToolProtocol {
         } else {
             arguments += ["-incremental"]
         }
-        arguments += ["-c", "@\(self.fileList.pathString)"]
+        if !prepareForIndexing {
+            arguments += ["-c"]
+        }
+        arguments += ["@\(self.fileList.pathString)"]
         arguments += ["-I", importPath.pathString]
         arguments += otherArguments
         return arguments

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
@@ -63,7 +63,7 @@ extension BuildParameters {
 
     /// The debugging strategy according to the current build parameters.
     public var debuggingStrategy: DebuggingStrategy? {
-        guard configuration == .debug else {
+        guard configuration == .debug, !prepareForIndexing else {
             return nil
         }
 

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -102,6 +102,9 @@ public struct BuildParameters: Encodable {
 
     public var shouldSkipBuilding: Bool
 
+    /// Do minimal build to prepare for indexing
+    public var prepareForIndexing: Bool
+
     /// Build parameters related to debugging.
     public var debuggingParameters: Debugging
 
@@ -131,6 +134,7 @@ public struct BuildParameters: Encodable {
         indexStoreMode: IndexStoreMode = .auto,
         isXcodeBuildSystemEnabled: Bool = false,
         shouldSkipBuilding: Bool = false,
+        prepareForIndexing: Bool = false,
         debuggingParameters: Debugging? = nil,
         driverParameters: Driver = .init(),
         linkingParameters: Linking = .init(),
@@ -185,6 +189,7 @@ public struct BuildParameters: Encodable {
         self.indexStoreMode = indexStoreMode
         self.isXcodeBuildSystemEnabled = isXcodeBuildSystemEnabled
         self.shouldSkipBuilding = shouldSkipBuilding
+        self.prepareForIndexing = prepareForIndexing
         self.driverParameters = driverParameters
         self.linkingParameters = linkingParameters
         self.outputParameters = outputParameters

--- a/Sources/SPMTestSupport/MockBuildTestHelper.swift
+++ b/Sources/SPMTestSupport/MockBuildTestHelper.swift
@@ -87,7 +87,8 @@ public func mockBuildParameters(
     useExplicitModuleBuild: Bool = false,
     linkerDeadStrip: Bool = true,
     linkTimeOptimizationMode: BuildParameters.LinkTimeOptimizationMode? = nil,
-    omitFramePointers: Bool? = nil
+    omitFramePointers: Bool? = nil,
+    prepareForIndexing: Bool = false
 ) -> BuildParameters {
     try! BuildParameters(
         dataPath: buildPath ?? AbsolutePath("/path/to/build").appending(triple.tripleString),
@@ -98,6 +99,7 @@ public func mockBuildParameters(
         pkgConfigDirectories: [],
         workers: 3,
         indexStoreMode: indexStoreMode,
+        prepareForIndexing: prepareForIndexing,
         debuggingParameters: .init(
             triple: triple,
             shouldEnableDebuggingEntitlement: config == .debug,

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -61,6 +61,8 @@ class PrepareForIndexTests: XCTestCase {
         XCTAssertFalse(toolSwiftc.otherArguments.contains("-experimental-skip-all-function-bodies"))
 
         // Make sure only object files for tools are built
-        XCTAssertTrue(outputs.filter({ $0.hasSuffix(".o") }).allSatisfy({ $0.contains("-tool.build/")}))
+        XCTAssertTrue(outputs.filter({ $0.hasSuffix(".o") }).allSatisfy({ $0.contains("-tool.build/")}),
+                      "outputs:\n\t\(outputs.filter({ $0.hasSuffix(".o") }).joined(separator: "\n\t"))"
+        )
     }
 }

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -30,14 +30,8 @@ class PrepareForIndexTests: XCTestCase {
         let builder = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: scope)
         let manifest = try builder.generatePrepareManifest(at: "/manifest")
 
-        // Make sure we're still building swift modules
-        XCTAssertNotNil(manifest.commands["<SwiftSyntax-debug.module>"])
-        // Make sure we're not building things that link
-        XCTAssertNil(manifest.commands["C.Core-debug.exe"])
-
-        let outputs = manifest.commands.flatMap(\.value.tool.outputs).map(\.name)
-
         // Make sure we're building the swift modules
+        let outputs = manifest.commands.flatMap(\.value.tool.outputs).map(\.name)
         XCTAssertTrue(outputs.contains(where: { $0.hasSuffix(".swiftmodule")}))
 
         // Ensure swiftmodules built with correct arguments

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -1,11 +1,14 @@
-// Copyright (C) 2024 Apple Inc. All rights reserved.
+//===----------------------------------------------------------------------===//
 //
-// This document is the property of Apple Inc.
-// It is considered confidential and proprietary.
+// This source file is part of the Swift open source project
 //
-// This document may not be reproduced or transmitted in any form,
-// in whole or in part, without the express written permission of
-// Apple Inc.
+// Copyright (c) 2015-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
 
 import Build
 import Foundation
@@ -32,31 +35,32 @@ class PrepareForIndexTests: XCTestCase {
 
         // Make sure we're building the swift modules
         let outputs = manifest.commands.flatMap(\.value.tool.outputs).map(\.name)
-        XCTAssertTrue(outputs.contains(where: { $0.hasSuffix(".swiftmodule")}))
+        XCTAssertTrue(outputs.contains(where: { $0.hasSuffix(".swiftmodule") }))
 
         // Ensure swiftmodules built with correct arguments
-        let coreCommands = manifest.commands.values.filter({
+        let coreCommands = manifest.commands.values.filter {
             $0.tool.outputs.contains(where: {
                 $0.name.hasSuffix("debug/Core.build/Core.swiftmodule")
             })
-        })
+        }
         XCTAssertEqual(coreCommands.count, 1)
         let coreSwiftc = try XCTUnwrap(coreCommands.first?.tool as? SwiftCompilerTool)
         XCTAssertTrue(coreSwiftc.otherArguments.contains("-experimental-skip-all-function-bodies"))
 
         // Ensure tools are built normally
-        let toolCommands = manifest.commands.values.filter({
+        let toolCommands = manifest.commands.values.filter {
             $0.tool.outputs.contains(where: {
                 $0.name.hasSuffix("debug/Modules-tool/SwiftSyntax.swiftmodule")
             })
-        })
+        }
         XCTAssertEqual(toolCommands.count, 1)
         let toolSwiftc = try XCTUnwrap(toolCommands.first?.tool as? SwiftCompilerTool)
         XCTAssertFalse(toolSwiftc.otherArguments.contains("-experimental-skip-all-function-bodies"))
 
         // Make sure only object files for tools are built
-        XCTAssertTrue(outputs.filter({ $0.hasSuffix(".o") }).allSatisfy({ $0.contains("-tool.build/")}),
-                      "outputs:\n\t\(outputs.filter({ $0.hasSuffix(".o") }).joined(separator: "\n\t"))"
+        XCTAssertTrue(
+            outputs.filter { $0.hasSuffix(".o") }.allSatisfy { $0.contains("-tool.build/") },
+            "outputs:\n\t\(outputs.filter { $0.hasSuffix(".o") }.joined(separator: "\n\t"))"
         )
     }
 }

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -21,7 +21,7 @@ class PrepareForIndexTests: XCTestCase {
 
         let plan = try BuildPlan(
             destinationBuildParameters: mockBuildParameters(prepareForIndexing: true),
-            toolsBuildParameters: mockBuildParameters(prepareForIndexing: true),
+            toolsBuildParameters: mockBuildParameters(prepareForIndexing: false),
             graph: graph,
             fileSystem: fs,
             observabilityScope: scope

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -1,0 +1,103 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// This document is the property of Apple Inc.
+// It is considered confidential and proprietary.
+//
+// This document may not be reproduced or transmitted in any form,
+// in whole or in part, without the express written permission of
+// Apple Inc.
+
+import Build
+import Foundation
+import LLBuildManifest
+@_spi(SwiftPMInternal)
+import SPMTestSupport
+import XCTest
+
+class PrepareForIndexTests: XCTestCase {
+    func testPrepare() throws {
+        let (graph, fs, scope) = try macrosPackageGraph()
+
+        let plan = try BuildPlan(
+            destinationBuildParameters: mockBuildParameters(prepareForIndexing: true),
+            toolsBuildParameters: mockBuildParameters(prepareForIndexing: true),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: scope
+        )
+
+        let builder = LLBuildManifestBuilder(plan, fileSystem: fs, observabilityScope: scope)
+        let manifest = try builder.generatePrepareManifest(at: "/manifest")
+
+        // Make sure we're still building swift modules
+        XCTAssertNotNil(manifest.commands["<SwiftSyntax-debug.module>"])
+        // Make sure we're not building things that link
+        XCTAssertNil(manifest.commands["C.Core-debug.exe"])
+
+        let outputs = manifest.commands.flatMap(\.value.tool.outputs).map(\.name)
+
+        // Make sure we're building the swift modules
+        let swiftModules = Set(outputs.filter({ $0.hasSuffix(".swiftmodule")}))
+        XCTAssertEqual(swiftModules, Set([
+            "/path/to/build/arm64-apple-macosx15.0/debug/Core.build/Core.swiftmodule",
+            "/path/to/build/arm64-apple-macosx15.0/debug/Modules/CoreTests.swiftmodule",
+            "/path/to/build/arm64-apple-macosx15.0/debug/Modules/HAL.swiftmodule",
+            "/path/to/build/arm64-apple-macosx15.0/debug/Modules/HALTests.swiftmodule",
+            "/path/to/build/arm64-apple-macosx15.0/debug/Modules/MMIO.swiftmodule",
+            "/path/to/build/arm64-apple-macosx15.0/debug/Modules/SwiftSyntax.swiftmodule",
+            "/path/to/build/arm64-apple-macosx15.0/debug/Modules-tool/MMIOMacros.swiftmodule",
+            "/path/to/build/arm64-apple-macosx15.0/debug/Modules-tool/SwiftSyntax.swiftmodule",
+        ]))
+
+        // Ensure swiftmodules built with correct arguments
+        let coreCommands = manifest.commands.values.filter({
+            $0.tool.outputs.contains(where: {
+                $0.name == "/path/to/build/arm64-apple-macosx15.0/debug/Core.build/Core.swiftmodule"
+            })
+        })
+        XCTAssertEqual(coreCommands.count, 1)
+        let coreSwiftc = try XCTUnwrap(coreCommands.first?.tool as? SwiftCompilerTool)
+        XCTAssertTrue(coreSwiftc.otherArguments.contains("-experimental-skip-all-function-bodies"))
+
+        // Ensure tools are built normally
+        let toolCommands = manifest.commands.values.filter({
+            $0.tool.outputs.contains(where: {
+                $0.name == "/path/to/build/arm64-apple-macosx15.0/debug/Modules-tool/SwiftSyntax.swiftmodule"
+            })
+        })
+        XCTAssertEqual(toolCommands.count, 1)
+        let toolSwiftc = try XCTUnwrap(toolCommands.first?.tool as? SwiftCompilerTool)
+        XCTAssertFalse(toolSwiftc.otherArguments.contains("-experimental-skip-all-function-bodies"))
+
+        // Make sure only object files for tools are built
+        let objectFiles = Set(outputs.filter({ $0.hasSuffix(".o") }))
+        XCTAssertEqual(objectFiles, Set([
+            "/path/to/build/arm64-apple-macosx15.0/debug/MMIOMacros-tool.build/source.swift.o",
+            "/path/to/build/arm64-apple-macosx15.0/debug/SwiftSyntax-tool.build/source.swift.o"
+        ]))
+
+        // Check diff with regular build plan
+        let plan0 = try BuildPlan(
+            destinationBuildParameters: mockBuildParameters(prepareForIndexing: false),
+            toolsBuildParameters: mockBuildParameters(prepareForIndexing: false),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: scope
+        )
+
+        let builder0 = LLBuildManifestBuilder(plan0, fileSystem: fs, observabilityScope: scope)
+        let manifest0 = try builder0.generateManifest(at: "/manifest")
+        let outputs0 = manifest0.commands.flatMap(\.value.tool.outputs).map(\.name)
+
+        // The prepare shouldn't create any other object files.
+        let objectFiles0 = Set(outputs0.filter({ $0.hasSuffix(".o") })).subtracting(objectFiles)
+        XCTAssertEqual(objectFiles0, Set([
+            "/path/to/build/arm64-apple-macosx15.0/debug/Core.build/source.swift.o",
+            "/path/to/build/arm64-apple-macosx15.0/debug/CoreTests.build/source.swift.o",
+            "/path/to/build/arm64-apple-macosx15.0/debug/HAL.build/source.swift.o",
+            "/path/to/build/arm64-apple-macosx15.0/debug/HALTests.build/source.swift.o",
+            "/path/to/build/arm64-apple-macosx15.0/debug/MMIO.build/source.swift.o",
+            "/path/to/build/arm64-apple-macosx15.0/debug/SwiftSyntax.build/source.swift.o",
+        ]))
+    }
+}


### PR DESCRIPTION
This will be used by sourcekit-lsp to build the swiftmodule files it needs for indexing.

Adds experimental-prepare-for-indexing flag to swift build. Creates a llbuild manifest specific for the prepare build that skips generating object files and linking of those files and calls swiftc to only create the swiftmodule as quickly as it can.

### Motivation:

To support background indexing in sourcekit-lsp, it will request a prepare for index build to build the swiftmodule files it needs to do indexing. This build should be minimal to ensure indexing is fast so it can respond to language server requests that require the index as soon as possible.

### Modifications:

- Add an experimental-prepare-for-indexing flag to the BuildOptions and pass it around to every that needs it.
- Build a custom llbuild manifest so that only the commands necessary are added to the prepare build
- Add a target property that also ensures tool builds required for the prepare build are performed as usual.
- In SwiftTargetBuildDescription, pass compile options that put the swift compiler in prepare "mode".
- Ensure object files and binaries are not generated when in prepare mode.

### Result:

Implements prepare build mode without affecting regular build mode.