### PR TITLE
Prefix linker flags with -Xlinker

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -390,7 +390,13 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         // Other linker flags.
         for target in self.staticTargets {
             let scope = self.buildParameters.createScope(for: target)
-            flags += scope.evaluate(.OTHER_LDFLAGS)
+            let additionalFlags = scope.evaluate(.OTHER_LDFLAGS)
+            // FIXME: this should be based on the target package's tools version
+            if self.toolsVersion.major >= 6 {
+                flags += additionalFlags.asSwiftcLinkerFlags()
+            } else {
+                flags += additionalFlags
+            }
         }
 
         return flags


### PR DESCRIPTION
Currently SwiftPM fowards unsafe flags under linker settings directly to swiftc un-prefixed. These flags should instead be prefixed with -Xlinker, swiftc flags can instead be passed as unsafe flags under Swift settings.

This commit updates SwiftPM to prefix unsafe linker flags with -Xlinker if the package the target is part of uses tools version 6.0.