### PR TITLE
Fix `swift-symbolgraph-extract` search paths

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -218,7 +218,7 @@ public final class ClangTargetBuildDescription {
             args += ["-Xcc", "-std=\(cxxLanguageStandard)"]
         }
         args += ["-I", self.clangTarget.includeDir.pathString]
-        args += self.additionalFlags
+        args += self.additionalFlags.asSwiftcCCompilerFlags()
         // Unconditionally use clang modules with swift tools.
         args += try self.clangModuleArguments().asSwiftcCCompilerFlags()
         args += try self.currentModuleMapFileArguments().asSwiftcCCompilerFlags()

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -257,6 +257,7 @@ public final class ClangTargetBuildDescription {
             args += self.buildParameters.indexStoreArguments(for: target)
         }
 
+        // Enable Clang module flags, if appropriate.
         let triple = self.buildParameters.triple
         // Swift is able to use modules on non-Darwin platforms because it injects its own module maps
         // via vfs. However, nothing does that for C based compilation, and so non-Darwin platforms can't

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -633,6 +633,7 @@ public final class SwiftTargetBuildDescription {
 
         // Include search paths determined during planning
         args += self.additionalFlags
+        // FIXME: only pass paths to the actual dependencies of the module
         // Include search paths for swift module dependencies.
         args += ["-I", self.modulesPath.pathString]
 

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -624,10 +624,25 @@ public final class SwiftTargetBuildDescription {
     
     /// Determines the arguments needed to run `swift-symbolgraph-extract` for
     /// this module.
-    public func symbolGraphExtractArguments() throws -> [String] {
+    package func symbolGraphExtractArguments() throws -> [String] {
         var args = [String]()
         args += try self.cxxInteroperabilityModeArguments(
             propagateFromCurrentModuleOtherSwiftFlags: true)
+
+        args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags
+
+        // Include search paths determined during planning
+        args += self.additionalFlags
+        // Include search paths for swift module dependencies.
+        args += ["-I", self.modulesPath.pathString]
+
+        // FIXME: Only include valid args
+        // This condition should instead only include args which are known to be
+        // compatible instead of filtering out specific unknown args.
+        //
+        // swift-symbolgraph-extract does not support parsing `-use-ld=lld` and
+        // will silently error failing the operation.
+        args = args.filter { !$0.starts(with: "-use-ld=") }
         return args
     }
 

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -118,7 +118,7 @@ public enum TargetBuildDescription {
 
     /// Determines the arguments needed to run `swift-symbolgraph-extract` for
     /// this module.
-    public func symbolGraphExtractArguments() throws -> [String] {
+    package func symbolGraphExtractArguments() throws -> [String] {
         switch self {
         case .swift(let target): try target.symbolGraphExtractArguments()
         case .clang(let target): try target.symbolGraphExtractArguments()

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -648,6 +648,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
     }
 
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// a particular module.
     public func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String] {
         guard let description = self.targetMap[module.id] else {
             throw InternalError("Expected description for module \(module)")

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -70,7 +70,6 @@ public struct SymbolGraphExtract {
         // FIXME: everything here should be in symbolGraphExtractArguments
         commandLine += ["-module-name", module.c99name]
         commandLine += try buildParameters.tripleArgs(for: module)
-        commandLine += try buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)
         commandLine += ["-module-cache-path", try buildParameters.moduleCache.pathString]
         if verboseOutput {
             commandLine += ["-v"]

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -91,6 +91,8 @@ public protocol BuildPlan {
     func createAPIToolCommonArgs(includeLibrarySearchPaths: Bool) throws -> [String]
     func createREPLArguments() throws -> [String]
 
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// a particular module.
     func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String]
 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2092,7 +2092,7 @@ final class BuildPlanTests: XCTestCase {
                 ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/B.build/module.modulemap"],
 
                 // C Module dependencies
-                ["-I", "/Pkg/Sources/D/include"],
+                ["-Xcc", "-I", "-Xcc", "/Pkg/Sources/C/include"],
                 ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/C.build/module.modulemap"],
 
                 // General Args

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1410,13 +1410,13 @@ final class BuildPlanTests: XCTestCase {
         args += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks"]
         #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules", "-fmodule-name=extlib"]
+        args += [
+            "-fmodules",
+            "-fmodule-name=extlib",
+            "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))",
+        ]
         #endif
         args += ["-I", ExtPkg.appending(components: "Sources", "extlib", "include").pathString]
-        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
-        #endif
-
         args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
 
         if hostTriple.isLinux() {
@@ -1439,7 +1439,11 @@ final class BuildPlanTests: XCTestCase {
         args += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks"]
         #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules", "-fmodule-name=exe"]
+        args += [
+            "-fmodules",
+            "-fmodule-name=exe",
+            "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))",
+        ]
         #endif
         args += [
             "-I", Pkg.appending(components: "Sources", "exe", "include").pathString,
@@ -1448,9 +1452,6 @@ final class BuildPlanTests: XCTestCase {
             "-I", ExtPkg.appending(components: "Sources", "extlib", "include").pathString,
             "-fmodule-map-file=\(buildPath.appending(components: "extlib.build", "module.modulemap"))",
         ]
-        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
-        #endif
         args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
 
         if hostTriple.isLinux() {
@@ -1796,12 +1797,13 @@ final class BuildPlanTests: XCTestCase {
         args += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks"]
         #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules", "-fmodule-name=lib"]
+        args += [
+            "-fmodules",
+            "-fmodule-name=lib",
+            "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))",
+        ]
         #endif
         args += ["-I", Pkg.appending(components: "Sources", "lib", "include").pathString]
-        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
-        #endif
         args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
 
         if hostTriple.isLinux() {
@@ -3035,12 +3037,13 @@ final class BuildPlanTests: XCTestCase {
         expectedExeBasicArgs += ["-target", defaultTargetTriple]
         expectedExeBasicArgs += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks"]
         #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        expectedExeBasicArgs += ["-fmodules", "-fmodule-name=exe"]
+        expectedExeBasicArgs += [
+            "-fmodules",
+            "-fmodule-name=exe",
+            "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"
+        ]
         #endif
         expectedExeBasicArgs += ["-I", Pkg.appending(components: "Sources", "exe", "include").pathString]
-        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        expectedExeBasicArgs += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
-        #endif
 
         expectedExeBasicArgs += [triple.isWindows() ? "-gdwarf" : "-g"]
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2088,9 +2088,6 @@ final class BuildPlanTests: XCTestCase {
                 ["-I", "/Pkg/Sources/D/include"],
                 ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/D.build/module.modulemap"],
 
-                // Swift Module dependencies
-                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/B.build/module.modulemap"],
-
                 // C Module dependencies
                 ["-Xcc", "-I", "-Xcc", "/Pkg/Sources/C/include"],
                 ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/C.build/module.modulemap"],
@@ -2102,6 +2099,14 @@ final class BuildPlanTests: XCTestCase {
                     "-Xcc", "-fmodules-cache-path=/path/to/build/\(triple)/debug/ModuleCache",
                 ]
             )
+
+#if os(macOS)
+            try XCTAssertMatchesSubSequences(
+                result.target(for: "D").symbolGraphExtractArguments(),
+                // Swift Module dependencies
+                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/B.build/module.modulemap"]
+            )
+#endif
         }
     }
 


### PR DESCRIPTION
Fixes an architecture and implementation bug where the include paths
for `swift-symbolgraph-extract` were being determined inside build plan
instead of by the target build description. This bug resulted in the
wrong set of paths being determined.

The new code moves the path determination logic into the proper target
build descriptions and releverages the already computed include paths.
The result of this is symbol graphs can be generated for Swift and C
targets properly now without duplicate module in the search paths and
with correct `-fmodule` usage.