### PR TITLE
Add destination C module targets so you can prepare them directly.

### DIFF
--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
@@ -110,4 +110,15 @@ extension LLBuildManifestBuilder {
             self.addNode(output, toTarget: .test)
         }
     }
+
+    /// Create a llbuild target for a Clang target preparation
+    func createClangPrepareCommand(
+        _ target: ClangTargetBuildDescription
+    ) throws {
+        // Create the node for the target so you can --target it.
+        // It is a no-op for index preparation.
+        let targetName = target.llbuildTargetName
+        let output: Node = .virtual(targetName)
+        self.manifest.addNode(output, toTarget: targetName)
+    }
 }

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -141,9 +141,12 @@ public class LLBuildManifestBuilder {
             case .swift(let desc):
                 try self.createSwiftCompileCommand(desc)
             case .clang(let desc):
-                // Need the clang targets for tools
                 if desc.target.buildTriple == .tools {
+                    // Need the clang targets for tools
                     try self.createClangCompileCommand(desc)
+                } else {
+                    // Hook up the clang module target
+                    try self.createClangPrepareCommand(desc)
                 }
             }
         }


### PR DESCRIPTION
This allows the C module to be targeted directly with the --target argument. It is a no-op however, since the output of C modules are not required for indexing.
