### PR TITLE
Fix create symbol graph plugin entrypoint

### DIFF
--- a/Sources/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/PackagePlugin/PackageManagerProxy.swift
@@ -301,6 +301,17 @@ public enum PackageManagerProxyError: Error {
     case unspecified(_ message: String)
 }
 
+extension PackageManagerProxyError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .unimplemented(let message):
+            "Unimplemented: \(message)"
+        case .unspecified(let message):
+            "Unspecified: \(message)"
+        }
+    }
+}
+
 fileprivate extension PluginToHostMessage.BuildSubset {
     init(_ subset: PackageManager.BuildSubset) {
         switch subset {


### PR DESCRIPTION
The functionality of `createSymbolGraphForPlugin` broke when the internal SwiftPM build graph was split into target and host graphs. A client running `createSymbolGraphForPlugin` on a host target would fail with `unspecified("could not find a target named “<Target-Name>”")`

This PR fixes the plugin entry point to search for targets in the host build graph if not found in the target graph.

This PR also includes a cosmetic fix for the above error so it renders as `Unspecified: Could not find a target named “MMIOMacros”.`
