### PR TITLE
[Build] Adjust `computeLLBuildTargetName` to attempt `host` destinati…

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -539,9 +539,12 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
             // It's possible to request a build of a macro or a plugin via `swift build`
             // which won't have the right destination set because it's impossible to indicate it.
+            //
+            // Same happens with `--test-product` - if one of the test targets directly references
+            // a macro then all if its targets and the product itself become `host`.
             if product == nil && destination == .target {
                 if let toolsProduct = graph.product(for: productName, destination: .tools),
-                   toolsProduct.type == .macro || toolsProduct.type == .plugin
+                   toolsProduct.type == .macro || toolsProduct.type == .plugin || toolsProduct.type == .test
                 {
                     product = toolsProduct
                     buildParameters = self.toolsBuildParameters


### PR DESCRIPTION
…on for test products

### Motivation:

Just like macros and plugins, tests products can also be built for the host depending on their test target(s) destinations (which are inferred based on dependencies). In order to properly support `--test-product` option we need to fallback to `host` lookup for test products just like we do for macros and plugins.

### Modifications:

- Added a fallback lookup to `computeLLBuildTargetName`

### Result:

`--test-product` now supports both `host` and `target` destination products.
