### PR TITLE
Require CMake 3.24 in `CMakeLists.txt`

### DIFF
--- a/BuildSupport/SwiftSyntax/CMakeLists.txt
+++ b/BuildSupport/SwiftSyntax/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(FetchContent)
 
+cmake_minimum_required(VERSION 3.24)
+
 find_package(SwiftSyntax CONFIG GLOBAL)
 if(NOT SwiftSyntax_FOUND)
   set(SWIFT_SYNTAX_INSTALL_TARGETS YES)

--- a/BuildSupport/SwiftSyntax/CMakeLists.txt
+++ b/BuildSupport/SwiftSyntax/CMakeLists.txt
@@ -1,7 +1,5 @@
 include(FetchContent)
 
-cmake_minimum_required(VERSION 3.24)
-
 find_package(SwiftSyntax CONFIG GLOBAL)
 if(NOT SwiftSyntax_FOUND)
   set(SWIFT_SYNTAX_INSTALL_TARGETS YES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.24)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 


### PR DESCRIPTION
Versions older than 3.24 don't support `GLOBAL` argument of `find_package` and this leads to obscure errors with older versions of CMake. See https://cmake.org/cmake/help/latest/release/3.24.html#commands for the detailed CMake 3.24 changelog. We should specify the required version explicitly to avoid this.
