### PR TITLE
[6.0][Testing] Disable `swift test` while cross compiling

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -601,6 +601,10 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         if options._deprecated_shouldListTests {
             observabilityScope.emit(warning: "'--list-tests' option is deprecated; use 'swift test list' instead")
         }
+
+        if globalOptions.build.swiftSDKSelector != nil {
+            throw StringError("Testing is not currently supported while cross-compiling")
+        }
     }
 
     public init() {}


### PR DESCRIPTION
- Explanation:

  Running tests is not currently supported while cross compiling.

- Scope: `swift test` with `--swift-sdk`

- Main Branch PRs: This is 6.0 only change.

- Risk: Very Low

- Reviewed By: @bnbarham 

- Testing: There is currently no way to properly test this.
