### PR TITLE
[6.0] Remove `Sendable` conformance on `Bundle` from SwiftPM

### DIFF
--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -380,11 +380,6 @@ public final class SwiftTargetBuildDescription {
             """
             import Foundation
 
-            #if compiler(>=6.0)
-            extension Foundation.Bundle: @unchecked @retroactive Sendable {}
-            #else
-            extension Foundation.Bundle: @unchecked Sendable {}
-            #endif
             extension Foundation.Bundle {
                 static let module: Bundle = {
                     let mainPath = \(mainPathSubstitution)


### PR DESCRIPTION
Cherry-pick of #7652.

**Explanation**: We shouldn't have two `Sendable` conformances on `Bundle` at the same time, and Foundation added this on their side in `main` (https://github.com/apple/swift-corelibs-foundation/pull/4963) and `release/6.0` (https://github.com/apple/swift-corelibs-foundation/pull/4978).
**Scope**: isolated to bundle resources.
**Risk**: low, the corresponding change on `main` branch of `swift-corelibs-foundation` was there for 3 weeks.
**Testing**: covered by existing tests and the compat suite.
**Issue**: rdar://129599679
**Reviewer**: @parkera, @bnbarham 
