### PR TITLE
Rename back to `swift package completion-tool`

### DIFF
--- a/Sources/Commands/PackageCommands/CompletionCommand.swift
+++ b/Sources/Commands/PackageCommands/CompletionCommand.swift
@@ -18,6 +18,7 @@ import var TSCBasic.stdoutStream
 extension SwiftPackageCommand {
     struct CompletionCommand: SwiftCommand {
         static let configuration = CommandConfiguration(
+            commandName: "completion-tool",
             abstract: "Completion command (for shell completions)"
         )
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -70,6 +70,11 @@ final class PackageCommandTests: CommandsTestCase {
         XCTAssertMatch(stdout, .contains("Swift Package Manager"))
     }
 	
+    func testCompletionTool() throws {
+        let stdout = try execute(["completion-tool", "--help"]).stdout
+        XCTAssertMatch(stdout, .contains("OVERVIEW: Completion command (for shell completions)"))
+    }
+
 	func testInitOverview() throws {
 		let stdout = try execute(["init", "--help"]).stdout
 		XCTAssertMatch(stdout, .contains("OVERVIEW: Initialize a new package"))


### PR DESCRIPTION
Rename `swift package completion-command` back to `swift package completion-tool`.

### Motivation:

The subcommand seems accidentally renamed to `swift package completion-command` while renaming the type name in https://github.com/apple/swift-package-manager/pull/7336

### Modifications:

This change renames it back to `swift package completion-tool` to keep compatibility with the previous version.

This should be cherry-picked to release/6.0 too.

### Result:

Keep command name compatibility