### PR TITLE
Remove `Sendable` conformance on `Bundle` from SwiftPM

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -380,11 +380,6 @@ public final class SwiftTargetBuildDescription {
             """
             import Foundation
 
-            #if compiler(>=6.0)
-            extension Foundation.Bundle: @unchecked @retroactive Sendable {}
-            #else
-            extension Foundation.Bundle: @unchecked Sendable {}
-            #endif
             extension Foundation.Bundle {
                 static let module: Bundle = {
                     let mainPath = \(mainPathSubstitution)


### PR DESCRIPTION
Foundation added this conformance on their side in `main` (https://github.com/apple/swift-corelibs-foundation/pull/4963) and `release/6.0` (https://github.com/apple/swift-corelibs-foundation/pull/4978).

rdar://129599679
