### PR TITLE
[Tests] Don't use invalid module to satisfy `canImport` check

### DIFF
--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -1043,11 +1043,14 @@ final class PluginInvocationTests: XCTestCase {
                   }
                   """)
             
-            // Create something that looks like another module that can be detected via `canImport()`.
+            // Create a valid swift interface file that can be detected via `canImport()`.
             let fakeExtraModulesDir = tmpPath.appending("ExtraModules")
             try localFileSystem.createDirectory(fakeExtraModulesDir, recursive: true)
-            let fakeExtraModuleFile = fakeExtraModulesDir.appending("ModuleFoundViaExtraSearchPaths.swiftmodule")
-            try localFileSystem.writeFileContents(fakeExtraModuleFile, string: "")
+            let fakeExtraModuleFile = fakeExtraModulesDir.appending("ModuleFoundViaExtraSearchPaths.swiftinterface")
+            try localFileSystem.writeFileContents(fakeExtraModuleFile, string: """
+                  // swift-interface-format-version: 1.0
+                  // swift-module-flags: -module-name ModuleFoundViaExtraSearchPaths
+                  """)
             
             /////////
             // Load a workspace from the package.


### PR DESCRIPTION
Stop using a fake invalid module to satisfy `canImport` check for testing as swift compiler will start to evaluate such checks to false in the future.

Instead, using a valid swift interfacefile to satisify the external module import dependency.

### Motivation:

In order for change in https://github.com/apple/swift/pull/74199 to land, update swiftpm tests to stop using invalid swiftmodule.
