### PR TITLE
Partially revert #7566 to fix amazon linux 2 crash

### DIFF
--- a/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
+++ b/Sources/Build/BuildOperationBuildSystemDelegateHandler.swift
@@ -266,15 +266,18 @@ final class TestEntryPointCommand: CustomLLBuildCommand, TestBuildCommand {
                 @main
                 @available(*, deprecated, message: "Not actually deprecated. Marked as deprecated to allow inclusion of deprecated tests (which test deprecated functionality) without warnings")
                 struct Runner {
+                    #if os(WASI)
+                    /// On WASI, we can't block the main thread, so XCTestMain is defined as async.
                     static func main() async {
                         \#(testObservabilitySetup)
-                #if os(WASI)
-                        /// On WASI, we can't block the main thread, so XCTestMain is defined as async.
                         await XCTMain(__allDiscoveredTests()) as Never
-                #else
-                        XCTMain(__allDiscoveredTests()) as Never
-                #endif
                     }
+                    #else
+                    static func main() {
+                        \#(testObservabilitySetup)
+                        XCTMain(__allDiscoveredTests()) as Never
+                    }
+                    #endif
                 }
                 """#
             )


### PR DESCRIPTION
Reverts unifying `main` to be async.

Amazon Linux 2 has been crashing (see below) in almost every test run since this change. It appears the crash existed before it, it's just *much* more consistent now.

Not clear if this is the backtrace every time, it's almost always just `getrn`, but we have seen this once:
```
 0      0x0000ffffa4e4b948 getrn + 136 in libcrypto.so.1.0.2k
 1 [ra] 0x0000ffffa4e4bddc lh_delete + 55 in libcrypto.so.1.0.2k
 2 [ra] 0x0000ffffa4e4eaac int_thread_del_item + 123 in libcrypto.so.1.0.2k
 3 [ra] 0x0000ffffa4e4f564 ERR_error_string + 151 in libcrypto.so.1.0.2k
 4 [ra] 0x0000ffffa5316d68 Curl_close + 135 in libcurl.so.4.8.0
 5 [ra] 0x0000ffffa52c2374 Curl_conncache_close_all_connections + 371 in libcurl.so.4.8.0
 6 [ra] 0x0000ffffa52f8884 curl_multi_cleanup + 215 in libcurl.so.4.8.0
 7 [ra] 0x0000ffffa7b893b0 URLSession._MultiHandle.deinit + 255 in libFoundationNetworking.so
 8 [ra] 0x0000ffffa7b895ec URLSession._MultiHandle.__deallocating_deinit + 11 in libFoundationNetworking.so
 9 [ra] 0x0000ffffa8ce86f8 _swift_release_dealloc + 27 in libswiftCore.so
10 [ra] 0x0000ffffa8ce9290 bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1> >::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 207 in libswiftCore.so
11 [ra] 0x0000ffffa7b7d984 URLSession.deinit + 79 in libFoundationNetworking.so
12 [ra] 0x0000ffffa7b7d9d4 URLSession.__deallocating_deinit + 11 in libFoundationNetworking.so
13 [ra] 0x0000ffffa8ce86f8 _swift_release_dealloc + 27 in libswiftCore.so
14 [ra] 0x0000ffffa8ce9404 bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1> >::doDecrementSideTable<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 351 in libswiftCore.so
15 [ra] 0x0000ffffa7b40f9c objectdestroy.11Tm + 23 in libFoundationNetworking.so
16 [ra] 0x0000ffffa8ce86f8 _swift_release_dealloc + 27 in libswiftCore.so
17 [ra] 0x0000ffffa8ce9290 bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1> >::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 207 in libswiftCore.so
18 [ra] 0x0000ffffa81c71f0 BlockOperation.__deallocating_deinit + 31 in libFoundation.so
19 [ra] 0x0000ffffa8ce86f8 _swift_release_dealloc + 27 in libswiftCore.so
20 [ra] 0x0000ffffa8ce9290 bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1> >::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 207 in libswiftCore.so
21 [ra] 0x0000ffffa7fb5b48 objectdestroy.20Tm + 23 in libFoundation.so
22 [ra] 0x0000ffffa8ce86f8 _swift_release_dealloc + 27 in libswiftCore.so
23 [ra] 0x0000ffffa8ce9290 bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1> >::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 207 in libswiftCore.so
24 [ra] 0x0000ffffa84f4e3c _Block_release + 271 in libBlocksRuntime.so
25 [ra] 0x0000ffffa84bedf0 __destroy_helper_block_8_32c35_ZTS29dispatch_block_private_data_s + 91 in libdispatch.so
26 [ra] 0x0000ffffa84f4e3c _Block_release + 271 in libBlocksRuntime.so
27 [ra] 0x0000ffffa84aa96c _dispatch_continuation_pop + 235 in libdispatch.so
28 [ra] 0x0000ffffa84aa79c _dispatch_async_redirect_invoke + 183 in libdispatch.so
29 [ra] 0x0000ffffa84b5c38 _dispatch_worker_thread + 467 in libdispatch.so
30 [ra] 0x0000ffffa78b4230 start_thread + 175 in libpthread-2.26.so
```