### PR TITLE
Fix retroactive conformance warnings for 6.0+ compilers

### DIFF
--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -80,7 +80,7 @@ extension SwiftPackageCommand {
     }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension InitPackage.PackageType: ExpressibleByArgument {}
 #else
 extension InitPackage.PackageType: @retroactive ExpressibleByArgument {}

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -328,7 +328,7 @@ extension SerializedDiagnostics.SourceLocation {
     }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension SerializedDiagnostics.SourceLocation: DiagnosticLocation {}
 #else
 extension SerializedDiagnostics.SourceLocation: @retroactive DiagnosticLocation {}

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -717,7 +717,7 @@ extension URL {
     }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension BuildConfiguration: ExpressibleByArgument {}
 extension AbsolutePath: ExpressibleByArgument {}
 extension WorkspaceConfiguration.CheckingMode: ExpressibleByArgument {}

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -247,7 +247,7 @@ extension SignatureFormat {
     }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension SignatureFormat: ExpressibleByArgument {}
 #else
 extension SignatureFormat: @retroactive ExpressibleByArgument {}

--- a/Sources/SPMTestSupport/misc.swift
+++ b/Sources/SPMTestSupport/misc.swift
@@ -446,7 +446,7 @@ extension InitPackage {
     }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension RelativePath: ExpressibleByStringLiteral {}
 extension RelativePath: ExpressibleByStringInterpolation {}
 extension URL: ExpressibleByStringLiteral {}

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -247,7 +247,7 @@ extension FileSystemError {
     }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension FileSystemError: CustomStringConvertible {}
 #else
 extension FileSystemError: @retroactive CustomStringConvertible {}

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1465,7 +1465,7 @@ private func warnToStderr(_ message: String) {
 }
 
 // used for manifest validation
-#if swift(<6.0)
+#if compiler(<6.0)
 extension RepositoryManager: ManifestSourceControlValidator {}
 #else
 extension RepositoryManager: @retroactive ManifestSourceControlValidator {}

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -481,7 +481,7 @@ extension BuildConfiguration {
     }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension AbsolutePath: ExpressibleByArgument {}
 extension BuildConfiguration: ExpressibleByArgument {}
 #else

--- a/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/DependencyResolverPerfTests.swift
@@ -201,7 +201,7 @@ extension ProductFilter {
     }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension ProductFilter: JSONSerializable, JSONMappable {}
 #else
 extension ProductFilter: @retroactive JSONSerializable, @retroactive JSONMappable {}

--- a/Tests/PackageGraphTests/PubgrubTests.swift
+++ b/Tests/PackageGraphTests/PubgrubTests.swift
@@ -3802,7 +3802,7 @@ extension PackageReference {
     }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension Term: ExpressibleByStringLiteral {}
 extension PackageReference: ExpressibleByStringLiteral {}
 #else

--- a/Tests/PackageGraphTests/TopologicalSortTests.swift
+++ b/Tests/PackageGraphTests/TopologicalSortTests.swift
@@ -34,7 +34,7 @@ extension Int {
     public var id: Self { self }
 }
 
-#if swift(<6.0)
+#if compiler(<6.0)
 extension Int: Identifiable {}
 #else
 extension Int: @retroactive Identifiable {}


### PR DESCRIPTION
`#if swift(<6.0)` is a wrong check to apply, since it has no effect with 6.0 compiler versions, unlike `#if compiler(<6.0)`.
