### PR TITLE
fix: bundlePath of ClangTarget to using C99ExtendedIdentifier

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -57,8 +57,11 @@ public final class ClangTargetBuildDescription {
             return .none
         }
 
-        let bundleName = target.underlying.c99name
-        return self.buildParameters.bundlePath(named: bundleName)
+        if let bundleName = target.underlying.potentialBundleName?.spm_mangledToC99ExtendedIdentifier() {
+           return self.buildParameters.bundlePath(named: bundleName)
+       } else {
+           return .none
+       }
     }
 
     /// The modulemap file for this target, if any.

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -58,10 +58,10 @@ public final class ClangTargetBuildDescription {
         }
 
         if let bundleName = target.underlying.potentialBundleName?.spm_mangledToC99ExtendedIdentifier() {
-           return self.buildParameters.bundlePath(named: bundleName)
-       } else {
-           return .none
-       }
+            return self.buildParameters.bundlePath(named: bundleName)
+        } else {
+            return .none
+        }
     }
 
     /// The modulemap file for this target, if any.

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -57,11 +57,8 @@ public final class ClangTargetBuildDescription {
             return .none
         }
 
-        if let bundleName = target.underlying.potentialBundleName {
-            return self.buildParameters.bundlePath(named: bundleName)
-        } else {
-            return .none
-        }
+        let bundleName = target.underlying.c99name
+        return self.buildParameters.bundlePath(named: bundleName)
     }
 
     /// The modulemap file for this target, if any.


### PR DESCRIPTION
### Motivation:

When attempting to access a ClangTarget resource bundle from Objective-C’s `SWIFTPM_MODULE_BUNDLE` where the package or target name contains “-”, a crash occurred.

For instance, in the following `Package.swift`, the generated bundle resource is named `SampleObjc-Package_SampleObjc-Target.bundle`, but `SWIFTPM_MODULE_BUNDLE` tries to access `SampleObjc_Package_SampleObjc_Target.bundle`.
```
import PackageDescription

let package = Package(
    name: "SampleObjc-Package",
    products: [
        .library(
            name: "SampleObjc-Target",
            targets: ["SampleObjc-Target"]),
    ],
    targets: [
        .target(
            name: "SampleObjc-Target",
            path: "Sources/SampleObjc",
            resources: [
                .process("Resources")
            ]
        )
    ]
)
```

This means that createResourcesBundle uses `target.bundlePath` for the filename, which is originally generated from the `potentialBundleName` below.:
```
let potentialBundleName = self.manifest.displayName + "_" + potentialModule.name
```

Therefore, when accessing a resource bundle with “-” in the package or target name, the access string uses `c99Name` (where “-” is replaced with “_”), but the actual generated resource bundle name does not replace “-”, leading to a mismatch and crash.

### Modifications:

Hence, this PR changes the resource bundle name (bundlePath) to use `c99Name`.

### Result:

After this change, the resource bundle names will use C99-compliant identifiers, ensuring consistency between the generated bundle resource name and the name accessed via `SWIFTPM_MODULE_BUNDLE`. This will prevent crashes when accessing resource bundles with package or target names that contain hyphens (”-”).