### PR TITLE
Fix: use bearer auth when pulling binaryTarget or packages from a package registry

### DIFF
--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -71,6 +71,9 @@ extension AuthorizationProvider {
         guard let (user, password) = self.authentication(for: url) else {
             return nil
         }
+        guard user != "token" else {
+            return "Bearer \(password)"
+        }
         let authString = "\(user):\(password)"
         let authData = Data(authString.utf8)
         return "Basic \(authData.base64EncodedString())"

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -63,6 +63,15 @@ final class AuthorizationProviderTests: XCTestCase {
         }
     }
 
+    func testBasicAPIsBearerToken() {
+        let url = URL("http://\(UUID().uuidString)")
+        let user = "token"
+        let token = UUID().uuidString
+
+        let provider = TestProvider(map: [url: (user: user, password: token)])
+        self.assertBearerAuthentication(provider, for: url, expected: token)
+    }
+
     func testProtocolHostPort() throws {
         #if !canImport(Security)
         try XCTSkipIf(true)
@@ -256,6 +265,20 @@ final class AuthorizationProviderTests: XCTestCase {
         XCTAssertEqual(
             provider.httpAuthorizationHeader(for: url),
             "Basic " + Data("\(expected.user):\(expected.password)".utf8).base64EncodedString()
+        )
+    }
+
+    private func assertBearerAuthentication(
+        _ provider: AuthorizationProvider,
+        for url: URL,
+        expected: String
+    ) {
+        let authentication = provider.authentication(for: url)
+        XCTAssertEqual(authentication?.user, "token")
+        XCTAssertEqual(authentication?.password, expected)
+        XCTAssertEqual(
+            provider.httpAuthorizationHeader(for: url),
+            "Bearer \(expected)"
         )
     }
 }


### PR DESCRIPTION

Use bearer auth when pulling binary targets or a package from a package registry and the user is `token`.

### Motivation:

When logging in to a package registry bearer auth works. However when fetching binaryTargets or pulling packages from a registry basic auth is used always.

This either breaks services that don't use basic auth or leads to nasty workarounds like first creating a netrc file with "token" as the user and after login changing the user back to the actual user. Assuming that basic auth is allowed with an identiy token.


### Modifications:

Check if the user is `token` when creating the authorization header and use Bearer auth in these cases.

### Result:

When the user is `token` the `Authorization` header will be set to `Bearer {{access_token}}` instead of `Basic token:{{access_token}}`. 

Before:
<img width="698" alt="Screenshot 2024-06-13 at 22 49 08" src="https://github.com/apple/swift-package-manager/assets/13999931/0f3eef32-55e3-417f-b129-c138ca452b08">

After:
<img width="699" alt="Screenshot 2024-06-13 at 22 48 38" src="https://github.com/apple/swift-package-manager/assets/13999931/d98daaa7-1535-40d0-96ea-a6736f5d1e3e">

