### PR TITLE
Make traits optional in manifest deserialization

### DIFF
--- a/Sources/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerialization.swift
@@ -145,7 +145,7 @@ enum Serialization {
 
         let kind: Kind
         let moduleAliases: [String: String]?
-        let traits: Set<Trait>
+        let traits: Set<Trait>?
     }
 
     // MARK: - platforms serialization
@@ -295,7 +295,7 @@ enum Serialization {
         let providers: [SystemPackageProvider]?
         let targets: [Target]
         let products: [Product]
-        let traits: Set<Trait>
+        let traits: Set<Trait>?
         let dependencies: [PackageDependency]
         let swiftLanguageVersions: [SwiftVersion]?
         let cLanguageStandard: CLanguageStandard?

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -115,7 +115,7 @@ enum ManifestJSONParser {
             dependencies: dependencies,
             providers: input.package.providers?.map { .init($0) },
             products: try input.package.products.map { try .init($0) },
-            traits: Set(input.package.traits.map { TraitDescription($0) }),
+            traits: Set(input.package.traits?.map { TraitDescription($0) } ?? []),
             cxxLanguageStandard: input.package.cxxLanguageStandard?.rawValue,
             cLanguageStandard: input.package.cLanguageStandard?.rawValue
         )
@@ -638,7 +638,7 @@ extension MappablePackageDependency {
                     path: path
                 ),
                 productFilter: .everything,
-                traits: Set(seed.traits.map { PackageDependency.Trait.init($0) })
+                traits: Set(seed.traits?.map { PackageDependency.Trait.init($0) } ?? [])
             )
         case .sourceControl(let name, let location, let requirement):
             self.init(
@@ -649,7 +649,7 @@ extension MappablePackageDependency {
                     requirement: .init(requirement)
                 ),
                 productFilter: .everything,
-                traits: Set(seed.traits.map { PackageDependency.Trait.init($0) })
+                traits: Set(seed.traits?.map { PackageDependency.Trait.init($0) } ?? [])
             )
         case .registry(let id, let requirement):
             self.init(
@@ -659,7 +659,7 @@ extension MappablePackageDependency {
                     requirement: .init(requirement)
                 ),
                 productFilter: .everything,
-                traits: Set(seed.traits.map { PackageDependency.Trait.init($0) })
+                traits: Set(seed.traits?.map { PackageDependency.Trait.init($0) } ?? [])
             )
         }
     }


### PR DESCRIPTION
# Motivation

We are caching manifest JSONs to speed up loading. It can happen that we cached a manifest with an older SwiftPM version and have to load the manifest from JSON with a newer SwiftPM version. With the first traits PR we made the new fields non-optional. This led to failures when loading the manifest from the cache https://github.com/apple/swift-package-manager/pull/7680.

# Modification
This PR makes the fields optional and we default to empty sets after loading deserialization.