### PR TITLE
Fix parameter documentation in `PackageDependency.swift`

### DIFF
--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -241,8 +241,8 @@ extension Package.Dependency {
     /// packages.
     ///
     /// - Parameters:
-    ///   - name: The name of the Swift package or `nil` to deduce the name from path.
-    ///   - path: The local path to the package.
+    ///   - name: The name of the Swift package.
+    ///   - path: The file system path to the package.
     ///
     /// - Returns: A package dependency.
     @available(_PackageDescription, introduced: 5.2)
@@ -261,8 +261,8 @@ extension Package.Dependency {
     /// packages.
     ///
     /// - Parameters:
-    ///   - name: The name of the Swift package or `nil` to deduce the name from path.
-    ///   - path: The local path to the package.
+    ///   - name: The name of the Swift package.
+    ///   - path: The file system path to the package.
     ///   - traits: The trait configuration of this dependency. Defaults to enabling the default traits.
     ///
     /// - Returns: A package dependency.


### PR DESCRIPTION
* Remove mention of `nil` name which is not allowed due to the parameters being non-optional.
* Synchronize wording describing local package paths.