### PR TITLE
Fix `swift-api-digester` search paths

### DIFF
--- a/Sources/Basics/Collections/IdentifiableSet.swift
+++ b/Sources/Basics/Collections/IdentifiableSet.swift
@@ -97,6 +97,16 @@ public struct IdentifiableSet<Element: Identifiable>: Collection {
     public func contains(id: Element.ID) -> Bool {
         self.storage.keys.contains(id)
     }
+
+    public func filter(_ isIncluded: (Self.Element) throws -> Bool) rethrows -> Self {
+        var copy = Self()
+        for element in self {
+            if try isIncluded(element) {
+                copy.insert(element)
+            }
+        }
+        return copy
+    }
 }
 
 extension OrderedDictionary where Value: Identifiable, Key == Value.ID {

--- a/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangTargetBuildDescription.swift
@@ -225,6 +225,18 @@ public final class ClangTargetBuildDescription {
         return args
     }
 
+    /// Determines the arguments needed to run `swift-api-digester` for emitting
+    /// an API baseline for this module.
+    package func apiDigesterEmitBaselineArguments() throws -> [String] {
+        throw InternalError("Unimplemented \(#function)")
+    }
+
+    /// Determines the arguments needed to run `swift-api-digester` for
+    /// comparing to an API baseline for this module.
+    package func apiDigesterCompareBaselineArguments() throws -> [String] {
+        throw InternalError("Unimplemented \(#function)")
+    }
+
     /// Builds up basic compilation arguments for a source file in this target; these arguments may be different for C++
     /// vs non-C++.
     /// NOTE: The parameter to specify whether to get C++ semantics is currently optional, but this is only for revlock

--- a/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftTargetBuildDescription.swift
@@ -641,6 +641,44 @@ public final class SwiftTargetBuildDescription {
         return args
     }
 
+    /// Determines the arguments needed to run `swift-api-digester` for emitting
+    /// an API baseline for this module.
+    package func apiDigesterEmitBaselineArguments() throws -> [String] {
+        var args = [String]()
+        args += try self.apiDigesterCommonArguments()
+        return args
+    }
+
+    /// Determines the arguments needed to run `swift-api-digester` for
+    /// comparing to an API baseline for this module.
+    package func apiDigesterCompareBaselineArguments() throws -> [String] {
+        var args = [String]()
+        args += try self.apiDigesterCommonArguments()
+        return args
+    }
+
+    public func apiDigesterCommonArguments() throws -> [String] {
+        var args = [String]()
+        args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags
+
+        // FIXME: remove additionalFlags
+        // Add search paths determined during planning
+        args += self.additionalFlags
+        args += ["-I", self.modulesPath.pathString]
+
+        // FIXME: Only include valid args
+        // `swift-api-digester` args doesn't support -L args.
+        for index in args.indices.dropLast().reversed() {
+            if args[index] == "-L" {
+                // Remove the flag
+                args.remove(at: index)
+                // Remove the argument
+                args.remove(at: index)
+            }
+        }
+        return args
+    }
+
     // FIXME: this function should operation on a strongly typed buildSetting
     // Move logic from PackageBuilder here.
     /// Determines the arguments needed for cxx interop for this module.

--- a/Sources/Build/BuildDescription/TargetBuildDescription.swift
+++ b/Sources/Build/BuildDescription/TargetBuildDescription.swift
@@ -124,4 +124,22 @@ public enum TargetBuildDescription {
         case .clang(let target): try target.symbolGraphExtractArguments()
         }
     }
+
+    /// Determines the arguments needed to run `swift-api-digester` for emitting
+    /// an API baseline for this module.
+    package func apiDigesterEmitBaselineArguments() throws -> [String] {
+        switch self {
+        case .swift(let target): try target.apiDigesterEmitBaselineArguments()
+        case .clang(let target): try target.apiDigesterEmitBaselineArguments()
+        }
+    }
+
+    /// Determines the arguments needed to run `swift-api-digester` for
+    /// comparing to an API baseline for this module.
+    package func apiDigesterCompareBaselineArguments() throws -> [String] {
+        switch self {
+        case .swift(let target): try target.apiDigesterCompareBaselineArguments()
+        case .clang(let target): try target.apiDigesterCompareBaselineArguments()
+        }
+    }
 }

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -94,7 +94,7 @@ extension ModulesGraph {
                 ))
 
                 return try ModulesGraph(
-                    rootPackages: [],
+                    rootPackages: .init(),
                     rootDependencies: [],
                     packages: IdentifiableSet(),
                     dependencies: requiredDependencies,
@@ -188,7 +188,7 @@ extension ModulesGraph {
 
 private func checkAllDependenciesAreUsed(
     packages: IdentifiableSet<ResolvedPackage>,
-    _ rootPackages: [ResolvedPackage],
+    _ rootPackages: IdentifiableSet<ResolvedPackage>,
     observabilityScope: ObservabilityScope
 ) {
     for package in rootPackages {

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -232,13 +232,12 @@ public struct ModulesGraph {
 
     /// Construct a package graph directly.
     public init(
-        rootPackages: [ResolvedPackage],
+        rootPackages: IdentifiableSet<ResolvedPackage>,
         rootDependencies: [ResolvedPackage] = [],
         packages: IdentifiableSet<ResolvedPackage>,
         dependencies requiredDependencies: [PackageReference],
         binaryArtifacts: [PackageIdentity: [String: BinaryArtifact]]
     ) throws {
-        let rootPackages = IdentifiableSet(rootPackages)
         self.requiredDependencies = requiredDependencies
         self.inputPackages = rootPackages + rootDependencies
         self.binaryArtifacts = binaryArtifacts

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -90,12 +90,19 @@ public protocol BuildPlan {
 
     var buildProducts: AnySequence<ProductBuildDescription> { get }
 
-    func createAPIToolCommonArgs(includeLibrarySearchPaths: Bool) throws -> [String]
     func createREPLArguments() throws -> [String]
 
     /// Determines the arguments needed to run `swift-symbolgraph-extract` for
     /// a particular module.
     func symbolGraphExtractArguments(for module: ResolvedModule) throws -> [String]
+
+    /// Determines the arguments needed to run `swift-api-digester` for emitting
+    /// an API baseline for a particular module.
+    func apiDigesterEmitBaselineArguments(for module: ResolvedModule) throws -> [String]
+  
+    /// Determines the arguments needed to run `swift-api-digester` for
+    /// comparing to an API baseline for a particular module.
+    func apiDigesterCompareBaselineArguments(for module: ResolvedModule) throws -> [String]
 }
 
 public protocol BuildSystemFactory {

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -43,7 +43,7 @@ final class APIDiffTests: CommandsTestCase {
         try skipIfApiDigesterUnsupported()
         // The following is added to separate out the integration point testing of the API
         // diff digester with SwiftPM from the functionality tests of the digester itself
-        guard ProcessEnv.block["SWIFTPM_TEST_API_DIFF_OUTPUT"] == "1" else {
+        guard try true || ProcessEnv.block["SWIFTPM_TEST_API_DIFF_OUTPUT"] == "1" else {
             throw XCTSkip("Env var SWIFTPM_TEST_API_DIFF_OUTPUT must be set to test the output")
         }
     }
@@ -57,7 +57,7 @@ final class APIDiffTests: CommandsTestCase {
       // not all of which can be tested for easily. Fortunately, we can test for the
       // `-disable-fail-on-error` option, and any version which supports this flag
       // will meet the other requirements.
-      guard DriverSupport.checkSupportedFrontendFlags(flags: ["disable-fail-on-error"], toolchain: try UserToolchain.default, fileSystem: localFileSystem) else {
+      guard try true || DriverSupport.checkSupportedFrontendFlags(flags: ["disable-fail-on-error"], toolchain: UserToolchain.default, fileSystem: localFileSystem) else {
         throw XCTSkip("swift-api-digester is too old")
       }
     }


### PR DESCRIPTION
Fixes an architecture and implementation bug where the include paths for `swift-api-digester` were being determined inside build plan instead of by the target build description.

This is effectively the same change as #7621 but for api-digester rather than symbolgraph-extract.

This commit also leaves hooks in to enable api-digester on clang modules as a future improvement.