### PR TITLE
Fix: cache not cleaned up if download fails

### DIFF
--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -136,6 +136,10 @@ public final class MockWorkspace {
         return self.sandbox.appending(components: ".build", "artifacts")
     }
 
+    public var workspaceLocation: Workspace.Location? {
+        return self._workspace?.location
+    }
+
     public func pathToRoot(withName name: String) throws -> AbsolutePath {
         return try AbsolutePath(validating: name, relativeTo: self.rootsDir)
     }

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -618,6 +618,9 @@ extension Workspace {
                 progress: progress,
                 completion: { result in
                     self.delegate?.willDownloadBinaryArtifact(from: artifact.url.absoluteString, fromCache: false)
+                    if case .failure = result {
+                        try? self.fileSystem.removeFileTree(cachedArtifactPath)
+                    }
                     completion(result.flatMap {
                         Result.init(catching: {
                             // copy from cache to destination

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -7471,6 +7471,7 @@ final class WorkspaceTests: XCTestCase {
         // make sure artifact downloaded is deleted
         XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
         XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/root/a.zip")))
+        XCTAssertFalse(fs.exists(AbsolutePath("/home/user/caches/org.swift.swiftpm/artifacts/https___a_com_a_zip")))
     }
 
     func testArtifactDownloaderOrArchiverError() throws {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -7416,6 +7416,7 @@ final class WorkspaceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let sandbox = AbsolutePath("/tmp/ws/")
         try fs.createDirectory(sandbox, recursive: true)
+        let artifactUrl = "https://a.com/a.zip"
 
         let httpClient = LegacyHTTPClient(handler: { request, _, completion in
             do {
@@ -7446,7 +7447,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(
                             name: "A1",
                             type: .binary,
-                            url: "https://a.com/a.zip",
+                            url: artifactUrl,
                             checksum: "a1"
                         ),
                     ]
@@ -7471,7 +7472,17 @@ final class WorkspaceTests: XCTestCase {
         // make sure artifact downloaded is deleted
         XCTAssertTrue(fs.isDirectory(AbsolutePath("/tmp/ws/.build/artifacts/root")))
         XCTAssertFalse(fs.exists(AbsolutePath("/tmp/ws/.build/artifacts/root/a.zip")))
-        XCTAssertFalse(fs.exists(AbsolutePath("/home/user/caches/org.swift.swiftpm/artifacts/https___a_com_a_zip")))
+
+        // make sure the cached artifact is also deleted
+        let artifactCacheKey = artifactUrl.spm_mangledToC99ExtendedIdentifier()
+        guard let cachePath = workspace.workspaceLocation?
+            .sharedBinaryArtifactsCacheDirectory?
+            .appending(artifactCacheKey) else {
+            XCTFail("Required workspace location wasn't found")
+            return
+        }
+
+        XCTAssertFalse(fs.exists(cachePath))
     }
 
     func testArtifactDownloaderOrArchiverError() throws {


### PR DESCRIPTION
If a server returns an error when trying to download a binaryTarget an invalid file remains in the artifacts cache.

### Motivation:

If the download of a binaryTarget fails a cache file still remains in the artifact cache.

The file only contains the server's response which is usually the status code and the error message.
Example:
```
$ ls ~/Library/Caches/org.swift.swiftpm/artifacts
.
..
https___test_example_local_foo_zip

$ cat ~/Library/Caches/org.swift.swiftpm/artifacts/https___test_example_local_foo_zip
404 page not found
```

Worse, all following `resolve` calls therefore fail because the cached file is used but is an invalid archive.

### Modifications:

If the download fails the cache file in the artifacts cache is deleted.

### Result:
As expected, the artifacts folder is empty.

Example:
```
$ ls ~/Library/Caches/org.swift.swiftpm/artifacts
.
..
```

