### PR TITLE
[6.0] Symbol graph cherry picks

### DIFF
--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -207,6 +207,20 @@ public final class ClangTargetBuildDescription {
         }
     }
 
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// this module.
+    public func symbolGraphExtractArguments() throws -> [String] {
+        var args = [String]()
+
+        if self.clangTarget.isCXX {
+            args += ["-cxx-interoperability-mode=default"]
+        }
+        if let cxxLanguageStandard = self.clangTarget.cxxLanguageStandard {
+            args += ["-Xcc", "-std=\(cxxLanguageStandard)"]
+        }
+        return args
+    }
+
     /// Builds up basic compilation arguments for a source file in this target; these arguments may be different for C++
     /// vs non-C++.
     /// NOTE: The parameter to specify whether to get C++ semantics is currently optional, but this is only for revlock

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -531,26 +531,8 @@ public final class SwiftTargetBuildDescription {
             args += ["-color-diagnostics"]
         }
 
-        // If this is a generated test discovery target or a test entry point, it might import a test
-        // target that is built with C++ interop enabled. In that case, the test
-        // discovery target must enable C++ interop as well
-        switch testTargetRole {
-        case .discovery, .entryPoint:
-            for dependency in try self.target.recursiveTargetDependencies() {
-                let dependencyScope = self.buildParameters.createScope(for: dependency)
-                let dependencySwiftFlags = dependencyScope.evaluate(.OTHER_SWIFT_FLAGS)
-                if let interopModeFlag = dependencySwiftFlags.first(where: { $0.hasPrefix("-cxx-interoperability-mode=") }) {
-                    args += [interopModeFlag]
-                    if interopModeFlag != "-cxx-interoperability-mode=off" {
-                        if let cxxStandard = self.package.manifest.cxxLanguageStandard {
-                            args += ["-Xcc", "-std=\(cxxStandard)"]
-                        }
-                    }
-                    break
-                }
-            }
-        default: break
-        }
+        args += try self.cxxInteroperabilityModeArguments(
+            propagateFromCurrentModuleOtherSwiftFlags: false)
 
         // Add arguments from declared build settings.
         args += try self.buildSettingsFlags()
@@ -627,6 +609,67 @@ public final class SwiftTargetBuildDescription {
         }
 
         return args
+    }
+    
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// this module.
+    public func symbolGraphExtractArguments() throws -> [String] {
+        var args = [String]()
+        args += try self.cxxInteroperabilityModeArguments(
+            propagateFromCurrentModuleOtherSwiftFlags: true)
+        return args
+    }
+
+    // FIXME: this function should operation on a strongly typed buildSetting
+    // Move logic from PackageBuilder here.
+    /// Determines the arguments needed for cxx interop for this module.
+    func cxxInteroperabilityModeArguments(
+        // FIXME: Remove argument
+        // This argument is added as a stop gap to support generating arguments
+        // for tools which currently don't leverage "OTHER_SWIFT_FLAGS". In the
+        // fullness of time this function should operate on a strongly typed
+        // "interopMode" property of SwiftTargetBuildDescription instead of
+        // digging through "OTHER_SWIFT_FLAGS" manually.
+        propagateFromCurrentModuleOtherSwiftFlags: Bool
+    ) throws -> [String] {
+        func cxxInteroperabilityModeAndStandard(
+            for module: ResolvedModule
+        ) -> [String]? {
+            let scope = self.buildParameters.createScope(for: module)
+            let flags = scope.evaluate(.OTHER_SWIFT_FLAGS)
+            let mode = flags.first { $0.hasPrefix("-cxx-interoperability-mode=") }
+            guard let mode else { return nil }
+            // FIXME: Use a stored self.cxxLanguageStandard property
+            // It definitely should _never_ reach back into the manifest
+            if let cxxStandard = self.package.manifest.cxxLanguageStandard {
+                return [mode, "-Xcc", "-std=\(cxxStandard)"]
+            } else {
+                return [mode]
+            }
+        }
+
+        if propagateFromCurrentModuleOtherSwiftFlags {
+            // Look for cxx interop mode in the current module, if set exit early,
+            // the flag is already present.
+            if let args = cxxInteroperabilityModeAndStandard(for: self.target) {
+                return args
+            }
+        }
+
+        // Implicitly propagate cxx interop flags for generated test targets.
+        // If the current module doesn't have cxx interop mode set, search
+        // through the module's dependencies looking for the a module that
+        // enables cxx interop and copy it's flag.
+        switch self.testTargetRole {
+        case .discovery, .entryPoint:
+            for module in try self.target.recursiveTargetDependencies() {
+                if let args = cxxInteroperabilityModeAndStandard(for: module) {
+                    return args
+                }
+            }
+        default: break
+        }
+        return []
     }
 
     /// When `scanInvocation` argument is set to `true`, omit the side-effect producing arguments

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -613,10 +613,26 @@ public final class SwiftTargetBuildDescription {
     
     /// Determines the arguments needed to run `swift-symbolgraph-extract` for
     /// this module.
-    public func symbolGraphExtractArguments() throws -> [String] {
+    package func symbolGraphExtractArguments() throws -> [String] {
         var args = [String]()
         args += try self.cxxInteroperabilityModeArguments(
             propagateFromCurrentModuleOtherSwiftFlags: true)
+
+        args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags
+
+        // Include search paths determined during planning
+        args += self.additionalFlags
+        // FIXME: only pass paths to the actual dependencies of the module
+        // Include search paths for swift module dependencies.
+        args += ["-I", self.modulesPath.pathString]
+
+        // FIXME: Only include valid args
+        // This condition should instead only include args which are known to be
+        // compatible instead of filtering out specific unknown args.
+        //
+        // swift-symbolgraph-extract does not support parsing `-use-ld=lld` and
+        // will silently error failing the operation.
+        args = args.filter { !$0.starts(with: "-use-ld=") }
         return args
     }
 

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -115,4 +115,13 @@ public enum TargetBuildDescription {
             return clangTargetBuildDescription.toolsVersion
         }
     }
+
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// this module.
+    public func symbolGraphExtractArguments() throws -> [String] {
+        switch self {
+        case .swift(let target): try target.symbolGraphExtractArguments()
+        case .clang(let target): try target.symbolGraphExtractArguments()
+        }
+    }
 }

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -118,7 +118,7 @@ public enum TargetBuildDescription {
 
     /// Determines the arguments needed to run `swift-symbolgraph-extract` for
     /// this module.
-    public func symbolGraphExtractArguments() throws -> [String] {
+    package func symbolGraphExtractArguments() throws -> [String] {
         switch self {
         case .swift(let target): try target.symbolGraphExtractArguments()
         case .clang(let target): try target.symbolGraphExtractArguments()

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -647,6 +647,13 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
             try binaryTarget.parseXCFrameworks(for: triple, fileSystem: self.fileSystem)
         }
     }
+
+    public func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String] {
+        guard let description = self.targetMap[module.id] else {
+            throw InternalError("Expected description for module \(module)")
+        }
+        return try description.symbolGraphExtractArguments()
+    }
 }
 
 extension Basics.Diagnostic {

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -648,6 +648,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
     }
 
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// a particular module.
     public func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String] {
         guard let description = self.targetMap[module.id] else {
             throw InternalError("Expected description for module \(module)")

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -65,6 +65,9 @@ public struct SymbolGraphExtract {
 
         // Construct arguments for extracting symbols for a single target.
         var commandLine = [self.tool.pathString]
+        commandLine += try buildPlan.symbolGraphExtractArguments(for: module)
+
+        // FIXME: everything here should be in symbolGraphExtractArguments
         commandLine += ["-module-name", module.c99name]
         commandLine += try buildParameters.tripleArgs(for: module)
         commandLine += try buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)

--- a/Sources/Commands/Utilities/SymbolGraphExtract.swift
+++ b/Sources/Commands/Utilities/SymbolGraphExtract.swift
@@ -70,7 +70,6 @@ public struct SymbolGraphExtract {
         // FIXME: everything here should be in symbolGraphExtractArguments
         commandLine += ["-module-name", module.c99name]
         commandLine += try buildParameters.tripleArgs(for: module)
-        commandLine += try buildPlan.createAPIToolCommonArgs(includeLibrarySearchPaths: true)
         commandLine += ["-module-cache-path", try buildParameters.moduleCache.pathString]
         if verboseOutput {
             commandLine += ["-v"]

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -90,6 +90,8 @@ public protocol BuildPlan {
 
     func createAPIToolCommonArgs(includeLibrarySearchPaths: Bool) throws -> [String]
     func createREPLArguments() throws -> [String]
+
+    func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String]
 }
 
 public protocol BuildSystemFactory {

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -91,6 +91,8 @@ public protocol BuildPlan {
     func createAPIToolCommonArgs(includeLibrarySearchPaths: Bool) throws -> [String]
     func createREPLArguments() throws -> [String]
 
+    /// Determines the arguments needed to run `swift-symbolgraph-extract` for
+    /// a particular module.
     func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String]
 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1713,6 +1713,7 @@ final class BuildPlanTests: XCTestCase {
             )
         )
 
+        // Assert compile args for swift modules importing cxx modules
         let swiftInteropLib = try result.target(for: "swiftInteropLib").swiftTarget().compileArguments()
         XCTAssertMatch(
             swiftInteropLib,
@@ -1720,6 +1721,28 @@ final class BuildPlanTests: XCTestCase {
         )
         let swiftLib = try result.target(for: "swiftLib").swiftTarget().compileArguments()
         XCTAssertNoMatch(swiftLib, [.anySequence, "-Xcc", "-std=c++1z", .anySequence])
+
+        // Assert symbolgraph-extract args for swift modules importing cxx modules
+        do {
+            let swiftInteropLib = try result.target(for: "swiftInteropLib").swiftTarget().compileArguments()
+            XCTAssertMatch(
+                swiftInteropLib,
+                [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++1z", .anySequence]
+            )
+            let swiftLib = try result.target(for: "swiftLib").swiftTarget().compileArguments()
+            XCTAssertNoMatch(swiftLib, [.anySequence, "-Xcc", "-std=c++1z", .anySequence])
+        }
+
+        // Assert symbolgraph-extract args for cxx modules
+        do {
+            let swiftInteropLib = try result.target(for: "swiftInteropLib").swiftTarget().compileArguments()
+            XCTAssertMatch(
+                swiftInteropLib,
+                [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++1z", .anySequence]
+            )
+            let swiftLib = try result.target(for: "swiftLib").swiftTarget().compileArguments()
+            XCTAssertNoMatch(swiftLib, [.anySequence, "-Xcc", "-std=c++1z", .anySequence])
+        }
     }
 
     func testSwiftCMixed() throws {
@@ -1890,6 +1913,88 @@ final class BuildPlanTests: XCTestCase {
             AbsolutePath("/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/lib.build/lib.S.o"),
             AbsolutePath("/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/lib.build/lib.c.o"),
         ])
+    }
+
+    func testSwiftSettings_interoperabilityMode_cxx() throws {
+        let Pkg: AbsolutePath = "/Pkg"
+
+        let fs: FileSystem = InMemoryFileSystem(
+            emptyFiles:
+            Pkg.appending(components: "Sources", "cxxLib", "lib.cpp").pathString,
+            Pkg.appending(components: "Sources", "cxxLib", "include", "lib.h").pathString,
+            Pkg.appending(components: "Sources", "swiftLib", "lib.swift").pathString,
+            Pkg.appending(components: "Sources", "swiftLib2", "lib2.swift").pathString
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: .init(validating: Pkg.pathString),
+                    cxxLanguageStandard: "c++20",
+                    targets: [
+                        TargetDescription(name: "cxxLib", dependencies: []),
+                        TargetDescription(
+                            name: "swiftLib",
+                            dependencies: ["cxxLib"],
+                            settings: [.init(tool: .swift, kind: .interoperabilityMode(.Cxx))]
+                        ),
+                        TargetDescription(name: "swiftLib2", dependencies: ["swiftLib"]),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let plan = try mockBuildPlan(
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let result = try BuildPlanResult(plan: plan)
+
+        // Cxx module
+        do {
+            try XCTAssertMatch(
+                result.target(for: "cxxLib").clangTarget().symbolGraphExtractArguments(),
+                [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++20", .anySequence]
+            )
+        }
+
+        // Swift module directly importing cxx module
+        do {
+            try XCTAssertMatch(
+                result.target(for: "swiftLib").swiftTarget().compileArguments(),
+                [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++20", .anySequence]
+            )
+            try XCTAssertMatch(
+                result.target(for: "swiftLib").swiftTarget().symbolGraphExtractArguments(),
+                [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++20", .anySequence]
+            )
+        }
+
+        // Swift module transitively importing cxx module
+        do {
+            try XCTAssertNoMatch(
+                result.target(for: "swiftLib2").swiftTarget().compileArguments(),
+                [.anySequence, "-cxx-interoperability-mode=default", .anySequence]
+            )
+            try XCTAssertNoMatch(
+                result.target(for: "swiftLib2").swiftTarget().compileArguments(),
+                [.anySequence, "-Xcc", "-std=c++20", .anySequence]
+            )
+            try XCTAssertNoMatch(
+                result.target(for: "swiftLib2").swiftTarget().symbolGraphExtractArguments(),
+                [.anySequence, "-cxx-interoperability-mode=default", .anySequence]
+            )
+            try XCTAssertNoMatch(
+                result.target(for: "swiftLib2").swiftTarget().symbolGraphExtractArguments(),
+                [.anySequence, "-Xcc", "-std=c++20", .anySequence]
+            )
+        }
     }
 
     func testREPLArguments() throws {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -1408,13 +1408,13 @@ final class BuildPlanTests: XCTestCase {
         args += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks"]
         #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules", "-fmodule-name=extlib"]
+        args += [
+            "-fmodules",
+            "-fmodule-name=extlib",
+            "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))",
+        ]
         #endif
         args += ["-I", ExtPkg.appending(components: "Sources", "extlib", "include").pathString]
-        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
-        #endif
-
         args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
 
         if hostTriple.isLinux() {
@@ -1437,7 +1437,11 @@ final class BuildPlanTests: XCTestCase {
         args += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks"]
         #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules", "-fmodule-name=exe"]
+        args += [
+            "-fmodules",
+            "-fmodule-name=exe",
+            "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))",
+        ]
         #endif
         args += [
             "-I", Pkg.appending(components: "Sources", "exe", "include").pathString,
@@ -1446,9 +1450,6 @@ final class BuildPlanTests: XCTestCase {
             "-I", ExtPkg.appending(components: "Sources", "extlib", "include").pathString,
             "-fmodule-map-file=\(buildPath.appending(components: "extlib.build", "module.modulemap"))",
         ]
-        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
-        #endif
         args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
 
         if hostTriple.isLinux() {
@@ -1794,12 +1795,13 @@ final class BuildPlanTests: XCTestCase {
         args += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1"]
         args += ["-fblocks"]
         #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules", "-fmodule-name=lib"]
+        args += [
+            "-fmodules",
+            "-fmodule-name=lib",
+            "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))",
+        ]
         #endif
         args += ["-I", Pkg.appending(components: "Sources", "lib", "include").pathString]
-        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        args += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
-        #endif
         args += [hostTriple.isWindows() ? "-gdwarf" : "-g"]
 
         if hostTriple.isLinux() {
@@ -1994,6 +1996,115 @@ final class BuildPlanTests: XCTestCase {
                 result.target(for: "swiftLib2").swiftTarget().symbolGraphExtractArguments(),
                 [.anySequence, "-Xcc", "-std=c++20", .anySequence]
             )
+        }
+    }
+
+    func test_symbolGraphExtract_arguments() throws {
+        // ModuleGraph:
+        // .
+        // ├── A (Swift)
+        // │   ├── B (Swift)
+        // │   └── C (C)
+        // └── D (C)
+        //     ├── B (Swift)
+        //     └── C (C)
+
+        let Pkg: AbsolutePath = "/Pkg"
+        let fs: FileSystem = InMemoryFileSystem(
+            emptyFiles:
+            // A
+            Pkg.appending(components: "Sources", "A", "A.swift").pathString,
+            // B
+            Pkg.appending(components: "Sources", "B", "B.swift").pathString,
+            // C
+            Pkg.appending(components: "Sources", "C", "C.c").pathString,
+            Pkg.appending(components: "Sources", "C", "include", "C.h").pathString,
+            // D
+            Pkg.appending(components: "Sources", "D", "D.c").pathString,
+            Pkg.appending(components: "Sources", "D", "include", "D.h").pathString
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: .init(validating: Pkg.pathString),
+                    targets: [
+                        TargetDescription(name: "A", dependencies: ["B", "C"]),
+                        TargetDescription(name: "B", dependencies: []),
+                        TargetDescription(name: "C", dependencies: []),
+                        TargetDescription(name: "D", dependencies: ["B", "C"]),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let plan = try mockBuildPlan(
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let result = try BuildPlanResult(plan: plan)
+        let triple = result.plan.destinationBuildParameters.triple
+
+        func XCTAssertMatchesSubSequences(
+            _ value: [String],
+            _ patterns: [StringPattern]...,
+            file: StaticString = #file,
+            line: UInt = #line
+        ) {
+            for pattern in patterns {
+                var pattern = pattern
+                pattern.insert(.anySequence, at: 0)
+                pattern.append(.anySequence)
+                XCTAssertMatch(value, pattern, file: file, line: line)
+            }
+        }
+
+        // A
+        do {
+            try XCTAssertMatchesSubSequences(
+                result.target(for: "A").symbolGraphExtractArguments(),
+                // Swift Module dependencies
+                ["-I", "/path/to/build/\(triple)/debug/Modules"],
+                // C Module dependencies
+                ["-Xcc", "-I", "-Xcc", "/Pkg/Sources/C/include"],
+                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/C.build/module.modulemap"]
+            )
+        }
+
+        // D
+        do {
+            try XCTAssertMatchesSubSequences(
+                result.target(for: "D").symbolGraphExtractArguments(),
+                // Self Module
+                ["-I", "/Pkg/Sources/D/include"],
+                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/D.build/module.modulemap"],
+
+                // C Module dependencies
+                ["-Xcc", "-I", "-Xcc", "/Pkg/Sources/C/include"],
+                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/C.build/module.modulemap"],
+
+                // General Args
+                [
+                    "-Xcc", "-fmodules",
+                    "-Xcc", "-fmodule-name=D",
+                    "-Xcc", "-fmodules-cache-path=/path/to/build/\(triple)/debug/ModuleCache",
+                ]
+            )
+
+#if os(macOS)
+            try XCTAssertMatchesSubSequences(
+                result.target(for: "D").symbolGraphExtractArguments(),
+                // Swift Module dependencies
+                ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/B.build/module.modulemap"]
+            )
+#endif
         }
     }
 
@@ -3033,12 +3144,13 @@ final class BuildPlanTests: XCTestCase {
         expectedExeBasicArgs += ["-target", defaultTargetTriple]
         expectedExeBasicArgs += ["-O0", "-DSWIFT_PACKAGE=1", "-DDEBUG=1", "-fblocks"]
         #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        expectedExeBasicArgs += ["-fmodules", "-fmodule-name=exe"]
+        expectedExeBasicArgs += [
+            "-fmodules",
+            "-fmodule-name=exe",
+            "-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"
+        ]
         #endif
         expectedExeBasicArgs += ["-I", Pkg.appending(components: "Sources", "exe", "include").pathString]
-        #if os(macOS) // FIXME(5473) - support modules on non-Apple platforms
-        expectedExeBasicArgs += ["-fmodules-cache-path=\(buildPath.appending(components: "ModuleCache"))"]
-        #endif
 
         expectedExeBasicArgs += [triple.isWindows() ? "-gdwarf" : "-g"]
 


### PR DESCRIPTION
**Explanation:** Updates `swift package dump-symbol-graph` to pass the correct set of include and cxx interoperability mode flags. This fixes a bug where were are unable to extract the symbol graph from swiftmodules with transitive cxx modules because we parsed cxx headers as c headers.

With these changes `swift-mmio` is able to generate symbol graphs and documentation using the `swift package dump-symbol-graph` and `swift package generate-documentation` commands.

**Scope:** Documentation generation

**Issue:** 

**Original PR**: #7610, #7621

**Risk**: Low

**Testing:** CI & at desk usage directly and via SwiftPM

**Reviewer:** @xedin 