### PR TITLE
Fix incremental builds for `embedInCode` resources

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -77,9 +77,12 @@ public final class SwiftTargetBuildDescription {
         return resources.filter { $0.rule != .embedInCode }.isEmpty == false
     }
 
-    private var needsResourceEmbedding: Bool {
-        return resources.filter { $0.rule == .embedInCode }.isEmpty == false
+    var resourceFilesToEmbed: [AbsolutePath] {
+        return resources.filter { $0.rule == .embedInCode }.map { $0.path }
     }
+
+    /// The path to Swift source file embedding resource contents if needed.
+    private(set) var resourcesEmbeddingSource: AbsolutePath?
 
     /// The list of all source files in the target, including the derived ones.
     public var sources: [AbsolutePath] {
@@ -317,7 +320,10 @@ public final class SwiftTargetBuildDescription {
             }
         }
 
-        try self.generateResourceEmbeddingCode()
+        if !resourceFilesToEmbed.isEmpty {
+            resourcesEmbeddingSource = try addResourceEmbeddingSource()
+        }
+
         try self.generateTestObservation()
     }
 
@@ -348,32 +354,10 @@ public final class SwiftTargetBuildDescription {
         try self.fileSystem.writeIfChanged(path: path, string: content)
     }
 
-    // FIXME: This will not work well for large files, as we will store the entire contents, plus its byte array
-    // representation in memory and also `writeIfChanged()` will read the entire generated file again.
-    private func generateResourceEmbeddingCode() throws {
-        guard needsResourceEmbedding else { return }
-
-        var content =
-            """
-            struct PackageResources {
-
-            """
-
-        try resources.forEach {
-            guard $0.rule == .embedInCode else { return }
-
-            let variableName = $0.path.basename.spm_mangledToC99ExtendedIdentifier()
-            let fileContent = try Data(contentsOf: URL(fileURLWithPath: $0.path.pathString)).map { String($0) }.joined(separator: ",")
-
-            content += "static let \(variableName): [UInt8] = [\(fileContent)]\n"
-        }
-
-        content += "}"
-
+    private func addResourceEmbeddingSource() throws -> AbsolutePath {
         let subpath = try RelativePath(validating: "embedded_resources.swift")
         self.derivedSources.relativePaths.append(subpath)
-        let path = self.derivedSources.root.appending(subpath)
-        try self.fileSystem.writeIfChanged(path: path, string: content)
+        return self.derivedSources.root.appending(subpath)
     }
 
     /// Generate the resource bundle accessor, if appropriate.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -417,6 +417,11 @@ extension LLBuildManifestBuilder {
             inputs.append(resourcesNode)
         }
 
+        if let resourcesEmbeddingSource = target.resourcesEmbeddingSource {
+            let resourceFilesToEmbed = target.resourceFilesToEmbed
+            self.manifest.addWriteEmbeddedResourcesCommand(resources: resourceFilesToEmbed, outputPath: resourcesEmbeddingSource)
+        }
+
         func addStaticTargetInputs(_ target: ResolvedModule) throws {
             // Ignore C Modules.
             if target.underlying is SystemLibraryTarget { return }

--- a/Sources/LLBuildManifest/LLBuildManifest.swift
+++ b/Sources/LLBuildManifest/LLBuildManifest.swift
@@ -27,7 +27,8 @@ public enum WriteAuxiliary {
         LinkFileList.self,
         SourcesFileList.self,
         SwiftGetVersion.self,
-        XCTestInfoPlist.self
+        XCTestInfoPlist.self,
+        EmbeddedResources.self,
     ]
 
     public struct EntitlementPlist: AuxiliaryFileType {
@@ -159,6 +160,35 @@ public enum WriteAuxiliary {
             case undefinedPrincipalClass
         }
     }
+
+    public struct EmbeddedResources: AuxiliaryFileType {
+        public static let name = "embedded-resources"
+
+        public static func computeInputs(resources: [AbsolutePath]) -> [Node] {
+            return [.virtual(Self.name)] + resources.map { Node.file($0) }
+        }
+
+        // FIXME: This will not work well for large files, as we will store the entire contents, plus its byte array
+        // representation in memory.
+        public static func getFileContents(inputs: [Node]) throws -> String {
+            var content =
+                """
+                struct PackageResources {
+
+                """
+
+            for input in inputs where input.kind == .file {
+                let resourcePath = try AbsolutePath(validating: input.name)
+                let variableName = resourcePath.basename.spm_mangledToC99ExtendedIdentifier()
+                let fileContent = try Data(contentsOf: URL(fileURLWithPath: resourcePath.pathString)).map { String($0) }.joined(separator: ",")
+
+                content += "static let \(variableName): [UInt8] = [\(fileContent)]\n"
+            }
+
+            content += "}"
+            return content
+        }
+    }
 }
 
 public struct LLBuildManifest {
@@ -275,6 +305,16 @@ public struct LLBuildManifest {
 
     public mutating func addWriteInfoPlistCommand(principalClass: String, outputPath: AbsolutePath) {
         let inputs = WriteAuxiliary.XCTestInfoPlist.computeInputs(principalClass: principalClass)
+        let tool = WriteAuxiliaryFile(inputs: inputs, outputFilePath: outputPath)
+        let name = outputPath.pathString
+        commands[name] = Command(name: name, tool: tool)
+    }
+
+    public mutating func addWriteEmbeddedResourcesCommand(
+        resources: [AbsolutePath],
+        outputPath: AbsolutePath
+    ) {
+        let inputs = WriteAuxiliary.EmbeddedResources.computeInputs(resources: resources)
         let tool = WriteAuxiliaryFile(inputs: inputs, outputFilePath: outputPath)
         let name = outputPath.pathString
         commands[name] = Command(name: name, tool: tool)


### PR DESCRIPTION
SwiftPM's incremental build did not detect changes in embedded resources.

### Motivation:

SwiftPM's `embedInCode` feature did not detect changes in the resource files and it led to using old resource contents even though they were modified.

You can reproduce it with the fixture in this repository like below:

```console
$ rm -rf Fixtures/Resources/EmbedInCodeSimple/.build
$ swift run --package-path Fixtures/Resources/EmbedInCodeSimple
hello world

$ echo "update 1" > Fixtures/Resources/EmbedInCodeSimple/Sources/EmbedInCodeSimple/best.txt
$ swift run --package-path Fixtures/Resources/EmbedInCodeSimple
update 1

$ echo "update 2" > Fixtures/Resources/EmbedInCodeSimple/Sources/EmbedInCodeSimple/best.txt
$ swift run --package-path Fixtures/Resources/EmbedInCodeSimple
update 1
```

The first update ("update 1") is reflected in the final executable output because:
- The `embedded_resources.swift` is generated while computing build descriptions
- Build descriptions are always re-computed in the 2nd build iteration to build `PackageStructure` build cache

However, the second update ("update 2") is not updated because we don't re-compute build descriptions in this stage, and the llbuild build system does not track embedding resource files.

### Modifications:

Generate `embedded_resources.swift` during llbuild build step instead of during computing build descriptions.


### Result:

In this way, llbuild build system can correctly detect resource file modifications in any build iterations.
