### PR TITLE
Relax version ranges for dependencies in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -827,9 +827,9 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-driver.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "3.0.0")),
         .package(url: "https://github.com/apple/swift-syntax.git", branch: relatedDependenciesBranch),
-        .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
+        .package(url: "https://github.com/apple/swift-system.git", "1.1.1" ..< "1.4.0"),
         .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),
-        .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/apple/swift-certificates.git", "1.0.1" ..< "1.4.0"),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
This replaces #7649 (which proposed the same change on the 5.10 branch, I'l open a PR to cherry-pick back to 5.10 and 6.0 as well)

Referencing the rationale from the original PR:

We're currently being held back from pulling in Vapor and NIO updates due to tighter dependency clauses on swift-system and swift-certificates in SwiftPM.

We need to depend on SwiftPM in order to use the package collection signing module. We do this by depending on `revision: "swift-5.10.1-RELEASE"` in the SwiftPackageIndex server project.