### PR TITLE
[6.0] Rename back to `swift package completion-tool`

### DIFF
--- a/Sources/Commands/PackageCommands/CompletionCommand.swift
+++ b/Sources/Commands/PackageCommands/CompletionCommand.swift
@@ -18,6 +18,7 @@ import var TSCBasic.stdoutStream
 extension SwiftPackageCommand {
     struct CompletionCommand: SwiftCommand {
         static let configuration = CommandConfiguration(
+            commandName: "completion-tool",
             abstract: "Completion command (for shell completions)"
         )
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -67,6 +67,11 @@ final class PackageCommandTests: CommandsTestCase {
         XCTAssertMatch(stdout, .contains("Swift Package Manager"))
     }
 	
+    func testCompletionTool() throws {
+        let stdout = try execute(["completion-tool", "--help"]).stdout
+        XCTAssertMatch(stdout, .contains("OVERVIEW: Completion command (for shell completions)"))
+    }
+
 	func testInitOverview() throws {
 		let stdout = try execute(["init", "--help"]).stdout
 		XCTAssertMatch(stdout, .contains("OVERVIEW: Initialize a new package"))


### PR DESCRIPTION
**Explanation**: Renames the accidentally renamed subcommand back to `swift package completion-tool` keep compatibility with the previous version.
**Scope**: Shell completion helper tool
**Risk**: Low. 
**Testing**: Added a new test to ensure the subcommand name
**Original PR**: https://github.com/apple/swift-package-manager/pull/7600
**Reviewers**: @MaxDesiatov