### PR TITLE
[6.0] Relax version ranges for dependencies in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -802,9 +802,9 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-driver.git", branch: relatedDependenciesBranch),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "3.0.0")),
         .package(url: "https://github.com/apple/swift-syntax.git", branch: relatedDependenciesBranch),
-        .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
+        .package(url: "https://github.com/apple/swift-system.git", "1.1.1" ..< "1.4.0"),
         .package(url: "https://github.com/apple/swift-collections.git", "1.0.1" ..< "1.2.0"),
-        .package(url: "https://github.com/apple/swift-certificates.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/apple/swift-certificates.git", "1.0.1" ..< "1.4.0"),
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
Cherry-pick of #7655

**Explanation**: Swift Package Index is currently held back from pulling in Vapor and NIO updates due to tighter dependency clauses on `swift-system` and `swift-certificates` in SwiftPM, as it needs to depend on SwiftPM in order to use the package collection signing module.
**Scope**: isolated to versions of dependencies in `Package.swift`
**Risk**: very low, the actual versions in toolchain builds are untouched as they're pinned in the `update-checkout-config.json` file of `swift` repository.
**Testing**: covered by existing tests and the compat suite.
**Issue**: N/A
**Reviewer**: @MaxDesiatov, @bnbarham 
