### PR TITLE
Remove --enable-library-evolution flag on prepare.

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -545,7 +545,6 @@ public final class SwiftTargetBuildDescription {
 
         if self.buildParameters.prepareForIndexing {
             args += [
-                "-Xfrontend", "-enable-library-evolution",
                 "-Xfrontend", "-experimental-skip-all-function-bodies",
                 "-Xfrontend", "-experimental-lazy-typecheck",
                 "-Xfrontend", "-experimental-skip-non-exportable-decls",


### PR DESCRIPTION
I have confirmed it's no longer necessary in latest 6.0 toolchain.
