### PR TITLE
[6.0] Update diagnostics for duplicated product/target names

### DIFF
--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -282,8 +282,7 @@ extension PackageGraphError: CustomStringConvertible {
                 }
                 return description
             }
-
-            return "multiple products named '\(product)' in: \(packagesDescriptions.joined(separator: ", "))"
+            return "multiple packages (\(packagesDescriptions.joined(separator: ", "))) declare products with a conflicting name: '\(product)’; product names need to be unique across the package graph"
         case .multipleModuleAliases(let target, let product, let package, let aliases):
             return "multiple aliases: ['\(aliases.joined(separator: "', '"))'] found for target '\(target)' in product '\(product)' from package '\(package)'"
         case .unsupportedPluginDependency(let targetName, let dependencyName, let dependencyType,  let dependencyPackage):

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -98,7 +98,7 @@ extension ModuleError: CustomStringConvertible {
         switch self {
         case .duplicateModule(let target, let packages):
             let packages = packages.map(\.description).sorted().joined(separator: "', '")
-            return "multiple targets named '\(target)' in: '\(packages)'"
+            return "multiple packages ('\(packages)') declare targets with a conflicting name: '\(target)’; target names need to be unique across the package graph"
         case .moduleNotFound(let target, let type, let shouldSuggestRelaxedSourceDir):
             let folderName = (type == .test) ? "Tests" : (type == .plugin) ? "Plugins" : "Sources"
             var clauses = ["Source files for target \(target) should be located under '\(folderName)/\(target)'"]

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -128,7 +128,7 @@ final class BuildPlanTests: XCTestCase {
         )) { error in
             XCTAssertEqual(
                 (error as? PackageGraphError)?.description,
-                "multiple products named 'Logging' in: 'barpkg' (at '\(barPkg)'), 'foopkg' (at '\(fooPkg)')"
+                "multiple packages (\'barpkg\' (at '\(barPkg)'), \'foopkg\' (at '\(fooPkg)')) declare products with a conflicting name: \'Logging’; product names need to be unique across the package graph"
             )
         }
     }
@@ -550,7 +550,7 @@ final class BuildPlanTests: XCTestCase {
         )) { error in
             XCTAssertEqual(
                 (error as? PackageGraphError)?.description,
-                "multiple products named 'Logging' in: 'barpkg' (at '\(barPkg)'), 'foopkg' (at '\(fooPkg)')"
+                "multiple packages (\'barpkg\' (at '\(barPkg)'), \'foopkg\' (at '\(fooPkg)')) declare products with a conflicting name: \'Logging’; product names need to be unique across the package graph"
             )
         }
     }

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -262,7 +262,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )) { error in
-            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'Logging' in: 'barpkg' (at '\(barPkg)'), 'foopkg' (at '\(fooPkg)')")
+            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple packages (\'barpkg\' (at '\(barPkg)'), \'foopkg\' (at '\(fooPkg)')) declare products with a conflicting name: \'Logging’; product names need to be unique across the package graph")
         }
     }
 
@@ -324,7 +324,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )) { error in
-            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'Logging' in: 'barpkg' (at '\(barPkg)'), 'foopkg' (at '\(fooPkg)')")
+            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple packages (\'barpkg\' (at '\(barPkg)'), \'foopkg\' (at '\(fooPkg)')) declare products with a conflicting name: \'Logging’; product names need to be unique across the package graph")
         }
     }
 
@@ -4692,7 +4692,7 @@ final class ModuleAliasingBuildTests: XCTestCase {
 
             XCTFail("unexpectedly resolved the package graph successfully")
         } catch {
-            XCTAssertEqual(error.interpolationDescription, "multiple products named 'SomeProduct' in: 'other' (at '\(AbsolutePath("/Other"))'), 'some' (at '\(AbsolutePath("/Some"))')")
+            XCTAssertEqual(error.interpolationDescription, "multiple packages ('other' (at '\(AbsolutePath("/Other"))'), 'some' (at '\(AbsolutePath("/Some"))')) declare products with a conflicting name: 'SomeProduct’; product names need to be unique across the package graph")
         }
         XCTAssertEqual(observability.diagnostics.map { $0.description }.sorted(), ["[warning]: product aliasing requires tools-version 5.2 or later, so it is not supported by \'other\'", "[warning]: product aliasing requires tools-version 5.2 or later, so it is not supported by \'some\'"])
     }

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -336,7 +336,7 @@ final class ModulesGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'Bar' in: 'bar', 'foo'", severity: .error)
+            result.check(diagnostic: "multiple packages ('bar', 'foo') declare targets with a conflicting name: 'Bar’; target names need to be unique across the package graph", severity: .error)
         }
     }
 
@@ -395,7 +395,7 @@ final class ModulesGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'First' in: 'first', 'fourth', 'second', 'third'", severity: .error)
+            result.check(diagnostic: "multiple packages ('first', 'fourth', 'second', 'third') declare targets with a conflicting name: 'First’; target names need to be unique across the package graph", severity: .error)
         }
     }
 
@@ -465,8 +465,8 @@ final class ModulesGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.checkUnordered(diagnostic: "multiple targets named 'Bar' in: 'fourth', 'third'", severity: .error)
-            result.checkUnordered(diagnostic: "multiple targets named 'Foo' in: 'first', 'second'", severity: .error)
+            result.checkUnordered(diagnostic: "multiple packages ('fourth', 'third') declare targets with a conflicting name: 'Bar’; target names need to be unique across the package graph", severity: .error)
+            result.checkUnordered(diagnostic: "multiple packages ('first', 'second') declare targets with a conflicting name: 'Foo’; target names need to be unique across the package graph", severity: .error)
         }
     }
 
@@ -534,7 +534,7 @@ final class ModulesGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'First' in: 'first', 'fourth'", severity: .error)
+            result.check(diagnostic: "multiple packages ('first', 'fourth') declare targets with a conflicting name: 'First’; target names need to be unique across the package graph", severity: .error)
         }
     }
 
@@ -1254,7 +1254,7 @@ final class ModulesGraphTests: XCTestCase {
         )
 
         testDiagnostics(observability.diagnostics) { result in
-            result.check(diagnostic: "multiple targets named 'Foo' in: 'dep2', 'start'", severity: .error)
+            result.check(diagnostic: "multiple packages ('dep2', 'start') declare targets with a conflicting name: 'Foo’; target names need to be unique across the package graph", severity: .error)
         }
     }
 
@@ -1303,8 +1303,7 @@ final class ModulesGraphTests: XCTestCase {
             ],
             observabilityScope: observability.topScope
         )) { error in
-            XCTAssertEqual((error as? PackageGraphError)?.description,
-                           "multiple products named 'Bar' in: 'bar' (at '\(barPkg)'), 'baz' (at '\(bazPkg)')")
+            XCTAssertEqual((error as? PackageGraphError)?.description, "multiple packages (\'bar\' (at '\(barPkg)'), \'baz\' (at '\(bazPkg)')) declare products with a conflicting name: \'Bar’; product names need to be unique across the package graph")
         }
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -12975,17 +12975,9 @@ final class WorkspaceTests: XCTestCase {
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
 
-            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                testDiagnostics(diagnostics) { result in
-                    result.check(
-                        diagnostic: .contains("""
-                        multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                        """),
-                        severity: .error
-                    )
-                }
+            XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, _ in
             }) { error in
-                XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
+                XCTAssertEqual((error as? PackageGraphError)?.description, "multiple packages (\'foo\' (from \'https://git/org/foo\'), \'org.foo\') declare products with a conflicting name: \'FooProduct’; product names need to be unique across the package graph")
             }
         }
 
@@ -13095,31 +13087,16 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                }) { error in
-                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
+            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+                testDiagnostics(diagnostics) { result in
+                    result.check(
+                        diagnostic: .contains("""
+                        multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
+                        """),
+                        severity: .error
+                    )
                 }
-            } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                })
-            }
+            })
         }
 
         // reset
@@ -13273,31 +13250,16 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                }) { error in
-                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
+            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+                testDiagnostics(diagnostics) { result in
+                    result.check(
+                        diagnostic: .contains("""
+                        multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
+                        """),
+                        severity: .error
+                    )
                 }
-            } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                })
-            }
+            })
         }
 
         // reset
@@ -13426,31 +13388,16 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                }) { error in
-                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
+            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+                testDiagnostics(diagnostics) { result in
+                    result.check(
+                        diagnostic: .contains("""
+                        multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
+                        """),
+                        severity: .error
+                    )
                 }
-            } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                })
-            }
+            })
         }
 
         // reset
@@ -13566,31 +13513,16 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                }) { error in
-                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
+            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+                testDiagnostics(diagnostics) { result in
+                    result.check(
+                        diagnostic: .contains("""
+                        multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
+                        """),
+                        severity: .error
+                    )
                 }
-            } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                })
-            }
+            })
         }
 
         // reset
@@ -13727,31 +13659,16 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                }) { error in
-                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
+            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+                testDiagnostics(diagnostics) { result in
+                    result.check(
+                        diagnostic: .contains("""
+                        multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
+                        """),
+                        severity: .error
+                    )
                 }
-            } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                })
-            }
+            })
         }
 
         // reset
@@ -13883,31 +13800,16 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple targets named 'BazTarget' in: 'baz', 'org.baz'
-                            """),
-                            severity: .error
-                        )
-                    }
-                }) { error in
-                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'BazProduct' in: 'baz' (from 'https://git/org/baz'), 'org.baz'")
+            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+                testDiagnostics(diagnostics) { result in
+                    result.check(
+                        diagnostic: .contains("""
+                        multiple similar targets 'BazTarget' appear in registry package 'org.baz' and source control package 'baz'
+                        """),
+                        severity: .error
+                    )
                 }
-            } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple similar targets 'BazTarget' appear in registry package 'org.baz' and source control package 'baz'
-                            """),
-                            severity: .error
-                        )
-                    }
-                })
-            }
+            })
         }
 
         // reset
@@ -14068,31 +13970,16 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple targets named 'BazTarget' in: 'baz', 'org.baz'
-                            """),
-                            severity: .error
-                        )
-                    }
-                }) { error in
-                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'BazProduct' in: 'baz' (from 'https://git/org/baz'), 'org.baz'")
+            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+                testDiagnostics(diagnostics) { result in
+                    result.check(
+                        diagnostic: .contains("""
+                        multiple similar targets 'BazTarget' appear in registry package 'org.baz' and source control package 'baz'
+                        """),
+                        severity: .error
+                    )
                 }
-            } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple similar targets 'BazTarget' appear in registry package 'org.baz' and source control package 'baz'
-                            """),
-                            severity: .error
-                        )
-                    }
-                })
-            }
+            })
         }
 
         // reset
@@ -14208,31 +14095,16 @@ final class WorkspaceTests: XCTestCase {
 
         do {
             workspace.sourceControlToRegistryDependencyTransformation = .disabled
-            if ToolsVersion.current < .v5_8 {
-                XCTAssertThrowsError(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple targets named 'FooTarget' in: 'foo', 'org.foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                }) { error in
-                    XCTAssertEqual((error as? PackageGraphError)?.description, "multiple products named 'FooProduct' in: 'foo' (from 'https://git/org/foo'), 'org.foo'")
+            XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+                testDiagnostics(diagnostics) { result in
+                    result.check(
+                        diagnostic: .contains("""
+                        multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
+                        """),
+                        severity: .error
+                    )
                 }
-            } else {
-                XCTAssertNoThrow(try workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
-                    testDiagnostics(diagnostics) { result in
-                        result.check(
-                            diagnostic: .contains("""
-                            multiple similar targets 'FooTarget' appear in registry package 'org.foo' and source control package 'foo'
-                            """),
-                            severity: .error
-                        )
-                    }
-                })
-            }
+            })
         }
 
         // reset


### PR DESCRIPTION
- Explanation:

  Improves diagnostic messages for duplicate product/target to include involved packages and other useful information.

- Scope: Package manifests/graphs with duplicate product/target names.

- Main Branch PRs: https://github.com/apple/swift-package-manager/pull/7572

- Resolves: rdar://127623219

- Risk: Very Low

- Reviewed By: @xedin 

- Testing: New tests were added to the suite and existing tests updated.


(cherry picked from commit e5123e483c18bff7afdc3b2029f9e1924779bbc8)