### PR TITLE
[6.0][Build/PackageGraph] Switch `BuildSubset.{product, target}` and `Modu…

### DIFF
--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -385,7 +385,7 @@ final class PluginDelegate: PluginInvocationDelegate {
 
         // Find the target in the build operation's package graph; it's an error if we don't find it.
         let packageGraph = try buildSystem.getPackageGraph()
-        guard let target = packageGraph.target(for: targetName, destination: .destination) else {
+        guard let target = packageGraph.target(for: targetName) else {
             throw StringError("could not find a target named “\(targetName)”")
         }
 

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -24,11 +24,13 @@ public enum BuildSubset {
     /// Represents the subset of all products and targets.
     case allIncludingTests
 
-    /// Represents a specific product.
-    case product(String, for: BuildParameters.Destination = .target)
+    /// Represents a specific product. Allows to set a specific
+    /// destination if it's known.
+    case product(String, for: BuildParameters.Destination? = .none)
 
-    /// Represents a specific target.
-    case target(String, for: BuildParameters.Destination = .target)
+    /// Represents a specific target. Allows to set a specific
+    /// destination if it's known.
+    case target(String, for: BuildParameters.Destination? = .none)
 }
 
 /// A protocol that represents a build system used by SwiftPM for all build operations. This allows factoring out the

--- a/Sources/SPMTestSupport/MockPackageGraphs.swift
+++ b/Sources/SPMTestSupport/MockPackageGraphs.swift
@@ -127,9 +127,11 @@ package func macrosPackageGraph() throws -> MockPackageGraph {
 
 package func macrosTestsPackageGraph() throws -> MockPackageGraph {
     let fs = InMemoryFileSystem(emptyFiles:
+        "/swift-mmio/Plugins/MMIOPlugin/source.swift",
         "/swift-mmio/Sources/MMIO/source.swift",
         "/swift-mmio/Sources/MMIOMacros/source.swift",
         "/swift-mmio/Sources/MMIOMacrosTests/source.swift",
+        "/swift-mmio/Sources/MMIOMacro+PluginTests/source.swift",
         "/swift-syntax/Sources/SwiftSyntax/source.swift",
         "/swift-syntax/Sources/SwiftSyntaxMacrosTestSupport/source.swift",
         "/swift-syntax/Sources/SwiftSyntaxMacros/source.swift",
@@ -156,6 +158,11 @@ package func macrosTestsPackageGraph() throws -> MockPackageGraph {
                         name: "MMIO",
                         type: .library(.automatic),
                         targets: ["MMIO"]
+                    ),
+                    ProductDescription(
+                        name: "MMIOPlugin",
+                        type: .plugin,
+                        targets: ["MMIOPlugin"]
                     )
                 ],
                 targets: [
@@ -172,10 +179,23 @@ package func macrosTestsPackageGraph() throws -> MockPackageGraph {
                         type: .macro
                     ),
                     TargetDescription(
+                        name: "MMIOPlugin",
+                        type: .plugin,
+                        pluginCapability: .buildTool
+                    ),
+                    TargetDescription(
                         name: "MMIOMacrosTests",
                         dependencies: [
                             .target(name: "MMIOMacros"),
                             .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+                        ],
+                        type: .test
+                    ),
+                    TargetDescription(
+                        name: "MMIOMacro+PluginTests",
+                        dependencies: [
+                            .target(name: "MMIOPlugin"),
+                            .target(name: "MMIOMacros")
                         ],
                         type: .test
                     )

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -88,7 +88,7 @@ public final class PackageGraphResult {
 
     package func checkTarget(
         _ name: String,
-        destination: BuildTriple = .destination,
+        destination: BuildTriple? = .none,
         file: StaticString = #file,
         line: UInt = #line,
         body: (ResolvedTargetResult) -> Void
@@ -113,7 +113,7 @@ public final class PackageGraphResult {
 
     public func checkProduct(
         _ name: String,
-        destination: BuildTriple = .destination,
+        destination: BuildTriple? = .none,
         file: StaticString = #file,
         line: UInt = #line,
         body: (ResolvedProductResult) -> Void

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -300,7 +300,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         )
         let result = try BuildPlanResult(plan: plan)
         result.checkProductsCount(2)
-        result.checkTargetsCount(15)
+        result.checkTargetsCount(16)
 
         XCTAssertTrue(try result.allTargets(named: "SwiftSyntax")
             .map { try $0.swiftTarget() }

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -82,6 +82,10 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
                 }
             }
 
+            result.checkProduct("MMIOMacros") { result in
+                result.check(buildTriple: .tools)
+            }
+
             result.checkTargets("SwiftSyntax") { results in
                 XCTAssertEqual(results.count, 2)
 
@@ -99,6 +103,7 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
             result.check(
                 targets: "MMIO",
                 "MMIOMacros",
+                "MMIOPlugin",
                 "SwiftCompilerPlugin",
                 "SwiftCompilerPlugin",
                 "SwiftCompilerPluginMessageHandling",
@@ -110,7 +115,7 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
                 "SwiftSyntaxMacrosTestSupport",
                 "SwiftSyntaxMacrosTestSupport"
             )
-            result.check(testModules: "MMIOMacrosTests")
+            result.check(testModules: "MMIOMacrosTests", "MMIOMacro+PluginTests")
             result.checkTarget("MMIO") { result in
                 result.check(buildTriple: .destination)
                 result.check(dependencies: "MMIOMacros")
@@ -118,6 +123,7 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
             result.checkTargets("MMIOMacros") { results in
                 XCTAssertEqual(results.count, 1)
             }
+
             result.checkTarget("MMIOMacrosTests", destination: .tools) { result in
                 result.check(buildTriple: .tools)
                 result.checkDependency("MMIOMacros") { result in
@@ -145,11 +151,50 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
                 }
             }
 
+            result.checkTarget("MMIOMacros") { result in
+                result.check(buildTriple: .tools)
+            }
+
+            result.checkTarget("MMIOMacrosTests") { result in
+                result.check(buildTriple: .tools)
+            }
+
             result.checkTargets("SwiftSyntax") { results in
                 XCTAssertEqual(results.count, 2)
 
                 XCTAssertEqual(results.filter({ $0.target.buildTriple == .tools }).count, 1)
                 XCTAssertEqual(results.filter({ $0.target.buildTriple == .destination }).count, 1)
+            }
+        }
+    }
+
+    func testPlugins() throws {
+        let graph = try macrosTestsPackageGraph().graph
+        PackageGraphTester(graph) { result in
+            result.checkProduct("MMIOPlugin", destination: .tools) { result in
+                result.check(buildTriple: .tools)
+            }
+
+            result.checkProduct("MMIOPlugin") { result in
+                result.check(buildTriple: .tools)
+            }
+
+            result.checkTarget("MMIOPlugin", destination: .tools) { result in
+                result.check(buildTriple: .tools)
+            }
+
+            result.checkTarget("MMIOPlugin") { result in
+                result.check(buildTriple: .tools)
+            }
+
+            result.checkTarget("MMIOMacro+PluginTests", destination: .tools) { result in
+                result.check(buildTriple: .tools)
+                result.check(dependencies: "MMIOPlugin", "MMIOMacros")
+            }
+
+            result.checkTarget("MMIOMacro+PluginTests") { result in
+                result.check(buildTriple: .tools)
+                result.check(dependencies: "MMIOPlugin", "MMIOMacros")
             }
         }
     }


### PR DESCRIPTION
…lesGraph.{product, target}(...)` to use optional destination

- Explanation:

  Follow-up to https://github.com/apple/swift-package-manager/pull/7646
  
  This is mostly NFC change. It makes more sense to default `destination` to "undefined" when applicable because it's not always possible to know intended destination based on user input.

  This kind of design makes more sense for internal APIs, instead of having users to pass `.destination` even though it might not be always correct.

- Main Branch PRs: https://github.com/apple/swift-package-manager/pull/7650

- Risk: Very Low

- Reviewed By: @MaxDesiatov 

- Testing: Existing test-cases were modified and new tests were added.