### PR TITLE
[Traits] Integrate traits into module loading

### DIFF
--- a/Fixtures/Traits/Example/Package.swift
+++ b/Fixtures/Traits/Example/Package.swift
@@ -1,0 +1,103 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "TraitsExample",
+    traits: [
+        Trait(name: "Package1", isDefault: true),
+        Trait(name: "Package2", isDefault: true),
+        Trait(name: "Package3", isDefault: true),
+        Trait(name: "Package4", isDefault: true),
+        "Package5",
+        "Package7",
+        "Package9",
+        "Package10",
+        Trait(name: "BuildCondition1", isDefault: true),
+        "BuildCondition2",
+        "BuildCondition3",
+    ],
+    dependencies: [
+        .package(
+            path: "../Package1",
+            traits: ["Package1Trait1"]
+        ),
+        .package(
+            path: "../Package2",
+            traits: ["Package2Trait1"]
+        ),
+        .package(
+            path: "../Package3"
+        ),
+        .package(
+            path: "../Package4",
+            traits: []
+        ),
+        .package(
+            path: "../Package5",
+            traits: ["Package5Trait1"]
+        ),
+        .package(
+            path: "../Package7"
+        ),
+        .package(
+            path: "../Package9"
+        ),
+        .package(
+            path: "../Package10",
+            traits: ["Package10Trait2"]
+        ),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Example",
+            dependencies: [
+                .product(
+                    name: "Package1Library1",
+                    package: "Package1",
+                    condition: .when(traits: ["Package1"])
+                ),
+                .product(
+                    name: "Package2Library1",
+                    package: "Package2",
+                    condition: .when(traits: ["Package2"])
+                ),
+                .product(
+                    name: "Package3Library1",
+                    package: "Package3",
+                    condition: .when(traits: ["Package3"])
+                ),
+                .product(
+                    name: "Package4Library1",
+                    package: "Package4",
+                    condition: .when(traits: ["Package4"])
+                ),
+                .product(
+                    name: "Package5Library1",
+                    package: "Package5",
+                    condition: .when(traits: ["Package5"])
+                ),
+                .product(
+                    name: "Package7Library1",
+                    package: "Package7",
+                    condition: .when(traits: ["Package7"])
+                ),
+                .product(
+                    name: "Package9Library1",
+                    package: "Package9",
+                    condition: .when(traits: ["Package9"])
+                ),
+                .product(
+                    name: "Package10Library1",
+                    package: "Package10",
+                    condition: .when(traits: ["Package10"])
+                ),
+            ],
+            swiftSettings: [
+                .define("DEFINE1", .when(traits: ["BuildCondition1"])),
+                .define("DEFINE2", .when(traits: ["BuildCondition2"])),
+                .define("DEFINE3", .when(traits: ["BuildCondition3"])),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Traits/Example/Sources/Example/Example.swift
+++ b/Fixtures/Traits/Example/Sources/Example/Example.swift
@@ -1,53 +1,53 @@
-#if TRAIT_Package1
+#if Package1
 import Package1Library1
 #endif
-#if TRAIT_Package2
+#if Package2
 import Package2Library1
 #endif
-#if TRAIT_Package3
+#if Package3
 import Package3Library1
 #endif
-#if TRAIT_Package4
+#if Package4
 import Package4Library1
 #endif
-#if TRAIT_Package5
+#if Package5
 import Package5Library1
 #endif
-#if TRAIT_Package7
+#if Package7
 import Package7Library1
 #endif
-#if TRAIT_Package9
+#if Package9
 import Package9Library1
 #endif
-#if TRAIT_Package10
+#if Package10
 import Package10Library1
 #endif
 
 @main
 struct Example {
     static func main() {
-        #if TRAIT_Package1
+        #if Package1
         Package1Library1.hello()
         #endif
-        #if TRAIT_Package2
+        #if Package2
         Package2Library1.hello()
         #endif
-        #if TRAIT_Package3
+        #if Package3
         Package3Library1.hello()
         #endif
-        #if TRAIT_Package4
+        #if Package4
         Package4Library1.hello()
         #endif
-        #if TRAIT_Package5
+        #if Package5
         Package5Library1.hello()
         #endif
-        #if TRAIT_Package7
+        #if Package7
         Package7Library1.hello()
         #endif
-        #if TRAIT_Package9
+        #if Package9
         Package9Library1.hello()
         #endif
-        #if TRAIT_Package10
+        #if Package10
         Package10Library1.hello()
         #endif
         #if DEFINE1

--- a/Fixtures/Traits/Example/Sources/Example/Example.swift
+++ b/Fixtures/Traits/Example/Sources/Example/Example.swift
@@ -1,0 +1,69 @@
+#if TRAIT_Package1
+import Package1Library1
+#endif
+#if TRAIT_Package2
+import Package2Library1
+#endif
+#if TRAIT_Package3
+import Package3Library1
+#endif
+#if TRAIT_Package4
+import Package4Library1
+#endif
+#if TRAIT_Package5
+import Package5Library1
+#endif
+#if TRAIT_Package7
+import Package7Library1
+#endif
+#if TRAIT_Package9
+import Package9Library1
+#endif
+#if TRAIT_Package10
+import Package10Library1
+#endif
+
+@main
+struct Example {
+    static func main() {
+        #if TRAIT_Package1
+        Package1Library1.hello()
+        #endif
+        #if TRAIT_Package2
+        Package2Library1.hello()
+        #endif
+        #if TRAIT_Package3
+        Package3Library1.hello()
+        #endif
+        #if TRAIT_Package4
+        Package4Library1.hello()
+        #endif
+        #if TRAIT_Package5
+        Package5Library1.hello()
+        #endif
+        #if TRAIT_Package7
+        Package7Library1.hello()
+        #endif
+        #if TRAIT_Package9
+        Package9Library1.hello()
+        #endif
+        #if TRAIT_Package10
+        Package10Library1.hello()
+        #endif
+        #if DEFINE1
+        print("DEFINE1 enabled")
+        #else
+        print("DEFINE1 disabled")
+        #endif
+        #if DEFINE2
+        print("DEFINE2 enabled")
+        #else
+        print("DEFINE2 disabled")
+        #endif
+        #if DEFINE3
+        print("DEFINE3 enabled")
+        #else
+        print("DEFINE3 disabled")
+        #endif
+    }
+}

--- a/Fixtures/Traits/Package1/Package.swift
+++ b/Fixtures/Traits/Package1/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package1",
+    products: [
+        .library(
+            name: "Package1Library1",
+            targets: ["Package1Library1"]
+        ),
+    ],
+    traits: [
+        "Package1Trait1"
+    ],
+    targets: [
+        .target(
+            name: "Package1Library1"
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package1/Sources/Package1Library1/Library.swift
+++ b/Fixtures/Traits/Package1/Sources/Package1Library1/Library.swift
@@ -1,0 +1,7 @@
+public func hello() {
+    #if TRAIT_Package1Trait1
+    print("Package1Library1 trait1 enabled")
+    #else
+    print("Package1Library1 trait1 disabled")
+    #endif
+}

--- a/Fixtures/Traits/Package1/Sources/Package1Library1/Library.swift
+++ b/Fixtures/Traits/Package1/Sources/Package1Library1/Library.swift
@@ -1,5 +1,5 @@
 public func hello() {
-    #if TRAIT_Package1Trait1
+    #if Package1Trait1
     print("Package1Library1 trait1 enabled")
     #else
     print("Package1Library1 trait1 disabled")

--- a/Fixtures/Traits/Package10/Package.swift
+++ b/Fixtures/Traits/Package10/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package10",
+    products: [
+        .library(
+            name: "Package10Library1",
+            targets: ["Package10Library1"]
+        ),
+    ],
+    traits: [
+        "Package10Trait1",
+        "Package10Trait2"
+    ],
+    targets: [
+        .target(
+            name: "Package10Library1"
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package10/Sources/Package10Library1/Library.swift
+++ b/Fixtures/Traits/Package10/Sources/Package10Library1/Library.swift
@@ -1,0 +1,12 @@
+public func hello() {
+    #if TRAIT_Package10Trait1
+    print("Package10Library1 trait1 enabled")
+    #else
+    print("Package10Library1 trait1 disabled")
+    #endif
+    #if TRAIT_Package10Trait2
+    print("Package10Library1 trait2 enabled")
+    #else
+    print("Package10Library1 trait2 disabled")
+    #endif
+}

--- a/Fixtures/Traits/Package10/Sources/Package10Library1/Library.swift
+++ b/Fixtures/Traits/Package10/Sources/Package10Library1/Library.swift
@@ -1,10 +1,10 @@
 public func hello() {
-    #if TRAIT_Package10Trait1
+    #if Package10Trait1
     print("Package10Library1 trait1 enabled")
     #else
     print("Package10Library1 trait1 disabled")
     #endif
-    #if TRAIT_Package10Trait2
+    #if Package10Trait2
     print("Package10Library1 trait2 enabled")
     #else
     print("Package10Library1 trait2 disabled")

--- a/Fixtures/Traits/Package2/Package.swift
+++ b/Fixtures/Traits/Package2/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package2",
+    products: [
+        .library(
+            name: "Package2Library1",
+            targets: ["Package2Library1"]
+        ),
+    ],
+    traits: [
+        Trait(name: "Package2Trait1", enabledTraits: ["Package2Trait2"]),
+        "Package2Trait2",
+    ],
+    targets: [
+        .target(
+            name: "Package2Library1"
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package2/Sources/Package2Library1/Library.swift
+++ b/Fixtures/Traits/Package2/Sources/Package2Library1/Library.swift
@@ -1,0 +1,7 @@
+public func hello() {
+    #if TRAIT_Package2Trait2
+    print("Package2Library1 trait2 enabled")
+    #else
+    print("Package2Library1 trait2 disabled")
+    #endif
+}

--- a/Fixtures/Traits/Package2/Sources/Package2Library1/Library.swift
+++ b/Fixtures/Traits/Package2/Sources/Package2Library1/Library.swift
@@ -1,5 +1,5 @@
 public func hello() {
-    #if TRAIT_Package2Trait2
+    #if Package2Trait2
     print("Package2Library1 trait2 enabled")
     #else
     print("Package2Library1 trait2 disabled")

--- a/Fixtures/Traits/Package3/Package.swift
+++ b/Fixtures/Traits/Package3/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package3",
+    products: [
+        .library(
+            name: "Package3Library1",
+            targets: ["Package3Library1"]
+        ),
+    ],
+    traits: [
+        Trait(name: "Package3Trait1", enabledTraits: ["Package3Trait2"]),
+        Trait(name: "Package3Trait2", enabledTraits: ["Package3Trait3"]),
+        Trait(name: "Package3Trait3", isDefault: true),
+    ],
+    targets: [
+        .target(
+            name: "Package3Library1"
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package3/Sources/Package3Library1/Library.swift
+++ b/Fixtures/Traits/Package3/Sources/Package3Library1/Library.swift
@@ -1,5 +1,5 @@
 public func hello() {
-    #if TRAIT_Package3Trait3
+    #if Package3Trait3
     print("Package3Library1 trait3 enabled")
     #else
     print("Package3Library1 trait3 disabled")

--- a/Fixtures/Traits/Package3/Sources/Package3Library1/Library.swift
+++ b/Fixtures/Traits/Package3/Sources/Package3Library1/Library.swift
@@ -1,0 +1,7 @@
+public func hello() {
+    #if TRAIT_Package3Trait3
+    print("Package3Library1 trait3 enabled")
+    #else
+    print("Package3Library1 trait3 disabled")
+    #endif
+}

--- a/Fixtures/Traits/Package4/Package.swift
+++ b/Fixtures/Traits/Package4/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package4",
+    products: [
+        .library(
+            name: "Package4Library1",
+            targets: ["Package4Library1"]
+        ),
+    ],
+    traits: [
+        Trait(name: "Package4Trait1", isDefault: true),
+    ],
+    targets: [
+        .target(
+            name: "Package4Library1"
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package4/Sources/Package4Library1/Library.swift
+++ b/Fixtures/Traits/Package4/Sources/Package4Library1/Library.swift
@@ -1,0 +1,7 @@
+public func hello() {
+    #if TRAIT_Package4Trait1
+    print("Package4Library1 trait1 enabled")
+    #else
+    print("Package4Library1 trait1 disabled")
+    #endif
+}

--- a/Fixtures/Traits/Package4/Sources/Package4Library1/Library.swift
+++ b/Fixtures/Traits/Package4/Sources/Package4Library1/Library.swift
@@ -1,5 +1,5 @@
 public func hello() {
-    #if TRAIT_Package4Trait1
+    #if Package4Trait1
     print("Package4Library1 trait1 enabled")
     #else
     print("Package4Library1 trait1 disabled")

--- a/Fixtures/Traits/Package5/Package.swift
+++ b/Fixtures/Traits/Package5/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package5",
+    products: [
+        .library(
+            name: "Package5Library1",
+            targets: ["Package5Library1"]
+        ),
+    ],
+    traits: [
+        "Package5Trait1"
+    ],
+    dependencies: [
+        .package(
+            path: "../Package6",
+            traits: [
+                Package.Dependency.Trait(name: "Package6Trait1", condition: .when(traits: ["Package5Trait1"]))
+            ]
+        )
+    ],
+    targets: [
+        .target(
+            name: "Package5Library1",
+            dependencies: [
+                .product(
+                    name: "Package6Library1",
+                    package: "Package6"
+                )
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package5/Sources/Package5Library1/Library.swift
+++ b/Fixtures/Traits/Package5/Sources/Package5Library1/Library.swift
@@ -1,0 +1,12 @@
+#if TRAIT_Package5Trait1
+import Package6Library1
+#endif
+
+public func hello() {
+    #if TRAIT_Package5Trait1
+    print("Package5Library1 trait1 enabled")
+    Package6Library1.hello()
+    #else
+    print("Package5Library1 trait1 disabled")
+    #endif
+}

--- a/Fixtures/Traits/Package5/Sources/Package5Library1/Library.swift
+++ b/Fixtures/Traits/Package5/Sources/Package5Library1/Library.swift
@@ -1,9 +1,9 @@
-#if TRAIT_Package5Trait1
+#if Package5Trait1
 import Package6Library1
 #endif
 
 public func hello() {
-    #if TRAIT_Package5Trait1
+    #if Package5Trait1
     print("Package5Library1 trait1 enabled")
     Package6Library1.hello()
     #else

--- a/Fixtures/Traits/Package6/Package.swift
+++ b/Fixtures/Traits/Package6/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package6",
+    products: [
+        .library(
+            name: "Package6Library1",
+            targets: ["Package6Library1"]
+        ),
+    ],
+    traits: [
+        "Package6Trait1"
+    ],
+    targets: [
+        .target(
+            name: "Package6Library1"
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package6/Sources/Package6Library1/Library.swift
+++ b/Fixtures/Traits/Package6/Sources/Package6Library1/Library.swift
@@ -1,0 +1,7 @@
+public func hello() {
+    #if TRAIT_Package6Trait1
+    print("Package6Library1 trait1 enabled")
+    #else
+    print("Package6Library1 trait1 disabled")
+    #endif
+}

--- a/Fixtures/Traits/Package6/Sources/Package6Library1/Library.swift
+++ b/Fixtures/Traits/Package6/Sources/Package6Library1/Library.swift
@@ -1,5 +1,5 @@
 public func hello() {
-    #if TRAIT_Package6Trait1
+    #if Package6Trait1
     print("Package6Library1 trait1 enabled")
     #else
     print("Package6Library1 trait1 disabled")

--- a/Fixtures/Traits/Package7/Package.swift
+++ b/Fixtures/Traits/Package7/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package7",
+    products: [
+        .library(
+            name: "Package7Library1",
+            targets: ["Package7Library1"]
+        ),
+    ],
+    traits: [
+        "Package7Trait1"
+    ],
+    dependencies: [
+        .package(
+            path: "../Package8"
+        )
+    ],
+    targets: [
+        .target(
+            name: "Package7Library1",
+            dependencies: [
+                .product(
+                    name: "Package8Library1",
+                    package: "Package8",
+                    condition: .when(traits: ["Package7Trait1"])
+                )
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package7/Sources/Package7Library1/Library.swift
+++ b/Fixtures/Traits/Package7/Sources/Package7Library1/Library.swift
@@ -1,9 +1,9 @@
-#if TRAIT_Package7Trait1
+#if Package7Trait1
 import Package8Library1
 #endif
 
 public func hello() {
-    #if TRAIT_Package7Trait1
+    #if Package7Trait1
     print("Package7Library1 trait1 enabled")
     Package8Library1.hello()
     #else

--- a/Fixtures/Traits/Package7/Sources/Package7Library1/Library.swift
+++ b/Fixtures/Traits/Package7/Sources/Package7Library1/Library.swift
@@ -1,0 +1,12 @@
+#if TRAIT_Package7Trait1
+import Package8Library1
+#endif
+
+public func hello() {
+    #if TRAIT_Package7Trait1
+    print("Package7Library1 trait1 enabled")
+    Package8Library1.hello()
+    #else
+    print("Package7Library1 trait1 disabled")
+    #endif
+}

--- a/Fixtures/Traits/Package8/Package.swift
+++ b/Fixtures/Traits/Package8/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package8",
+    products: [
+        .library(
+            name: "Package8Library1",
+            targets: ["Package8Library1"]
+        ),
+    ],
+    traits: [
+        "Package8Trait1"
+    ],
+    targets: [
+        .target(
+            name: "Package8Library1"
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package8/Sources/Package6Library1/Library.swift
+++ b/Fixtures/Traits/Package8/Sources/Package6Library1/Library.swift
@@ -1,5 +1,5 @@
 public func hello() {
-    #if TRAIT_Package8Trait1
+    #if Package8Trait1
     print("Package8Library1 trait1 enabled")
     #else
     print("Package8Library1 trait1 disabled")

--- a/Fixtures/Traits/Package8/Sources/Package6Library1/Library.swift
+++ b/Fixtures/Traits/Package8/Sources/Package6Library1/Library.swift
@@ -1,0 +1,7 @@
+public func hello() {
+    #if TRAIT_Package8Trait1
+    print("Package8Library1 trait1 enabled")
+    #else
+    print("Package8Library1 trait1 disabled")
+    #endif
+}

--- a/Fixtures/Traits/Package9/Package.swift
+++ b/Fixtures/Traits/Package9/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 999.0.0
+
+@_spi(ExperimentalTraits) import PackageDescription
+
+let package = Package(
+    name: "Package9",
+    products: [
+        .library(
+            name: "Package9Library1",
+            targets: ["Package9Library1"]
+        ),
+    ],
+    dependencies: [
+        .package(
+            path: "../Package10",
+            traits: ["Package10Trait1"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "Package9Library1",
+            dependencies: [
+                .product(
+                    name: "Package10Library1",
+                    package: "Package10"
+                )
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Traits/Package9/Sources/Package9Library1/Library.swift
+++ b/Fixtures/Traits/Package9/Sources/Package9Library1/Library.swift
@@ -1,0 +1,5 @@
+import Package10Library1
+
+public func hello() {
+    Package10Library1.hello()
+}

--- a/Sources/PackageDescription/PackageDependency.swift
+++ b/Sources/PackageDescription/PackageDependency.swift
@@ -53,7 +53,7 @@ extension Package {
         /// The dependencies traits configuration.
         @_spi(ExperimentalTraits)
         @available(_PackageDescription, introduced: 999.0)
-        public let traits: Set<Trait>?
+        public let traits: Set<Trait>
 
         /// The name of the dependency.
         ///
@@ -145,7 +145,7 @@ extension Package {
 
         init(kind: Kind, traits: Set<Trait>?) {
             self.kind = kind
-            self.traits = traits
+            self.traits = traits ?? [.defaults]
         }
 
         convenience init(

--- a/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -172,7 +172,7 @@ extension Serialization.PackageDependency {
     init(_ dependency: PackageDescription.Package.Dependency) {
         self.kind = .init(dependency.kind)
         self.moduleAliases = dependency.moduleAliases
-        self.traits = Set(dependency.traits?.map { Serialization.PackageDependency.Trait.init($0) } ?? [])
+        self.traits = Set(dependency.traits.map { Serialization.PackageDependency.Trait.init($0) })
     }
 }
 

--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -29,10 +29,58 @@ public struct GraphLoadingNode: Equatable, Hashable {
     /// The product filter applied to the package.
     public let productFilter: ProductFilter
 
-    public init(identity: PackageIdentity, manifest: Manifest, productFilter: ProductFilter) {
+    /// The enabled traits for this package.
+    public var enabledTraits: Set<String>
+
+    public init(
+        identity: PackageIdentity,
+        manifest: Manifest,
+        productFilter: ProductFilter,
+        enabledTraits: Set<String>?
+    ) throws {
         self.identity = identity
         self.manifest = manifest
         self.productFilter = productFilter
+
+        // We are going to calculate which traits are actually enabled for a node here. To do this
+        // we have to check if default traits should be used and then flatten all the enabled traits.
+        for trait in enabledTraits ?? [] {
+            if trait == "defaults" {
+                // The defaults trait is special and every package has it
+                continue
+            }
+            // Check if the enabled trait is a valid trait
+            if self.manifest.traits.first(where: { $0.name == trait }) == nil {
+                // The enabled trait is invalid
+                throw ModuleError.invalidTrait(package: identity, trait: trait)
+            }
+        }
+
+        // This the point where we flatten the enabled traits and resolve the recursive traits
+        var recursiveEnabledTraits = enabledTraits ?? []
+
+        // We have to enable all default traits if no traits are enabled or the defaults are explicitly enabled
+        let areDefaultsEnabled = enabledTraits?.contains("defaults") ?? false
+        if enabledTraits == nil || areDefaultsEnabled {
+            recursiveEnabledTraits.formUnion(self.manifest.traits.lazy.filter { $0.isDefault }.map { $0.name })
+        }
+
+        while true {
+            let flattendEnabledTraits = Set(self.manifest.traits
+                .lazy
+                .filter { recursiveEnabledTraits.contains($0.name) }
+                .map { $0.enabledTraits }
+                .joined()
+            )
+            let newRecursiveEnabledTraits = recursiveEnabledTraits.union(flattendEnabledTraits)
+            if newRecursiveEnabledTraits.count == recursiveEnabledTraits.count {
+                break
+            } else {
+                recursiveEnabledTraits = newRecursiveEnabledTraits
+            }
+        }
+
+        self.enabledTraits = recursiveEnabledTraits
     }
 
     /// Returns the dependencies required by this node.
@@ -50,8 +98,4 @@ extension GraphLoadingNode: CustomStringConvertible {
             return "\(self.identity.description)[\(set.sorted().joined(separator: ", "))]"
         }
     }
-}
-
-extension GraphLoadingNode: Identifiable {
-    public var id: PackageIdentity { self.identity }
 }

--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -42,13 +42,13 @@ public struct GraphLoadingNode: Equatable, Hashable {
         self.manifest = manifest
         self.productFilter = productFilter
 
+        // This the point where we flatten the enabled traits and resolve the recursive traits
+        var recursiveEnabledTraits = enabledTraits ?? []
+        let areDefaultsEnabled = recursiveEnabledTraits.remove("defaults") != nil
+
         // We are going to calculate which traits are actually enabled for a node here. To do this
         // we have to check if default traits should be used and then flatten all the enabled traits.
-        for trait in enabledTraits ?? [] {
-            if trait == "defaults" {
-                // The defaults trait is special and every package has it
-                continue
-            }
+        for trait in recursiveEnabledTraits {
             // Check if the enabled trait is a valid trait
             if self.manifest.traits.first(where: { $0.name == trait }) == nil {
                 // The enabled trait is invalid
@@ -56,11 +56,7 @@ public struct GraphLoadingNode: Equatable, Hashable {
             }
         }
 
-        // This the point where we flatten the enabled traits and resolve the recursive traits
-        var recursiveEnabledTraits = enabledTraits ?? []
-
         // We have to enable all default traits if no traits are enabled or the defaults are explicitly enabled
-        let areDefaultsEnabled = enabledTraits?.contains("defaults") ?? false
         if enabledTraits == nil || areDefaultsEnabled {
             recursiveEnabledTraits.formUnion(self.manifest.traits.lazy.filter { $0.isDefault }.map { $0.name })
         }

--- a/Sources/PackageGraph/GraphLoadingNode.swift
+++ b/Sources/PackageGraph/GraphLoadingNode.swift
@@ -30,7 +30,7 @@ public struct GraphLoadingNode: Equatable, Hashable {
     public let productFilter: ProductFilter
 
     /// The enabled traits for this package.
-    public var enabledTraits: Set<String>
+    package var enabledTraits: Set<String>
 
     public init(
         identity: PackageIdentity,

--- a/Sources/PackageGraph/Resolution/ResolvedPackage.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedPackage.swift
@@ -40,7 +40,7 @@ public struct ResolvedPackage {
     public let products: [ResolvedProduct]
 
     /// The enabled traits of this package.
-    public let enabledTraits: Set<String>
+    package let enabledTraits: Set<String>
 
     /// The dependencies of the package.
     public let dependencies: [PackageIdentity]

--- a/Sources/PackageGraph/Resolution/ResolvedPackage.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedPackage.swift
@@ -39,6 +39,9 @@ public struct ResolvedPackage {
     /// The products produced by the package.
     public let products: [ResolvedProduct]
 
+    /// The enabled traits of this package.
+    public let enabledTraits: Set<String>
+
     /// The dependencies of the package.
     public let dependencies: [PackageIdentity]
 
@@ -58,6 +61,7 @@ public struct ResolvedPackage {
         defaultLocalization: String?,
         supportedPlatforms: [SupportedPlatform],
         dependencies: [PackageIdentity],
+        enabledTraits: Set<String>,
         targets: IdentifiableSet<ResolvedModule>,
         products: [ResolvedProduct],
         registryMetadata: RegistryReleaseMetadata?,
@@ -71,6 +75,7 @@ public struct ResolvedPackage {
         self.supportedPlatforms = supportedPlatforms
         self.registryMetadata = registryMetadata
         self.platformVersionProvider = platformVersionProvider
+        self.enabledTraits = enabledTraits
     }
 
     public func getSupportedPlatform(for platform: Platform, usingXCTest: Bool) -> SupportedPlatform {

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -638,7 +638,7 @@ extension MappablePackageDependency {
                     path: path
                 ),
                 productFilter: .everything,
-                traits: Set(seed.traits?.map { PackageDependency.Trait.init($0) } ?? [])
+                traits: seed.traits.flatMap { Set($0.map { PackageDependency.Trait.init($0) } ) }
             )
         case .sourceControl(let name, let location, let requirement):
             self.init(
@@ -649,7 +649,7 @@ extension MappablePackageDependency {
                     requirement: .init(requirement)
                 ),
                 productFilter: .everything,
-                traits: Set(seed.traits?.map { PackageDependency.Trait.init($0) } ?? [])
+                traits: seed.traits.flatMap { Set($0.map { PackageDependency.Trait.init($0) } ) }
             )
         case .registry(let id, let requirement):
             self.init(
@@ -659,7 +659,7 @@ extension MappablePackageDependency {
                     requirement: .init(requirement)
                 ),
                 productFilter: .everything,
-                traits: Set(seed.traits?.map { PackageDependency.Trait.init($0) } ?? [])
+                traits: seed.traits.flatMap { Set($0.map { PackageDependency.Trait.init($0) } ) }
             )
         }
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -177,7 +177,7 @@ extension ModuleError: CustomStringConvertible {
             """
         case .invalidTrait(let package, let trait):
             return """
-            Tried to enable invalid trait "\(trait)" for package \(package)
+            Trait '"\(trait)"' is not declared by package '\(package)'.
             """
         }
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -91,6 +91,12 @@ public enum ModuleError: Swift.Error {
         scmPackage: PackageIdentity,
         targets: [String]
     )
+
+    /// Indicates that an invalid trait was enabled.
+    case invalidTrait(
+        package: PackageIdentity,
+        trait: String
+    )
 }
 
 extension ModuleError: CustomStringConvertible {
@@ -168,6 +174,10 @@ extension ModuleError: CustomStringConvertible {
             this may indicate that the two packages are the same and can be de-duplicated \
             by activating the automatic source-control to registry replacement, or by using mirrors. \
             if they are not duplicate consider using the `moduleAliases` parameter in manifest to provide unique names
+            """
+        case .invalidTrait(let package, let trait):
+            return """
+            Tried to enable invalid trait "\(trait)" for package \(package)
             """
         }
     }
@@ -321,6 +331,9 @@ public final class PackageBuilder {
     // Caches the version we chose to build for.
     private var swiftVersionCache: SwiftLanguageVersion? = nil
 
+    /// The enabled traits of this package.
+    private let enabledTraits: Set<String>
+
     /// Create a builder for the given manifest and package `path`.
     ///
     /// - Parameters:
@@ -343,7 +356,8 @@ public final class PackageBuilder {
         warnAboutImplicitExecutableTargets: Bool = true,
         createREPLProduct: Bool = false,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
+        enabledTraits: Set<String>
     ) {
         self.identity = identity
         self.manifest = manifest
@@ -360,6 +374,7 @@ public final class PackageBuilder {
             metadata: .packageMetadata(identity: self.identity, kind: self.manifest.packageKind)
         )
         self.fileSystem = fileSystem
+        self.enabledTraits = enabledTraits
     }
 
     /// Build a new package following the conventions.
@@ -1069,6 +1084,11 @@ public final class PackageBuilder {
 
         // Process each setting.
         for setting in target.settings {
+            if let traits = setting.condition?.traits, traits.intersection(self.enabledTraits).isEmpty {
+                // The setting is currently not enabled so we should skip it
+                continue
+            }
+        
             let decl: BuildSettings.Declaration
             let values: [String]
 
@@ -1198,6 +1218,14 @@ public final class PackageBuilder {
             table.add(assignment, for: decl)
         }
 
+        // For each trait we are now generating an additional define
+        for trait in self.enabledTraits {
+            var assignment = BuildSettings.Assignment()
+            assignment.values = ["\(trait)"]
+            assignment.conditions = []
+            table.add(assignment, for: .SWIFT_ACTIVE_COMPILATION_CONDITIONS)
+        }
+
         return table
     }
 
@@ -1216,6 +1244,10 @@ public final class PackageBuilder {
             }
         }), !platforms.isEmpty {
             conditions.append(.init(platforms: platforms))
+        }
+
+        if let traits = condition?.traits {
+            conditions.append(.traits(.init(traits: traits)))
         }
 
         return conditions

--- a/Sources/PackageModel/DependencyMapper.swift
+++ b/Sources/PackageModel/DependencyMapper.swift
@@ -133,9 +133,9 @@ public struct MappablePackageDependency {
     public let parentPackagePath: AbsolutePath
     public let kind: Kind
     public let productFilter: ProductFilter
-    public let traits: Set<PackageDependency.Trait>?
+    package let traits: Set<PackageDependency.Trait>?
 
-    public init(
+    package init(
         parentPackagePath: AbsolutePath,
         kind: Kind,
         productFilter: ProductFilter,
@@ -145,6 +145,19 @@ public struct MappablePackageDependency {
         self.kind = kind
         self.productFilter = productFilter
         self.traits = traits
+    }
+
+    public init(
+        parentPackagePath: AbsolutePath,
+        kind: Kind,
+        productFilter: ProductFilter
+    ) {
+        self.init(
+            parentPackagePath: parentPackagePath,
+            kind: kind,
+            productFilter: productFilter,
+            traits: nil
+        )
     }
 
     public enum Kind {

--- a/Sources/PackageModel/DependencyMapper.swift
+++ b/Sources/PackageModel/DependencyMapper.swift
@@ -133,13 +133,13 @@ public struct MappablePackageDependency {
     public let parentPackagePath: AbsolutePath
     public let kind: Kind
     public let productFilter: ProductFilter
-    public let traits: Set<PackageDependency.Trait>
+    public let traits: Set<PackageDependency.Trait>?
 
     public init(
         parentPackagePath: AbsolutePath,
         kind: Kind,
         productFilter: ProductFilter,
-        traits: Set<PackageDependency.Trait>
+        traits: Set<PackageDependency.Trait>?
     ) {
         self.parentPackagePath = parentPackagePath
         self.kind = kind

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -24,7 +24,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         /// A condition that limits the application of a dependencies trait.
         public struct Condition: Hashable, Sendable, Codable {
             /// The set of traits of this package that enable the dependencie's trait.
-            let traits: Set<String>?
+            public let traits: Set<String>?
 
             public init(traits: Set<String>?) {
                 self.traits = traits
@@ -79,7 +79,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         public let nameForTargetDependencyResolutionOnly: String?
         public let path: AbsolutePath
         public let productFilter: ProductFilter
-        public let traits: Set<Trait>
+        public let traits: Set<Trait>?
     }
 
     public struct SourceControl: Equatable, Hashable, Encodable, Sendable {
@@ -88,7 +88,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         public let location: Location
         public let requirement: Requirement
         public let productFilter: ProductFilter
-        public let traits: Set<Trait>
+        public let traits: Set<Trait>?
 
         public enum Requirement: Equatable, Hashable, Sendable {
             case exact(Version)
@@ -107,7 +107,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         public let identity: PackageIdentity
         public let requirement: Requirement
         public let productFilter: ProductFilter
-        public let traits: Set<Trait>
+        public let traits: Set<Trait>?
 
         /// The dependency requirement.
         public enum Requirement: Equatable, Hashable, Sendable {
@@ -116,7 +116,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         }
     }
 
-    public var traits: Set<Trait> {
+    public var traits: Set<Trait>? {
         switch self {
         case .fileSystem(let settings):
             return settings.traits
@@ -214,7 +214,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         nameForTargetDependencyResolutionOnly: String?,
         path: AbsolutePath,
         productFilter: ProductFilter,
-        traits: Set<Trait>
+        traits: Set<Trait>?
     ) -> Self {
         .fileSystem(
             .init(
@@ -233,7 +233,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         path: AbsolutePath,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter,
-        traits: Set<Trait>
+        traits: Set<Trait>?
     ) -> Self {
         .sourceControl(
             identity: identity,
@@ -251,7 +251,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         url: SourceControlURL,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter,
-        traits: Set<Trait>
+        traits: Set<Trait>?
     ) -> Self {
         .sourceControl(
             identity: identity,
@@ -269,7 +269,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         location: SourceControl.Location,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter,
-        traits: Set<Trait>
+        traits: Set<Trait>?
     ) -> Self {
         .sourceControl(
             .init(
@@ -287,7 +287,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         identity: PackageIdentity,
         requirement: Registry.Requirement,
         productFilter: ProductFilter,
-        traits: Set<Trait>
+        traits: Set<Trait>?
     ) -> Self {
         .registry(
             .init(

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -20,11 +20,11 @@ import struct TSCUtility.Version
 /// Represents a package dependency.
 public enum PackageDependency: Equatable, Hashable, Sendable {
     /// A struct representing an enabled trait of a dependency.
-    public struct Trait: Hashable, Sendable, Codable, ExpressibleByStringLiteral {
+    package struct Trait: Hashable, Sendable, Codable, ExpressibleByStringLiteral {
         /// A condition that limits the application of a dependencies trait.
-        public struct Condition: Hashable, Sendable, Codable {
+        package struct Condition: Hashable, Sendable, Codable {
             /// The set of traits of this package that enable the dependencie's trait.
-            public let traits: Set<String>?
+            package let traits: Set<String>?
 
             public init(traits: Set<String>?) {
                 self.traits = traits
@@ -32,17 +32,17 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         }
 
         /// The name of the enabled trait.
-        public var name: String
+        package var name: String
 
         /// The condition under which the trait is enabled.
-        public var condition: Condition?
+        package var condition: Condition?
 
         /// Initializes a new enabled trait.
         ///
         /// - Parameters:
         ///   - name: The name of the enabled trait.
         ///   - condition: The condition under which the trait is enabled.
-        public init(
+        package init(
             name: String,
             condition: Condition? = nil
         ) {
@@ -59,7 +59,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         /// - Parameters:
         ///   - name: The name of the enabled trait.
         ///   - condition: The condition under which the trait is enabled.
-        public static func trait(
+        package static func trait(
             name: String,
             condition: Condition? = nil
         ) -> Trait {
@@ -79,7 +79,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         public let nameForTargetDependencyResolutionOnly: String?
         public let path: AbsolutePath
         public let productFilter: ProductFilter
-        public let traits: Set<Trait>?
+        package let traits: Set<Trait>?
     }
 
     public struct SourceControl: Equatable, Hashable, Encodable, Sendable {
@@ -88,7 +88,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         public let location: Location
         public let requirement: Requirement
         public let productFilter: ProductFilter
-        public let traits: Set<Trait>?
+        package let traits: Set<Trait>?
 
         public enum Requirement: Equatable, Hashable, Sendable {
             case exact(Version)
@@ -107,7 +107,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         public let identity: PackageIdentity
         public let requirement: Requirement
         public let productFilter: ProductFilter
-        public let traits: Set<Trait>?
+        package let traits: Set<Trait>?
 
         /// The dependency requirement.
         public enum Requirement: Equatable, Hashable, Sendable {
@@ -116,7 +116,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         }
     }
 
-    public var traits: Set<Trait>? {
+    package var traits: Set<Trait>? {
         switch self {
         case .fileSystem(let settings):
             return settings.traits
@@ -213,6 +213,21 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         identity: PackageIdentity,
         nameForTargetDependencyResolutionOnly: String?,
         path: AbsolutePath,
+        productFilter: ProductFilter
+    ) -> Self {
+        .fileSystem(
+            identity: identity,
+            nameForTargetDependencyResolutionOnly: nameForTargetDependencyResolutionOnly,
+            path: path,
+            productFilter: productFilter,
+            traits: nil
+        )
+    }
+
+    package static func fileSystem(
+        identity: PackageIdentity,
+        nameForTargetDependencyResolutionOnly: String?,
+        path: AbsolutePath,
         productFilter: ProductFilter,
         traits: Set<Trait>?
     ) -> Self {
@@ -228,6 +243,23 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
     }
 
     public static func localSourceControl(
+        identity: PackageIdentity,
+        nameForTargetDependencyResolutionOnly: String?,
+        path: AbsolutePath,
+        requirement: SourceControl.Requirement,
+        productFilter: ProductFilter
+    ) -> Self {
+        .localSourceControl(
+            identity: identity,
+            nameForTargetDependencyResolutionOnly: nameForTargetDependencyResolutionOnly,
+            path: path,
+            requirement: requirement,
+            productFilter: productFilter,
+            traits: nil
+        )
+    }
+
+    package static func localSourceControl(
         identity: PackageIdentity,
         nameForTargetDependencyResolutionOnly: String?,
         path: AbsolutePath,
@@ -250,6 +282,23 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         nameForTargetDependencyResolutionOnly: String?,
         url: SourceControlURL,
         requirement: SourceControl.Requirement,
+        productFilter: ProductFilter
+    ) -> Self {
+        .remoteSourceControl(
+            identity: identity,
+            nameForTargetDependencyResolutionOnly: nameForTargetDependencyResolutionOnly,
+            url: url,
+            requirement: requirement,
+            productFilter: productFilter,
+            traits: nil
+        )
+    }
+
+    package static func remoteSourceControl(
+        identity: PackageIdentity,
+        nameForTargetDependencyResolutionOnly: String?,
+        url: SourceControlURL,
+        requirement: SourceControl.Requirement,
         productFilter: ProductFilter,
         traits: Set<Trait>?
     ) -> Self {
@@ -264,6 +313,23 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
     }
 
     public static func sourceControl(
+        identity: PackageIdentity,
+        nameForTargetDependencyResolutionOnly: String?,
+        location: SourceControl.Location,
+        requirement: SourceControl.Requirement,
+        productFilter: ProductFilter
+    ) -> Self {
+        .sourceControl(
+            identity: identity,
+            nameForTargetDependencyResolutionOnly: nameForTargetDependencyResolutionOnly,
+            location: location,
+            requirement: requirement,
+            productFilter: productFilter,
+            traits: nil
+        )
+    }
+
+    package static func sourceControl(
         identity: PackageIdentity,
         nameForTargetDependencyResolutionOnly: String?,
         location: SourceControl.Location,
@@ -284,6 +350,19 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
     }
 
     public static func registry(
+        identity: PackageIdentity,
+        requirement: Registry.Requirement,
+        productFilter: ProductFilter
+    ) -> Self {
+        .registry(
+            identity: identity,
+            requirement: requirement,
+            productFilter: productFilter,
+            traits: nil
+        )
+    }
+
+    package static func registry(
         identity: PackageIdentity,
         requirement: Registry.Requirement,
         productFilter: ProductFilter,

--- a/Sources/SPMTestSupport/ManifestExtensions.swift
+++ b/Sources/SPMTestSupport/ManifestExtensions.swift
@@ -31,7 +31,8 @@ extension Manifest {
         swiftLanguageVersions: [SwiftLanguageVersion]? = nil,
         dependencies: [PackageDependency] = [],
         products: [ProductDescription] = [],
-        targets: [TargetDescription] = []
+        targets: [TargetDescription] = [],
+        traits: Set<TraitDescription> = []
     ) -> Manifest {
         Self.createManifest(
             displayName: displayName,
@@ -49,7 +50,8 @@ extension Manifest {
             swiftLanguageVersions: swiftLanguageVersions,
             dependencies: dependencies,
             products: products,
-            targets: targets
+            targets: targets,
+            traits: traits
         )
     }
 
@@ -67,7 +69,8 @@ extension Manifest {
         swiftLanguageVersions: [SwiftLanguageVersion]? = nil,
         dependencies: [PackageDependency] = [],
         products: [ProductDescription] = [],
-        targets: [TargetDescription] = []
+        targets: [TargetDescription] = [],
+        traits: Set<TraitDescription> = []
     ) -> Manifest {
         Self.createManifest(
             displayName: displayName,
@@ -85,7 +88,8 @@ extension Manifest {
             swiftLanguageVersions: swiftLanguageVersions,
             dependencies: dependencies,
             products: products,
-            targets: targets
+            targets: targets,
+            traits: traits
         )
     }
 

--- a/Sources/SPMTestSupport/MockDependency.swift
+++ b/Sources/SPMTestSupport/MockDependency.swift
@@ -22,7 +22,7 @@ public struct MockDependency {
     public let deprecatedName: String?
     public let location: Location
     public let products: ProductFilter
-    public let traits: Set<PackageDependency.Trait>
+    package let traits: Set<PackageDependency.Trait>
 
     init(
         deprecatedName: String? = nil,

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -22,6 +22,7 @@ public struct MockPackage {
     public let products: [MockProduct]
     public let dependencies: [MockDependency]
     public let versions: [String?]
+    package let traits: Set<TraitDescription>
     /// Provides revision identifier for the given version. A random identifier might be assigned if this is nil.
     public let revisionProvider: ((String) -> String)?
     // FIXME: This should be per-version.
@@ -34,6 +35,7 @@ public struct MockPackage {
         targets: [MockTarget],
         products: [MockProduct] = [],
         dependencies: [MockDependency] = [],
+        traits: Set<TraitDescription> = [],
         versions: [String?] = [],
         revisionProvider: ((String) -> String)? = nil,
         toolsVersion: ToolsVersion? = nil
@@ -45,6 +47,7 @@ public struct MockPackage {
         self.targets = targets
         self.products = products
         self.dependencies = dependencies
+        self.traits = traits
         self.versions = versions
         self.revisionProvider = revisionProvider
         self.toolsVersion = toolsVersion
@@ -57,6 +60,7 @@ public struct MockPackage {
         targets: [MockTarget],
         products: [MockProduct],
         dependencies: [MockDependency] = [],
+        traits: Set<TraitDescription> = [],
         versions: [String?] = [],
         revisionProvider: ((String) -> String)? = nil,
         toolsVersion: ToolsVersion? = nil
@@ -67,6 +71,7 @@ public struct MockPackage {
         self.targets = targets
         self.products = products
         self.dependencies = dependencies
+        self.traits = traits
         self.versions = versions
         self.revisionProvider = revisionProvider
         self.toolsVersion = toolsVersion
@@ -81,6 +86,7 @@ public struct MockPackage {
         targets: [MockTarget],
         products: [MockProduct],
         dependencies: [MockDependency] = [],
+        traits: Set<TraitDescription> = [],
         versions: [String?] = [],
         revisionProvider: ((String) -> String)? = nil,
         toolsVersion: ToolsVersion? = nil
@@ -95,6 +101,7 @@ public struct MockPackage {
         self.targets = targets
         self.products = products
         self.dependencies = dependencies
+        self.traits = traits
         self.versions = versions
         self.revisionProvider = revisionProvider
         self.toolsVersion = toolsVersion

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -265,7 +265,8 @@ public final class MockWorkspace {
                     toolsVersion: packageToolsVersion,
                     dependencies: package.dependencies.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) },
                     products: package.products.map { try ProductDescription(name: $0.name, type: .library(.automatic), targets: $0.targets) },
-                    targets: try package.targets.map { try $0.convert(identityResolver: self.identityResolver) }
+                    targets: try package.targets.map { try $0.convert(identityResolver: self.identityResolver) },
+                    traits: package.traits
                 )
             }
 

--- a/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -16,7 +16,7 @@ import PackageModel
 
 import struct TSCUtility.Version
 
-public extension PackageDependency {
+package extension PackageDependency {
     static func fileSystem(
         identity: PackageIdentity? = nil,
         deprecatedName: String? = nil,

--- a/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/SPMTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -22,7 +22,7 @@ public extension PackageDependency {
         deprecatedName: String? = nil,
         path: AbsolutePath,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = []
+        traits: Set<Trait> = [.init(name: "defaults")]
     ) -> Self {
         let identity = identity ?? PackageIdentity(path: path)
         return .fileSystem(
@@ -40,7 +40,7 @@ public extension PackageDependency {
         path: AbsolutePath,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = []
+        traits: Set<Trait> = [.init(name: "defaults")]
     ) -> Self {
         let identity = identity ?? PackageIdentity(path: path)
         return .localSourceControl(
@@ -59,7 +59,7 @@ public extension PackageDependency {
         url: SourceControlURL,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = []
+        traits: Set<Trait> = [.init(name: "defaults")]
     ) -> Self {
         let identity = identity ?? PackageIdentity(url: url)
         return .remoteSourceControl(
@@ -76,7 +76,7 @@ public extension PackageDependency {
         identity: String,
         requirement: Registry.Requirement,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = []
+        traits: Set<Trait> = [.init(name: "defaults")]
     ) -> Self {
         return .registry(
             identity: .plain(identity),

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -127,6 +127,18 @@ public final class PackageGraphResult {
         body(ResolvedProductResult(product))
     }
 
+    package func checkPackage(
+        _ name: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        body: (ResolvedPackage) -> Void
+    ) {
+        guard let package = find(package: .init(stringLiteral: name)) else {
+            return XCTFail("Product \(name) not found", file: file, line: line)
+        }
+        body(package)
+    }
+
     public func check(testModules: String..., file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(
             graph.allTargets
@@ -217,6 +229,19 @@ public final class ResolvedTargetResult {
         XCTAssertEqual(platform.options, options, file: file, line: line)
     }
 
+    package func checkBuildSetting(
+        declaration: BuildSettings.Declaration,
+        assignments: Set<BuildSettings.Assignment>?,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            target.underlying.buildSettings.assignments[declaration].flatMap { Set($0) },
+            assignments,
+            file: file,
+            line: line
+        )
+    }
     public func check(buildTriple: BuildTriple, file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(self.target.buildTriple, buildTriple, file: file, line: line)
     }

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1108,7 +1108,9 @@ extension Workspace {
                     additionalFileRules: [],
                     binaryArtifacts: binaryArtifacts,
                     fileSystem: self.fileSystem,
-                    observabilityScope: observabilityScope
+                    observabilityScope: observabilityScope,
+                    // For now we enable all traits
+                    enabledTraits: Set(manifest.traits.map { $0.name })
                 )
                 return try builder.construct()
             }
@@ -1188,7 +1190,9 @@ extension Workspace {
                     shouldCreateMultipleTestProducts: self.configuration.shouldCreateMultipleTestProducts,
                     createREPLProduct: self.configuration.createREPLProduct,
                     fileSystem: self.fileSystem,
-                    observabilityScope: observabilityScope
+                    observabilityScope: observabilityScope,
+                    // For now we enable all traits
+                    enabledTraits: Set(manifest.traits.map { $0.name })
                 )
                 return try builder.construct()
             }

--- a/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
@@ -106,6 +106,7 @@ final class ClangTargetBuildDescriptionTests: XCTestCase {
                            defaultLocalization: nil,
                            supportedPlatforms: [],
                            dependencies: [],
+                           enabledTraits: [],
                            targets: .init([target]),
                            products: [],
                            registryMetadata: nil,

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -9,7 +9,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-
+#if compiler(>=6.0)
 import DriverSupport
 import SPMTestSupport
 import PackageModel
@@ -32,3 +32,4 @@ final class TraitTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import DriverSupport
+import SPMTestSupport
+import PackageModel
+import XCTest
+
+final class TraitTests: XCTestCase {
+    func testTraits_whenNoFlagPassed() throws {
+        try fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try executeSwiftRun(fixturePath.appending("Example"), "Example")
+            XCTAssertEqual(stdout, """
+            Package1Library1 trait1 enabled
+            Package2Library1 trait2 enabled
+            Package3Library1 trait3 enabled
+            Package4Library1 trait1 disabled
+            DEFINE1 enabled
+            DEFINE2 disabled
+            DEFINE3 disabled
+
+            """)
+        }
+    }
+}

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -3137,7 +3137,8 @@ final class PackageBuilderTester {
                 warnAboutImplicitExecutableTargets: true,
                 createREPLProduct: createREPLProduct,
                 fileSystem: fs,
-                observabilityScope: observability.topScope
+                observabilityScope: observability.topScope,
+                enabledTraits: []
             )
             let loadedPackage = try builder.construct()
             self.result = .package(loadedPackage)


### PR DESCRIPTION
# Motivation
In my previous PR I landed the APIs for package traits. We now have to take this information into consideration when evaluating the module graph.

# Modification
This PR implements the various trait features in the module graph loading stage. Including resolving optional dependencies, enabled traits of dependencies, build settings based on traits and passing defines for traits.

This PR also contains an exhaustive test fixtures which we can use to check if all trait functionality is working as expected.