### PR TITLE
Update versions in `Examples/package-info/Package.swift`

### DIFF
--- a/Examples/package-info/Package.swift
+++ b/Examples/package-info/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 import PackageDescription
 
 let package = Package(
     name: "package-info",
     platforms: [
-        .macOS(.v12),
+        .macOS(.v13),
         .iOS(.v13)
     ],
     dependencies: [


### PR DESCRIPTION
Update swift-tools-version and platform version for Example package-info project

### Motivation:

I needed to run the  Examples/package-info project fails with following the [readme](https://github.com/apple/swift-package-manager/blob/main/Documentation/libSwiftPM.md).

### Modifications:

Update swift-tools-version and platform version for Example package-info project to be able to buld with the current SwiftPM.

### Result:

The Examples/package-info project builds succesfully
