### PR TITLE
Add cxx interop support to symbolgraph-extract

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -207,6 +207,20 @@ public final class ClangTargetBuildDescription {
         }
     }
 
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// this module.
+    public func symbolGraphExtractArguments() throws -> [String] {
+        var args = [String]()
+
+        if self.clangTarget.isCXX {
+            args += ["-cxx-interoperability-mode=default"]
+        }
+        if let cxxLanguageStandard = self.clangTarget.cxxLanguageStandard {
+            args += ["-Xcc", "-std=\(cxxLanguageStandard)"]
+        }
+        return args
+    }
+
     /// Builds up basic compilation arguments for a source file in this target; these arguments may be different for C++
     /// vs non-C++.
     /// NOTE: The parameter to specify whether to get C++ semantics is currently optional, but this is only for revlock

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -547,26 +547,7 @@ public final class SwiftTargetBuildDescription {
             args += ["-color-diagnostics"]
         }
 
-        // If this is a generated test discovery target or a test entry point, it might import a test
-        // target that is built with C++ interop enabled. In that case, the test
-        // discovery target must enable C++ interop as well
-        switch testTargetRole {
-        case .discovery, .entryPoint:
-            for dependency in try self.target.recursiveTargetDependencies() {
-                let dependencyScope = self.buildParameters.createScope(for: dependency)
-                let dependencySwiftFlags = dependencyScope.evaluate(.OTHER_SWIFT_FLAGS)
-                if let interopModeFlag = dependencySwiftFlags.first(where: { $0.hasPrefix("-cxx-interoperability-mode=") }) {
-                    args += [interopModeFlag]
-                    if interopModeFlag != "-cxx-interoperability-mode=off" {
-                        if let cxxStandard = self.package.manifest.cxxLanguageStandard {
-                            args += ["-Xcc", "-std=\(cxxStandard)"]
-                        }
-                    }
-                    break
-                }
-            }
-        default: break
-        }
+        args += try self.cxxInteroperabilityModeArguments(allowDuplicate: false)
 
         // Add arguments from declared build settings.
         args += try self.buildSettingsFlags()
@@ -644,6 +625,67 @@ public final class SwiftTargetBuildDescription {
 
         return args
     }
+    
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// this module.
+    public func symbolGraphExtractArguments() throws -> [String] {
+        var args = [String]()
+        args += try self.cxxInteroperabilityModeArguments(allowDuplicate: true)
+        return args
+    }
+
+    /// Determines the arguments needed for cxx interop for this module.
+    ///
+    /// If the current module or any of its linked dependencies requires cxx
+    /// interop, cxx interop will be enabled on the current module.
+    func cxxInteroperabilityModeArguments(
+        // FIXME: Remove argument
+        // This argument is added as a stop gap to support generating arguments
+        // for tools which currently dont leverage "OTHER_SWIFT_FLAGS". In the
+        // fullness of time, this function should operate on a strongly typed
+        // "interopMode" property of SwiftTargetBuildDescription. Instead of
+        // digging through "OTHER_SWIFT_FLAGS" manually.
+        allowDuplicate: Bool
+    ) throws -> [String] {
+        func _cxxInteroperabilityMode(for module: ResolvedModule) -> String? {
+            let scope = self.buildParameters.createScope(for: module)
+            let flags = scope.evaluate(.OTHER_SWIFT_FLAGS)
+            return flags.first { $0.hasPrefix("-cxx-interoperability-mode=") }
+        }
+
+        // Look for cxx interop mode in the current module, if set exit early,
+        // the flag is already present.
+        var cxxInteroperabilityMode: String?
+        if let mode = _cxxInteroperabilityMode(for: self.target) {
+            if allowDuplicate {
+                cxxInteroperabilityMode = mode
+            }
+        }
+
+        // If the current module doesn't have cxx interop mode set, search
+        // through the module's dependencies looking for the a module that
+        // enables cxx interop and copy it's flag.
+        if cxxInteroperabilityMode == nil {
+            for module in try self.target.recursiveTargetDependencies() {
+                if let mode = _cxxInteroperabilityMode(for: module) {
+                    cxxInteroperabilityMode = mode
+                    break
+                }
+            }
+        }
+
+        var args = [String]()
+        if let cxxInteroperabilityMode {
+            // FIXME: this should reference a local cxxLanguageStandard property
+            // It definitely should _never_ reach back into the manifest
+            args = [cxxInteroperabilityMode]
+            if let cxxStandard = self.package.manifest.cxxLanguageStandard {
+                args += ["-Xcc", "-std=\(cxxStandard)"]
+            }
+        }
+        return args
+    }
+
 
     /// When `scanInvocation` argument is set to `true`, omit the side-effect producing arguments
     /// such as emitting a module or supplementary outputs.

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -115,4 +115,13 @@ public enum TargetBuildDescription {
             return clangTargetBuildDescription.toolsVersion
         }
     }
+
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// this module.
+    public func symbolGraphExtractArguments() throws -> [String] {
+        switch self {
+        case .swift(let target): try target.symbolGraphExtractArguments()
+        case .clang(let target): try target.symbolGraphExtractArguments()
+        }
+    }
 }

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -647,6 +647,13 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
             try binaryTarget.parseXCFrameworks(for: triple, fileSystem: self.fileSystem)
         }
     }
+
+    public func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String] {
+        guard let description = self.targetMap[module.id] else {
+            throw InternalError("Expected description for module \(module)")
+        }
+        return try description.symbolGraphExtractArguments()
+    }
 }
 
 extension Basics.Diagnostic {

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -13,7 +13,7 @@
 import ArgumentParser
 import Basics
 import PackageGraph
-import PackageModel
+@_spi(SwiftPMInternal) import PackageModel
 import SPMBuildCore
 
 #if USE_IMPL_ONLY_IMPORTS
@@ -82,7 +82,22 @@ public struct SymbolGraphExtract {
         if includeSPISymbols {
             commandLine += ["-include-spi-symbols"]
         }
-        
+
+        // If this target or any dependencies is is built with C++ interop
+        // enabled then swift-symbolgraph-extract must also enable C++ interop.
+        var cxxInterop = module.cxxInterop()
+        if !cxxInterop {
+            for module in try module.recursiveTargetDependencies() {
+                if module.cxxInterop() {
+                    cxxInterop = true
+                    break
+                }
+            }
+        }
+        if cxxInterop {
+            commandLine += ["-cxx-interoperability-mode=default"]
+        }
+
         let extensionBlockSymbolsFlag = emitExtensionBlockSymbols ? "-emit-extension-block-symbols" : "-omit-extension-block-symbols"
         if DriverSupport.checkSupportedFrontendFlags(flags: [extensionBlockSymbolsFlag.trimmingCharacters(in: ["-"])], toolchain: buildParameters.toolchain, fileSystem: fileSystem) {
             commandLine += [extensionBlockSymbolsFlag]
@@ -105,5 +120,16 @@ public struct SymbolGraphExtract {
         )
         try process.launch()
         return try process.waitUntilExit()
+    }
+}
+
+extension ResolvedModule {
+    func cxxInterop() -> Bool {
+        for setting in self.underlying.buildSettingsDescription {
+            if case .interoperabilityMode(.Cxx) = setting.kind {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -90,6 +90,8 @@ public protocol BuildPlan {
 
     func createAPIToolCommonArgs(includeLibrarySearchPaths: Bool) throws -> [String]
     func createREPLArguments() throws -> [String]
+
+    func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String]
 }
 
 public protocol BuildSystemFactory {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1951,8 +1951,7 @@ final class BuildPlanTests: XCTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        let plan = try BuildPlan(
-            buildParameters: mockBuildParameters(),
+        let plan = try mockBuildPlan(
             graph: graph,
             fileSystem: fs,
             observabilityScope: observability.topScope

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1980,13 +1980,21 @@ final class BuildPlanTests: XCTestCase {
 
         // Swift module transitively importing cxx module
         do {
-            try XCTAssertMatch(
+            try XCTAssertNoMatch(
                 result.target(for: "swiftLib2").swiftTarget().compileArguments(),
-                [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++20", .anySequence]
+                [.anySequence, "-cxx-interoperability-mode=default", .anySequence]
             )
-            try XCTAssertMatch(
+            try XCTAssertNoMatch(
+                result.target(for: "swiftLib2").swiftTarget().compileArguments(),
+                [.anySequence, "-Xcc", "-std=c++20", .anySequence]
+            )
+            try XCTAssertNoMatch(
                 result.target(for: "swiftLib2").swiftTarget().symbolGraphExtractArguments(),
-                [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++20", .anySequence]
+                [.anySequence, "-cxx-interoperability-mode=default", .anySequence]
+            )
+            try XCTAssertNoMatch(
+                result.target(for: "swiftLib2").swiftTarget().symbolGraphExtractArguments(),
+                [.anySequence, "-Xcc", "-std=c++20", .anySequence]
             )
         }
     }


### PR DESCRIPTION
In order to extract symbol graphs for modules with transitive imports on C++ modules we need parse headers in C++ interop mode using the option: `-cxx-interoperability-mode=default`. This commit updates `swift-symbolgraph-extract` to pass the option when there is a C++ module in the import graph.

This option is a new addition to `swift-symbolgraph-extract` added in apple/swift#73963.

Prior to this option's introduction, extracting the symbol graph for C++ dependent modules would fail with an error similar to: "unknown type name 'namespace'".

With this SwiftPM commit and `swift-symbolgraph-extract` _prior_ to apple/swift#73963, users will instead see an argument parsing error like: "unknown option -cxx-interoperability-mode".

With this change and `swift-symbolgraph-extract` change in apple/swift#73963, the symbol graph is extracted properly.