### PR TITLE
Pass the "available modules" for a target down to Swift commands

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -15,6 +15,7 @@ import Basics
 import Dispatch
 import Foundation
 import LLBuildManifest
+import PackageGraph
 import PackageModel
 import SPMBuildCore
 import SPMLLBuild

--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -110,6 +110,7 @@ extension BuildPlan {
                     toolsBuildParameters: toolsBuildParameters,
                     testTargetRole: .discovery,
                     shouldDisableSandbox: shouldDisableSandbox,
+                    availableModules: nil,
                     fileSystem: fileSystem,
                     observabilityScope: observabilityScope
                 )
@@ -160,6 +161,7 @@ extension BuildPlan {
                     toolsBuildParameters: toolsBuildParameters,
                     testTargetRole: .entryPoint(isSynthesized: true),
                     shouldDisableSandbox: shouldDisableSandbox,
+                    availableModules: nil,
                     fileSystem: fileSystem,
                     observabilityScope: observabilityScope
                 )
@@ -206,6 +208,7 @@ extension BuildPlan {
                             toolsBuildParameters: toolsBuildParameters,
                             testTargetRole: .entryPoint(isSynthesized: false),
                             shouldDisableSandbox: shouldDisableSandbox,
+                            availableModules: nil,
                             fileSystem: fileSystem,
                             observabilityScope: observabilityScope
                         )
@@ -229,6 +232,7 @@ extension BuildPlan {
                         toolsBuildParameters: toolsBuildParameters,
                         testTargetRole: .entryPoint(isSynthesized: false),
                         shouldDisableSandbox: shouldDisableSandbox,
+                        availableModules: nil,
                         fileSystem: fileSystem,
                         observabilityScope: observabilityScope
                     )

--- a/Sources/DriverSupport/DriverSupportUtils.swift
+++ b/Sources/DriverSupport/DriverSupportUtils.swift
@@ -88,4 +88,8 @@ public enum DriverSupport {
     public static func isPackageNameSupported(toolchain: PackageModel.Toolchain, fileSystem: FileSystem) -> Bool {
         DriverSupport.checkToolchainDriverFlags(flags: ["-package-name"], toolchain: toolchain, fileSystem: fileSystem)
     }
+
+    package static func isPackageAvailableModulesSupported(toolchain: PackageModel.Toolchain, fileSystem: FileSystem) -> Bool {
+        DriverSupport.checkToolchainDriverFlags(flags: ["-package-available-modules"], toolchain: toolchain, fileSystem: fileSystem)
+    }
 }

--- a/Sources/PackageGraph/AvailableModules.swift
+++ b/Sources/PackageGraph/AvailableModules.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2015-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+
+/// Describes the set of modules that are available to targets within a
+/// given package along with the target dependency that's required to import
+/// that module into a given
+package struct AvailableModules: Codable {
+    /// A description of the target dependency that would be needed to
+    /// import a given module.
+    package enum TargetDependency: Codable {
+        case target(name: String)
+        case product(name: String, package: String?)
+
+        static func <(lhs: TargetDependency, rhs: TargetDependency) -> Bool {
+            switch (lhs, rhs) {
+            case (.target(name: let lhsName), .target(name: let rhsName)):
+                lhsName < rhsName
+            case (.product(name: let lhsName, package: nil),
+                  .product(name: let rhsName, package: nil)):
+                lhsName < rhsName
+            case (.product(name: _, package: nil),
+                  .product(name: _, package: _?)):
+                true
+            case (.product(name: _, package: _?),
+                  .product(name: _, package: nil)):
+                false
+            case (.product(name: let lhsName, package: let lhsPackage?),
+                  .product(name: let rhsName, package: let rhsPackage?)):
+                (lhsPackage, lhsName) < (rhsPackage, rhsName)
+            case (.product, .target):
+                false
+            case (.target, .product):
+                true
+            }
+        }
+    }
+
+    /// The set of modules that are available within the package described by
+    /// the manifest, along with the target dependency required to reference
+    /// the module.
+    package var modules: [String: TargetDependency] = [:]
+}
+
+extension ModulesGraph {
+    /// A flat list of available modules, used as an intermediary for the
+    /// creation of an `AvailableModules` instance.
+    fileprivate typealias AvailableModulesList =
+        [(String, AvailableModules.TargetDependency)]
+
+    /// Collect the module names that are made available by all of the products
+    /// in this package, along with how the target dependency should be
+    /// expressed to make the corresponding modules importable.
+    ///
+    /// The resulting module names are available to any package with a
+    /// dependency on this package.
+    fileprivate func productsAsAvailableModules(
+        from package: ResolvedPackage
+    ) -> AvailableModulesList {
+        package.products.flatMap { product in
+            let productDependency: AvailableModules.TargetDependency = .product(
+                name: product.name,
+                package: product.packageIdentity.description
+            )
+
+            return product.targets.map { target in
+                (target.c99name, productDependency)
+            }
+        }
+    }
+
+    /// Collect the module names that are made available by all of the targets
+    /// in this package, along with how the target dependency should be
+    /// expressed to make the corresponding module importable.
+    ///
+    /// The resulting module names are available within the targets of this
+    /// package.
+    fileprivate func targetsAsAvailableModules(
+        in package: ResolvedPackage
+    ) -> AvailableModulesList {
+        package.targets.map { target in
+            (target.c99name, .target(name: target.name))
+        }
+    }
+
+    /// Produce the complete set of modules that are available within the
+    /// given resolved package.
+    package func availableModules(
+        in package: ResolvedPackage
+    ) -> AvailableModules {
+        var availableModules = AvailableModules()
+
+        // Add available modules from targets within this package.
+        availableModules.modules.merge(
+            targetsAsAvailableModules(in: package),
+            uniquingKeysWith: uniqueTargetDependency
+        )
+
+        // Add available modules from the products of any package this package
+        // depends on.
+        for dependencyID in package.dependencies {
+            guard let dependencyPackage = self.package(for: dependencyID) else {
+                continue
+            }
+
+            availableModules.modules.merge(
+                productsAsAvailableModules(from: dependencyPackage),
+                uniquingKeysWith: uniqueTargetDependency
+            )
+        }
+
+        return availableModules
+    }
+}
+
+/// "Unique" two target dependencies by picking the target dependency that we
+/// prefer.
+fileprivate func uniqueTargetDependency(
+    lhs: AvailableModules.TargetDependency,
+    rhs: AvailableModules.TargetDependency
+) -> AvailableModules.TargetDependency {
+    lhs < rhs ? lhs : rhs
+}

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(PackageGraph
+  AvailableModules.swift
   BoundVersion.swift
   BuildTriple.swift
   DependencyMirrors.swift

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Driver.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Driver.swift
@@ -26,7 +26,8 @@ extension BuildParameters {
             explicitTargetDependencyImportCheckingMode: TargetDependencyImportCheckingMode = .none,
             useIntegratedSwiftDriver: Bool = false,
             useExplicitModuleBuild: Bool = false,
-            isPackageAccessModifierSupported: Bool = false
+            isPackageAccessModifierSupported: Bool = false,
+            isPackageAvailableModulesSupported: Bool = false
         ) {
             self.canRenameEntrypointFunctionName = canRenameEntrypointFunctionName
             self.enableParseableModuleInterfaces = enableParseableModuleInterfaces
@@ -34,6 +35,7 @@ extension BuildParameters {
             self.useIntegratedSwiftDriver = useIntegratedSwiftDriver
             self.useExplicitModuleBuild = useExplicitModuleBuild
             self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
+            self.isPackageAvailableModulesSupported = isPackageAvailableModulesSupported
         }
 
         /// Whether to enable the entry-point-function-name feature.
@@ -58,5 +60,10 @@ extension BuildParameters {
         /// supports `-package-name` options.
         @_spi(SwiftPMInternal)
         public var isPackageAccessModifierSupported: Bool
+
+        /// Whether the version of Swift Driver used in the currently selected
+        /// toolchain supports '-package-available-modules' options.
+        @_spi(SwiftPMInternal)
+        public var isPackageAvailableModulesSupported: Bool
     }
 }

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -295,6 +295,10 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
                     isPackageAccessModifierSupported: DriverSupport.isPackageNameSupported(
                         toolchain: targetToolchain,
                         fileSystem: self.fileSystem
+                    ),
+                    isPackageAvailableModulesSupported: DriverSupport.isPackageAvailableModulesSupported(
+                        toolchain: targetToolchain,
+                        fileSystem: self.fileSystem
                     )
                 ),
                 linkingParameters: .init(

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -654,6 +654,23 @@ final class BuildPlanTests: XCTestCase {
         }
     }
 
+    func testPackageAvailableModulesFlag() throws {
+        let isFlagSupportedInDriver = try DriverSupport.checkToolchainDriverFlags(
+            flags: ["package-available-modules"],
+            toolchain: UserToolchain.default,
+            fileSystem: localFileSystem
+        )
+
+        try fixture(name: "Miscellaneous/PackageNameFlag") { fixturePath in
+            let (stdout, _) = try executeSwiftBuild(fixturePath.appending("appPkg"), extraArgs: ["-vv"])
+
+            if isFlagSupportedInDriver {
+                XCTAssertMatch(stdout, .contains("-package-target-name App"))
+                XCTAssertMatch(stdout, .contains("-package-available-modules"))
+            }
+        }
+    }
+
     #if os(macOS)
     func testPackageNameFlagXCBuild() throws {
         let isFlagSupportedInDriver = try DriverSupport.checkToolchainDriverFlags(


### PR DESCRIPTION
When the Swift driver can handle it, produce the complete set of modules that are available within a package (either from targets in that package or products of packages it depends on). Provide that set of available modules as a JSON file to the Swift driver so it can reason about modules that are available to the given target. Also provide the package manifest path and the current target name in the package for use by the compiler.

This goes along with https://github.com/apple/swift/pull/73745