### PR TITLE
Remove unused `Codable` conformances on `PackageModel` types

### DIFF
--- a/Sources/PackageModel/BuildConfiguration.swift
+++ b/Sources/PackageModel/BuildConfiguration.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The configuration of the build environment.
-public enum BuildConfiguration: String, CaseIterable, Codable, Sendable {
+public enum BuildConfiguration: String, CaseIterable, Encodable, Sendable {
     case debug
     case release
 

--- a/Sources/PackageModel/BuildEnvironment.swift
+++ b/Sources/PackageModel/BuildEnvironment.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A build environment with which to evaluate conditions.
-public struct BuildEnvironment: Codable {
+public struct BuildEnvironment {
     public let platform: Platform
     public let configuration: BuildConfiguration?
 

--- a/Sources/PackageModel/BuildSettings.swift
+++ b/Sources/PackageModel/BuildSettings.swift
@@ -13,7 +13,7 @@
 /// Namespace for build settings.
 public enum BuildSettings {
     /// Build settings declarations.
-    public struct Declaration: Hashable, Codable {
+    public struct Declaration: Hashable {
         // Swift.
         public static let SWIFT_ACTIVE_COMPILATION_CONDITIONS: Declaration =
             .init("SWIFT_ACTIVE_COMPILATION_CONDITIONS")
@@ -40,35 +40,23 @@ public enum BuildSettings {
     }
 
     /// An individual build setting assignment.
-    public struct Assignment: Codable, Equatable, Hashable {
+    public struct Assignment: Equatable, Hashable {
         /// The assignment value.
         public var values: [String]
 
-        // FIXME: This should use `Set` but we need to investigate potential build failures on Linux caused by using it.
-        /// The condition associated with this assignment.
-        public var conditions: [PackageCondition] {
-            get {
-                self._conditions.map(\.underlying)
-            }
-            set {
-                self._conditions = newValue.map { PackageConditionWrapper($0) }
-            }
-        }
-
-        private var _conditions: [PackageConditionWrapper]
+        public var conditions: [PackageCondition]
 
         /// Indicates whether this assignment represents a default
         /// that should be used only if no other assignments match.
         public let `default`: Bool
 
         public init(default: Bool = false) {
-            self._conditions = []
+            self.conditions = []
             self.values = []
             self.default = `default`
         }
 
         public init(values: [String] = [], conditions: [PackageCondition] = []) {
-            self._conditions = []
             self.values = values
             self.default = false // TODO(franz): Check again
             self.conditions = conditions
@@ -76,7 +64,7 @@ public enum BuildSettings {
     }
 
     /// Build setting assignment table which maps a build setting to a list of assignments.
-    public struct AssignmentTable: Codable {
+    public struct AssignmentTable {
         public private(set) var assignments: [Declaration: [Assignment]]
 
         public init() {
@@ -93,7 +81,7 @@ public enum BuildSettings {
     /// Provides a view onto assignment table with a given set of bound parameters.
     ///
     /// This class can be used to get the assignments matching the bound parameters.
-    public final class Scope {
+    public struct Scope {
         /// The assignment table.
         public let table: AssignmentTable
 

--- a/Sources/PackageModel/Manifest/PackageConditionDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageConditionDescription.swift
@@ -24,64 +24,6 @@ public struct PackageConditionDescription: Codable, Hashable, Sendable {
     }
 }
 
-/// A manifest condition.
-public protocol PackageConditionProtocol: Codable {
-    func satisfies(_ environment: BuildEnvironment) -> Bool
-}
-
-/// Wrapper for package condition so it can conform to Codable.
-struct PackageConditionWrapper: Codable, Equatable, Hashable {
-    var platform: PlatformsCondition?
-    var config: ConfigurationCondition?
-    var traits: TraitCondition?
-
-    @available(*, deprecated, renamed: "underlying")
-    var condition: PackageConditionProtocol {
-        if let platform {
-            return platform
-        } else if let config {
-            return config
-        } else {
-            fatalError("unreachable")
-        }
-    }
-
-    var underlying: PackageCondition {
-        if let platform {
-            return .platforms(platform)
-        } else if let config {
-            return .configuration(config)
-        } else if let traits {
-            return .traits(traits)
-        } else {
-            fatalError("unreachable")
-        }
-    }
-
-    @available(*, deprecated, message: "Use .init(_ condition: PackageCondition) instead")
-    init(_ condition: PackageConditionProtocol) {
-        switch condition {
-        case let platform as PlatformsCondition:
-            self.platform = platform
-        case let config as ConfigurationCondition:
-            self.config = config
-        default:
-            fatalError("unknown condition \(condition)")
-        }
-    }
-
-    init(_ condition: PackageCondition) {
-        switch condition {
-        case let .platforms(platforms):
-            self.platform = platforms
-        case let .configuration(configuration):
-            self.config = configuration
-        case .traits(let traits):
-            self.traits = traits
-        }
-    }
-}
-
 /// One of possible conditions used in package manifests to restrict targets from being built for certain platforms or
 /// build configurations.
 public enum PackageCondition: Hashable, Sendable {
@@ -134,7 +76,7 @@ public enum PackageCondition: Hashable, Sendable {
 }
 
 /// Platforms condition implies that an assignment is valid on these platforms.
-public struct PlatformsCondition: PackageConditionProtocol, Hashable, Sendable {
+public struct PlatformsCondition: Hashable, Sendable {
     public let platforms: [Platform]
 
     public init(platforms: [Platform]) {
@@ -149,7 +91,7 @@ public struct PlatformsCondition: PackageConditionProtocol, Hashable, Sendable {
 
 /// A configuration condition implies that an assignment is valid on
 /// a particular build configuration.
-public struct ConfigurationCondition: PackageConditionProtocol, Hashable, Sendable {
+public struct ConfigurationCondition: Hashable, Sendable {
     public let configuration: BuildConfiguration
 
     public init(configuration: BuildConfiguration) {
@@ -168,7 +110,7 @@ public struct ConfigurationCondition: PackageConditionProtocol, Hashable, Sendab
 
 /// A configuration condition implies that an assignment is valid on
 /// a particular build configuration.
-public struct TraitCondition: PackageConditionProtocol, Hashable, Sendable {
+public struct TraitCondition: Hashable, Sendable {
     public let traits: Set<String>
 
     public init(traits: Set<String>) {

--- a/Sources/PackageModel/PackageModel.swift
+++ b/Sources/PackageModel/PackageModel.swift
@@ -14,7 +14,6 @@ import Basics
 import struct Foundation.URL
 
 import enum TSCUtility.PackageLocation
-import struct TSCUtility.PolymorphicCodableArray
 import struct TSCUtility.Version
 
 /// The basic package representation.
@@ -45,7 +44,7 @@ import struct TSCUtility.Version
 /// 5. A loaded package, as in #4, for which the targets have also been
 /// loaded. There is not currently a data structure for this, but it is the
 /// result after `PackageLoading.transmute()`.
-public final class Package: Encodable {
+public final class Package {
     /// The identity of the package.
     public let identity: PackageIdentity
 
@@ -56,7 +55,6 @@ public final class Package: Encodable {
     public let path: AbsolutePath
 
     /// The targets contained in the package.
-    @PolymorphicCodableArray
     public var targets: [Target]
 
     /// The products produced by the package.
@@ -84,7 +82,7 @@ public final class Package: Encodable {
         self.identity = identity
         self.manifest = manifest
         self.path = path
-        self._targets = .init(wrappedValue: targets)
+        self.targets = targets
         self.products = products
         self.targetSearchPath = targetSearchPath
         self.testTargetSearchPath = testTargetSearchPath

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -12,9 +12,7 @@
 
 import Basics
 
-import struct TSCUtility.PolymorphicCodableArray
-
-public class Product: Codable {
+public class Product {
     /// The name of the product.
     public let name: String
 
@@ -28,7 +26,6 @@ public class Product: Codable {
     ///
     /// This is never empty, and is only the targets which are required to be in
     /// the product, but not necessarily their transitive dependencies.
-    @PolymorphicCodableArray
     public var targets: [Target]
 
     /// The path to test entry point file.
@@ -54,7 +51,7 @@ public class Product: Codable {
         self.name = name
         self.type = type
         self.identity = package.description.lowercased() + "_" + name
-        self._targets = .init(wrappedValue: targets)
+        self.targets = targets
         self.testEntryPointPath = testEntryPointPath
     }
 }

--- a/Sources/PackageModel/Target/BinaryTarget.swift
+++ b/Sources/PackageModel/Target/BinaryTarget.swift
@@ -47,36 +47,7 @@ public final class BinaryTarget: Target {
         )
     }
 
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case origin
-        case artifactSource // backwards compatibility 2/2021
-    }
-
-    public override func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.origin, forKey: .origin)
-        try container.encode(self.kind, forKey: .kind)
-    }
-
-    required public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        // backwards compatibility 2/2021
-        if !container.contains(.kind) {
-            self.kind = .xcframework
-        } else {
-            self.kind = try container.decode(Kind.self, forKey: .kind)
-        }
-        // backwards compatibility 2/2021
-        if container.contains(.artifactSource)  {
-            self.origin = try container.decode(Origin.self, forKey: .artifactSource)
-        } else {
-            self.origin = try container.decode(Origin.self, forKey: .origin)
-        }
-        try super.init(from: decoder)
-    }
-
-    public enum Kind: String, RawRepresentable, Codable, CaseIterable {
+    public enum Kind: String, RawRepresentable, CaseIterable {
         case xcframework
         case artifactsArchive
         case unknown // for non-downloaded artifacts
@@ -98,42 +69,12 @@ public final class BinaryTarget: Target {
         return self.kind == .artifactsArchive
     }
 
-    public enum Origin: Equatable, Codable {
+    public enum Origin: Equatable {
 
         /// Represents an artifact that was downloaded from a remote URL.
         case remote(url: String)
 
         /// Represents an artifact that was available locally.
         case local
-
-        private enum CodingKeys: String, CodingKey {
-            case remote, local
-        }
-
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            switch self {
-            case .remote(let a1):
-                var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .remote)
-                try unkeyedContainer.encode(a1)
-            case .local:
-                try container.encodeNil(forKey: .local)
-            }
-        }
-
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            guard let key = values.allKeys.first(where: values.contains) else {
-                throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Did not find a matching key"))
-            }
-            switch key {
-            case .remote:
-                var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
-                let a1 = try unkeyedValues.decode(String.self)
-                self = .remote(url: a1)
-            case .local:
-                self = .local
-            }
-        }
     }
 }

--- a/Sources/PackageModel/Target/ClangTarget.swift
+++ b/Sources/PackageModel/Target/ClangTarget.swift
@@ -82,30 +82,4 @@ public final class ClangTarget: Target {
             usesUnsafeFlags: usesUnsafeFlags
         )
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case includeDir, moduleMapType, headers, isCXX, cLanguageStandard, cxxLanguageStandard
-    }
-
-    public override func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(includeDir, forKey: .includeDir)
-        try container.encode(moduleMapType, forKey: .moduleMapType)
-        try container.encode(headers, forKey: .headers)
-        try container.encode(isCXX, forKey: .isCXX)
-        try container.encode(cLanguageStandard, forKey: .cLanguageStandard)
-        try container.encode(cxxLanguageStandard, forKey: .cxxLanguageStandard)
-        try super.encode(to: encoder)
-    }
-
-    required public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.includeDir = try container.decode(AbsolutePath.self, forKey: .includeDir)
-        self.moduleMapType = try container.decode(ModuleMapType.self, forKey: .moduleMapType)
-        self.headers = try container.decode([AbsolutePath].self, forKey: .headers)
-        self.isCXX = try container.decode(Bool.self, forKey: .isCXX)
-        self.cLanguageStandard = try container.decodeIfPresent(String.self, forKey: .cLanguageStandard)
-        self.cxxLanguageStandard = try container.decodeIfPresent(String.self, forKey: .cxxLanguageStandard)
-        try super.init(from: decoder)
-    }
 }

--- a/Sources/PackageModel/Target/PluginTarget.swift
+++ b/Sources/PackageModel/Target/PluginTarget.swift
@@ -41,62 +41,11 @@ public final class PluginTarget: Target {
             usesUnsafeFlags: false
         )
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case capability
-        case apiVersion
-    }
-
-    public override func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.capability, forKey: .capability)
-        try container.encode(self.apiVersion, forKey: .apiVersion)
-        try super.encode(to: encoder)
-    }
-
-    required public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.capability = try container.decode(PluginCapability.self, forKey: .capability)
-        self.apiVersion = try container.decode(ToolsVersion.self, forKey: .apiVersion)
-        try super.init(from: decoder)
-    }
 }
 
-public enum PluginCapability: Hashable, Codable {
+public enum PluginCapability: Hashable {
     case buildTool
     case command(intent: PluginCommandIntent, permissions: [PluginPermission])
-
-    private enum CodingKeys: String, CodingKey {
-        case buildTool, command
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case .buildTool:
-            try container.encodeNil(forKey: .buildTool)
-        case .command(let a1, let a2):
-            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .command)
-            try unkeyedContainer.encode(a1)
-            try unkeyedContainer.encode(a2)
-        }
-    }
-
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        guard let key = values.allKeys.first(where: values.contains) else {
-            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Did not find a matching key"))
-        }
-        switch key {
-        case .buildTool:
-            self = .buildTool
-        case .command:
-            var unkeyedValues = try values.nestedUnkeyedContainer(forKey: key)
-            let a1 = try unkeyedValues.decode(PluginCommandIntent.self)
-            let a2 = try unkeyedValues.decode([PluginPermission].self)
-            self = .command(intent: a1, permissions: a2)
-        }
-    }
 
     public init(from desc: TargetDescription.PluginCapability) {
         switch desc {
@@ -108,7 +57,7 @@ public enum PluginCapability: Hashable, Codable {
     }
 }
 
-public enum PluginCommandIntent: Hashable, Codable {
+public enum PluginCommandIntent: Hashable {
     case documentationGeneration
     case sourceCodeFormatting
     case custom(verb: String, description: String)
@@ -125,7 +74,7 @@ public enum PluginCommandIntent: Hashable, Codable {
     }
 }
 
-public enum PluginNetworkPermissionScope: Hashable, Codable {
+public enum PluginNetworkPermissionScope: Hashable {
     case none
     case local(ports: [Int])
     case all(ports: [Int])
@@ -161,7 +110,7 @@ public enum PluginNetworkPermissionScope: Hashable, Codable {
     }
 }
 
-public enum PluginPermission: Hashable, Codable {
+public enum PluginPermission: Hashable {
     case allowNetworkConnections(scope: PluginNetworkPermissionScope, reason: String)
     case writeToPackageDirectory(reason: String)
 

--- a/Sources/PackageModel/Target/ProvidedLibraryTarget.swift
+++ b/Sources/PackageModel/Target/ProvidedLibraryTarget.swift
@@ -32,13 +32,4 @@ public final class ProvidedLibraryTarget: Target {
             usesUnsafeFlags: false
         )
     }
-
-
-    public override func encode(to encoder: Encoder) throws {
-        try super.encode(to: encoder)
-    }
-
-    required public init(from decoder: Decoder) throws {
-        try super.init(from: decoder)
-    }
 }

--- a/Sources/PackageModel/Target/SwiftTarget.swift
+++ b/Sources/PackageModel/Target/SwiftTarget.swift
@@ -126,22 +126,6 @@ public final class SwiftTarget: Target {
         )
     }
 
-    private enum CodingKeys: String, CodingKey {
-        case declaredSwiftVersions
-    }
-
-    override public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.declaredSwiftVersions, forKey: .declaredSwiftVersions)
-        try super.encode(to: encoder)
-    }
-
-    public required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.declaredSwiftVersions = try container.decode([SwiftLanguageVersion].self, forKey: .declaredSwiftVersions)
-        try super.init(from: decoder)
-    }
-
     public var supportsTestableExecutablesFeature: Bool {
         // Exclude macros from testable executables if they are built as dylibs.
         #if BUILD_MACROS_AS_DYLIBS

--- a/Sources/PackageModel/Target/SystemLibraryTarget.swift
+++ b/Sources/PackageModel/Target/SystemLibraryTarget.swift
@@ -48,24 +48,4 @@ public final class SystemLibraryTarget: Target {
             usesUnsafeFlags: false
         )
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case pkgConfig, providers, isImplicit
-    }
-
-    public override func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(pkgConfig, forKey: .pkgConfig)
-        try container.encode(providers, forKey: .providers)
-        try container.encode(isImplicit, forKey: .isImplicit)
-        try super.encode(to: encoder)
-    }
-
-    required public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.pkgConfig = try container.decodeIfPresent(String.self, forKey: .pkgConfig)
-        self.providers = try container.decodeIfPresent([SystemPackageProviderDescription].self, forKey: .providers)
-        self.isImplicit = try container.decode(Bool.self, forKey: .isImplicit)
-        try super.init(from: decoder)
-    }
 }

--- a/Sources/PackageModel/Target/Target.swift
+++ b/Sources/PackageModel/Target/Target.swift
@@ -12,20 +12,9 @@
 
 import Basics
 
-import protocol TSCUtility.PolymorphicCodableProtocol
-
-public class Target: PolymorphicCodableProtocol {
-    public static var implementations: [PolymorphicCodableProtocol.Type] = [
-        SwiftTarget.self,
-        ClangTarget.self,
-        SystemLibraryTarget.self,
-        BinaryTarget.self,
-        PluginTarget.self,
-        ProvidedLibraryTarget.self,
-    ]
-
+public class Target {
     /// The target kind.
-    public enum Kind: String, Codable {
+    public enum Kind: String {
         case executable
         case library
         case systemModule = "system-target"
@@ -39,13 +28,13 @@ public class Target: PolymorphicCodableProtocol {
 
     /// A group a target belongs to that allows customizing access boundaries. A target is treated as
     /// a client outside of the package if `excluded`, inside the package boundary if `package`.
-    public enum Group: Codable, Equatable {
+    public enum Group: Equatable {
         case package
         case excluded
     }
 
     /// A reference to a product from a target dependency.
-    public struct ProductReference: Codable {
+    public struct ProductReference {
         /// The name of the product dependency.
         public let name: String
 
@@ -275,71 +264,6 @@ public class Target: PolymorphicCodableProtocol {
         self.buildSettingsDescription = buildSettingsDescription
         self.pluginUsages = pluginUsages
         self.usesUnsafeFlags = usesUnsafeFlags
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case potentialBundleName
-        case defaultLocalization
-        case platforms
-        case type
-        case path
-        case sources
-        case resources
-        case ignored
-        case others
-        case packageAccess
-        case buildSettings
-        case buildSettingsDescription
-        case pluginUsages
-        case usesUnsafeFlags
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
-        // FIXME: dependencies property is skipped on purpose as it points to
-        // the actual target dependency object.
-        try container.encode(name, forKey: .name)
-        try container.encode(potentialBundleName, forKey: .potentialBundleName)
-        try container.encode(type, forKey: .type)
-        try container.encode(path, forKey: .path)
-        try container.encode(sources, forKey: .sources)
-        try container.encode(resources, forKey: .resources)
-        try container.encode(ignored, forKey: .ignored)
-        try container.encode(others, forKey: .others)
-        try container.encode(packageAccess, forKey: .packageAccess)
-        try container.encode(buildSettings, forKey: .buildSettings)
-        try container.encode(buildSettingsDescription, forKey: .buildSettingsDescription)
-        // FIXME: pluginUsages property is skipped on purpose as it points to
-        // the actual target dependency object.
-        try container.encode(usesUnsafeFlags, forKey: .usesUnsafeFlags)
-    }
-
-    required public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.name = try container.decode(String.self, forKey: .name)
-        self.potentialBundleName = try container.decodeIfPresent(String.self, forKey: .potentialBundleName)
-        self.type = try container.decode(Kind.self, forKey: .type)
-        self.path = try container.decode(AbsolutePath.self, forKey: .path)
-        self.sources = try container.decode(Sources.self, forKey: .sources)
-        self.resources = try container.decode([Resource].self, forKey: .resources)
-        self.ignored = try container.decode([AbsolutePath].self, forKey: .ignored)
-        self.others = try container.decode([AbsolutePath].self, forKey: .others)
-        // FIXME: dependencies property is skipped on purpose as it points to
-        // the actual target dependency object.
-        self.dependencies = []
-        self.c99name = self.name.spm_mangledToC99ExtendedIdentifier()
-        self.packageAccess = try container.decode(Bool.self, forKey: .packageAccess)
-        self.buildSettings = try container.decode(BuildSettings.AssignmentTable.self, forKey: .buildSettings)
-        self.buildSettingsDescription = try container.decode(
-            [TargetBuildSettingDescription.Setting].self,
-            forKey: .buildSettingsDescription
-        )
-        // FIXME: pluginUsages property is skipped on purpose as it points to
-        // the actual target dependency object.
-        self.pluginUsages = []
-        self.usesUnsafeFlags = try container.decode(Bool.self, forKey: .usesUnsafeFlags)
     }
 
     @_spi(SwiftPMInternal)


### PR DESCRIPTION
The conformances are unused and pull in an additional `TSCUtility.PolymorphicCodableProtocol` dependency. This change removes about 0.2-0.4 MB from final executables on macOS when comparing with `swift build -c release` to `main`.

Also allows us to rename these types more easily to disambiguate between host/target triples and manifest targets/modules in our code.

If there's an existing user of this JSON manifest serialization we're unaware of, they should rely on `swift package describe --type json` instead, which has stable, consistent, and tested output.