### PR TITLE
Remove Foundation_DIR argument from Yams build in bootstrap

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -335,7 +335,7 @@ def build(args):
         ]
         build_dependency(args, "tsc", tsc_cmake_flags)
         build_dependency(args, "swift-argument-parser", ["-DBUILD_TESTING=NO", "-DBUILD_EXAMPLES=NO"])
-        build_dependency(args, "yams", [], [get_foundation_cmake_arg(args)] if args.foundation_build_dir else [])
+        build_dependency(args, "yams", [], [])
 
         swift_driver_cmake_flags = [
             get_llbuild_cmake_arg(args),


### PR DESCRIPTION
Prevent passing `Foundation_DIR` to Yams build from bootstrap script

### Motivation:

When building a toolchain, Foundation's modules have already been installed into the destination toolchain by time SwiftPM builds. However, the bootstrap script also passes `Foundation_DIR` to the Yams build. Currently this is fine as Foundation's CMake dependencies don't expose any public clang modules, however with the new swift-foundation re-core we will be adding multiple clang modules (`CoreFoundation`, `_FoundationCShims`, `_FoundationICU`, etc.) to the dependency graph and installing them into the toolchain. This breaks the Yams build because the modules exist in two locations (`Foundation_DIR` and in the destination installed toolchain).

### Modifications:

This removes `Foundation_DIR` from the arguments list so that Yams builds against the installed Foundation rather than the modules in the cmake build directory

### Result:

Now Yams builds successfully because it doesn't have multiple search paths that contain these clang modules
