### PR TITLE
Update versions in `Utilities/Docker/Dockerfile`

### DIFF
--- a/Utilities/Docker/Dockerfile
+++ b/Utilities/Docker/Dockerfile
@@ -1,13 +1,13 @@
 # This source file is part of the Swift open source project
 #
-# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-ARG swift_version=5.3
-ARG ubuntu_version=bionic
+ARG swift_version=5.9
+ARG ubuntu_version=jammy
 ARG base_image=swift:$swift_version-$ubuntu_version
 FROM $base_image
 # needed to do again after FROM due to docker limitation


### PR DESCRIPTION
Versions of Swift and Ubuntu specified in this `Dockerfile` are too old to successfully build SwiftPM. Let's update them to make this `Dockefile` usable again.
