### PR TITLE
[6.0] Enable `-user-module-version` for 6.0

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -609,7 +609,7 @@ public final class SwiftTargetBuildDescription {
           let version = package.manifest.version, 
           version.prereleaseIdentifiers.isEmpty &&
           version.buildMetadataIdentifiers.isEmpty &&
-          toolsVersion >= .v5_11
+          toolsVersion >= .v6_0
         {
             args += ["-user-module-version", version.description]
         }

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -609,7 +609,7 @@ public final class SwiftTargetBuildDescription {
           let version = package.manifest.version, 
           version.prereleaseIdentifiers.isEmpty &&
           version.buildMetadataIdentifiers.isEmpty &&
-          toolsVersion >= .v5_10
+          toolsVersion >= .v5_11
         {
             args += ["-user-module-version", version.description]
         }

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -605,7 +605,12 @@ public final class SwiftTargetBuildDescription {
         }
 
         // Pass `-user-module-version` for versioned packages that aren't pre-releases.
-        if let version = package.manifest.version, version.prereleaseIdentifiers.isEmpty, version.buildMetadataIdentifiers.isEmpty, toolsVersion >= .vNext {
+        if
+          let version = package.manifest.version, 
+          version.prereleaseIdentifiers.isEmpty &&
+          version.buildMetadataIdentifiers.isEmpty &&
+          toolsVersion >= .v5_10
+        {
             args += ["-user-module-version", version.description]
         }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -6050,7 +6050,7 @@ final class BuildPlanTests: XCTestCase {
                     displayName: "ExtPkg",
                     path: "/ExtPkg",
                     version: "1.0.0",
-                    toolsVersion: .vNext,
+                    toolsVersion: .v6_0,
                     products: [
                         ProductDescription(name: "ExtPkg", type: .library(.automatic), targets: ["ExtLib"]),
                     ],


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-package-manager/pull/7263.

**Explanation**:  `#if canImport(LibFoo, _version: "1.2.3")` is not currently supported by SwiftPM, as this feature was gated on `.vNext`, even though it landed before SwiftPM 5.10 branched off.
**Scope**: Isolated to llbuild build manifests and packages that have 6.0 set as their tools version.
**Risk**: Low as covered with a test and gated to 6.0 tools version, so shouldn't impact existing packages.
**Testing**: Existing `testPackageDependencySetsUserModuleVersion` case updated to check for 6.0 version.
**Issue**: rdar://121124842
**Reviewer**: @bnbarham 