### PR TITLE
[5.10] Relax version ranges for dependencies in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -738,9 +738,9 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.2")),
         .package(url: "https://github.com/apple/swift-driver.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "3.0.0")),
-        .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
+        .package(url: "https://github.com/apple/swift-system.git", "1.1.1" ..< "1.4.0"),
         .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),
-        .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/apple/swift-certificates.git", "1.0.1" ..< "1.4.0"),
     ]
 } else {
     package.dependencies += [

--- a/Package.swift
+++ b/Package.swift
@@ -739,7 +739,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-driver.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "3.0.0")),
         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
-        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "1.0.1")),
     ]
 } else {

--- a/Sources/PackageGraph/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/PubGrub/PubGrubDependencyResolver.swift
@@ -581,7 +581,7 @@ public struct PubGrubDependencyResolver {
 
             let priorCause = _mostRecentSatisfier.cause!
 
-            var newTerms = incompatibility.terms.filter { $0 != mostRecentTerm }
+            var newTerms = Array(incompatibility.terms.filter { $0 != mostRecentTerm })
             newTerms += priorCause.terms.filter { $0.node != _mostRecentSatisfier.term.node }
 
             if let _difference = difference {


### PR DESCRIPTION
Cherry-pick of #7655 and 1c626233f51e66af2e08f3a6d0939504a0fe476a

**Explanation**: Swift Package Index is currently held back from pulling in Vapor and NIO updates due to tighter dependency clauses on `swift-system` and `swift-certificates` in SwiftPM, as it needs to depend on SwiftPM in order to use the package collection signing module.
**Scope**: isolated to versions of dependencies in `Package.swift`
**Risk**: very low, the actual versions in toolchain builds are untouched as they're pinned in the `update-checkout-config.json` file of `swift` repository.
**Testing**: covered by existing tests and the compat suite.
**Issue**: N/A
**Reviewer**: @MaxDesiatov, @bnbarham 
