### PR TITLE
[6.0] Add support for swift-collections 1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -802,7 +802,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "3.0.0")),
         .package(url: "https://github.com/apple/swift-syntax.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
-        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "1.0.1")),
     ]
 } else {

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -638,7 +638,7 @@ public struct PubGrubDependencyResolver {
 
             let priorCause = _mostRecentSatisfier.cause!
 
-            var newTerms = incompatibility.terms.filter { $0 != mostRecentTerm }
+            var newTerms = Array(incompatibility.terms.filter { $0 != mostRecentTerm })
             newTerms += priorCause.terms.filter { $0.node != _mostRecentSatisfier.term.node }
 
             if let _difference = difference {


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift-package-manager/pull/7607

**Explanation:**  SwiftPM fails to build against swift-collections@1.1, this change allows SwiftPM to be compatible with both swift-collections@1.0 and swift-collections@1.1
**Scope:** Isolated to one specific line where the build failure occurred and initializes the return value to an `Array` explicitly
**Risk:** Low as the change is minimal and has been validated via testing
**Testing:** Existing SwiftPM testing has passed and I have been able to build a toolchain locally with the change
**Reviewer:** @MaxDesiatov 