### PR TITLE
Add support for swift-collections 1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -827,7 +827,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "3.0.0")),
         .package(url: "https://github.com/apple/swift-syntax.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
-        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "1.0.1")),
     ]
 } else {

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -638,7 +638,7 @@ public struct PubGrubDependencyResolver {
 
             let priorCause = _mostRecentSatisfier.cause!
 
-            var newTerms = incompatibility.terms.filter { $0 != mostRecentTerm }
+            var newTerms = Array(incompatibility.terms.filter { $0 != mostRecentTerm })
             newTerms += priorCause.terms.filter { $0.node != _mostRecentSatisfier.term.node }
 
             if let _difference = difference {


### PR DESCRIPTION
This PR makes a necessary update to the source in order to support building against swift-collections 1.1

### Motivation:

swift-collections added a new API in v1.1:

```swift
extension OrderedSet {
  @inlinable
  public func filter(
    _ isIncluded: (Element) throws -> Bool
  ) rethrows -> Self
}
```

swift-package-manager was previously calling `filter` on an `OrderedSet` and expecting to get back an `Array` (via the extension on `Sequence`) however with this new swift-collections change, the returned value of `filter` became an `OrderedSet`. This caused build failures when the `+=` operator (which exists for `Array` but not `OrderedSet` operands) was used on the return value.

We should update this code to support swift-collections 1.1 so that we can begin using swift-collections 1.1 in toolchain builds.

### Modifications:

The code is updated to convert the return type of `filter` to an `Array` 

### Result:

The same source will now successfully compile against both swift-collections 1.0.x and 1.1.x
