### PR TITLE
[6.0][Test-only] Don't use invalid module to satisfy `canImport` check (#7647)

### DIFF
--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -1044,11 +1044,14 @@ final class PluginInvocationTests: XCTestCase {
                   }
                   """)
             
-            // Create something that looks like another module that can be detected via `canImport()`.
+            // Create a valid swift interface file that can be detected via `canImport()`.
             let fakeExtraModulesDir = tmpPath.appending("ExtraModules")
             try localFileSystem.createDirectory(fakeExtraModulesDir, recursive: true)
-            let fakeExtraModuleFile = fakeExtraModulesDir.appending("ModuleFoundViaExtraSearchPaths.swiftmodule")
-            try localFileSystem.writeFileContents(fakeExtraModuleFile, string: "")
+            let fakeExtraModuleFile = fakeExtraModulesDir.appending("ModuleFoundViaExtraSearchPaths.swiftinterface")
+            try localFileSystem.writeFileContents(fakeExtraModuleFile, string: """
+                  // swift-interface-format-version: 1.0
+                  // swift-module-flags: -module-name ModuleFoundViaExtraSearchPaths
+                  """)
             
             /////////
             // Load a workspace from the package.


### PR DESCRIPTION
Explanation: This is a test-only change to allow for `canImport` change https://github.com/apple/swift/pull/74519
Scope: Test only. Update a test that relies on an invalid module as test input. Replace that with a swiftinterface.
Original PR: https://github.com/apple/swift-package-manager/pull/7647
Test: Unit-Test
Reviewer: @tshortli 
