### PR TITLE
Fix most "target"/"module" internal naming inconsistencies

### DIFF
--- a/Examples/package-info/Sources/package-info/example.swift
+++ b/Examples/package-info/Sources/package-info/example.swift
@@ -39,11 +39,11 @@ struct Example {
         print("Targets:", targets)
 
         // Package
-        let executables = package.targets.filter({ $0.type == .executable }).map({ $0.name })
+        let executables = package.modules.filter({ $0.type == .executable }).map({ $0.name })
         print("Executable targets:", executables)
 
         // PackageGraph
-        let numberOfFiles = graph.reachableTargets.reduce(0, { $0 + $1.sources.paths.count })
+        let numberOfFiles = graph.reachableModules.reduce(0, { $0 + $1.sources.paths.count })
         print("Total number of source files (including dependencies):", numberOfFiles)
     }
 }

--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -22,8 +22,11 @@ import struct SPMBuildCore.PrebuildCommandResult
 
 import enum TSCBasic.ProcessEnv
 
-/// Target description for a Clang target i.e. C language family target.
-public final class ClangTargetBuildDescription {
+@available(*, deprecated, renamed: "ClangModuleBuildDescription")
+public typealias ClangTargetBuildDescription = ClangModuleBuildDescription
+
+/// Build description for a Clang target i.e. C language family module.
+public final class ClangModuleBuildDescription {
     /// The package this target belongs to.
     public let package: ResolvedPackage
 
@@ -31,7 +34,7 @@ public final class ClangTargetBuildDescription {
     public let target: ResolvedModule
 
     /// The underlying clang target.
-    public let clangTarget: ClangTarget
+    public let clangTarget: ClangModule
 
     /// The tools version of the package that declared the target.  This can
     /// can be used to conditionalize semantically significant changes in how
@@ -123,7 +126,7 @@ public final class ClangTargetBuildDescription {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope
     ) throws {
-        guard let clangTarget = target.underlying as? ClangTarget else {
+        guard let clangTarget = target.underlying as? ClangModule else {
             throw InternalError("underlying target type mismatch \(target)")
         }
 

--- a/Sources/Build/BuildDescription/ModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ModuleBuildDescription.swift
@@ -21,22 +21,25 @@ public enum BuildDescriptionError: Swift.Error {
     case requestedFileNotPartOfTarget(targetName: String, requestedFilePath: AbsolutePath)
 }
 
-/// A target description which can either be for a Swift or Clang target.
-public enum TargetBuildDescription {
+@available(*, deprecated, renamed: "ModuleBuildDescription")
+public typealias TargetBuildDescription = ModuleBuildDescription
+
+/// A module build description which can either be for a Swift or Clang module.
+public enum ModuleBuildDescription {
     /// Swift target description.
-    case swift(SwiftTargetBuildDescription)
+    case swift(SwiftModuleBuildDescription)
 
     /// Clang target description.
-    case clang(ClangTargetBuildDescription)
+    case clang(ClangModuleBuildDescription)
 
     /// The objects in this target.
     var objects: [AbsolutePath] {
         get throws {
             switch self {
-            case .swift(let target):
-                return try target.objects
-            case .clang(let target):
-                return try target.objects
+            case .swift(let module):
+                return try module.objects
+            case .clang(let module):
+                return try module.objects
             }
         }
     }
@@ -44,29 +47,29 @@ public enum TargetBuildDescription {
     /// The resources in this target.
     var resources: [Resource] {
         switch self {
-        case .swift(let target):
-            return target.resources
-        case .clang(let target):
-            return target.resources
+        case .swift(let buildDescription):
+            return buildDescription.resources
+        case .clang(let buildDescription):
+            return buildDescription.resources
         }
     }
 
     /// Path to the bundle generated for this module (if any).
     var bundlePath: AbsolutePath? {
         switch self {
-        case .swift(let target):
-            return target.bundlePath
-        case .clang(let target):
-            return target.bundlePath
+        case .swift(let buildDescription):
+            return buildDescription.bundlePath
+        case .clang(let buildDescription):
+            return buildDescription.bundlePath
         }
     }
 
     var target: ResolvedModule {
         switch self {
-        case .swift(let target):
-            return target.target
-        case .clang(let target):
-            return target.target
+        case .swift(let buildDescription):
+            return buildDescription.target
+        case .clang(let buildDescription):
+            return buildDescription.target
         }
     }
 
@@ -82,37 +85,37 @@ public enum TargetBuildDescription {
 
     var resourceBundleInfoPlistPath: AbsolutePath? {
         switch self {
-        case .swift(let target):
-            return target.resourceBundleInfoPlistPath
-        case .clang(let target):
-            return target.resourceBundleInfoPlistPath
+        case .swift(let buildDescription):
+            return buildDescription.resourceBundleInfoPlistPath
+        case .clang(let buildDescription):
+            return buildDescription.resourceBundleInfoPlistPath
         }
     }
 
     var buildToolPluginInvocationResults: [BuildToolPluginInvocationResult] {
         switch self {
-        case .swift(let target):
-            return target.buildToolPluginInvocationResults
-        case .clang(let target):
-            return target.buildToolPluginInvocationResults
+        case .swift(let buildDescription):
+            return buildDescription.buildToolPluginInvocationResults
+        case .clang(let buildDescription):
+            return buildDescription.buildToolPluginInvocationResults
         }
     }
 
     var buildParameters: BuildParameters {
         switch self {
-        case .swift(let swiftTargetBuildDescription):
-            return swiftTargetBuildDescription.buildParameters
-        case .clang(let clangTargetBuildDescription):
-            return clangTargetBuildDescription.buildParameters
+        case .swift(let buildDescription):
+            return buildDescription.buildParameters
+        case .clang(let buildDescription):
+            return buildDescription.buildParameters
         }
     }
 
     var toolsVersion: ToolsVersion {
         switch self {
-        case .swift(let swiftTargetBuildDescription):
-            return swiftTargetBuildDescription.toolsVersion
-        case .clang(let clangTargetBuildDescription):
-            return clangTargetBuildDescription.toolsVersion
+        case .swift(let buildDescription):
+            return buildDescription.toolsVersion
+        case .clang(let buildDescription):
+            return buildDescription.toolsVersion
         }
     }
 
@@ -120,8 +123,8 @@ public enum TargetBuildDescription {
     /// this module.
     package func symbolGraphExtractArguments() throws -> [String] {
         switch self {
-        case .swift(let target): try target.symbolGraphExtractArguments()
-        case .clang(let target): try target.symbolGraphExtractArguments()
+        case .swift(let buildDescription): try buildDescription.symbolGraphExtractArguments()
+        case .clang(let buildDescription): try buildDescription.symbolGraphExtractArguments()
         }
     }
 }

--- a/Sources/Build/BuildDescription/PluginBuildDescription.swift
+++ b/Sources/Build/BuildDescription/PluginBuildDescription.swift
@@ -16,52 +16,52 @@ import PackageModel
 import struct Basics.InternalError
 import protocol Basics.FileSystem
 
-/// Description for a plugin target. This is treated a bit differently from the
-/// regular kinds of targets, and is not included in the LLBuild description.
-/// But because the package graph and build plan are not loaded for incremental
+/// Description for a plugin module. This is treated a bit differently from the
+/// regular kinds of modules, and is not included in the LLBuild description.
+/// But because the modules graph and build plan are not loaded for incremental
 /// builds, this information is included in the BuildDescription, and the plugin
-/// targets are compiled directly.
-public final class PluginDescription: Codable {
+/// modules are compiled directly.
+public final class PluginBuildDescription: Codable {
     /// The identity of the package in which the plugin is defined.
     public let package: PackageIdentity
 
-    /// The name of the plugin target in that package (this is also the name of
+    /// The name of the plugin module in that package (this is also the name of
     /// the plugin).
-    public let targetName: String
+    public let moduleName: String
 
-    /// The language-level target name.
-    public let targetC99Name: String
+    /// The language-level module name.
+    public let moduleC99Name: String
 
     /// The names of any plugin products in that package that vend the plugin
     /// to other packages.
     public let productNames: [String]
 
-    /// The tools version of the package that declared the target. This affects
+    /// The tools version of the package that declared the module. This affects
     /// the API that is available in the PackagePlugin module.
     public let toolsVersion: ToolsVersion
 
     /// Swift source files that comprise the plugin.
     public let sources: Sources
 
-    /// Initialize a new plugin target description. The target is expected to be
+    /// Initialize a new plugin module description. The module is expected to be
     /// a `PluginTarget`.
     init(
-        target: ResolvedModule,
+        module: ResolvedModule,
         products: [ResolvedProduct],
         package: ResolvedPackage,
         toolsVersion: ToolsVersion,
         testDiscoveryTarget: Bool = false,
         fileSystem: FileSystem
     ) throws {
-        guard target.underlying is PluginTarget else {
-            throw InternalError("underlying target type mismatch \(target)")
+        guard module.underlying is PluginModule else {
+            throw InternalError("underlying target type mismatch \(module)")
         }
 
         self.package = package.identity
-        self.targetName = target.name
-        self.targetC99Name = target.c99name
+        self.moduleName = module.name
+        self.moduleC99Name = module.c99name
         self.productNames = products.map(\.name)
         self.toolsVersion = toolsVersion
-        self.sources = target.sources
+        self.sources = module.sources
     }
 }

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -172,7 +172,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             args += ["-profile-coverage-mapping", "-profile-generate"]
         }
 
-        let containsSwiftTargets = self.product.containsSwiftTargets
+        let containsSwiftTargets = self.product.containsSwiftModules
 
         let derivedProductType: ProductType
         switch self.product.type {
@@ -240,8 +240,8 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             // we will instead have generated a source file containing the redirect.
             // Support for linking tests against executables is conditional on the tools
             // version of the package that defines the executable product.
-            let executableTarget = try product.executableTarget
-            if let target = executableTarget.underlying as? SwiftTarget, 
+            let executableTarget = try product.executableModule
+            if let target = executableTarget.underlying as? SwiftModule, 
                 self.toolsVersion >= .v5_5,
                 self.buildParameters.driverParameters.canRenameEntrypointFunctionName,
                 target.supportsTestableExecutablesFeature
@@ -280,7 +280,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
             // Pass experimental features to link jobs in addition to compile jobs. Preserve ordering while eliminating
             // duplicates with `OrderedSet`.
             var experimentalFeatures = OrderedSet<String>()
-            for target in self.product.targets {
+            for target in self.product.modules {
                 let swiftSettings = target.underlying.buildSettingsDescription.filter { $0.tool == .swift }
                 for case let .enableExperimentalFeature(feature) in swiftSettings.map(\.kind)  {
                     experimentalFeatures.append(feature)
@@ -327,7 +327,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         // setting is the package-level right now. We might need to figure out a better
         // answer for libraries if/when we support specifying deployment target at the
         // target-level.
-        args += try self.buildParameters.tripleArgs(for: self.product.targets[self.product.targets.startIndex])
+        args += try self.buildParameters.tripleArgs(for: self.product.modules[self.product.modules.startIndex])
 
         // Add arguments from declared build settings.
         args += self.buildSettingsFlags

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Clang.swift
@@ -20,7 +20,7 @@ import PackageModel
 extension LLBuildManifestBuilder {
     /// Create a llbuild target for a Clang target description.
     func createClangCompileCommand(
-        _ target: ClangTargetBuildDescription
+        _ target: ClangModuleBuildDescription
     ) throws {
         var inputs: [Node] = []
 
@@ -40,7 +40,7 @@ extension LLBuildManifestBuilder {
 
         for dependency in target.target.dependencies(satisfying: target.buildEnvironment) {
             switch dependency {
-            case .target(let target, _):
+            case .module(let target, _):
                 addStaticTargetInputs(target)
 
             case .product(let product, _):
@@ -54,7 +54,7 @@ extension LLBuildManifestBuilder {
                     inputs.append(file: binary)
 
                 case .library(.automatic), .library(.static), .plugin:
-                    for target in product.targets {
+                    for target in product.modules {
                         addStaticTargetInputs(target)
                     }
                 case .test:
@@ -113,7 +113,7 @@ extension LLBuildManifestBuilder {
 
     /// Create a llbuild target for a Clang target preparation
     func createClangPrepareCommand(
-        _ target: ClangTargetBuildDescription
+        _ target: ClangModuleBuildDescription
     ) throws {
         // Create the node for the target so you can --target it.
         // It is a no-op for index preparation.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Product.swift
@@ -29,7 +29,7 @@ extension LLBuildManifestBuilder {
             testInputs = [testBundleInfoPlistPath]
 
             self.manifest.addWriteInfoPlistCommand(
-                principalClass: "\(buildProduct.product.targets[buildProduct.product.targets.startIndex].c99name).SwiftPMXCTestObserver",
+                principalClass: "\(buildProduct.product.modules[buildProduct.product.modules.startIndex].c99name).SwiftPMXCTestObserver",
                 outputPath: testBundleInfoPlistPath
             )
         } else {

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Resources.swift
@@ -18,7 +18,7 @@ extension LLBuildManifestBuilder {
     ///
     /// Returns the virtual node that will build the entire bundle.
     func createResourcesBundle(
-        for target: TargetBuildDescription
+        for target: ModuleBuildDescription
     ) throws -> Node? {
         guard let bundlePath = target.bundlePath else { return nil }
 

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -33,9 +33,9 @@ import SwiftDriver
 import PackageModel
 
 extension LLBuildManifestBuilder {
-    /// Create a llbuild target for a Swift target description.
+    /// Create a llbuild target for a Swift module description.
     func createSwiftCompileCommand(
-        _ target: SwiftTargetBuildDescription
+        _ target: SwiftModuleBuildDescription
     ) throws {
         // Inputs.
         let inputs = try self.computeSwiftCompileCmdInputs(target)
@@ -60,12 +60,12 @@ extension LLBuildManifestBuilder {
     }
 
     private func addSwiftCmdsViaIntegratedDriver(
-        _ target: SwiftTargetBuildDescription,
+        _ target: SwiftModuleBuildDescription,
         inputs: [Node],
         moduleNode: Node
     ) throws {
         // Use the integrated Swift driver to compute the set of frontend
-        // jobs needed to build this Swift target.
+        // jobs needed to build this Swift module.
         var commandLine = try target.emitCommandLine()
         commandLine.append("-driver-use-frontend-path")
         commandLine.append(target.buildParameters.toolchain.swiftCompilerPath.pathString)
@@ -96,7 +96,7 @@ extension LLBuildManifestBuilder {
     }
 
     private func addSwiftDriverJobs(
-        for targetDescription: SwiftTargetBuildDescription,
+        for targetDescription: SwiftModuleBuildDescription,
         jobs: [Job],
         inputs: [Node],
         resolver: ArgsResolver,
@@ -124,11 +124,11 @@ extension LLBuildManifestBuilder {
             let jobInputs = try job.inputs.map { try $0.resolveToNode(fileSystem: self.fileSystem) }
             let jobOutputs = try job.outputs.map { try $0.resolveToNode(fileSystem: self.fileSystem) }
 
-            // Add target dependencies as inputs to the main module build command.
+            // Add module dependencies as inputs to the main module build command.
             //
-            // Jobs for a target's intermediate build artifacts, such as PCMs or
+            // Jobs for a module's intermediate build artifacts, such as PCMs or
             // modules built from a .swiftinterface, do not have a
-            // dependency on cross-target build products. If multiple targets share
+            // dependency on cross-module build products. If multiple targets share
             // common intermediate dependency modules, such dependencies can lead
             // to cycles in the resulting manifest.
             var manifestNodeInputs: [Node] = []
@@ -169,22 +169,22 @@ extension LLBuildManifestBuilder {
 
     // Building a Swift module in Explicit Module Build mode requires passing all of its module
     // dependencies as explicit arguments to the build command. Thus, building a SwiftPM package
-    // with multiple inter-dependent targets requires that each target’s build job must
-    // have its target dependencies’ modules passed into it as explicit module dependencies.
+    // with multiple inter-dependent targets requires that each module’s build job must
+    // have its module dependencies’ modules passed into it as explicit module dependencies.
     // Because none of the targets have been built yet, a given target's dependency scanning
-    // action will not be able to discover its target dependencies' modules. Instead, it is
-    // SwiftPM's responsibility to communicate to the driver, when planning a given target's
-    // build, that this target has dependencies that are other targets, along with a list of
+    // action will not be able to discover its module dependencies' modules. Instead, it is
+    // SwiftPM's responsibility to communicate to the driver, when planning a given module's
+    // build, that this module has dependencies that are other targets, along with a list of
     // future artifacts of such dependencies (.swiftmodule and .pcm files).
     // The driver will then use those artifacts as explicit inputs to its module’s build jobs.
     //
-    // Consider an example SwiftPM package with two targets: target B, and target A, where A
+    // Consider an example SwiftPM package with two targets: module B, and module A, where A
     // depends on B:
-    // SwiftPM will process targets in a topological order and “bubble-up” each target’s
+    // SwiftPM will process targets in a topological order and “bubble-up” each module’s
     // inter-module dependency graph to its dependencies. First, SwiftPM will process B, and be
-    // able to plan its full build because it does not have any target dependencies. Then the
+    // able to plan its full build because it does not have any module dependencies. Then the
     // driver is tasked with planning a build for A. SwiftPM will pass as input to the driver
-    // the module dependency graph of its target’s dependencies, in this case, just the
+    // the module dependency graph of its module’s dependencies, in this case, just the
     // dependency graph of B. The driver is then responsible for the necessary post-processing
     // to merge the dependency graphs and plan the build for A, using artifacts of B as explicit
     // inputs.
@@ -192,7 +192,7 @@ extension LLBuildManifestBuilder {
         // Sort the product targets in topological order in order to collect and "bubble up"
         // their respective dependency graphs to the depending targets.
         let nodes = self.plan.targets.compactMap {
-            ResolvedModule.Dependency.target($0.target, conditions: [])
+            ResolvedModule.Dependency.module($0.target, conditions: [])
         }
         let allPackageDependencies = try topologicalSort(nodes, successors: { $0.dependencies })
         // Instantiate the inter-module dependency oracle which will cache commonly-scanned
@@ -204,9 +204,9 @@ extension LLBuildManifestBuilder {
         // downstream LLBuild manifest
         let explicitDependencyJobTracker = UniqueExplicitDependencyJobTracker()
 
-        // Create commands for all target descriptions in the plan.
+        // Create commands for all module descriptions in the plan.
         for dependency in allPackageDependencies.reversed() {
-            guard case .target(let target, _) = dependency else {
+            guard case .module(let target, _) = dependency else {
                 // Product dependency build jobs are added after the fact.
                 // Targets that depend on product dependencies will expand the corresponding
                 // product into its constituent targets.
@@ -242,7 +242,7 @@ extension LLBuildManifestBuilder {
     }
 
     private func createExplicitSwiftTargetCompileCommand(
-        description: SwiftTargetBuildDescription,
+        description: SwiftModuleBuildDescription,
         dependencyOracle: InterModuleDependencyOracle,
         explicitDependencyJobTracker: UniqueExplicitDependencyJobTracker?
     ) throws {
@@ -267,21 +267,21 @@ extension LLBuildManifestBuilder {
     }
 
     private func addExplicitBuildSwiftCmds(
-        _ targetDescription: SwiftTargetBuildDescription,
+        _ targetDescription: SwiftModuleBuildDescription,
         inputs: [Node],
         dependencyOracle: InterModuleDependencyOracle,
         explicitDependencyJobTracker: UniqueExplicitDependencyJobTracker? = nil
     ) throws {
-        // Pass the driver its external dependencies (target dependencies)
+        // Pass the driver its external dependencies (module dependencies)
         var dependencyModuleDetailsMap: SwiftDriver.ExternalTargetModuleDetailsMap = [:]
-        // Collect paths for target dependencies of this target (direct and transitive)
+        // Collect paths for module dependencies of this module (direct and transitive)
         try self.collectTargetDependencyModuleDetails(
             for: .swift(targetDescription),
             dependencyModuleDetailsMap: &dependencyModuleDetailsMap
         )
 
         // Compute the set of frontend
-        // jobs needed to build this Swift target.
+        // jobs needed to build this Swift module.
         var commandLine = try targetDescription.emitCommandLine()
         commandLine.append("-driver-use-frontend-path")
         commandLine.append(targetDescription.buildParameters.toolchain.swiftCompilerPath.pathString)
@@ -312,11 +312,11 @@ extension LLBuildManifestBuilder {
         )
     }
 
-    /// Collect a map from all target dependencies of the specified target to the build planning artifacts for said
+    /// Collect a map from all module dependencies of the specified module to the build planning artifacts for said
     /// dependency,
     /// in the form of a path to a .swiftmodule file and the dependency's InterModuleDependencyGraph.
     private func collectTargetDependencyModuleDetails(
-        for targetDescription: TargetBuildDescription,
+        for targetDescription: ModuleBuildDescription,
         dependencyModuleDetailsMap: inout SwiftDriver.ExternalTargetModuleDetailsMap
     ) throws {
         for dependency in targetDescription.target.dependencies(satisfying: targetDescription.buildParameters.buildEnvironment) {
@@ -326,7 +326,7 @@ extension LLBuildManifestBuilder {
                 guard let dependencyProduct = dependency.product else {
                     throw InternalError("unknown dependency product for \(dependency)")
                 }
-                for dependencyProductTarget in dependencyProduct.targets {
+                for dependencyProductTarget in dependencyProduct.modules {
                     guard let dependencyTargetDescription = self.plan.targetMap[dependencyProductTarget.id] else {
                         throw InternalError("unknown dependency target for \(dependencyProductTarget)")
                     }
@@ -335,10 +335,10 @@ extension LLBuildManifestBuilder {
                         dependencyModuleDetailsMap: &dependencyModuleDetailsMap
                     )
                 }
-            case .target:
+            case .module:
                 // Product dependencies are broken down into the targets that make them up.
                 guard
-                    let dependencyTarget = dependency.target,
+                    let dependencyTarget = dependency.module,
                     let dependencyTargetDescription = self.plan.targetMap[dependencyTarget.id]
                 else {
                     throw InternalError("unknown dependency target for \(dependency)")
@@ -352,7 +352,7 @@ extension LLBuildManifestBuilder {
     }
 
     private func addTargetDependencyInfo(
-        for targetDescription: TargetBuildDescription,
+        for targetDescription: ModuleBuildDescription,
         dependencyModuleDetailsMap: inout SwiftDriver.ExternalTargetModuleDetailsMap
     ) throws {
         guard case .swift(let dependencySwiftTargetDescription) = targetDescription else {
@@ -370,7 +370,7 @@ extension LLBuildManifestBuilder {
     }
 
     private func addCmdWithBuiltinSwiftTool(
-        _ target: SwiftTargetBuildDescription,
+        _ target: SwiftModuleBuildDescription,
         inputs: [Node],
         cmdOutputs: [Node]
     ) throws {
@@ -400,14 +400,14 @@ extension LLBuildManifestBuilder {
     }
 
     private func computeSwiftCompileCmdInputs(
-        _ target: SwiftTargetBuildDescription
+        _ target: SwiftModuleBuildDescription
     ) throws -> [Node] {
         var inputs = target.sources.map(Node.file)
 
         let swiftVersionFilePath = addSwiftGetVersionCommand(buildParameters: target.buildParameters)
         inputs.append(.file(swiftVersionFilePath))
 
-        // Add resources node as the input to the target. This isn't great because we
+        // Add resources node as the input to the module. This isn't great because we
         // don't need to block building of a module until its resources are assembled but
         // we don't currently have a good way to express that resources should be built
         // whenever a module is being built.
@@ -424,19 +424,19 @@ extension LLBuildManifestBuilder {
 
         func addStaticTargetInputs(_ target: ResolvedModule) throws {
             // Ignore C Modules.
-            if target.underlying is SystemLibraryTarget { return }
+            if target.underlying is SystemLibraryModule { return }
             // Ignore Binary Modules.
-            if target.underlying is BinaryTarget { return }
+            if target.underlying is BinaryModule { return }
             // Ignore Plugin Targets.
-            if target.underlying is PluginTarget { return }
+            if target.underlying is PluginModule { return }
             // Ignore Provided Libraries.
-            if target.underlying is ProvidedLibraryTarget { return }
+            if target.underlying is ProvidedLibraryModule { return }
 
             // Depend on the binary for executable targets.
             if target.type == .executable && !prepareForIndexing {
                 // FIXME: Optimize.
                 if let productDescription = try plan.productMap.values.first(where: {
-                    try $0.product.type == .executable && $0.product.executableTarget.id == target.id
+                    try $0.product.type == .executable && $0.product.executableModule.id == target.id
                 }) {
                     try inputs.append(file: productDescription.binaryPath)
                 }
@@ -465,7 +465,7 @@ extension LLBuildManifestBuilder {
 
         for dependency in target.target.dependencies(satisfying: target.buildParameters.buildEnvironment) {
             switch dependency {
-            case .target(let target, _):
+            case .module(let target, _):
                 try addStaticTargetInputs(target)
 
             case .product(let product, _):
@@ -479,7 +479,7 @@ extension LLBuildManifestBuilder {
 
                 // For automatic and static libraries, and plugins, add their targets as static input.
                 case .library(.automatic), .library(.static), .plugin:
-                    for target in product.targets {
+                    for target in product.modules {
                         try addStaticTargetInputs(target)
                     }
 
@@ -508,9 +508,9 @@ extension LLBuildManifestBuilder {
         return inputs + additionalInputs
     }
 
-    /// Adds a top-level phony command that builds the entire target.
-    private func addTargetCmd(_ target: SwiftTargetBuildDescription, cmdOutputs: [Node]) {
-        // Create a phony node to represent the entire target.
+    /// Adds a top-level phony command that builds the entire module.
+    private func addTargetCmd(_ target: SwiftModuleBuildDescription, cmdOutputs: [Node]) {
+        // Create a phony node to represent the entire module.
         let targetName = target.getLLBuildTargetName()
         let targetOutput: Node = .virtual(targetName)
 
@@ -528,7 +528,7 @@ extension LLBuildManifestBuilder {
         }
     }
 
-    private func addModuleWrapCmd(_ target: SwiftTargetBuildDescription) throws {
+    private func addModuleWrapCmd(_ target: SwiftModuleBuildDescription) throws {
         // Add commands to perform the module wrapping Swift modules when debugging strategy is `modulewrap`.
         guard target.buildParameters.debuggingStrategy == .modulewrap else { return }
         var moduleWrapArgs = [
@@ -618,7 +618,7 @@ extension Driver {
     }
 }
 
-extension SwiftTargetBuildDescription {
+extension SwiftModuleBuildDescription {
     public func getCommandName() -> String {
         "C." + self.getLLBuildTargetName()
     }

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -142,7 +142,7 @@ public class LLBuildManifestBuilder {
                 try self.createSwiftCompileCommand(desc)
             case .clang(let desc):
                 if desc.target.buildTriple == .tools {
-                    // Need the clang targets for tools
+                    // Need the clang modules for tools
                     try self.createClangCompileCommand(desc)
                 } else {
                     // Hook up the clang module target
@@ -175,7 +175,7 @@ public class LLBuildManifestBuilder {
 extension LLBuildManifestBuilder {
     private func addPackageStructureCommand() {
         let inputs = self.plan.graph.rootPackages.flatMap { package -> [Node] in
-            var inputs = package.targets
+            var inputs = package.modules
                 .map(\.sources.root)
                 .sorted()
                 .map { Node.directoryStructure($0) }
@@ -232,7 +232,7 @@ extension LLBuildManifestBuilder {
 // MARK: - Compilation
 
 extension LLBuildManifestBuilder {
-    func addBuildToolPlugins(_ target: TargetBuildDescription) throws -> [Node] {
+    func addBuildToolPlugins(_ target: ModuleBuildDescription) throws -> [Node] {
         // For any build command that doesn't declare any outputs, we need to create a phony output to ensure they will still be run by the build system.
         var phonyOutputs = [Node]()
         // If we have multiple commands with no output files and no display name, this serves as a way to disambiguate the virtual nodes being created.
@@ -291,7 +291,7 @@ extension LLBuildManifestBuilder {
     private func addTestDiscoveryGenerationCommand() throws {
         for testDiscoveryTarget in self.plan.targets.compactMap(\.testDiscoveryTargetBuildDescription) {
             let testTargets = testDiscoveryTarget.target.dependencies
-                .compactMap(\.target).compactMap { self.plan.targetMap[$0.id] }
+                .compactMap(\.module).compactMap { self.plan.targetMap[$0.id] }
             let objectFiles = try testTargets.flatMap { try $0.objects }.sorted().map(Node.file)
             let outputs = testDiscoveryTarget.target.sources.paths
 
@@ -315,14 +315,14 @@ extension LLBuildManifestBuilder {
 
             let testEntryPointTarget = target
 
-            // Get the Swift target build descriptions of all discovery targets this synthesized entry point target
+            // Get the Swift target build descriptions of all discovery modules this synthesized entry point target
             // depends on.
             let discoveredTargetDependencyBuildDescriptions = testEntryPointTarget.target.dependencies
-                .compactMap(\.target?.id)
+                .compactMap(\.module?.id)
                 .compactMap { self.plan.targetMap[$0] }
                 .compactMap(\.testDiscoveryTargetBuildDescription)
 
-            // The module outputs of the discovery targets this synthesized entry point target depends on are
+            // The module outputs of the discovery modules this synthesized entry point target depends on are
             // considered the inputs to the entry point command.
             let inputs = discoveredTargetDependencyBuildDescriptions.map(\.moduleOutputPath)
 
@@ -344,23 +344,23 @@ extension LLBuildManifestBuilder {
     }
 }
 
-extension TargetBuildDescription {
+extension ModuleBuildDescription {
     /// If receiver represents a Swift target build description whose test target role is Discovery,
     /// then this returns that Swift target build description, else returns nil.
-    fileprivate var testDiscoveryTargetBuildDescription: SwiftTargetBuildDescription? {
+    fileprivate var testDiscoveryTargetBuildDescription: SwiftModuleBuildDescription? {
         guard case .swift(let targetBuildDescription) = self,
               case .discovery = targetBuildDescription.testTargetRole else { return nil }
         return targetBuildDescription
     }
 }
 
-extension TargetBuildDescription {
+extension ModuleBuildDescription {
     package var llbuildResourcesCmdName: String {
         "\(self.target.name)-\(self.buildParameters.triple.tripleString)-\(self.buildParameters.buildConfig)\(self.buildParameters.suffix).module-resources"
     }
 }
 
-extension ClangTargetBuildDescription {
+extension ClangModuleBuildDescription {
     package var llbuildTargetName: String {
         self.target.getLLBuildTargetName(buildParameters: self.buildParameters)
     }

--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -20,8 +20,8 @@ import struct PackageGraph.ResolvedPackage
 import struct PackageGraph.ResolvedProduct
 import struct PackageGraph.ResolvedModule
 import struct PackageModel.Sources
-import class PackageModel.SwiftTarget
-import class PackageModel.Target
+import class PackageModel.SwiftModule
+import class PackageModel.Module
 import struct SPMBuildCore.BuildParameters
 import protocol TSCBasic.FileSystem
 
@@ -33,7 +33,7 @@ extension BuildPlan {
         shouldDisableSandbox: Bool,
         _ fileSystem: FileSystem,
         _ observabilityScope: ObservabilityScope
-    ) throws -> [(product: ResolvedProduct, discoveryTargetBuildDescription: SwiftTargetBuildDescription?, entryPointTargetBuildDescription: SwiftTargetBuildDescription)] {
+    ) throws -> [(product: ResolvedProduct, discoveryTargetBuildDescription: SwiftModuleBuildDescription?, entryPointTargetBuildDescription: SwiftModuleBuildDescription)] {
         guard destinationBuildParameters.testingParameters.testProductStyle.requiresAdditionalDerivedTestTargets,
               case .entryPointExecutable(let explicitlyEnabledDiscovery, let explicitlySpecifiedPath) =
                 destinationBuildParameters.testingParameters.testProductStyle
@@ -44,11 +44,11 @@ extension BuildPlan {
         let isEntryPointPathSpecifiedExplicitly = explicitlySpecifiedPath != nil
 
         var isDiscoveryEnabledRedundantly = explicitlyEnabledDiscovery && !isEntryPointPathSpecifiedExplicitly
-        var result: [(ResolvedProduct, SwiftTargetBuildDescription?, SwiftTargetBuildDescription)] = []
+        var result: [(ResolvedProduct, SwiftModuleBuildDescription?, SwiftModuleBuildDescription)] = []
         for (testProduct, testBuildDescription) in testProducts {
             let package = testBuildDescription.package
 
-            isDiscoveryEnabledRedundantly = isDiscoveryEnabledRedundantly && nil == testProduct.testEntryPointTarget
+            isDiscoveryEnabledRedundantly = isDiscoveryEnabledRedundantly && nil == testProduct.testEntryPointModule
             // If a non-explicitly specified test entry point file exists, prefer that over test discovery.
             // This is designed as an escape hatch when test discovery is not appropriate and for backwards
             // compatibility for projects that have existing test entry point files (e.g. XCTMain.swift, LinuxMain.swift).
@@ -59,45 +59,45 @@ extension BuildPlan {
             // `--experimental-test-entry-point-path <file>`. The latter is useful because it still performs test discovery and places the discovered
             // tests into a separate target/module named "<PackageName>PackageDiscoveredTests". Then, that entry point file may import that module and
             // obtain that list to pass it to the `XCTMain(...)` function and avoid needing to maintain a list of tests itself.
-            if testProduct.testEntryPointTarget != nil && explicitlyEnabledDiscovery && !isEntryPointPathSpecifiedExplicitly {
-                let testEntryPointName = testProduct.underlying.testEntryPointPath?.basename ?? SwiftTarget.defaultTestEntryPointName
+            if testProduct.testEntryPointModule != nil && explicitlyEnabledDiscovery && !isEntryPointPathSpecifiedExplicitly {
+                let testEntryPointName = testProduct.underlying.testEntryPointPath?.basename ?? SwiftModule.defaultTestEntryPointName
                 observabilityScope.emit(warning: "'--enable-test-discovery' was specified so the '\(testEntryPointName)' entry point file for '\(testProduct.name)' will be ignored and an entry point will be generated automatically. To use test discovery with a custom entry point file, pass '--experimental-test-entry-point-path <file>'.")
-            } else if testProduct.testEntryPointTarget == nil, let testEntryPointPath = explicitlySpecifiedPath, !fileSystem.exists(testEntryPointPath) {
+            } else if testProduct.testEntryPointModule == nil, let testEntryPointPath = explicitlySpecifiedPath, !fileSystem.exists(testEntryPointPath) {
                 observabilityScope.emit(error: "'--experimental-test-entry-point-path' was specified but the file '\(testEntryPointPath)' could not be found.")
             }
 
-            /// Generates test discovery targets, which contain derived sources listing the discovered tests.
-            func generateDiscoveryTargets() throws -> (target: SwiftTarget, resolved: ResolvedModule, buildDescription: SwiftTargetBuildDescription) {
+            /// Generates test discovery modules, which contain derived sources listing the discovered tests.
+            func generateDiscoveryTargets() throws -> (target: SwiftModule, resolved: ResolvedModule, buildDescription: SwiftModuleBuildDescription) {
                 let discoveryTargetName = "\(package.manifest.displayName)PackageDiscoveredTests"
                 let discoveryDerivedDir = destinationBuildParameters.buildPath.appending(components: "\(discoveryTargetName).derived")
                 let discoveryMainFile = discoveryDerivedDir.appending(component: TestDiscoveryTool.mainFileName)
 
                 var discoveryPaths: [AbsolutePath] = []
                 discoveryPaths.append(discoveryMainFile)
-                for testTarget in testProduct.targets {
+                for testTarget in testProduct.modules {
                     let path = discoveryDerivedDir.appending(components: testTarget.name + ".swift")
                     discoveryPaths.append(path)
                 }
 
-                let discoveryTarget = SwiftTarget(
+                let discoveryTarget = SwiftModule(
                     name: discoveryTargetName,
-                    dependencies: testProduct.underlying.targets.map { .target($0, conditions: []) },
+                    dependencies: testProduct.underlying.modules.map { .module($0, conditions: []) },
                     packageAccess: true, // test target is allowed access to package decls by default
                     testDiscoverySrc: Sources(paths: discoveryPaths, root: discoveryDerivedDir)
                 )
-                var discoveryResolvedTarget = ResolvedModule(
+                var discoveryResolvedModule = ResolvedModule(
                     packageIdentity: testProduct.packageIdentity,
                     underlying: discoveryTarget,
-                    dependencies: testProduct.targets.map { .target($0, conditions: []) },
+                    dependencies: testProduct.modules.map { .module($0, conditions: []) },
                     defaultLocalization: testProduct.defaultLocalization,
                     supportedPlatforms: testProduct.supportedPlatforms,
                     platformVersionProvider: testProduct.platformVersionProvider
                 )
-                discoveryResolvedTarget.buildTriple = testProduct.buildTriple
+                discoveryResolvedModule.buildTriple = testProduct.buildTriple
 
-                let discoveryTargetBuildDescription = try SwiftTargetBuildDescription(
+                let discoveryTargetBuildDescription = try SwiftModuleBuildDescription(
                     package: package,
-                    target: discoveryResolvedTarget,
+                    target: discoveryResolvedModule,
                     toolsVersion: toolsVersion,
                     buildParameters: testBuildDescription.buildParameters,
                     testTargetRole: .discovery,
@@ -106,38 +106,38 @@ extension BuildPlan {
                     observabilityScope: observabilityScope
                 )
 
-                return (discoveryTarget, discoveryResolvedTarget, discoveryTargetBuildDescription)
+                return (discoveryTarget, discoveryResolvedModule, discoveryTargetBuildDescription)
             }
 
             /// Generates a synthesized test entry point target, consisting of a single "main" file which calls the test entry
             /// point API and leverages the test discovery target to reference which tests to run.
             func generateSynthesizedEntryPointTarget(
-                swiftTargetDependencies: [Target.Dependency],
+                swiftTargetDependencies: [Module.Dependency],
                 resolvedTargetDependencies: [ResolvedModule.Dependency]
-            ) throws -> SwiftTargetBuildDescription {
+            ) throws -> SwiftModuleBuildDescription {
                 let entryPointDerivedDir = destinationBuildParameters.buildPath.appending(components: "\(testProduct.name).derived")
                 let entryPointMainFileName = TestEntryPointTool.mainFileName(for: destinationBuildParameters.testingParameters.library)
                 let entryPointMainFile = entryPointDerivedDir.appending(component: entryPointMainFileName)
                 let entryPointSources = Sources(paths: [entryPointMainFile], root: entryPointDerivedDir)
 
-                let entryPointTarget = SwiftTarget(
+                let entryPointTarget = SwiftModule(
                     name: testProduct.name,
                     type: .library,
-                    dependencies: testProduct.underlying.targets.map { .target($0, conditions: []) } + swiftTargetDependencies,
+                    dependencies: testProduct.underlying.modules.map { .module($0, conditions: []) } + swiftTargetDependencies,
                     packageAccess: true, // test target is allowed access to package decls
                     testEntryPointSources: entryPointSources
                 )
                 var entryPointResolvedTarget = ResolvedModule(
                     packageIdentity: testProduct.packageIdentity,
                     underlying: entryPointTarget,
-                    dependencies: testProduct.targets.map { .target($0, conditions: []) } + resolvedTargetDependencies,
+                    dependencies: testProduct.modules.map { .module($0, conditions: []) } + resolvedTargetDependencies,
                     defaultLocalization: testProduct.defaultLocalization,
                     supportedPlatforms: testProduct.supportedPlatforms,
                     platformVersionProvider: testProduct.platformVersionProvider
                 )
                 entryPointResolvedTarget.buildTriple = testProduct.buildTriple
 
-                return try SwiftTargetBuildDescription(
+                return try SwiftModuleBuildDescription(
                     package: package,
                     target: entryPointResolvedTarget,
                     toolsVersion: toolsVersion,
@@ -149,26 +149,26 @@ extension BuildPlan {
                 )
             }
 
-            let discoveryTargets: (target: SwiftTarget, resolved: ResolvedModule, buildDescription: SwiftTargetBuildDescription)?
-            let swiftTargetDependencies: [Target.Dependency]
+            let discoveryTargets: (target: SwiftModule, resolved: ResolvedModule, buildDescription: SwiftModuleBuildDescription)?
+            let swiftTargetDependencies: [Module.Dependency]
             let resolvedTargetDependencies: [ResolvedModule.Dependency]
 
             switch destinationBuildParameters.testingParameters.library {
             case .xctest:
                 discoveryTargets = try generateDiscoveryTargets()
-                swiftTargetDependencies = [.target(discoveryTargets!.target, conditions: [])]
-                resolvedTargetDependencies = [.target(discoveryTargets!.resolved, conditions: [])]
+                swiftTargetDependencies = [.module(discoveryTargets!.target, conditions: [])]
+                resolvedTargetDependencies = [.module(discoveryTargets!.resolved, conditions: [])]
             case .swiftTesting:
                 discoveryTargets = nil
-                swiftTargetDependencies = testProduct.targets.map { .target($0.underlying, conditions: []) }
-                resolvedTargetDependencies = testProduct.targets.map { .target($0, conditions: []) }
+                swiftTargetDependencies = testProduct.modules.map { .module($0.underlying, conditions: []) }
+                resolvedTargetDependencies = testProduct.modules.map { .module($0, conditions: []) }
             }
 
-            if let entryPointResolvedTarget = testProduct.testEntryPointTarget {
+            if let entryPointResolvedTarget = testProduct.testEntryPointModule {
                 if isEntryPointPathSpecifiedExplicitly || explicitlyEnabledDiscovery {
                     if isEntryPointPathSpecifiedExplicitly {
-                        // Allow using the explicitly-specified test entry point target, but still perform test discovery and thus declare a dependency on the discovery targets.
-                        let entryPointTarget = SwiftTarget(
+                        // Allow using the explicitly-specified test entry point target, but still perform test discovery and thus declare a dependency on the discovery modules.
+                        let entryPointTarget = SwiftModule(
                             name: entryPointResolvedTarget.underlying.name,
                             dependencies: entryPointResolvedTarget.underlying.dependencies + swiftTargetDependencies,
                             packageAccess: entryPointResolvedTarget.packageAccess,
@@ -182,7 +182,7 @@ extension BuildPlan {
                             supportedPlatforms: testProduct.supportedPlatforms,
                             platformVersionProvider: testProduct.platformVersionProvider
                         )
-                        let entryPointTargetBuildDescription = try SwiftTargetBuildDescription(
+                        let entryPointTargetBuildDescription = try SwiftModuleBuildDescription(
                             package: package,
                             target: entryPointResolvedTarget,
                             toolsVersion: toolsVersion,
@@ -204,7 +204,7 @@ extension BuildPlan {
                     }
                 } else {
                     // Use the test entry point as-is, without performing test discovery.
-                    let entryPointTargetBuildDescription = try SwiftTargetBuildDescription(
+                    let entryPointTargetBuildDescription = try SwiftModuleBuildDescription(
                         package: package,
                         target: entryPointResolvedTarget,
                         toolsVersion: toolsVersion,
@@ -234,12 +234,12 @@ extension BuildPlan {
     }
 }
 
-private extension PackageModel.SwiftTarget {
+private extension PackageModel.SwiftModule {
     /// Initialize a SwiftTarget representing a test entry point.
     convenience init(
         name: String,
-        type: PackageModel.Target.Kind? = nil,
-        dependencies: [PackageModel.Target.Dependency],
+        type: PackageModel.Module.Kind? = nil,
+        dependencies: [PackageModel.Module.Dependency],
         packageAccess: Bool,
         testEntryPointSources sources: Sources
     ) {

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -190,17 +190,17 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     public let graph: ModulesGraph
 
     /// The target build description map.
-    public let targetMap: [ResolvedModule.ID: TargetBuildDescription]
+    public let targetMap: [ResolvedModule.ID: ModuleBuildDescription]
 
     /// The product build description map.
     public let productMap: [ResolvedProduct.ID: ProductBuildDescription]
 
     /// The plugin descriptions. Plugins are represented in the package graph
     /// as targets, but they are not directly included in the build graph.
-    public let pluginDescriptions: [PluginDescription]
+    public let pluginDescriptions: [PluginBuildDescription]
 
     /// The build targets.
-    public var targets: AnySequence<TargetBuildDescription> {
+    public var targets: AnySequence<ModuleBuildDescription> {
         AnySequence(self.targetMap.values)
     }
 
@@ -220,13 +220,13 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     public private(set) var derivedTestTargetsMap: [ResolvedProduct.ID: [ResolvedModule]] = [:]
 
     /// Cache for pkgConfig flags.
-    private var pkgConfigCache = [SystemLibraryTarget: (cFlags: [String], libs: [String])]()
+    private var pkgConfigCache = [SystemLibraryModule: (cFlags: [String], libs: [String])]()
 
     /// Cache for library information.
-    private var externalLibrariesCache = [BinaryTarget: [LibraryInfo]]()
+    private var externalLibrariesCache = [BinaryModule: [LibraryInfo]]()
 
     /// Cache for tools information.
-    var externalExecutablesCache = [BinaryTarget: [ExecutableInfo]]()
+    var externalExecutablesCache = [BinaryModule: [ExecutableInfo]]()
 
     /// Whether to disable sandboxing (e.g. for macros).
     private let shouldDisableSandbox: Bool
@@ -305,7 +305,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
         let macroProductsByTarget = productMap.values.filter { $0.product.type == .macro }
             .reduce(into: [ResolvedModule.ID: ResolvedProduct]()) {
-                if let target = $1.product.targets.first {
+                if let target = $1.product.modules.first {
                     $0[target.id] = $1.product
                 }
             }
@@ -314,10 +314,10 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         // Plugin targets are noted, since they need to be compiled, but they do
         // not get directly incorporated into the build description that will be
         // given to LLBuild.
-        var targetMap = [ResolvedModule.ID: TargetBuildDescription]()
-        var pluginDescriptions = [PluginDescription]()
+        var targetMap = [ResolvedModule.ID: ModuleBuildDescription]()
+        var pluginDescriptions = [PluginBuildDescription]()
         var shouldGenerateTestObservation = true
-        for target in graph.allTargets.sorted(by: { $0.name < $1.name }) {
+        for target in graph.allModules.sorted(by: { $0.name < $1.name }) {
             let buildParameters: BuildParameters
             switch target.buildTriple {
             case .tools:
@@ -333,7 +333,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 }
 
                 switch dependency {
-                case .target: break
+                case .module: break
                 case .product(let product, _):
                     if buildParameters.triple.isDarwin() {
                         try BuildPlan.validateDeploymentVersionOfProductDependency(
@@ -351,12 +351,12 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
             let toolsVersion = graph.package(for: target)?.manifest.toolsVersion ?? .v5_5
 
             switch target.underlying {
-            case is SwiftTarget:
+            case is SwiftModule:
                 guard let package = graph.package(for: target) else {
                     throw InternalError("package not found for \(target)")
                 }
 
-                let requiredMacroProducts = try target.recursiveTargetDependencies()
+                let requiredMacroProducts = try target.recursiveModuleDependencies()
                     .filter { $0.underlying.type == .macro }
                     .compactMap {
                         guard let product = macroProductsByTarget[$0.id],
@@ -375,7 +375,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 }
 
                 targetMap[target.id] = try .swift(
-                    SwiftTargetBuildDescription(
+                    SwiftModuleBuildDescription(
                         package: package,
                         target: target,
                         toolsVersion: toolsVersion,
@@ -390,13 +390,13 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                         observabilityScope: observabilityScope
                     )
                 )
-            case is ClangTarget:
+            case is ClangModule:
                 guard let package = graph.package(for: target) else {
                     throw InternalError("package not found for \(target)")
                 }
 
                 targetMap[target.id] = try .clang(
-                    ClangTargetBuildDescription(
+                    ClangModuleBuildDescription(
                         package: package,
                         target: target,
                         toolsVersion: toolsVersion,
@@ -408,18 +408,18 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                         observabilityScope: observabilityScope
                     )
                 )
-            case is PluginTarget:
+            case is PluginModule:
                 guard let package = graph.package(for: target) else {
                     throw InternalError("package not found for \(target)")
                 }
-                try pluginDescriptions.append(PluginDescription(
-                    target: target,
-                    products: package.products.filter { $0.targets.contains(id: target.id) },
+                try pluginDescriptions.append(PluginBuildDescription(
+                    module: target,
+                    products: package.products.filter { $0.modules.contains(id: target.id) },
                     package: package,
                     toolsVersion: toolsVersion,
                     fileSystem: fileSystem
                 ))
-            case is SystemLibraryTarget, is BinaryTarget, is ProvidedLibraryTarget:
+            case is SystemLibraryModule, is BinaryModule, is ProvidedLibraryModule:
                 break
             default:
                 throw InternalError("unhandled \(target.underlying)")
@@ -559,8 +559,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
 
         // Add search paths from the system library targets.
-        for target in self.graph.reachableTargets {
-            if let systemLib = target.underlying as? SystemLibraryTarget {
+        for target in self.graph.reachableModules {
+            if let systemLib = target.underlying as? SystemLibraryModule {
                 try arguments.append(contentsOf: self.pkgConfig(for: systemLib).cFlags)
                 // Add the path to the module map.
                 arguments += ["-I", systemLib.moduleMapPath.parentDirectory.pathString]
@@ -596,8 +596,8 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         }
 
         // Add search paths from the system library targets.
-        for target in self.graph.reachableTargets {
-            if let systemLib = target.underlying as? SystemLibraryTarget {
+        for target in self.graph.reachableModules {
+            if let systemLib = target.underlying as? SystemLibraryModule {
                 arguments += try self.pkgConfig(for: systemLib).cFlags
             }
         }
@@ -606,7 +606,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     }
 
     /// Get pkgConfig arguments for a system library target.
-    func pkgConfig(for target: SystemLibraryTarget) throws -> (cFlags: [String], libs: [String]) {
+    func pkgConfig(for target: SystemLibraryModule) throws -> (cFlags: [String], libs: [String]) {
         // If we already have these flags, we're done.
         if let flags = pkgConfigCache[target] {
             return flags
@@ -642,7 +642,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     }
 
     /// Extracts the library information from an XCFramework.
-    func parseXCFramework(for binaryTarget: BinaryTarget, triple: Basics.Triple) throws -> [LibraryInfo] {
+    func parseXCFramework(for binaryTarget: BinaryModule, triple: Basics.Triple) throws -> [LibraryInfo] {
         try self.externalLibrariesCache.memoize(key: binaryTarget) {
             try binaryTarget.parseXCFrameworks(for: triple, fileSystem: self.fileSystem)
         }
@@ -749,7 +749,7 @@ extension ResolvedProduct {
     }
 
     private var isBinaryOnly: Bool {
-        self.targets.filter { !($0.underlying is BinaryTarget) }.isEmpty
+        self.modules.filter { !($0.underlying is BinaryModule) }.isEmpty
     }
 
     private var isPlugin: Bool {

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -7,12 +7,12 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(Build
-  BuildDescription/ClangTargetBuildDescription.swift
-  BuildDescription/PluginDescription.swift
+  BuildDescription/ClangModuleBuildDescription.swift
+  BuildDescription/PluginBuildDescription.swift
   BuildDescription/ProductBuildDescription.swift
   BuildDescription/ResolvedModule+BuildDescription.swift
   BuildDescription/SwiftModuleBuildDescription.swift
-  BuildDescription/TargetBuildDescription.swift
+  BuildDescription/ModuleBuildDescription.swift
   BuildManifest/LLBuildManifestBuilder.swift
   BuildManifest/LLBuildManifestBuilder+Clang.swift
   BuildManifest/LLBuildManifestBuilder+Product.swift

--- a/Sources/Build/CMakeLists.txt
+++ b/Sources/Build/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(Build
   BuildDescription/PluginDescription.swift
   BuildDescription/ProductBuildDescription.swift
   BuildDescription/ResolvedModule+BuildDescription.swift
-  BuildDescription/SwiftTargetBuildDescription.swift
+  BuildDescription/SwiftModuleBuildDescription.swift
   BuildDescription/TargetBuildDescription.swift
   BuildManifest/LLBuildManifestBuilder.swift
   BuildManifest/LLBuildManifestBuilder+Clang.swift

--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -132,7 +132,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
             // Write one file for each test module.
             //
             // We could write everything in one file but that can easily run into type conflicts due
-            // in complex packages with large number of test targets.
+            // in complex packages with large number of test modules.
             for file in outputs where file != mainFile {
                 // FIXME: This is relying on implementation detail of the output but passing the
                 // the context all the way through is not worth it right now.

--- a/Sources/Build/LLBuildDescription.swift
+++ b/Sources/Build/LLBuildDescription.swift
@@ -58,7 +58,7 @@ public struct BuildDescription: Codable {
     public let builtTestProducts: [BuiltTestProduct]
 
     /// Distilled information about any plugins defined in the package.
-    let pluginDescriptions: [PluginDescription]
+    let pluginDescriptions: [PluginBuildDescription]
 
     public init(
         plan: BuildPlan,
@@ -68,7 +68,7 @@ public struct BuildDescription: Codable {
         testEntryPointCommands: [LLBuildManifest.CmdName: TestEntryPointTool],
         copyCommands: [LLBuildManifest.CmdName: CopyTool],
         writeCommands: [LLBuildManifest.CmdName: WriteAuxiliaryFile],
-        pluginDescriptions: [PluginDescription]
+        pluginDescriptions: [PluginBuildDescription]
     ) throws {
         self.swiftCommands = swiftCommands
         self.swiftFrontendCommands = swiftFrontendCommands
@@ -83,7 +83,7 @@ public struct BuildDescription: Codable {
                 let deps = try targetBuildDescription.target.recursiveDependencies(
                     satisfying: targetBuildDescription.buildParameters.buildEnvironment
                 )
-                .compactMap(\.target).map(\.c99name)
+                .compactMap(\.module).map(\.c99name)
                 partial[targetBuildDescription.target.c99name] = deps
             }
         var targetCommandLines: [TargetName: [CommandLineFlag]] = [:]
@@ -103,7 +103,7 @@ public struct BuildDescription: Codable {
         }
         generatedSourceTargets.append(
             contentsOf: plan.pluginDescriptions
-                .map(\.targetC99Name)
+                .map(\.moduleC99Name)
         )
         self.swiftTargetScanArgs = targetCommandLines
         self.generatedSourceTargetSet = Set(generatedSourceTargets)

--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -177,12 +177,12 @@ struct APIDiff: SwiftCommand {
                     observabilityScope.emit(error: "'\(productName)' is not a library product")
                     continue
                 }
-                modulesToDiff.formUnion(product.targets.filter { $0.underlying is SwiftTarget }.map(\.c99name))
+                modulesToDiff.formUnion(product.modules.filter { $0.underlying is SwiftModule }.map(\.c99name))
             }
             for targetName in targets {
                 guard let target = packageGraph
                         .rootPackages
-                        .flatMap(\.targets)
+                        .flatMap(\.modules)
                         .first(where: { $0.name == targetName }) else {
                     observabilityScope.emit(error: "no such target '\(targetName)'")
                     continue
@@ -191,7 +191,7 @@ struct APIDiff: SwiftCommand {
                     observabilityScope.emit(error: "'\(targetName)' is not a library target")
                     continue
                 }
-                guard target.underlying is SwiftTarget else {
+                guard target.underlying is SwiftModule else {
                     observabilityScope.emit(error: "'\(targetName)' is not a Swift language target")
                     continue
                 }

--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -90,7 +90,7 @@ extension SwiftPackageCommand {
             }
 
             // Map the target type.
-            let type: TargetDescription.TargetType = switch self.type {
+            let type: TargetDescription.TargetKind = switch self.type {
                 case .library: .regular
                 case .executable: .executable
                 case .test: .test

--- a/Sources/Commands/PackageCommands/CompletionCommand.swift
+++ b/Sources/Commands/PackageCommands/CompletionCommand.swift
@@ -76,14 +76,14 @@ extension SwiftPackageCommand {
             case .listExecutables:
                 let graph = try swiftCommandState.loadPackageGraph()
                 let package = graph.rootPackages[graph.rootPackages.startIndex].underlying
-                let executables = package.targets.filter { $0.type == .executable }
+                let executables = package.modules.filter { $0.type == .executable }
                 for executable in executables {
                     print(executable.name)
                 }
             case .listSnippets:
                 let graph = try swiftCommandState.loadPackageGraph()
                 let package = graph.rootPackages[graph.rootPackages.startIndex].underlying
-                let executables = package.targets.filter { $0.type == .snippet }
+                let executables = package.modules.filter { $0.type == .snippet }
                 for executable in executables {
                     print(executable.name)
                 }

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -66,7 +66,7 @@ struct DumpSymbolGraph: SwiftCommand {
         // Run the tool once for every library and executable target in the root package.
         let buildPlan = try buildSystem.buildPlan
         let symbolGraphDirectory = buildPlan.destinationBuildParameters.dataPath.appending("symbolgraph")
-        let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.targets }.filter{ $0.type == .library }
+        let targets = try buildSystem.getPackageGraph().rootPackages.flatMap{ $0.modules }.filter{ $0.type == .library }
         for target in targets {
             print("-- Emitting symbol graph for", target.name)
             let result = try symbolGraphExtractor.extractSymbolGraph(

--- a/Sources/Commands/PackageCommands/Format.swift
+++ b/Sources/Commands/PackageCommands/Format.swift
@@ -60,7 +60,7 @@ extension SwiftPackageCommand {
                 : swiftFormatFlags
 
             // Process each target in the root package.
-            let paths = package.targets.flatMap { target in
+            let paths = package.modules.flatMap { target in
                 target.sources.paths.filter { file in
                     file.extension == SupportedLanguageExtension.swift.rawValue
                 }

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -96,7 +96,7 @@ struct SnippetCard: Card {
         let buildSystem = try swiftCommandState.createBuildSystem(explicitProduct: snippet.name)
         try buildSystem.build(subset: .product(snippet.name))
         let executablePath = try swiftCommandState.productsBuildParameters.buildPath.appending(component: snippet.name)
-        if let exampleTarget = try buildSystem.getPackageGraph().target(for: snippet.name, destination: .destination) {
+        if let exampleTarget = try buildSystem.getPackageGraph().module(for: snippet.name, destination: .destination) {
             try ProcessEnv.chdir(exampleTarget.sources.paths[0].parentDirectory)
         }
         try exec(path: executablePath.pathString, args: [])

--- a/Sources/Commands/Snippets/Cards/TopCard.swift
+++ b/Sources/Commands/Snippets/Cards/TopCard.swift
@@ -132,7 +132,7 @@ struct TopCard: Card {
     }
 }
 
-fileprivate extension Target.Kind {
+fileprivate extension Module.Kind {
     var pluralDescription: String {
         switch self {
         case .executable:

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -316,8 +316,8 @@ extension ModulesGraph {
         self.rootPackages
             .flatMap(\.products)
             .filter { $0.type.isLibrary }
-            .flatMap(\.targets)
-            .filter { $0.underlying is SwiftTarget }
+            .flatMap(\.modules)
+            .filter { $0.underlying is SwiftModule }
             .map { $0.c99name }
     }
 }

--- a/Sources/Commands/Utilities/MermaidPackageSerializer.swift
+++ b/Sources/Commands/Utilities/MermaidPackageSerializer.swift
@@ -13,7 +13,7 @@
 import struct OrderedCollections.OrderedDictionary
 import class PackageModel.Package
 import class PackageModel.Product
-import class PackageModel.Target
+import class PackageModel.Module
 
 struct MermaidPackageSerializer {
     let package: Package
@@ -23,7 +23,7 @@ struct MermaidPackageSerializer {
         var subgraphs = OrderedDictionary<String, [Edge]>()
         subgraphs[package.identity.description] = package.products.productTargetEdges
         
-        for edge in package.targets.targetDependencyEdges {
+        for edge in package.modules.targetDependencyEdges {
             if let subgraph = edge.to.subgraph {
                 subgraphs[subgraph, default: []].append(edge)
             } else {
@@ -102,11 +102,11 @@ extension MermaidPackageSerializer.Node {
         self.init(id: "product:\(product.name)", title: product.name, border: .doubled, subgraph: nil)
     }
 
-    init(target: Target) {
+    init(target: Module) {
         self.init(id: "target:\(target.name)", title: target.name)
     }
 
-    init(dependency: Target.Dependency) {
+    init(dependency: Module.Dependency) {
         switch dependency {
         case let .product(product, _):
             self.init(
@@ -115,7 +115,7 @@ extension MermaidPackageSerializer.Node {
                 border: .hexagon,
                 subgraph: product.package
             )
-        case let .target(target, _):
+        case let .module(target, _):
             self.init(target: target)
         }
     }
@@ -128,7 +128,7 @@ extension MermaidPackageSerializer.Node: CustomStringConvertible {
 }
 
 extension MermaidPackageSerializer.Edge {
-    init(product: Product, target: Target) {
+    init(product: Product, target: Module) {
         self.from = .init(product: product)
         self.to = .init(target: target)
     }
@@ -143,12 +143,12 @@ extension MermaidPackageSerializer.Edge: CustomStringConvertible {
 extension [Product] {
     fileprivate var productTargetEdges: [MermaidPackageSerializer.Edge] {
         self.flatMap { product in
-            product.targets.map { target in (product, target) }
+            product.modules.map { target in (product, target) }
         }.map(MermaidPackageSerializer.Edge.init)
     }
 }
 
-extension [Target] {
+extension [Module] {
     fileprivate var targetDependencyEdges: [MermaidPackageSerializer.Edge] {
         self.flatMap { target in
             target.dependencies.map {

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -23,10 +23,10 @@ import struct TSCBasic.ProcessResult
 
 final class PluginDelegate: PluginInvocationDelegate {
     let swiftCommandState: SwiftCommandState
-    let plugin: PluginTarget
+    let plugin: PluginModule
     var lineBufferedOutput: Data
 
-    init(swiftCommandState: SwiftCommandState, plugin: PluginTarget) {
+    init(swiftCommandState: SwiftCommandState, plugin: PluginModule) {
         self.swiftCommandState = swiftCommandState
         self.plugin = plugin
         self.lineBufferedOutput = Data()
@@ -385,7 +385,7 @@ final class PluginDelegate: PluginInvocationDelegate {
 
         // Find the target in the build operation's package graph; it's an error if we don't find it.
         let packageGraph = try buildSystem.getPackageGraph()
-        guard let target = packageGraph.target(for: targetName) else {
+        guard let target = packageGraph.module(for: targetName) else {
             throw StringError("could not find a target named “\(targetName)”")
         }
 
@@ -430,7 +430,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         guard let package = packageGraph.package(for: target) else {
             throw StringError("could not determine the package for target “\(target.name)”")
         }
-        let outputDir = try buildParameters.dataPath.appending(
+        let outputDir = buildParameters.dataPath.appending(
             components: "extracted-symbols",
             package.identity.description,
             target.name

--- a/Sources/PackageGraph/BuildTriple.swift
+++ b/Sources/PackageGraph/BuildTriple.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import class PackageModel.Target
+import class PackageModel.Module
 import class PackageModel.Product
 
 /// Triple for which code should be compiled for.
@@ -24,7 +24,7 @@ public enum BuildTriple: String {
     case destination = "destination"
 }
 
-extension Target {
+extension Module {
     var buildTriple: BuildTriple {
         if self.type == .macro || self.type == .plugin {
             .tools

--- a/Sources/PackageGraph/ModuleAliasTracker.swift
+++ b/Sources/PackageGraph/ModuleAliasTracker.swift
@@ -18,18 +18,18 @@ import Basics
 struct ModuleAliasTracker {
     fileprivate var aliasMap = [String: [ModuleAliasModel]]()
     fileprivate var idToAliasMap = [PackageIdentity: [String: [ModuleAliasModel]]]()
-    var idToProductToAllTargets = [PackageIdentity: [String: [Target]]]()
-    var productToDirectTargets = [String: [Target]]()
-    var productToAllTargets = [String: [Target]]()
+    var idToProductToAllModules = [PackageIdentity: [String: [Module]]]()
+    var productToDirectModules = [String: [Module]]()
+    var productToAllModules = [String: [Module]]()
     var parentToChildProducts = [String: [String]]()
     var parentToChildIDs = [PackageIdentity: [PackageIdentity]]()
     var childToParentID = [PackageIdentity: PackageIdentity]()
     var appliedAliases = Set<String>()
 
     init() {}
-    mutating func addTargetAliases(targets: [Target], package: PackageIdentity) throws {
-        let targetDependencies = targets.map{$0.dependencies}.flatMap{$0}
-        for dep in targetDependencies {
+    mutating func addModuleAliases(modules: [Module], package: PackageIdentity) throws {
+        let moduleDependencies = modules.flatMap(\.dependencies)
+        for dep in moduleDependencies {
             if case let .product(productRef, _) = dep,
                let productPkg = productRef.package {
                 let productPkgID = PackageIdentity.plain(productPkg)
@@ -59,8 +59,8 @@ struct ModuleAliasTracker {
             for existingAlias in existingAliases {
                 if let newAlias = aliases[existingAlias.name], newAlias != existingAlias.alias {
                     // Error if there are multiple different aliases specified for
-                    // targets in this product
-                    throw PackageGraphError.multipleModuleAliases(target: existingAlias.name, product: productName, package: originPackage.description, aliases: existingAliases.map{$0.alias} + [newAlias])
+                    // modules in this product
+                    throw PackageGraphError.multipleModuleAliases(module: existingAlias.name, product: productName, package: originPackage.description, aliases: existingAliases.map{$0.alias} + [newAlias])
                 }
             }
         }
@@ -83,34 +83,34 @@ struct ModuleAliasTracker {
     }
 
     // This func should be called once per product
-    mutating func trackTargetsPerProduct(product: Product, package: PackageIdentity) {
-        let targetDeps = product.targets.map{$0.dependencies}.flatMap{$0}
-        var allTargetDeps = product.targets.map{$0.recursiveDependentTargets.map{$0.dependencies}}.flatMap{$0}.flatMap{$0}
-        allTargetDeps.append(contentsOf: targetDeps)
-        for dep in allTargetDeps {
+    mutating func trackModulesPerProduct(product: Product, package: PackageIdentity) {
+        let moduleDeps = product.modules.flatMap(\.dependencies)
+        var allModuleDeps = product.modules.flatMap{$0.recursiveDependentModules.map{$0.dependencies}}.flatMap{$0}
+        allModuleDeps.append(contentsOf: moduleDeps)
+        for dep in allModuleDeps {
             if case let .product(depRef, _) = dep {
                 parentToChildProducts[product.identity, default: []].append(depRef.identity)
             }
         }
 
-        var allTargetsInProduct = targetDeps.compactMap{$0.target}
-        allTargetsInProduct.append(contentsOf: product.targets)
-        idToProductToAllTargets[package, default: [:]][product.identity] = allTargetsInProduct
-        productToDirectTargets[product.identity] = product.targets
-        productToAllTargets[product.identity] = allTargetsInProduct
+        var allModulesInProduct = moduleDeps.compactMap(\.module)
+        allModulesInProduct.append(contentsOf: product.modules)
+        idToProductToAllModules[package, default: [:]][product.identity] = allModulesInProduct
+        productToDirectModules[product.identity] = product.modules
+        productToAllModules[product.identity] = allModulesInProduct
     }
 
     func validateAndApplyAliases(product: Product,
                                  package: PackageIdentity,
                                  observabilityScope: ObservabilityScope) throws {
-        guard let targets = idToProductToAllTargets[package]?[product.identity] else { return }
-        let targetsWithAliases = targets.filter{ $0.moduleAliases != nil }
-        for targetWithAlias in targetsWithAliases {
-            if targetWithAlias.sources.containsNonSwiftFiles {
-                let aliasesMsg = targetWithAlias.moduleAliases?.map{"'\($0.key)' as '\($0.value)'"}.joined(separator: ", ") ?? ""
-                observabilityScope.emit(warning: "target '\(targetWithAlias.name)' for product '\(product.name)' from package '\(package.description)' has module aliases: [\(aliasesMsg)] but may contain non-Swift sources; there might be a conflict among non-Swift symbols")
+        guard let modules = idToProductToAllModules[package]?[product.identity] else { return }
+        let modulesWithAliases = modules.filter{ $0.moduleAliases != nil }
+        for moduleWithAlias in modulesWithAliases {
+            if moduleWithAlias.sources.containsNonSwiftFiles {
+                let aliasesMsg = moduleWithAlias.moduleAliases?.map{"'\($0.key)' as '\($0.value)'"}.joined(separator: ", ") ?? ""
+                observabilityScope.emit(warning: "target '\(moduleWithAlias.name)' for product '\(product.name)' from package '\(package.description)' has module aliases: [\(aliasesMsg)] but may contain non-Swift sources; there might be a conflict among non-Swift symbols")
             }
-            targetWithAlias.applyAlias()
+            moduleWithAlias.applyAlias()
         }
     }
 
@@ -125,19 +125,19 @@ struct ModuleAliasTracker {
         }
         guard let rootPkg else { return }
 
-        if let productToAllTargets = idToProductToAllTargets[rootPkg] {
+        if let productToAllModules = idToProductToAllModules[rootPkg] {
             // First, propagate aliases upstream
-            for productID in productToAllTargets.keys {
+            for productID in productToAllModules.keys {
                 var aliasBuffer = [String: ModuleAliasModel]()
                 propagate(productID: productID, observabilityScope: observabilityScope, aliasBuffer: &aliasBuffer)
             }
 
             // Then, merge or override upstream aliases downwards
-            for productID in productToAllTargets.keys {
+            for productID in productToAllModules.keys {
                 merge(productID: productID, observabilityScope: observabilityScope)
             }
         }
-        // Finally, fill in aliases for targets in products that are in the
+        // Finally, fill in aliases for modules in products that are in the
         // dependency chain but not in a product consumed by other packages
         fillInRest(package: rootPkg)
     }
@@ -160,20 +160,20 @@ struct ModuleAliasTracker {
             }
         }
 
-        if let curDirectTargets = productToDirectTargets[productID] {
-            var relevantTargets = curDirectTargets.map{$0.recursiveDependentTargets}.flatMap{$0}
-            relevantTargets.append(contentsOf: curDirectTargets)
+        if let curDirectModules = productToDirectModules[productID] {
+            var relevantModules = curDirectModules.map{$0.recursiveDependentModules}.flatMap{$0}
+            relevantModules.append(contentsOf: curDirectModules)
 
-            for relTarget in relevantTargets {
-                if let val = lookupAlias(key: relTarget.name, in: aliasBuffer) {
-                    appliedAliases.insert(relTarget.name)
-                    relTarget.addModuleAlias(for: relTarget.name, as: val)
-                    if let prechainVal = aliasBuffer[relTarget.name],
+            for relevantModule in relevantModules {
+                if let val = lookupAlias(key: relevantModule.name, in: aliasBuffer) {
+                    appliedAliases.insert(relevantModule.name)
+                    relevantModule.addModuleAlias(for: relevantModule.name, as: val)
+                    if let prechainVal = aliasBuffer[relevantModule.name],
                        prechainVal.alias != val {
-                        relTarget.addPrechainModuleAlias(for: relTarget.name, as: prechainVal.alias)
+                        relevantModule.addPrechainModuleAlias(for: relevantModule.name, as: prechainVal.alias)
                         appliedAliases.insert(prechainVal.alias)
-                        relTarget.addPrechainModuleAlias(for: prechainVal.alias, as: val)
-                        observabilityScope.emit(info: "Module alias '\(prechainVal.alias)' defined in package '\(prechainVal.consumingPackage)' for target '\(relTarget.name)' in package/product '\(productID)' is overridden by alias '\(val)'; if this override is not intended, remove '\(val)' from 'moduleAliases' in its manifest")
+                        relevantModule.addPrechainModuleAlias(for: prechainVal.alias, as: val)
+                        observabilityScope.emit(info: "Module alias '\(prechainVal.alias)' defined in package '\(prechainVal.consumingPackage)' for target '\(relevantModule.name)' in package/product '\(productID)' is overridden by alias '\(val)'; if this override is not intended, remove '\(val)' from 'moduleAliases' in its manifest")
                         aliasBuffer.removeValue(forKey: prechainVal.alias)
 
                         // Since we're overriding an alias here, we have to pretend it was applied to avoid follow-on warnings.
@@ -183,7 +183,7 @@ struct ModuleAliasTracker {
                             currentAlias = aliasBuffer.values.first { $0.alias == _currentAlias }?.name
                         }
                     }
-                    aliasBuffer.removeValue(forKey: relTarget.name)
+                    aliasBuffer.removeValue(forKey: relevantModule.name)
                 }
             }
         }
@@ -208,33 +208,33 @@ struct ModuleAliasTracker {
                   observabilityScope: observabilityScope)
         }
 
-        if let curDirectTargets = productToDirectTargets[productID] {
-            let depTargets = curDirectTargets.map{$0.recursiveDependentTargets}.flatMap{$0}
-            let depTargetAliases = toDictionary(depTargets.compactMap{$0.moduleAliases})
-            let depChildTargets = dependencyProductTargets(of: depTargets)
-            let depChildAliases = toDictionary(depChildTargets.compactMap{$0.moduleAliases})
-            let depChildPrechainAliases = toDictionary(depChildTargets.compactMap{$0.prechainModuleAliases})
-            chainModuleAliases(targets: depTargets,
-                               checkedTargets: depTargets,
-                               targetAliases: depTargetAliases,
-                               childTargets: depChildTargets,
+        if let curDirectModules = productToDirectModules[productID] {
+            let depModules = curDirectModules.map{$0.recursiveDependentModules}.flatMap{$0}
+            let depModuleAliases = toDictionary(depModules.compactMap{$0.moduleAliases})
+            let depChildModules = dependencyProductModules(of: depModules)
+            let depChildAliases = toDictionary(depChildModules.compactMap{$0.moduleAliases})
+            let depChildPrechainAliases = toDictionary(depChildModules.compactMap{$0.prechainModuleAliases})
+            chainModuleAliases(modules: depModules,
+                               checkedModules: depModules,
+                               moduleAliases: depModuleAliases,
+                               childModules: depChildModules,
                                childAliases: depChildAliases,
                                childPrechainAliases: depChildPrechainAliases,
                                observabilityScope: observabilityScope)
 
-            let relevantTargets = depTargets + curDirectTargets
-            let targetAliases = toDictionary(relevantTargets.compactMap{$0.moduleAliases})
-            let depProductTargets = dependencyProductTargets(of: relevantTargets)
+            let relevantModules = depModules + curDirectModules
+            let moduleAliases = toDictionary(relevantModules.compactMap{$0.moduleAliases})
+            let depProductModules = dependencyProductModules(of: relevantModules)
             var depProductAliases = [String: [String]]()
-            let depProductPrechainAliases = toDictionary(depProductTargets.compactMap{$0.prechainModuleAliases})
+            let depProductPrechainAliases = toDictionary(depProductModules.compactMap{$0.prechainModuleAliases})
 
-            for depProdTarget in depProductTargets {
-                let depProdTargetAliases = depProdTarget.moduleAliases ?? [:]
-                for (key, val) in depProdTargetAliases {
+            for depProdModule in depProductModules {
+                let depProdModuleAliases = depProdModule.moduleAliases ?? [:]
+                for (key, val) in depProdModuleAliases {
                     var shouldAddAliases = false
-                    if depProdTarget.name == key {
+                    if depProdModule.name == key {
                         shouldAddAliases = true
-                    } else if !depProductTargets.map({$0.name}).contains(key) {
+                    } else if !depProductModules.map({$0.name}).contains(key) {
                         shouldAddAliases = true
                     }
                     if shouldAddAliases {
@@ -246,30 +246,30 @@ struct ModuleAliasTracker {
                     }
                 }
             }
-            chainModuleAliases(targets: curDirectTargets,
-                               checkedTargets: relevantTargets,
-                               targetAliases: targetAliases,
-                               childTargets: depProductTargets,
+            chainModuleAliases(modules: curDirectModules,
+                               checkedModules: relevantModules,
+                               moduleAliases: moduleAliases,
+                               childModules: depProductModules,
                                childAliases: depProductAliases,
                                childPrechainAliases: depProductPrechainAliases,
                                observabilityScope: observabilityScope)
         }
     }
 
-    // This fills in aliases for targets in products that are in the dependency
-    // chain but not in a product consumed by other packages. Such targets still
+    // This fills in aliases for modules in products that are in the dependency
+    // chain but not in a product consumed by other packages. Such modules still
     // need to have aliases applied to them so they can be built with correct
     // dependent binary names
     mutating func fillInRest(package: PackageIdentity) {
-        if let productToTargets = idToProductToAllTargets[package] {
-            for (_, productTargets) in productToTargets {
-                let unAliased = productTargets.contains{$0.moduleAliases == nil}
+        if let productToModules = idToProductToAllModules[package] {
+            for (_, productModules) in productToModules {
+                let unAliased = productModules.contains { $0.moduleAliases == nil }
                 if unAliased {
-                    for target in productTargets {
-                        let depAliases = target.recursiveDependentTargets.compactMap{$0.moduleAliases}.flatMap{$0}
+                    for module in productModules {
+                        let depAliases = module.recursiveDependentModules.compactMap{$0.moduleAliases}.flatMap{$0}
                         for (key, alias) in depAliases {
                             appliedAliases.insert(key)
-                            target.addModuleAlias(for: key, as: alias)
+                            module.addModuleAlias(for: key, as: alias)
                         }
                     }
                 }
@@ -292,45 +292,45 @@ struct ModuleAliasTracker {
     }
 
     private mutating func chainModuleAliases(
-        targets: [Target],
-        checkedTargets: [Target],
-        targetAliases: [String: [String]],
-        childTargets: [Target],
+        modules: [Module],
+        checkedModules: [Module],
+        moduleAliases: [String: [String]],
+        childModules: [Module],
         childAliases: [String: [String]],
         childPrechainAliases: [String: [String]],
         observabilityScope: ObservabilityScope
     ) {
-        guard !targets.isEmpty else { return }
+        guard !modules.isEmpty else { return }
         var aliasDict = [String: String]()
         var prechainAliasDict = [String: [String]]()
         var directRefAliasDict = [String: [String]]()
-        let childDirectRefAliases = toDictionary(childTargets.compactMap{$0.directRefAliases})
-        for (childTargetName, childTargetAliases) in childAliases {
-            // Tracks whether to add prechain aliases to targets
+        let childDirectRefAliases = toDictionary(childModules.compactMap{$0.directRefAliases})
+        for (childModuleName, childModuleAliases) in childAliases {
+            // Tracks whether to add prechain aliases to modules
             var addPrechainAliases = false
-            // Current targets and their dependents contain this child product
-            // target name
-            if checkedTargets.map({$0.name}).contains(childTargetName) {
+            // Current modules and their dependents contain this child product
+            // module name
+            if checkedModules.map(\.name).contains(childModuleName) {
                 addPrechainAliases = true
             }
-            if let overlappingTargetAliases = targetAliases[childTargetName], !overlappingTargetAliases.isEmpty {
-                // Current target aliases have the same key as this child
-                // target name, so the child target alias should not be applied
+            if let overlappingModuleAliases = moduleAliases[childModuleName], !overlappingModuleAliases.isEmpty {
+                // Current module aliases have the same key as this child
+                // module name, so the child module alias should not be applied
                 addPrechainAliases = true
-                aliasDict[childTargetName] = overlappingTargetAliases.first
-            } else if childTargetAliases.count > 1 {
-                // Multiple aliases from different products for this child target
+                aliasDict[childModuleName] = overlappingModuleAliases.first
+            } else if childModuleAliases.count > 1 {
+                // Multiple aliases from different products for this child module
                 // name exist so they should not be applied; their aliases / new
                 // names should be used directly
                 addPrechainAliases = true
-            } else if childTargets.filter({$0.name == childTargetName}).count > 1 {
-                // Targets from different products have the same name as this child
-                // target name, so their aliases should not be applied
+            } else if childModules.filter({$0.name == childModuleName}).count > 1 {
+                // Modules from different products have the same name as this child
+                // module name, so their aliases should not be applied
                 addPrechainAliases = true
             }
 
             if addPrechainAliases {
-                if let prechainAliases = childPrechainAliases[childTargetName] {
+                if let prechainAliases = childPrechainAliases[childModuleName] {
                    for prechainAliasKey in prechainAliases {
                        if let prechainAliasVals = childPrechainAliases[prechainAliasKey] {
                            // If aliases are chained, keep track of prechain
@@ -338,42 +338,42 @@ struct ModuleAliasTracker {
                            prechainAliasDict[prechainAliasKey, default: []].append(contentsOf: prechainAliasVals)
                            // Add prechained aliases to the list of aliases
                            // that should be directly referenced in source code
-                           directRefAliasDict[childTargetName, default: []].append(prechainAliasKey)
+                           directRefAliasDict[childModuleName, default: []].append(prechainAliasKey)
                            directRefAliasDict[prechainAliasKey, default: []].append(contentsOf: prechainAliasVals)
                        }
                     }
-                } else if aliasDict[childTargetName] == nil {
+                } else if aliasDict[childModuleName] == nil {
                     // If not added to aliasDict, use the renamed module directly
-                    directRefAliasDict[childTargetName, default: []].append(contentsOf: childTargetAliases)
+                    directRefAliasDict[childModuleName, default: []].append(contentsOf: childModuleAliases)
                 }
-            } else if let productTargetAlias = childTargetAliases.first {
-                if childTargetAliases.count > 1 {
-                    observabilityScope.emit(warning: "There should be one alias for target '\(childTargetName)' but there are [\(childTargetAliases.map{"'\($0)'"}.joined(separator: ", "))]")
+            } else if let productModuleAlias = childModuleAliases.first {
+                if childModuleAliases.count > 1 {
+                    observabilityScope.emit(warning: "There should be one alias for target '\(childModuleName)' but there are [\(childModuleAliases.map{"'\($0)'"}.joined(separator: ", "))]")
                 }
-                // Check if not in child targets' direct ref aliases list, then add
-                if lookupAlias(value: childTargetName, in: childDirectRefAliases).isEmpty,
-                   childDirectRefAliases[childTargetName] == nil {
-                    aliasDict[childTargetName] = productTargetAlias
+                // Check if not in child modules' direct ref aliases list, then add
+                if lookupAlias(value: childModuleName, in: childDirectRefAliases).isEmpty,
+                   childDirectRefAliases[childModuleName] == nil {
+                    aliasDict[childModuleName] = productModuleAlias
                 }
             }
         }
 
-        for target in targets {
+        for module in modules {
             for (key, val) in aliasDict {
                 appliedAliases.insert(key)
-                target.addModuleAlias(for: key, as: val)
+                module.addModuleAlias(for: key, as: val)
             }
             for (key, valList) in prechainAliasDict {
                 if let val = valList.first,
                     valList.count <= 1 {
                     appliedAliases.insert(key)
-                    target.addModuleAlias(for: key, as: val)
-                    target.addPrechainModuleAlias(for: key, as: val)
+                    module.addModuleAlias(for: key, as: val)
+                    module.addPrechainModuleAlias(for: key, as: val)
                 }
             }
             for (key, list) in directRefAliasDict {
-                target.addDirectRefAliases(for: key, as: list)
-                observabilityScope.emit(info: "Target '\(target.name)' has a dependency on multiple targets named '\(key)'; the aliased names are [\(list.map{"'\($0)'"}.joined(separator: ", "))] and should be used directly in source code if referenced from '\(target.name)'")
+                module.addDirectRefAliases(for: key, as: list)
+                observabilityScope.emit(info: "Target '\(module.name)' has a dependency on multiple targets named '\(key)'; the aliased names are [\(list.map{"'\($0)'"}.joined(separator: ", "))] and should be used directly in source code if referenced from '\(module.name)'")
             }
         }
     }
@@ -415,8 +415,8 @@ struct ModuleAliasTracker {
         return dict
     }
 
-    private func dependencyProductTargets(of targets: [Target]) -> [Target] {
-        let result = targets.map{$0.dependencies.compactMap{$0.product?.identity}}.flatMap{$0}.compactMap{productToAllTargets[$0]}.flatMap{$0}
+    private func dependencyProductModules(of modules: [Module]) -> [Module] {
+        let result = modules.map{$0.dependencies.compactMap{$0.product?.identity}}.flatMap{$0}.compactMap{productToAllModules[$0]}.flatMap{$0}
         return result
     }
 }
@@ -438,7 +438,7 @@ private class ModuleAliasModel {
     }
 }
 
-extension Target {
+extension Module {
     func dependsOn(productID: String) -> Bool {
         return self.dependencies.contains { dep in
             if case let .product(prodRef, _) = dep {
@@ -448,13 +448,13 @@ extension Target {
         }
     }
 
-    var recursiveDependentTargets: [Target] {
-        var list = [Target]()
+    var recursiveDependentModules: [Module] {
+        var list = [Module]()
         var nextDeps = self.dependencies
         while !nextDeps.isEmpty {
-            let nextTargets = nextDeps.compactMap{$0.target}
-            list.append(contentsOf: nextTargets)
-            nextDeps = nextTargets.map{$0.dependencies}.flatMap{$0}
+            let nextModules = nextDeps.compactMap{$0.module}
+            list.append(contentsOf: nextModules)
+            nextDeps = nextModules.map{$0.dependencies}.flatMap{$0}
         }
         return list
     }

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -103,7 +103,7 @@ extension ModulesGraph {
             }
         }
 
-        // Cycles in dependencies don't matter as long as there are no target cycles between packages.
+        // Cycles in dependencies don't matter as long as there are no module cycles between packages.
         depthFirstSearch(
             inputManifests,
             successors: nodeSuccessorProvider
@@ -145,7 +145,7 @@ extension ModulesGraph {
                 manifestToPackage[manifest] = package
 
                 // Throw if any of the non-root package is empty.
-                if package.targets.isEmpty // System packages have targets in the package but not the manifest.
+                if package.modules.isEmpty // System packages have modules in the package but not the manifest.
                     && package.manifest.targets.isEmpty // An unneeded dependency will not have loaded anything from the manifest.
                     && !manifest.packageKind.isRoot {
                     throw PackageGraphError.noModules(package)
@@ -192,13 +192,13 @@ private func checkAllDependenciesAreUsed(
     observabilityScope: ObservabilityScope
 ) {
     for package in rootPackages {
-        // List all dependency products dependent on by the package targets.
-        let productDependencies = IdentifiableSet(package.targets.flatMap { target in
-            return target.dependencies.compactMap { targetDependency in
-                switch targetDependency {
+        // List all dependency products dependent on by the package modules.
+        let productDependencies = IdentifiableSet(package.modules.flatMap { module in
+            return module.dependencies.compactMap { moduleDependency in
+                switch moduleDependency {
                 case .product(let product, _):
                     return product
-                case .target:
+                case .module:
                     return nil
                 }
             }
@@ -219,7 +219,7 @@ private func checkAllDependenciesAreUsed(
             // have no products.
             //
             // FIXME: Do/should we print a warning if a dependency has no products?
-            if dependency.products.isEmpty && dependency.targets.filter({ $0.type == .systemModule }).count == 1 {
+            if dependency.products.isEmpty && dependency.modules.filter({ $0.type == .systemModule }).count == 1 {
                 continue
             }
 
@@ -249,11 +249,11 @@ private func checkAllDependenciesAreUsed(
 }
 
 fileprivate extension ResolvedProduct {
-    /// Returns true if and only if the product represents a command plugin target.
+    /// Returns true if and only if the product represents a command plugin module.
     var isCommandPlugin: Bool {
         guard type == .plugin else { return false }
-        guard let target = underlying.targets.compactMap({ $0 as? PluginTarget }).first else { return false }
-        guard case .command = target.capability else { return false }
+        guard let module = underlying.modules.compactMap({ $0 as? PluginModule }).first else { return false }
+        guard case .command = module.capability else { return false }
         return true
     }
 }
@@ -295,8 +295,8 @@ private func createResolvedPackages(
         return ($0.package.identity, $0)
     }
 
-    // Resolve module aliases, if specified, for targets and their dependencies
-    // across packages. Aliasing will result in target renaming.
+    // Resolve module aliases, if specified, for modules and their dependencies
+    // across packages. Aliasing will result in module renaming.
     let moduleAliasingUsed = try resolveModuleAliases(
         packageBuilders: packageBuilders,
         observabilityScope: observabilityScope
@@ -312,8 +312,8 @@ private func createResolvedPackages(
         )
         
         var dependencies = OrderedCollections.OrderedDictionary<PackageIdentity, ResolvedPackageBuilder>()
-        var dependenciesByNameForTargetDependencyResolution = [String: ResolvedPackageBuilder]()
-        var dependencyNamesForTargetDependencyResolutionOnly = [PackageIdentity: String]()
+        var dependenciesByNameForModuleDependencyResolution = [String: ResolvedPackageBuilder]()
+        var dependencyNamesForModuleDependencyResolutionOnly = [PackageIdentity: String]()
 
         // Establish the manifest-declared package dependencies.
         package.manifest.dependenciesRequired(for: packageBuilder.productFilter).forEach { dependency in
@@ -345,8 +345,8 @@ private func createResolvedPackages(
                     // 9/2021 this is currently emitting a warning only to support
                     // backwards compatibility with older versions of SwiftPM that had too weak of a validation
                     // we will upgrade this to an error in a few versions to tighten up the validation
-                    if dependency.explicitNameForTargetDependencyResolutionOnly == .none ||
-                        resolvedPackage.package.manifest.displayName == dependency.explicitNameForTargetDependencyResolutionOnly {
+                    if dependency.explicitNameForModuleDependencyResolutionOnly == .none ||
+                        resolvedPackage.package.manifest.displayName == dependency.explicitNameForModuleDependencyResolutionOnly {
                         packageObservabilityScope.emit(warning: error.description + ". this will be escalated to an error in future versions of SwiftPM.")
                     } else {
                         return packageObservabilityScope.emit(error)
@@ -357,9 +357,9 @@ private func createResolvedPackages(
                     packageObservabilityScope.emit(info: "dependency on '\(resolvedPackage.package.identity)' is represented by similar locations ('\(resolvedPackage.package.manifest.packageLocation)' and '\(dependencyPackageRef.locationString)') which are treated as the same canonical location '\(dependencyPackageRef.canonicalLocation)'.")
                 }
 
-                // checks if two dependencies have the same explicit name which can cause target based dependency package lookup issue
-                if let explicitDependencyName = dependency.explicitNameForTargetDependencyResolutionOnly {
-                    if let previouslyResolvedPackage = dependenciesByNameForTargetDependencyResolution[explicitDependencyName] {
+                // checks if two dependencies have the same explicit name which can cause module based dependency package lookup issue
+                if let explicitDependencyName = dependency.explicitNameForModuleDependencyResolutionOnly {
+                    if let previouslyResolvedPackage = dependenciesByNameForModuleDependencyResolution[explicitDependencyName] {
                         let error = PackageGraphError.dependencyAlreadySatisfiedByName(
                             package: package.identity.description,
                             dependencyLocation: dependencyPackageRef.locationString,
@@ -369,8 +369,8 @@ private func createResolvedPackages(
                     }
                 }
 
-                // checks if two dependencies have the same implicit (identity based) name which can cause target based dependency package lookup issue
-                if let previouslyResolvedPackage = dependenciesByNameForTargetDependencyResolution[dependency.identity.description] {
+                // checks if two dependencies have the same implicit (identity based) name which can cause module based dependency package lookup issue
+                if let previouslyResolvedPackage = dependenciesByNameForModuleDependencyResolution[dependency.identity.description] {
                     let error = PackageGraphError.dependencyAlreadySatisfiedByName(
                         package: package.identity.description,
                         dependencyLocation: dependencyPackageRef.locationString,
@@ -379,16 +379,16 @@ private func createResolvedPackages(
                     return packageObservabilityScope.emit(error)
                 }
 
-                let nameForTargetDependencyResolution = dependency.explicitNameForTargetDependencyResolutionOnly ?? dependency.identity.description
-                dependenciesByNameForTargetDependencyResolution[nameForTargetDependencyResolution] = resolvedPackage
-                dependencyNamesForTargetDependencyResolutionOnly[resolvedPackage.package.identity] = nameForTargetDependencyResolution
+                let nameForModuleDependencyResolution = dependency.explicitNameForModuleDependencyResolutionOnly ?? dependency.identity.description
+                dependenciesByNameForModuleDependencyResolution[nameForModuleDependencyResolution] = resolvedPackage
+                dependencyNamesForModuleDependencyResolutionOnly[resolvedPackage.package.identity] = nameForModuleDependencyResolution
 
                 dependencies[resolvedPackage.package.identity] = resolvedPackage
             }
         }
 
         packageBuilder.dependencies = Array(dependencies.values)
-        packageBuilder.dependencyNamesForTargetDependencyResolutionOnly = dependencyNamesForTargetDependencyResolutionOnly
+        packageBuilder.dependencyNamesForModuleDependencyResolutionOnly = dependencyNamesForModuleDependencyResolutionOnly
 
         packageBuilder.defaultLocalization = package.manifest.defaultLocalization
 
@@ -397,43 +397,43 @@ private func createResolvedPackages(
             platformRegistry: platformRegistry
         )
 
-        // Create target builders for each target in the package.
-        let targetBuilders = package.targets.map {
-            ResolvedTargetBuilder(
+        // Create module builders for each module in the package.
+        let moduleBuilders = package.modules.map {
+            ResolvedModuleBuilder(
                 packageIdentity: package.identity,
-                target: $0,
+                module: $0,
                 observabilityScope: packageObservabilityScope,
                 platformVersionProvider: platformVersionProvider
             )
         }
-        packageBuilder.targets = targetBuilders
+        packageBuilder.modules = moduleBuilders
 
-        // Establish dependencies between the targets. A target can only depend on another target present in the same package.
-        let targetMap = targetBuilders.spm_createDictionary({ ($0.target, $0) })
-        for targetBuilder in targetBuilders {
-            targetBuilder.dependencies += try targetBuilder.target.dependencies.compactMap { dependency in
+        // Establish dependencies between the modules. A module can only depend on another module present in the same package.
+        let modulesMap = moduleBuilders.spm_createDictionary({ ($0.module, $0) })
+        for moduleBuilder in moduleBuilders {
+            moduleBuilder.dependencies += try moduleBuilder.module.dependencies.compactMap { dependency in
                 switch dependency {
-                case .target(let target, let conditions):
-                    try targetBuilder.target.validateDependency(target: target)
-                    guard let targetBuilder = targetMap[target] else {
-                        throw InternalError("unknown target \(target.name)")
+                case .module(let moduleDependency, let conditions):
+                    try moduleBuilder.module.validateDependency(module: moduleDependency)
+                    guard let moduleBuilder = modulesMap[moduleDependency] else {
+                        throw InternalError("unknown target \(moduleDependency.name)")
                     }
-                    return .target(targetBuilder, conditions: conditions)
+                    return .module(moduleBuilder, conditions: conditions)
                 case .product:
                     return nil
                 }
             }
-            targetBuilder.defaultLocalization = packageBuilder.defaultLocalization
-            targetBuilder.supportedPlatforms = packageBuilder.supportedPlatforms
+            moduleBuilder.defaultLocalization = packageBuilder.defaultLocalization
+            moduleBuilder.supportedPlatforms = packageBuilder.supportedPlatforms
         }
 
-        // Create product builders for each product in the package. A product can only contain a target present in the same package.
+        // Create product builders for each product in the package. A product can only contain a module present in the same package.
         packageBuilder.products = try package.products.map{
-            try ResolvedProductBuilder(product: $0, packageBuilder: packageBuilder, targets: $0.targets.map {
-                guard let target = targetMap[$0] else {
+            try ResolvedProductBuilder(product: $0, packageBuilder: packageBuilder, moduleBuilders: $0.modules.map {
+                guard let module = modulesMap[$0] else {
                     throw InternalError("unknown target \($0)")
                 }
-                return target
+                return module
             })
         }
 
@@ -453,20 +453,20 @@ private func createResolvedPackages(
     )
     try dupProductsChecker.run(lookupByProductIDs: moduleAliasingUsed, observabilityScope: observabilityScope)
 
-    // The set of all target names.
-    var allTargetNames = Set<String>()
+    // The set of all module names.
+    var allModuleNames = Set<String>()
 
-    // Track if multiple targets are found with the same name.
-    var foundDuplicateTarget = false
+    // Track if multiple modules are found with the same name.
+    var foundDuplicateModule = false
 
     for packageBuilder in packageBuilders {
-        for target in packageBuilder.targets {
-            // Record if we see a duplicate target.
-            foundDuplicateTarget = foundDuplicateTarget || !allTargetNames.insert(target.target.name).inserted
+        for moduleBuilder in packageBuilder.modules {
+            // Record if we see a duplicate module.
+            foundDuplicateModule = foundDuplicateModule || !allModuleNames.insert(moduleBuilder.module.name).inserted
         }
     }
 
-    // Do another pass and establish product dependencies of each target.
+    // Do another pass and establish product dependencies of each module.
     for packageBuilder in packageBuilders {
         let package = packageBuilder.package
 
@@ -476,10 +476,10 @@ private func createResolvedPackages(
         )
 
         // Get all implicit system library dependencies in this package.
-        let implicitSystemTargetDeps = packageBuilder.dependencies
-            .flatMap({ $0.targets })
+        let implicitSystemLibraryDeps = packageBuilder.dependencies
+            .flatMap(\.modules)
             .filter({
-                if case let systemLibrary as SystemLibraryTarget = $0.target {
+                if case let systemLibrary as SystemLibraryModule = $0.module {
                     return systemLibrary.isImplicit
                 }
                 return false
@@ -502,7 +502,7 @@ private func createResolvedPackages(
         let productDependencyMap: [String: ResolvedProductBuilder]
         if lookupByProductIDs {
             productDependencyMap = try Dictionary(uniqueKeysWithValues: productDependencies.map {
-                guard let packageName = packageBuilder.dependencyNamesForTargetDependencyResolutionOnly[$0.packageBuilder.package.identity] else {
+                guard let packageName = packageBuilder.dependencyNamesForModuleDependencyResolutionOnly[$0.packageBuilder.package.identity] else {
                     throw InternalError("could not determine name for dependency on package '\($0.packageBuilder.package.identity)' from package '\(packageBuilder.package.identity)'")
                 }
                 let key = "\(packageName.lowercased())_\($0.product.name)"
@@ -523,13 +523,13 @@ private func createResolvedPackages(
             )
         }
 
-        // Establish dependencies in each target.
-        for targetBuilder in packageBuilder.targets {
+        // Establish dependencies in each module.
+        for moduleBuilder in packageBuilder.modules {
             // Directly add all the system module dependencies.
-            targetBuilder.dependencies += implicitSystemTargetDeps.map { .target($0, conditions: []) }
+            moduleBuilder.dependencies += implicitSystemLibraryDeps.map { .module($0, conditions: []) }
 
             // Establish product dependencies.
-            for case .product(let productRef, let conditions) in targetBuilder.target.dependencies {
+            for case .product(let productRef, let conditions) in moduleBuilder.module.dependencies {
                 // Find the product in this package's dependency products.
                 // Look it up by ID if module aliasing is used, otherwise by name.
                 let product = lookupByProductIDs ? productDependencyMap[productRef.identity] : productDependencyMap[productRef.name]
@@ -539,26 +539,26 @@ private func createResolvedPackages(
                     // found errors when there are more important errors to
                     // resolve (like authentication issues).
                     if !observabilityScope.errorsReportedInAnyScope {
-                        // Emit error if a product (not target) declared in the package is also a productRef (dependency)
+                        // Emit error if a product (not module) declared in the package is also a productRef (dependency)
                         let declProductsAsDependency = package.products.filter { product in
                             lookupByProductIDs ? product.identity == productRef.identity : product.name == productRef.name
-                        }.map {$0.targets}.flatMap{$0}.filter { t in
+                        }.map {$0.modules}.flatMap{$0}.filter { t in
                             t.name != productRef.name
                         }
 
                         // Find a product name from the available product dependencies that is most similar to the required product name.
-                        let bestMatchedProductName = bestMatch(for: productRef.name, from: Array(allTargetNames))
+                        let bestMatchedProductName = bestMatch(for: productRef.name, from: Array(allModuleNames))
                         var packageContainingBestMatchedProduct: String?
                         if let bestMatchedProductName, productRef.name == bestMatchedProductName {
                             let dependentPackages = packageBuilder.dependencies.map(\.package)
-                            for p in dependentPackages where p.targets.contains(where: { $0.name == bestMatchedProductName }) {
+                            for p in dependentPackages where p.modules.contains(where: { $0.name == bestMatchedProductName }) {
                                 packageContainingBestMatchedProduct = p.identity.description
                                 break
                             }
                         }
                         let error = PackageGraphError.productDependencyNotFound(
                             package: package.identity.description,
-                            targetName: targetBuilder.target.name,
+                            moduleName: moduleBuilder.module.name,
                             dependencyProductName: productRef.name,
                             dependencyPackageName: productRef.package,
                             dependencyProductInDecl: !declProductsAsDependency.isEmpty,
@@ -570,7 +570,7 @@ private func createResolvedPackages(
                     continue
                 }
 
-                // Starting in 5.2, and target-based dependency, we require target product dependencies to
+                // Starting in 5.2, and module-based dependency, we require module product dependencies to
                 // explicitly reference the package containing the product, or for the product, package and
                 // dependency to share the same name. We don't check this in manifest loading for root-packages so
                 // we can provide a more detailed diagnostic here.
@@ -581,49 +581,49 @@ private func createResolvedPackages(
                     }) else {
                         throw InternalError("dependency reference for \(product.packageBuilder.package.manifest.packageLocation) not found")
                     }
-                    let referencedPackageName = referencedPackageDependency.nameForTargetDependencyResolutionOnly
+                    let referencedPackageName = referencedPackageDependency.nameForModuleDependencyResolutionOnly
                     if productRef.name != referencedPackageName {
                         let error = PackageGraphError.productDependencyMissingPackage(
                             productName: productRef.name,
-                            targetName: targetBuilder.target.name,
+                            moduleName: moduleBuilder.module.name,
                             packageIdentifier: referencedPackageName
                         )
                         packageObservabilityScope.emit(error)
                     }
                 }
 
-                targetBuilder.dependencies.append(.product(product, conditions: conditions))
+                moduleBuilder.dependencies.append(.product(product, conditions: conditions))
             }
         }
     }
 
-    // If a target with similar name was encountered before, we emit a diagnostic.
-    if foundDuplicateTarget {
-        var duplicateTargets = [String: [Package]]()
-        for targetName in Set(allTargetNames).sorted() {
+    // If a module with similar name was encountered before, we emit a diagnostic.
+    if foundDuplicateModule {
+        var duplicateModules = [String: [Package]]()
+        for moduleName in Set(allModuleNames).sorted() {
             let packages = packageBuilders
-                .filter({ $0.targets.contains(where: { $0.target.name == targetName }) })
+                .filter({ $0.modules.contains(where: { $0.module.name == moduleName }) })
                 .map{ $0.package }
             if packages.count > 1 {
-                duplicateTargets[targetName, default: []].append(contentsOf: packages)
+                duplicateModules[moduleName, default: []].append(contentsOf: packages)
             }
         }
 
         var potentiallyDuplicatePackages = [Pair: [String]]()
-        for entry in duplicateTargets {
+        for entry in duplicateModules {
             // the duplicate is across exactly two packages
             if entry.value.count == 2 {
                 potentiallyDuplicatePackages[Pair(package1: entry.value[0], package2: entry.value[1]), default: []].append(entry.key)
             }
         }
 
-        var duplicateTargetsAddressed = [String]()
+        var duplicateModulesAddressed = [String]()
         for potentiallyDuplicatePackage in potentiallyDuplicatePackages {
-            // more than three target matches, or all targets in the package match
+            // more than three module matches, or all modules in the package match
             if potentiallyDuplicatePackage.value.count > 3 ||
-                (potentiallyDuplicatePackage.value.sorted() == potentiallyDuplicatePackage.key.package1.targets.map({ $0.name }).sorted()
+                (potentiallyDuplicatePackage.value.sorted() == potentiallyDuplicatePackage.key.package1.modules.map({ $0.name }).sorted()
                 &&
-                potentiallyDuplicatePackage.value.sorted() == potentiallyDuplicatePackage.key.package2.targets.map({ $0.name }).sorted())
+                potentiallyDuplicatePackage.value.sorted() == potentiallyDuplicatePackage.key.package2.modules.map({ $0.name }).sorted())
             {
                 switch (potentiallyDuplicatePackage.key.package1.identity.registry, potentiallyDuplicatePackage.key.package2.identity.registry) {
                 case (.some(let registryIdentity), .none):
@@ -631,7 +631,7 @@ private func createResolvedPackages(
                         ModuleError.duplicateModulesScmAndRegistry(
                             registryPackage: registryIdentity,
                             scmPackage: potentiallyDuplicatePackage.key.package2.identity,
-                            targets: potentiallyDuplicatePackage.value
+                            modules: potentiallyDuplicatePackage.value
                         )
                     )
                 case (.none, .some(let registryIdentity)):
@@ -639,7 +639,7 @@ private func createResolvedPackages(
                         ModuleError.duplicateModulesScmAndRegistry(
                             registryPackage: registryIdentity,
                             scmPackage: potentiallyDuplicatePackage.key.package1.identity,
-                            targets: potentiallyDuplicatePackage.value
+                            modules: potentiallyDuplicatePackage.value
                         )
                     )
                 default:
@@ -647,36 +647,36 @@ private func createResolvedPackages(
                         ModuleError.duplicateModules(
                             package: potentiallyDuplicatePackage.key.package1.identity,
                             otherPackage: potentiallyDuplicatePackage.key.package2.identity,
-                            targets: potentiallyDuplicatePackage.value
+                            modules: potentiallyDuplicatePackage.value
                         )
                     )
                 }
-                duplicateTargetsAddressed += potentiallyDuplicatePackage.value
+                duplicateModulesAddressed += potentiallyDuplicatePackage.value
             }
         }
 
-        for entry in duplicateTargets.filter({ !duplicateTargetsAddressed.contains($0.key) }) {
+        for entry in duplicateModules.filter({ !duplicateModulesAddressed.contains($0.key) }) {
             observabilityScope.emit(
                 ModuleError.duplicateModule(
-                    targetName: entry.key,
+                    moduleName: entry.key,
                     packages: entry.value.map { $0.identity })
             )
         }
     }
 
     do {
-        let targetBuilders = packageBuilders.flatMap {
-            $0.targets.map {
-                KeyedPair($0, key: $0.target)
+        let moduleBuilders = packageBuilders.flatMap {
+            $0.modules.map {
+                KeyedPair($0, key: $0.module)
             }
         }
-        if let cycle = findCycle(targetBuilders, successors: {
+        if let cycle = findCycle(moduleBuilders, successors: {
             $0.item.dependencies.flatMap {
                 switch $0 {
                 case .product(let productBuilder, conditions: _):
-                    return productBuilder.targets.map { KeyedPair($0, key: $0.target) }
-                case .target:
-                    return [] // local targets were checked by PackageBuilder.
+                    return productBuilder.moduleBuilders.map { KeyedPair($0, key: $0.module) }
+                case .module:
+                    return [] // local modules were checked by PackageBuilder.
                 }
             }
         }) {
@@ -758,7 +758,7 @@ private class DuplicateProductsChecker {
         var productToPkgMap = [String: Set<PackageIdentity>]()
         for (pkgID, pkgBuilder) in packageIDToBuilder {
             let useProductIDs = pkgBuilder.package.manifest.disambiguateByProductIDs || lookupByProductIDs
-            let depProductRefs = pkgBuilder.package.targets.map{$0.dependencies}.flatMap{$0}.compactMap{$0.product}
+            let depProductRefs = pkgBuilder.package.modules.map{$0.dependencies}.flatMap{$0}.compactMap{$0.product}
             for depRef in depProductRefs {
                 if let depPkg =  depRef.package.map(PackageIdentity.plain) {
                     if !checkedPkgIDs.contains(depPkg) {
@@ -835,11 +835,11 @@ private func computePlatforms(
     return declaredPlatforms.sorted(by: { $0.platform.name < $1.platform.name })
 }
 
-// Track and override module aliases specified for targets in a package graph
+// Track and override module aliases specified for modules in a package graph
 private func resolveModuleAliases(packageBuilders: [ResolvedPackageBuilder],
                                   observabilityScope: ObservabilityScope) throws -> Bool {
     // If there are no module aliases specified, return early
-    let hasAliases = packageBuilders.contains { $0.package.targets.contains {
+    let hasAliases = packageBuilders.contains { $0.package.modules.contains {
             $0.dependencies.contains { dep in
                 if case let .product(prodRef, _) = dep {
                     return prodRef.moduleAliases != nil
@@ -852,14 +852,14 @@ private func resolveModuleAliases(packageBuilders: [ResolvedPackageBuilder],
     guard hasAliases else { return false }
     var aliasTracker = ModuleAliasTracker()
     for packageBuilder in packageBuilders {
-        try aliasTracker.addTargetAliases(targets: packageBuilder.package.targets,
+        try aliasTracker.addModuleAliases(modules: packageBuilder.package.modules,
                                           package: packageBuilder.package.identity)
     }
 
-    // Track targets that need module aliases for each package
+    // Track modules that need module aliases for each package
     for packageBuilder in packageBuilders {
         for product in packageBuilder.package.products {
-            aliasTracker.trackTargetsPerProduct(product: product,
+            aliasTracker.trackModulesPerProduct(product: product,
                                                 package: packageBuilder.package.identity)
         }
     }
@@ -916,31 +916,31 @@ private final class ResolvedProductBuilder: ResolvedBuilder<ResolvedProduct> {
     /// The product reference.
     let product: Product
 
-    /// The target builders in the product.
-    let targets: [ResolvedTargetBuilder]
+    /// The module builders in the product.
+    let moduleBuilders: [ResolvedModuleBuilder]
 
-    init(product: Product, packageBuilder: ResolvedPackageBuilder, targets: [ResolvedTargetBuilder]) {
+    init(product: Product, packageBuilder: ResolvedPackageBuilder, moduleBuilders: [ResolvedModuleBuilder]) {
         self.product = product
         self.packageBuilder = packageBuilder
-        self.targets = targets
+        self.moduleBuilders = moduleBuilders
     }
 
     override func constructImpl() throws -> ResolvedProduct {
         return ResolvedProduct(
             packageIdentity: packageBuilder.package.identity,
             product: product,
-            targets: IdentifiableSet(try targets.map { try $0.construct() })
+            modules: IdentifiableSet(try moduleBuilders.map { try $0.construct() })
         )
     }
 }
 
-/// Builder for resolved target.
-private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedModule> {
-    /// Enumeration to represent target dependencies.
+/// Builder for resolved module.
+private final class ResolvedModuleBuilder: ResolvedBuilder<ResolvedModule> {
+    /// Enumeration to represent module dependencies.
     enum Dependency {
 
-        /// Dependency to another target, with conditions.
-        case target(_ target: ResolvedTargetBuilder, conditions: [PackageCondition])
+        /// Dependency to another module, with conditions.
+        case module(_ module: ResolvedModuleBuilder, conditions: [PackageCondition])
 
         /// Dependency to a product, with conditions.
         case product(_ product: ResolvedProductBuilder, conditions: [PackageCondition])
@@ -949,10 +949,10 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedModule> {
     /// The reference to its package.
     let packageIdentity: PackageIdentity
 
-    /// The target reference.
-    let target: Target
+    /// The module reference.
+    let module: Module
 
-    /// The target dependencies of this target.
+    /// The module dependencies of this module.
     var dependencies: [Dependency] = []
 
     /// The defaultLocalization for this package
@@ -966,12 +966,12 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedModule> {
 
     init(
         packageIdentity: PackageIdentity,
-        target: Target,
+        module: Module,
         observabilityScope: ObservabilityScope,
         platformVersionProvider: PlatformVersionProvider
     ) {
         self.packageIdentity = packageIdentity
-        self.target = target
+        self.module = module
         self.observabilityScope = observabilityScope
         self.platformVersionProvider = platformVersionProvider
     }
@@ -979,16 +979,16 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedModule> {
     override func constructImpl() throws -> ResolvedModule {
         let diagnosticsEmitter = self.observabilityScope.makeDiagnosticsEmitter() {
             var metadata = ObservabilityMetadata()
-            metadata.targetName = target.name
+            metadata.moduleName = module.name
             return metadata
         }
 
         let dependencies = try self.dependencies.map { dependency -> ResolvedModule.Dependency in
             switch dependency {
-            case .target(let targetBuilder, let conditions):
-                return .target(try targetBuilder.construct(), conditions: conditions)
+            case .module(let moduleBuilder, let conditions):
+                return .module(try moduleBuilder.construct(), conditions: conditions)
             case .product(let productBuilder, let conditions):
-                try self.target.validateDependency(
+                try self.module.validateDependency(
                     product: productBuilder.product,
                     productPackage: productBuilder.packageBuilder.package.identity
                 )
@@ -1002,7 +1002,7 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedModule> {
 
         return ResolvedModule(
             packageIdentity: self.packageIdentity,
-            underlying: self.target,
+            underlying: self.module,
             dependencies: dependencies,
             defaultLocalization: self.defaultLocalization,
             supportedPlatforms: self.supportedPlatforms,
@@ -1011,13 +1011,13 @@ private final class ResolvedTargetBuilder: ResolvedBuilder<ResolvedModule> {
     }
 }
 
-extension Target {
-    func validateDependency(target: Target) throws {
-        if self.type == .plugin && target.type == .library {
+extension Module {
+    func validateDependency(module: Module) throws {
+        if self.type == .plugin && module.type == .library {
             throw PackageGraphError.unsupportedPluginDependency(
-                targetName: self.name,
-                dependencyName: target.name,
-                dependencyType: target.type.rawValue,
+                moduleName: self.name,
+                dependencyName: module.name,
+                dependencyType: module.type.rawValue,
                 dependencyPackage: nil
             )
         }
@@ -1026,7 +1026,7 @@ extension Target {
     func validateDependency(product: Product, productPackage: PackageIdentity) throws {
         if self.type == .plugin && product.type.isLibrary {
             throw PackageGraphError.unsupportedPluginDependency(
-                targetName: self.name,
+                moduleName: self.name,
                 dependencyName: product.name,
                 dependencyType: product.type.description,
                 dependencyPackage: productPackage.description
@@ -1048,8 +1048,8 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
     /// Package can be overridden
     let allowedToOverride: Bool
 
-    /// The targets in the package.
-    var targets: [ResolvedTargetBuilder] = []
+    /// The modules in the package.
+    var modules: [ResolvedModuleBuilder] = []
 
     /// The products in this package.
     var products: [ResolvedProductBuilder] = []
@@ -1057,8 +1057,8 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
     /// The dependencies of this package.
     var dependencies: [ResolvedPackageBuilder] = []
 
-    /// Map from package identity to the local name for target dependency resolution that has been given to that package through the dependency declaration.
-    var dependencyNamesForTargetDependencyResolutionOnly: [PackageIdentity: String] = [:]
+    /// Map from package identity to the local name for module dependency resolution that has been given to that package through the dependency declaration.
+    var dependencyNamesForModuleDependencyResolutionOnly: [PackageIdentity: String] = [:]
 
     /// The defaultLocalization for this package.
     var defaultLocalization: String? = nil
@@ -1087,15 +1087,15 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
 
     override func constructImpl() throws -> ResolvedPackage {
         let products = try self.products.map { try $0.construct() }
-        var targets = products.reduce(into: IdentifiableSet()) { $0.formUnion($1.targets) }
-        try targets.formUnion(self.targets.map { try $0.construct() })
+        var modules = products.reduce(into: IdentifiableSet()) { $0.formUnion($1.modules) }
+        try modules.formUnion(self.modules.map { try $0.construct() })
 
         return ResolvedPackage(
             underlying: self.package,
             defaultLocalization: self.defaultLocalization,
             supportedPlatforms: self.supportedPlatforms,
             dependencies: self.dependencies.map { $0.package.identity },
-            targets: targets,
+            modules: modules,
             products: products,
             registryMetadata: self.registryMetadata,
             platformVersionProvider: self.platformVersionProvider

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -18,7 +18,7 @@ import PackageLoading
 import PackageModel
 
 enum PackageGraphError: Swift.Error {
-    /// Indicates a non-root package with no targets.
+    /// Indicates a non-root package with no modules.
     case noModules(Package)
 
     /// The package dependency declaration has cycle in it.
@@ -27,7 +27,7 @@ enum PackageGraphError: Swift.Error {
     /// The product dependency not found.
     case productDependencyNotFound(
         package: String,
-        targetName: String,
+        moduleName: String,
         dependencyProductName: String,
         dependencyPackageName: String?,
         dependencyProductInDecl: Bool,
@@ -54,12 +54,12 @@ enum PackageGraphError: Swift.Error {
     /// The product dependency was found but the package name was not referenced correctly (tools version > 5.2).
     case productDependencyMissingPackage(
         productName: String,
-        targetName: String,
+        moduleName: String,
         packageIdentifier: String
     )
     /// Dependency between a plugin and a dependent target/product of a given type is unsupported
     case unsupportedPluginDependency(
-        targetName: String,
+        moduleName: String,
         dependencyName: String,
         dependencyType: String,
         dependencyPackage: String?
@@ -70,7 +70,7 @@ enum PackageGraphError: Swift.Error {
 
     /// Duplicate aliases for a target found in a product.
     case multipleModuleAliases(
-        target: String,
+        module: String,
         product: String,
         package: String,
         aliases: [String]
@@ -92,24 +92,30 @@ public struct ModulesGraph {
     /// The complete set of contained packages.
     public let packages: IdentifiableSet<ResolvedPackage>
 
-    /// The list of all targets reachable from root targets.
-    public private(set) var reachableTargets: IdentifiableSet<ResolvedModule>
+    @available(*, deprecated, renamed: "reachableModules")
+    public var reachableTargets: IdentifiableSet<ResolvedModule> { self.reachableModules }
 
-    /// The list of all products reachable from root targets.
+    /// The list of all modules reachable from root modules.
+    public private(set) var reachableModules: IdentifiableSet<ResolvedModule>
+
+    /// The list of all products reachable from root modules.
     public private(set) var reachableProducts: IdentifiableSet<ResolvedProduct>
 
-    /// Returns all the targets in the graph, regardless if they are reachable from the root targets or not.
-    public private(set) var allTargets: IdentifiableSet<ResolvedModule>
+    @available(*, deprecated, renamed: "allModules")
+    public var allTargets: IdentifiableSet<ResolvedModule> { self.allModules }
 
-    /// Returns all targets within the module graph in topological order, starting with low-level targets (that have no
+    /// Returns all the modules in the graph, regardless if they are reachable from the root modules or not.
+    public private(set) var allModules: IdentifiableSet<ResolvedModule>
+
+    /// Returns all modules within the graph in topological order, starting with low-level modules (that have no
     /// dependencies).
-    package var allTargetsInTopologicalOrder: [ResolvedModule] {
+    package var allModulesInTopologicalOrder: [ResolvedModule] {
         get throws {
-            try topologicalSort(Array(allTargets)) { $0.dependencies.compactMap { $0.target } }.reversed()
+            try topologicalSort(Array(allModules)) { $0.dependencies.compactMap { $0.module } }.reversed()
         }
     }
 
-    /// Returns all the products in the graph, regardless if they are reachable from the root targets or not.
+    /// Returns all the products in the graph, regardless if they are reachable from the root modules or not.
     public private(set) var allProducts: IdentifiableSet<ResolvedProduct>
 
     /// Package dependencies required for a fully resolved graph.
@@ -118,27 +124,27 @@ public struct ModulesGraph {
     /// in the graph due to loading errors. This does not include the root packages.
     public let requiredDependencies: [PackageReference]
 
-    /// Returns true if a given target is present in root packages and is not excluded for the given build environment.
-    public func isInRootPackages(_ target: ResolvedModule, satisfying buildEnvironment: BuildEnvironment) -> Bool {
+    /// Returns true if a given module is present in root packages and is not excluded for the given build environment.
+    public func isInRootPackages(_ module: ResolvedModule, satisfying buildEnvironment: BuildEnvironment) -> Bool {
         // FIXME: This can be easily cached.
         return rootPackages.reduce(
             into: IdentifiableSet<ResolvedModule>()
         ) { (accumulator: inout IdentifiableSet<ResolvedModule>, package: ResolvedPackage) in
-            let allDependencies = package.targets.flatMap { $0.dependencies }
+            let allDependencies = package.modules.flatMap { $0.dependencies }
             let unsatisfiedDependencies = allDependencies.filter { !$0.satisfies(buildEnvironment) }
-            let unsatisfiedDependencyTargets = unsatisfiedDependencies.compactMap { (
+            let unsatisfiedDependencyModules = unsatisfiedDependencies.compactMap { (
                 dep: ResolvedModule.Dependency
             ) -> ResolvedModule? in
                 switch dep {
-                case .target(let target, _):
-                    return target
+                case .module(let moduleDependency, _):
+                    return moduleDependency
                 default:
                     return nil
                 }
             }
 
-            accumulator.formUnion(IdentifiableSet(package.targets).subtracting(unsatisfiedDependencyTargets))
-        }.contains(id: target.id)
+            accumulator.formUnion(IdentifiableSet(package.modules).subtracting(unsatisfiedDependencyModules))
+        }.contains(id: module.id)
     }
 
     public func isRootPackage(_ package: ResolvedPackage) -> Bool {
@@ -184,8 +190,8 @@ public struct ModulesGraph {
         // It's possible to request a build of a macro, a plugin, or a test via `swift build`
         // which won't have the right destination set because it's impossible to indicate it.
         //
-        // Same happens with `--test-product` - if one of the test targets directly references
-        // a macro then all if its targets and the product itself become `host`.
+        // Same happens with `--test-product` - if one of the test modules directly references
+        // a macro then all if its modules and the product itself become `host`.
         if let toolsProduct = findProduct(name: name, destination: .tools),
             toolsProduct.type == .macro || toolsProduct.type == .plugin || toolsProduct.type == .test
         {
@@ -195,11 +201,16 @@ public struct ModulesGraph {
         return nil
     }
 
-    /// Find a target given a name and an optional destination. If a destination is not specified
-    /// this method uses `.destination` and falls back to `.tools` for macros, plugins, and tests.
+    @available(*, deprecated, renamed: "module(for:destination:)")
     public func target(for name: String, destination: BuildTriple? = .none) -> ResolvedModule? {
+        self.module(for: name, destination: destination)
+    }
+
+    /// Find a module given a name and an optional destination. If a destination is not specified
+    /// this method uses `.destination` and falls back to `.tools` for macros, plugins, and tests.
+    public func module(for name: String, destination: BuildTriple? = .none) -> ResolvedModule? {
         func findModule(name: String, destination: BuildTriple) -> ResolvedModule? {
-            self.allTargets.first { $0.name == name && $0.buildTriple == destination }
+            self.allModules.first { $0.name == name && $0.buildTriple == destination }
         }
 
         if let destination {
@@ -213,8 +224,8 @@ public struct ModulesGraph {
         // It's possible to request a build of a macro, a plugin or a test via `swift build`
         // which won't have the right destination set because it's impossible to indicate it.
         //
-        // Same happens with `--test-product` - if one of the test targets directly references
-        // a macro then all if its targets and the product itself become `host`.
+        // Same happens with `--test-product` - if one of the test modules directly references
+        // a macro then all if its modules and the product itself become `host`.
         if let toolsModule = findModule(name: name, destination: .tools),
             toolsModule.type == .macro || toolsModule.type == .plugin || toolsModule.type == .test
         {
@@ -244,57 +255,57 @@ public struct ModulesGraph {
         self.binaryArtifacts = binaryArtifacts
         self.packages = packages
 
-        var allTargets = IdentifiableSet<ResolvedModule>()
+        var allModules = IdentifiableSet<ResolvedModule>()
         var allProducts = IdentifiableSet<ResolvedProduct>()
         for package in self.packages {
-            let targetsToInclude: [ResolvedModule]
+            let modulesToInclude: [ResolvedModule]
             if rootPackages.contains(id: package.id) {
-                targetsToInclude = Array(package.targets)
+                modulesToInclude = Array(package.modules)
             } else {
-                // Don't include tests targets from non-root packages so swift-test doesn't
+                // Don't include tests modules from non-root packages so swift-test doesn't
                 // try to run them.
-                targetsToInclude = package.targets.filter { $0.type != .test }
+                modulesToInclude = package.modules.filter { $0.type != .test }
             }
 
-            for target in targetsToInclude {
-                allTargets.insert(target)
+            for module in modulesToInclude {
+                allModules.insert(module)
 
-                // Explicitly include dependencies of host tools in the maps of all targets or all products
-                if target.buildTriple == .tools {
-                    for dependency in try target.recursiveDependencies() {
+                // Explicitly include dependencies of host tools in the maps of all modules or all products
+                if module.buildTriple == .tools {
+                    for dependency in try module.recursiveDependencies() {
                         switch dependency {
-                        case .target(let targetDependency, _):
-                            allTargets.insert(targetDependency)
+                        case .module(let moduleDependency, _):
+                            allModules.insert(moduleDependency)
                         case .product(let productDependency, _):
                             allProducts.insert(productDependency)
                         }
                     }
                 }
 
-                // Create a new executable product if plugin depends on an executable target.
+                // Create a new executable product if plugin depends on an executable module.
                 // This is necessary, even though PackageBuilder creates one already, because
                 // that product is going to be built for `destination`, and this one has to
                 // be built for `tools`.
-                if target.underlying is PluginTarget {
-                    for dependency in target.dependencies {
+                if module.underlying is PluginModule {
+                    for dependency in module.dependencies {
                         switch dependency {
                         case .product(_, conditions: _):
                             break
 
-                        case .target(let target, conditions: _):
-                            if target.type != .executable {
+                        case .module(let module, conditions: _):
+                            if module.type != .executable {
                                 continue
                             }
 
                             var product = try ResolvedProduct(
-                                packageIdentity: target.packageIdentity,
+                                packageIdentity: module.packageIdentity,
                                 product: .init(
-                                    package: target.packageIdentity,
-                                    name: target.name,
+                                    package: module.packageIdentity,
+                                    name: module.name,
                                     type: .executable,
-                                    targets: [target.underlying]
+                                    modules: [module.underlying]
                                 ),
-                                targets: IdentifiableSet([target])
+                                modules: IdentifiableSet([module])
                             )
                             product.buildTriple = .tools
 
@@ -313,46 +324,52 @@ public struct ModulesGraph {
             }
         }
 
-        // Compute the reachable targets and products.
-        let inputTargets = self.inputPackages.flatMap { $0.targets }
+        // Compute the reachable modules and products.
+        let inputModules = self.inputPackages.flatMap { $0.modules }
         let inputProducts = self.inputPackages.flatMap { $0.products }
-        let recursiveDependencies = try inputTargets.lazy.flatMap { try $0.recursiveDependencies() }
+        let recursiveDependencies = try inputModules.lazy.flatMap { try $0.recursiveDependencies() }
 
-        self.reachableTargets = IdentifiableSet(inputTargets).union(recursiveDependencies.compactMap { $0.target })
+        self.reachableModules = IdentifiableSet(inputModules).union(recursiveDependencies.compactMap { $0.module })
         self.reachableProducts = IdentifiableSet(inputProducts).union(recursiveDependencies.compactMap { $0.product })
         self.rootPackages = rootPackages
-        self.allTargets = allTargets
+        self.allModules = allModules
         self.allProducts = allProducts
     }
 
-    /// Computes a map from each executable target in any of the root packages to the corresponding test targets.
     @_spi(SwiftPMInternal)
+    @available(*, deprecated, renamed: "computeTestModulesForExecutableModules")
     public func computeTestTargetsForExecutableTargets() throws -> [ResolvedModule.ID: [ResolvedModule]] {
+        try self.computeTestModulesForExecutableModules()
+    }
+
+    /// Computes a map from each executable module in any of the root packages to the corresponding test modules.
+    @_spi(SwiftPMInternal)
+    public func computeTestModulesForExecutableModules() throws -> [ResolvedModule.ID: [ResolvedModule]] {
         var result = [ResolvedModule.ID: [ResolvedModule]]()
 
-        let rootTargets = IdentifiableSet(rootPackages.flatMap { $0.targets })
+        let rootModules = IdentifiableSet(rootPackages.flatMap { $0.modules })
 
-        // Create map of test target to set of its direct dependencies.
-        let testTargetDepMap: [ResolvedModule.ID: IdentifiableSet<ResolvedModule>] = try {
-            let testTargetDeps = rootTargets.filter({ $0.type == .test }).map({
-                ($0.id, IdentifiableSet($0.dependencies.compactMap { $0.target }.filter { $0.type != .plugin }))
+        // Create map of test module to set of its direct dependencies.
+        let testModuleDepMap: [ResolvedModule.ID: IdentifiableSet<ResolvedModule>] = try {
+            let testModuleDeps = rootModules.filter({ $0.type == .test }).map({
+                ($0.id, IdentifiableSet($0.dependencies.compactMap { $0.module }.filter { $0.type != .plugin }))
             })
-            return try Dictionary(throwingUniqueKeysWithValues: testTargetDeps)
+            return try Dictionary(throwingUniqueKeysWithValues: testModuleDeps)
         }()
 
-        for target in rootTargets where target.type == .executable {
-            // Find all dependencies of this target within its package. Note that we do not traverse plugin usages.
-            let dependencies = try topologicalSort(target.dependencies, successors: {
-                $0.dependencies.compactMap{ $0.target }.filter{ $0.type != .plugin }.map{ .target($0, conditions: []) }
-            }).compactMap({ $0.target })
+        for module in rootModules where module.type == .executable {
+            // Find all dependencies of this module within its package. Note that we do not traverse plugin usages.
+            let dependencies = try topologicalSort(module.dependencies, successors: {
+                $0.dependencies.compactMap{ $0.module }.filter{ $0.type != .plugin }.map{ .module($0, conditions: []) }
+            }).compactMap({ $0.module })
 
-            // Include the test targets whose dependencies intersect with the
-            // current target's (recursive) dependencies.
-            let testTargets = testTargetDepMap.filter({ (testTarget, deps) in
-                !deps.intersection(dependencies + [target]).isEmpty
+            // Include the test modules whose dependencies intersect with the
+            // current module's (recursive) dependencies.
+            let testModules = testModuleDepMap.filter({ (testModule, deps) in
+                !deps.intersection(dependencies + [module]).isEmpty
             }).map({ $0.key })
 
-            result[target.id] = testTargets.compactMap { rootTargets[$0] }
+            result[module.id] = testModules.compactMap { rootModules[$0] }
         }
 
         return result
@@ -370,11 +387,11 @@ extension PackageGraphError: CustomStringConvertible {
             (path.map({ $0.displayName }).joined(separator: " -> ")) +
             " -> \(package.displayName) requires tools-version 6.0 or later"
 
-        case .productDependencyNotFound(let package, let targetName, let dependencyProductName, let dependencyPackageName, let dependencyProductInDecl, let similarProductName, let packageContainingSimilarProduct):
+        case .productDependencyNotFound(let package, let moduleName, let dependencyProductName, let dependencyPackageName, let dependencyProductInDecl, let similarProductName, let packageContainingSimilarProduct):
             if dependencyProductInDecl {
-                return "product '\(dependencyProductName)' is declared in the same package '\(package)' and can't be used as a dependency for target '\(targetName)'."
+                return "product '\(dependencyProductName)' is declared in the same package '\(package)' and can't be used as a dependency for target '\(moduleName)'."
             } else {
-                var description = "product '\(dependencyProductName)' required by package '\(package)' target '\(targetName)' \(dependencyPackageName.map{ "not found in package '\($0)'" } ?? "not found")."
+                var description = "product '\(dependencyProductName)' required by package '\(package)' target '\(moduleName)' \(dependencyPackageName.map{ "not found in package '\($0)'" } ?? "not found")."
                 if let similarProductName, let packageContainingSimilarProduct {
                     description += " Did you mean '.product(name: \"\(similarProductName)\", package: \"\(packageContainingSimilarProduct)\")'?"
                 } else if let similarProductName {
@@ -390,7 +407,7 @@ extension PackageGraphError: CustomStringConvertible {
 
         case .productDependencyMissingPackage(
             let productName,
-            let targetName,
+            let moduleName,
             let packageIdentifier
         ):
 
@@ -399,7 +416,7 @@ extension PackageGraphError: CustomStringConvertible {
             "\(packageIdentifier)")'
             """
 
-            return "dependency '\(productName)' in target '\(targetName)' requires explicit declaration; \(solution)"
+            return "dependency '\(productName)' in target '\(moduleName)' requires explicit declaration; \(solution)"
 
         case .duplicateProduct(let product, let packages):
             let packagesDescriptions = packages.sorted(by: { $0.identity < $1.identity }).map {

--- a/Sources/PackageGraph/Resolution/DependencyResolutionNode.swift
+++ b/Sources/PackageGraph/Resolution/DependencyResolutionNode.swift
@@ -37,7 +37,7 @@ public enum DependencyResolutionNode {
     /// - one implicit dependency on its own package at an exact version (as an empty package node).
     ///   This dependency is what ensures the resolver does not select two products from the same package at different versions.
     /// - zero or more dependencies on the product nodes of other packages.
-    ///   These are all the external products required to build all of the targets vended by this product.
+    ///   These are all the external products required to build all of the modules vended by this product.
     ///   They derive from the manifest.
     ///
     ///   Tools versions before 5.2 do not know which products belong to which packages, so each product is required from every dependency.
@@ -52,7 +52,7 @@ public enum DependencyResolutionNode {
     ///
     /// Root nodes may have dependencies. A root node has...
     ///
-    /// - zero or more dependencies on each external product node required to build any of its targets (vended or not).
+    /// - zero or more dependencies on each external product node required to build any of its modules (vended or not).
     /// - zero or more dependencies directly on external empty package nodes.
     ///   This special case occurs when a dependency is declared but not used.
     ///   It is a warning condition, and builds do not actually need these dependencies.

--- a/Sources/PackageGraph/Resolution/PlatformVersionProvider.swift
+++ b/Sources/PackageGraph/Resolution/PlatformVersionProvider.swift
@@ -32,7 +32,7 @@ func merge(into partial: inout [SupportedPlatform], platforms: [SupportedPlatfor
 
 public struct PlatformVersionProvider: Hashable {
     public enum Implementation: Hashable {
-        case mergingFromTargets(IdentifiableSet<ResolvedModule>)
+        case mergingFromModules(IdentifiableSet<ResolvedModule>)
         case customXCTestMinimumDeploymentTargets([PackageModel.Platform: PlatformVersion])
         case minimumDeploymentTargetDefault
     }
@@ -45,7 +45,7 @@ public struct PlatformVersionProvider: Hashable {
 
     func derivedXCTestPlatformProvider(_ declared: PackageModel.Platform) -> PlatformVersion? {
         switch self.implementation {
-        case .mergingFromTargets(let targets):
+        case .mergingFromModules(let targets):
             let platforms = targets.reduce(into: [SupportedPlatform]()) { partial, item in
                 merge(
                     into: &partial,

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -17,31 +17,31 @@ public typealias ResolvedTarget = ResolvedModule
 
 /// Represents a fully resolved module. All the dependencies for this module are also stored as resolved.
 public struct ResolvedModule {
-    /// Represents dependency of a resolved target.
+    /// Represents dependency of a resolved module.
     public enum Dependency {
-        /// Direct dependency of the target. This target is in the same package and should be statically linked.
-        case target(_ target: ResolvedModule, conditions: [PackageCondition])
+        /// Direct dependency of the module. This module is in the same package and should be statically linked.
+        case module(_ module: ResolvedModule, conditions: [PackageCondition])
 
-        /// The target depends on this product.
+        /// The module depends on this product.
         case product(_ product: ResolvedProduct, conditions: [PackageCondition])
 
-        public var target: ResolvedModule? {
+        public var module: ResolvedModule? {
             switch self {
-            case .target(let target, _): return target
+            case .module(let module, _): return module
             case .product: return nil
             }
         }
 
         public var product: ResolvedProduct? {
             switch self {
-            case .target: return nil
+            case .module: return nil
             case .product(let product, _): return product
             }
         }
 
         public var conditions: [PackageCondition] {
             switch self {
-            case .target(_, let conditions): return conditions
+            case .module(_, let conditions): return conditions
             case .product(_, let conditions): return conditions
             }
         }
@@ -49,18 +49,18 @@ public struct ResolvedModule {
         /// Returns the direct dependencies of the underlying dependency, across the package graph.
         public var dependencies: [ResolvedModule.Dependency] {
             switch self {
-            case .target(let target, _):
-                return target.dependencies
+            case .module(let module, _):
+                return module.dependencies
             case .product(let product, _):
-                return product.targets.map { .target($0, conditions: []) }
+                return product.modules.map { .module($0, conditions: []) }
             }
         }
 
-        /// Returns the direct dependencies of the underlying dependency, limited to the target's package.
+        /// Returns the direct dependencies of the underlying dependency, limited to the module's package.
         public var packageDependencies: [ResolvedModule.Dependency] {
             switch self {
-            case .target(let target, _):
-                return target.dependencies
+            case .module(let module, _):
+                return module.dependencies
             case .product:
                 return []
             }
@@ -71,7 +71,7 @@ public struct ResolvedModule {
         }
     }
 
-    /// The name of this target.
+    /// The name of this module.
     public var name: String {
         self.underlying.name
     }
@@ -88,12 +88,12 @@ public struct ResolvedModule {
         try topologicalSort(self.dependencies) { $0.dependencies }
     }
 
-    /// Returns the recursive target dependencies, across the whole package-graph.
-    public func recursiveTargetDependencies() throws -> [ResolvedModule] {
-        try topologicalSort(self.dependencies) { $0.dependencies }.compactMap { $0.target }
+    /// Returns the recursive module dependencies, across the whole package-graph.
+    public func recursiveModuleDependencies() throws -> [ResolvedModule] {
+        try topologicalSort(self.dependencies) { $0.dependencies }.compactMap { $0.module }
     }
 
-    /// Returns the recursive dependencies, across the whole package-graph, which satisfy the input build environment,
+    /// Returns the recursive dependencies, across the whole modules graph, which satisfy the input build environment,
     /// based on their conditions.
     /// - Parameters:
     ///     - environment: The build environment to use to filter dependencies on.
@@ -103,60 +103,60 @@ public struct ResolvedModule {
         }
     }
 
-    /// The language-level target name.
+    /// The language-level module name.
     public var c99name: String {
         self.underlying.c99name
     }
 
-    /// Module aliases for dependencies of this target. The key is an
-    /// original target name and the value is a new unique name mapped
+    /// Module aliases for dependencies of this module. The key is an
+    /// original module name and the value is a new unique name mapped
     /// to the name of its .swiftmodule binary.
     public var moduleAliases: [String: String]? {
         self.underlying.moduleAliases
     }
 
-    /// Allows access to package symbols from other targets in the package
+    /// Allows access to package symbols from other modules in the package
     public var packageAccess: Bool {
         self.underlying.packageAccess
     }
 
-    /// The "type" of target.
-    public var type: Target.Kind {
+    /// The "type" of the module.
+    public var type: Module.Kind {
         self.underlying.type
     }
 
-    /// The sources for the target.
+    /// The sources for the module.
     public var sources: Sources {
         self.underlying.sources
     }
 
     let packageIdentity: PackageIdentity
 
-    /// The underlying target represented in this resolved target.
-    public let underlying: Target
+    /// The underlying module represented in this resolved module.
+    public let underlying: Module
 
-    /// The dependencies of this target.
+    /// The dependencies of this module.
     public internal(set) var dependencies: [Dependency]
 
     /// The default localization for resources.
     public let defaultLocalization: String?
 
-    /// The list of platforms that are supported by this target.
+    /// The list of platforms that are supported by this module.
     public let supportedPlatforms: [SupportedPlatform]
 
     private let platformVersionProvider: PlatformVersionProvider
 
-    /// Triple for which this resolved target should be compiled for.
+    /// Triple for which this resolved module should be compiled for.
     public package(set) var buildTriple: BuildTriple {
         didSet {
             self.updateBuildTriplesOfDependencies()
         }
     }
 
-    /// Create a resolved target instance.
+    /// Create a resolved module instance.
     public init(
         packageIdentity: PackageIdentity,
-        underlying: Target,
+        underlying: Module,
         dependencies: [ResolvedModule.Dependency],
         defaultLocalization: String? = nil,
         supportedPlatforms: [SupportedPlatform],
@@ -177,8 +177,8 @@ public struct ResolvedModule {
             var inferredBuildTriple = BuildTriple.destination
             loop: for dependency in dependencies {
                 switch dependency {
-                case .target(let targetDependency, _):
-                    if targetDependency.type == .macro {
+                case .module(let moduleDependency, _):
+                    if moduleDependency.type == .macro {
                         inferredBuildTriple = .tools
                         break loop
                     }
@@ -201,9 +201,9 @@ public struct ResolvedModule {
             for (i, dependency) in dependencies.enumerated() {
                 let updatedDependency: Dependency
                 switch dependency {
-                case .target(var target, let conditions):
-                    target.buildTriple = self.buildTriple
-                    updatedDependency = .target(target, conditions: conditions)
+                case .module(var module, let conditions):
+                    module.buildTriple = self.buildTriple
+                    updatedDependency = .module(module, conditions: conditions)
                 case .product(var product, let conditions):
                     product.buildTriple = self.buildTriple
                     updatedDependency = .product(product, conditions: conditions)
@@ -235,7 +235,7 @@ extension ResolvedModule.Dependency: CustomStringConvertible {
         switch self {
         case .product(let p, _):
             str += p.description
-        case .target(let t, _):
+        case .module(let t, _):
             str += t.description
         }
         str += ">"
@@ -260,8 +260,8 @@ extension ResolvedModule.Dependency: Identifiable {
 
     public var id: ID {
         switch self {
-        case .target(let target, _):
-            return .init(kind: .module, packageIdentity: target.packageIdentity, name: target.name)
+        case .module(let module, _):
+            return .init(kind: .module, packageIdentity: module.packageIdentity, name: module.name)
         case .product(let product, _):
             return .init(kind: .product, packageIdentity: product.packageIdentity, name: product.name)
         }
@@ -271,11 +271,11 @@ extension ResolvedModule.Dependency: Identifiable {
 extension ResolvedModule.Dependency: Equatable {
     public static func == (lhs: ResolvedModule.Dependency, rhs: ResolvedModule.Dependency) -> Bool {
         switch (lhs, rhs) {
-        case (.target(let lhsTarget, _), .target(let rhsTarget, _)):
-            return lhsTarget.id == rhsTarget.id
+        case (.module(let lhsModule, _), .module(let rhsModule, _)):
+            return lhsModule.id == rhsModule.id
         case (.product(let lhsProduct, _), .product(let rhsProduct, _)):
             return lhsProduct.id == rhsProduct.id
-        case (.product, .target), (.target, .product):
+        case (.product, .module), (.module, .product):
             return false
         }
     }
@@ -284,8 +284,8 @@ extension ResolvedModule.Dependency: Equatable {
 extension ResolvedModule.Dependency: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch self {
-        case .target(let target, _):
-            hasher.combine(target.id)
+        case .module(let module, _):
+            hasher.combine(module.id)
         case .product(let product, _):
             hasher.combine(product.id)
         }
@@ -293,17 +293,20 @@ extension ResolvedModule.Dependency: Hashable {
 }
 
 extension ResolvedModule: Identifiable {
-    /// Resolved target identity that uniquely identifies it in a resolution graph.
+    /// Resolved module identity that uniquely identifies it in a modules graph.
     public struct ID: Hashable {
-        public let targetName: String
+        @available(*, deprecated, renamed: "moduleName")
+        public var targetName: String { self.moduleName }
+
+        public let moduleName: String
         let packageIdentity: PackageIdentity
         public var buildTriple: BuildTriple
     }
 
     public var id: ID {
-        ID(targetName: self.name, packageIdentity: self.packageIdentity, buildTriple: self.buildTriple)
+        ID(moduleName: self.name, packageIdentity: self.packageIdentity, buildTriple: self.buildTriple)
     }
 }
 
 @available(*, unavailable, message: "Use `Identifiable` conformance or `IdentifiableSet` instead")
-extension ResolvedTarget: Hashable {}
+extension ResolvedModule: Hashable {}

--- a/Sources/PackageGraph/Resolution/ResolvedPackage.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedPackage.swift
@@ -13,7 +13,7 @@
 import Basics
 import PackageModel
 
-/// A fully resolved package. Contains resolved targets, products and dependencies of the package.
+/// A fully resolved package. Contains resolved modules, products and dependencies of the package.
 public struct ResolvedPackage {
     // The identity of the package.
     public var identity: PackageIdentity {
@@ -33,8 +33,8 @@ public struct ResolvedPackage {
     /// The underlying package reference.
     public let underlying: Package
 
-    /// The targets contained in the package.
-    public let targets: IdentifiableSet<ResolvedModule>
+    /// The modules contained in the package.
+    public let modules: IdentifiableSet<ResolvedModule>
 
     /// The products produced by the package.
     public let products: [ResolvedProduct]
@@ -45,7 +45,7 @@ public struct ResolvedPackage {
     /// The default localization for resources.
     public let defaultLocalization: String?
 
-    /// The list of platforms that are supported by this target.
+    /// The list of platforms that are supported by this package.
     public let supportedPlatforms: [SupportedPlatform]
 
     /// If the given package's source is a registry release, this provides additional metadata and signature information.
@@ -58,14 +58,14 @@ public struct ResolvedPackage {
         defaultLocalization: String?,
         supportedPlatforms: [SupportedPlatform],
         dependencies: [PackageIdentity],
-        targets: IdentifiableSet<ResolvedModule>,
+        modules: IdentifiableSet<ResolvedModule>,
         products: [ResolvedProduct],
         registryMetadata: RegistryReleaseMetadata?,
         platformVersionProvider: PlatformVersionProvider
     ) {
         self.underlying = underlying
         self.products = products
-        self.targets = targets
+        self.modules = modules
         self.dependencies = dependencies
         self.defaultLocalization = defaultLocalization
         self.supportedPlatforms = supportedPlatforms

--- a/Sources/PackageGraph/Resolution/ResolvedProduct.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedProduct.swift
@@ -29,11 +29,17 @@ public struct ResolvedProduct {
     /// The underlying product.
     public let underlying: Product
 
-    /// The top level targets contained in this product.
-    public internal(set) var targets: IdentifiableSet<ResolvedModule>
+    @available(*, deprecated, renamed: "modules")
+    public var targets: IdentifiableSet<ResolvedModule> { self.modules }
 
-    /// Executable target for test entry point file.
-    public let testEntryPointTarget: ResolvedModule?
+    /// The top level modules contained in this product.
+    public internal(set) var modules: IdentifiableSet<ResolvedModule>
+
+    @available(*, deprecated, renamed: "testEntryPointModule")
+    public var testEntryPointTarget: ResolvedModule? { self.testEntryPointModule }
+
+    /// Executable module for test entry point file.
+    public let testEntryPointModule: ResolvedModule?
 
     /// The default localization for resources.
     public let defaultLocalization: String?
@@ -50,55 +56,67 @@ public struct ResolvedProduct {
         }
     }
 
-    /// The main executable target of product.
+    @available(*, deprecated, renamed: "executableModule")
+    public var executableTarget: ResolvedModule { get throws { try self.executableModule } }
+
+    /// The main executable module of this product.
     ///
     /// Note: This property is only valid for executable products.
-    public var executableTarget: ResolvedModule {
+    public var executableModule: ResolvedModule {
         get throws {
             guard self.type == .executable || self.type == .snippet || self.type == .macro else {
                 throw InternalError("`executableTarget` should only be called for executable targets")
             }
-            guard let underlyingExecutableTarget = targets.map(\.underlying).executables.first,
-                  let executableTarget = targets.first(where: { $0.underlying == underlyingExecutableTarget })
+            guard let underlyingExecutableModule = modules.map(\.underlying).executables.first,
+                  let executableModule = modules.first(where: { $0.underlying == underlyingExecutableModule })
             else {
                 throw InternalError("could not determine executable target")
             }
-            return executableTarget
+            return executableModule
         }
     }
 
+    @available(*, deprecated, renamed: "init(packageIdentity:product:modules:)")
     public init(
         packageIdentity: PackageIdentity,
         product: Product,
         targets: IdentifiableSet<ResolvedModule>
     ) {
-        assert(product.targets.count == targets.count && product.targets.map(\.name).sorted() == targets.map(\.name).sorted())
+        self.init(packageIdentity: packageIdentity, product: product, modules: targets)
+    }
+
+    public init(
+        packageIdentity: PackageIdentity,
+        product: Product,
+        modules: IdentifiableSet<ResolvedModule>
+    ) {
+        assert(product.modules.count == modules.count && product.modules.map(\.name).sorted() == modules.map(\.name).sorted())
         self.packageIdentity = packageIdentity
         self.underlying = product
-        self.targets = targets
+        self.modules = modules
 
         // defaultLocalization is currently shared across the entire package
-        // this may need to be enhanced if / when we support localization per target or product
-        let defaultLocalization = self.targets.first?.defaultLocalization
+        // this may need to be enhanced if / when we support localization per module or product
+        let defaultLocalization = self.modules.first?.defaultLocalization
         self.defaultLocalization = defaultLocalization
 
-        let (platforms, platformVersionProvider) = Self.computePlatforms(targets: targets)
+        let (platforms, platformVersionProvider) = Self.computePlatforms(modules: modules)
         self.supportedPlatforms = platforms
         self.platformVersionProvider = platformVersionProvider
 
-        self.testEntryPointTarget = product.testEntryPointPath.map { testEntryPointPath in
-            // Create an executable resolved target with the entry point file, adding product's targets as dependencies.
-            let dependencies: [Target.Dependency] = product.targets.map { .target($0, conditions: []) }
-            let swiftTarget = SwiftTarget(
+        self.testEntryPointModule = product.testEntryPointPath.map { testEntryPointPath in
+            // Create an executable resolved module with the entry point file, adding product's modules as dependencies.
+            let dependencies: [Module.Dependency] = product.modules.map { .module($0, conditions: []) }
+            let swiftModule = SwiftModule(
                 name: product.name,
                 dependencies: dependencies,
-                packageAccess: true, // entry point target so treated as a part of the package
+                packageAccess: true, // entry point module so treated as a part of the package
                 testEntryPointPath: testEntryPointPath
             )
             return ResolvedModule(
                 packageIdentity: packageIdentity,
-                underlying: swiftTarget,
-                dependencies: targets.map { .target($0, conditions: []) },
+                underlying: swiftModule,
+                dependencies: modules.map { .module($0, conditions: []) },
                 defaultLocalization: defaultLocalization ?? .none, // safe since this is a derived product
                 supportedPlatforms: platforms,
                 platformVersionProvider: platformVersionProvider
@@ -111,18 +129,18 @@ public struct ResolvedProduct {
             // and SwiftSyntax to be built for the same triple as the tests.
             // See https://github.com/apple/swift-package-manager/pull/7349 for more context.
             var inferredBuildTriple = BuildTriple.destination
-            targetsLoop: for target in targets {
-                for dependency in target.dependencies {
+            modulesLoop: for module in modules {
+                for dependency in module.dependencies {
                     switch dependency {
-                    case .target(let targetDependency, _):
-                        if targetDependency.type == .macro {
+                    case .module(let moduleDependency, _):
+                        if moduleDependency.type == .macro {
                             inferredBuildTriple = .tools
-                            break targetsLoop
+                            break modulesLoop
                         }
                     case .product(let productDependency, _):
                         if productDependency.type == .macro {
                             inferredBuildTriple = .tools
-                            break targetsLoop
+                            break modulesLoop
                         }
                     }
                 }
@@ -135,41 +153,47 @@ public struct ResolvedProduct {
     }
 
     mutating func updateBuildTriplesOfDependencies() {
-        self.targets = IdentifiableSet(self.targets.map {
-            var target = $0
-            target.buildTriple = self.buildTriple
-            return target
+        self.modules = IdentifiableSet(self.modules.map {
+            var module = $0
+            module.buildTriple = self.buildTriple
+            return module
         })
     }
 
-    /// True if this product contains Swift targets.
-    public var containsSwiftTargets: Bool {
-        //  C targets can't import Swift targets in SwiftPM (at least not right
-        // now), so we can just look at the top-level targets.
+    @available(*, deprecated, renamed: "containsSwiftModules")
+    public var containsSwiftTargets: Bool { self.containsSwiftModules }
+
+    /// True if this product contains Swift modules.
+    public var containsSwiftModules: Bool {
+        //  C modules can't import Swift modules in SwiftPM (at least not right
+        // now), so we can just look at the top-level modules.
         //
         // If that ever changes, we'll need to do something more complex here,
-        // recursively checking dependencies for SwiftTargets, and considering
-        // dynamic library targets to be Swift targets (since the dylib could
+        // recursively checking dependencies for SwiftModules, and considering
+        // dynamic library modules to be Swift modules (since the dylib could
         // contain Swift code we don't know about as part of this build).
-        self.targets.contains { $0.underlying is SwiftTarget }
+        self.modules.contains { $0.underlying is SwiftModule }
     }
 
-    /// Returns the recursive target dependencies.
-    public func recursiveTargetDependencies() throws -> [ResolvedModule] {
-        let recursiveDependencies = try targets.lazy.flatMap { try $0.recursiveTargetDependencies() }
-        return Array(IdentifiableSet(self.targets).union(recursiveDependencies))
+    @available(*, deprecated, renamed: "recursiveModuleDependencies")
+    public func recursiveTargetDependencies() throws -> [ResolvedModule] { try self.recursiveModuleDependencies() }
+
+    /// Returns the recursive module dependencies.
+    public func recursiveModuleDependencies() throws -> [ResolvedModule] {
+        let recursiveDependencies = try modules.lazy.flatMap { try $0.recursiveModuleDependencies() }
+        return Array(IdentifiableSet(self.modules).union(recursiveDependencies))
     }
 
     private static func computePlatforms(
-        targets: IdentifiableSet<ResolvedModule>
+        modules: IdentifiableSet<ResolvedModule>
     ) -> ([SupportedPlatform], PlatformVersionProvider) {
-        let declaredPlatforms = targets.reduce(into: [SupportedPlatform]()) { partial, item in
+        let declaredPlatforms = modules.reduce(into: [SupportedPlatform]()) { partial, item in
             merge(into: &partial, platforms: item.supportedPlatforms)
         }
 
         return (
             declaredPlatforms.sorted(by: { $0.platform.name < $1.platform.name }),
-            PlatformVersionProvider(implementation: .mergingFromTargets(targets))
+            PlatformVersionProvider(implementation: .mergingFromModules(modules))
         )
     }
 
@@ -182,10 +206,10 @@ public struct ResolvedProduct {
     }
 
     func diagnoseInvalidUseOfUnsafeFlags(_ diagnosticsEmitter: DiagnosticsEmitter) throws {
-        // Diagnose if any target in this product uses an unsafe flag.
-        for target in try self.recursiveTargetDependencies() {
-            if target.underlying.usesUnsafeFlags {
-                diagnosticsEmitter.emit(.productUsesUnsafeFlags(product: self.name, target: target.name))
+        // Diagnose if any module in this product uses an unsafe flag.
+        for module in try self.recursiveModuleDependencies() {
+            if module.underlying.usesUnsafeFlags {
+                diagnosticsEmitter.emit(.productUsesUnsafeFlags(product: self.name, target: module.name))
             }
         }
     }
@@ -200,13 +224,13 @@ extension ResolvedProduct: CustomStringConvertible {
 extension ResolvedProduct {
     public var isLinkingXCTest: Bool {
         // To retain existing behavior, we have to check both the product type, as well as the types of all of its
-        // targets.
-        self.type == .test || self.targets.contains(where: { $0.type == .test })
+        // modules.
+        self.type == .test || self.modules.contains(where: { $0.type == .test })
     }
 }
 
 extension ResolvedProduct: Identifiable {
-    /// Resolved target identity that uniquely identifies it in a resolution graph.
+    /// Resolved module identity that uniquely identifies it in a resolution graph.
     public struct ID: Hashable {
         public let productName: String
         let packageIdentity: PackageIdentity

--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -14,7 +14,7 @@ import Basics
 import PackageModel
 
 extension Basics.Diagnostic {
-    static func targetHasNoSources(name: String, type: TargetDescription.TargetType, shouldSuggestRelaxedSourceDir: Bool) -> Self {
+    static func targetHasNoSources(name: String, type: TargetDescription.TargetKind, shouldSuggestRelaxedSourceDir: Bool) -> Self {
         let folderName = PackageBuilder.suggestedPredefinedSourceDirectory(type: type)
         var clauses = ["Source files for target \(name) should be located under '\(folderName)/\(name)'"]
         if shouldSuggestRelaxedSourceDir {

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -356,7 +356,7 @@ extension PackageConditionDescription {
     }
 }
 
-extension TargetDescription.TargetType {
+extension TargetDescription.TargetKind {
     init(_ type: Serialization.TargetType) {
         switch type {
         case .regular:

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -16,7 +16,7 @@ import PackageModel
 
 public struct ManifestValidator {
     static var supportedLocalBinaryDependencyExtensions: [String] {
-        ["zip"] + BinaryTarget.Kind.allCases.filter{ $0 != .unknown }.map { $0.fileExtension }
+        ["zip"] + BinaryModule.Kind.allCases.filter{ $0 != .unknown }.map { $0.fileExtension }
     }
     static var supportedRemoteBinaryDependencyExtensions: [String] {
         ["zip", "artifactbundleindex"]
@@ -398,7 +398,7 @@ extension TargetDescription {
 
 extension PackageDependency {
     fileprivate var descriptionForValidation: String {
-        var description = "'\(self.nameForTargetDependencyResolutionOnly)'"
+        var description = "'\(self.nameForModuleDependencyResolutionOnly)'"
 
         if let locationsString = {
             switch self {

--- a/Sources/PackageLoading/ModuleMapGenerator.swift
+++ b/Sources/PackageLoading/ModuleMapGenerator.swift
@@ -30,7 +30,7 @@ protocol ModuleMapProtocol {
     var moduleMapDirectory: AbsolutePath { get }
 }
 
-extension SystemLibraryTarget: ModuleMapProtocol {
+extension SystemLibraryModule: ModuleMapProtocol {
     var moduleMapDirectory: AbsolutePath {
         return path
     }
@@ -40,7 +40,7 @@ extension SystemLibraryTarget: ModuleMapProtocol {
     }
 }
 
-extension ClangTarget: ModuleMapProtocol {
+extension ClangModule: ModuleMapProtocol {
     var moduleMapDirectory: AbsolutePath {
         return includeDir
     }
@@ -51,8 +51,8 @@ extension ClangTarget: ModuleMapProtocol {
 }
 
 /// A module map generator for Clang targets.  Module map generation consists of two steps:
-/// 1. Examining a target's public-headers directory to determine the appropriate module map type
-/// 2. Generating a module map for any target that doesn't have a custom module map file
+/// 1. Examining a module's public-headers directory to determine the appropriate module map type
+/// 2. Generating a module map for any module that doesn't have a custom module map file
 ///
 /// When a custom module map exists in the header directory, it is used as-is.  When a custom module map does not exist, a module map is generated based on the following rules:
 ///
@@ -63,9 +63,9 @@ extension ClangTarget: ModuleMapProtocol {
 /// *  Otherwise, if the "include" directory only contains header files and no other subdirectory:
 ///    Generates: `umbrella "path/to/include"`
 ///
-/// These rules are documented at https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#creating-c-language-targets.  To avoid breaking existing packages, do not change the semantics here without making any change conditional on the tools version of the package that defines the target.
+/// These rules are documented at https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#creating-c-language-targets.  To avoid breaking existing packages, do not change the semantics here without making any change conditional on the tools version of the package that defines the module.
 ///
-/// Note that a module map generator doesn't require a target to already have been instantiated; it can operate on information that will later be used to instantiate a target.
+/// Note that a module map generator doesn't require a module to already have been instantiated; it can operate on information that will later be used to instantiate a module.
 public struct ModuleMapGenerator {
 
     /// The name of the Clang target (for diagnostics).
@@ -89,11 +89,11 @@ public struct ModuleMapGenerator {
 
     /// Inspects the file system at the public-headers directory with which the module map generator was instantiated, and returns the type of module map that applies to that directory.  This function contains all of the heuristics that implement module map policy for package targets; other functions just use the results of this determination.
     public func determineModuleMapType(observabilityScope: ObservabilityScope) -> ModuleMapType {
-        // The following rules are documented at https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#creating-c-language-targets.  To avoid breaking existing packages, do not change the semantics here without making any change conditional on the tools version of the package that defines the target.
+        // The following rules are documented at https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#creating-c-language-targets.  To avoid breaking existing packages, do not change the semantics here without making any change conditional on the tools version of the package that defines the module.
 
         let diagnosticsEmitter = observabilityScope.makeDiagnosticsEmitter {
             var metadata = ObservabilityMetadata()
-            metadata.targetName = self.targetName
+            metadata.moduleName = self.targetName
             return metadata
         }
 
@@ -169,7 +169,7 @@ public struct ModuleMapGenerator {
             return .umbrellaDirectory(publicHeadersDir)
         }
 
-        // Otherwise, the target's public headers are considered to be incompatible with modules.  Per the original design, though, an umbrella directory is still created for them.  This will lead to build failures if those headers are included and they are not compatible with modules.  A future evolution proposal should revisit these semantics, especially to make it easier to existing wrap C source bases that are incompatible with modules.
+        // Otherwise, the module's public headers are considered to be incompatible with modules.  Per the original design, though, an umbrella directory is still created for them.  This will lead to build failures if those headers are included and they are not compatible with modules.  A future evolution proposal should revisit these semantics, especially to make it easier to existing wrap C source bases that are incompatible with modules.
         return .umbrellaDirectory(publicHeadersDir)
     }
 

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -29,19 +29,19 @@ public enum ModuleError: Swift.Error {
     }
 
     /// Indicates two targets with the same name and their corresponding packages.
-    case duplicateModule(targetName: String, packages: [PackageIdentity])
+    case duplicateModule(moduleName: String, packages: [PackageIdentity])
 
     /// The referenced target could not be found.
     case moduleNotFound(String, TargetDescription.TargetType, shouldSuggestRelaxedSourceDir: Bool)
 
     /// The artifact for the binary target could not be found.
-    case artifactNotFound(targetName: String, expectedArtifactName: String)
+    case artifactNotFound(moduleName: String, expectedArtifactName: String)
 
     /// Invalid module alias.
     case invalidModuleAlias(originalName: String, newName: String)
 
     /// Invalid custom path.
-    case invalidCustomPath(target: String, path: String)
+    case invalidCustomPath(moduleName: String, path: String)
 
     /// Package layout is invalid.
     case invalidLayout(InvalidLayoutType)
@@ -83,13 +83,13 @@ public enum ModuleError: Swift.Error {
     case embedInCodeNotSupported(target: String)
 
     /// Indicates several targets with the same name exist in packages
-    case duplicateModules(package: PackageIdentity, otherPackage: PackageIdentity, targets: [String])
+    case duplicateModules(package: PackageIdentity, otherPackage: PackageIdentity, modules: [String])
 
     /// Indicates several targets with the same name exist in a registry and scm package
     case duplicateModulesScmAndRegistry(
         registryPackage: PackageIdentity.RegistryIdentity,
         scmPackage: PackageIdentity,
-        targets: [String]
+        modules: [String]
     )
 }
 
@@ -186,7 +186,7 @@ extension ModuleError.InvalidLayoutType: CustomStringConvertible {
     }
 }
 
-extension Target {
+extension Module {
     /// An error in the organization or configuration of an individual target.
     enum Error: Swift.Error {
         /// The target's name is invalid.
@@ -201,7 +201,7 @@ extension Target {
     }
 }
 
-extension Target.Error: CustomStringConvertible {
+extension Module.Error: CustomStringConvertible {
     var description: String {
         switch self {
         case .invalidName(let path, let problem):
@@ -212,7 +212,7 @@ extension Target.Error: CustomStringConvertible {
     }
 }
 
-extension Target.Error.ModuleNameProblem: CustomStringConvertible {
+extension Module.Error.ModuleNameProblem: CustomStringConvertible {
     var description: String {
         switch self {
         case .emptyName:
@@ -243,7 +243,7 @@ extension Product.Error: CustomStringConvertible {
 /// A structure representing the remote artifact information necessary to construct the package.
 public struct BinaryArtifact {
     /// The kind of the artifact.
-    public let kind: BinaryTarget.Kind
+    public let kind: BinaryModule.Kind
 
     /// The URL the artifact was downloaded from.
     public let originURL: String?
@@ -251,7 +251,7 @@ public struct BinaryArtifact {
     /// The path to the  artifact.
     public let path: AbsolutePath
 
-    public init(kind: BinaryTarget.Kind, originURL: String?, path: AbsolutePath) {
+    public init(kind: BinaryModule.Kind, originURL: String?, path: AbsolutePath) {
         self.kind = kind
         self.originURL = originURL
         self.path = path
@@ -381,7 +381,7 @@ public final class PackageBuilder {
     }
 
     /// Computes the special directory where targets are present or should be placed in future.
-    private func findTargetSpecialDirs(_ targets: [Target]) -> (targetDir: String, testTargetDir: String) {
+    private func findTargetSpecialDirs(_ targets: [Module]) -> (targetDir: String, testTargetDir: String) {
         let predefinedDirs = self.findPredefinedTargetDirectory()
 
         // Select the preferred tests directory.
@@ -419,7 +419,7 @@ public final class PackageBuilder {
         if basename.hasPrefix(".") { return false }
 
         // Ignore test entry point files.
-        if SwiftTarget.testEntryPointNames.contains(basename) { return false }
+        if SwiftModule.testEntryPointNames.contains(basename) { return false }
 
         // Ignore paths which are not valid files.
         if !self.fileSystem.isFile(path) {
@@ -452,7 +452,7 @@ public final class PackageBuilder {
     }
 
     /// Private function that creates and returns a list of targets defined by a package.
-    private func constructTargets() throws -> [Target] {
+    private func constructTargets() throws -> [Module] {
         // Check for a modulemap file, which indicates a system target.
         let moduleMapPath = self.packagePath.appending(component: moduleMapFilename)
         if self.fileSystem.isFile(moduleMapPath) {
@@ -471,7 +471,7 @@ public final class PackageBuilder {
             // Package contains a modulemap at the top level, so we assuming
             // it's a system library target.
             return [
-                SystemLibraryTarget(
+                SystemLibraryModule(
                     name: self.manifest.displayName, // FIXME: use identity instead?
                     path: self.packagePath,
                     isImplicit: true,
@@ -518,7 +518,7 @@ public final class PackageBuilder {
     }
 
     /// Construct targets according to PackageDescription 4 conventions.
-    private func constructV4Targets() throws -> [Target] {
+    private func constructV4Targets() throws -> [Module] {
         // Select the correct predefined directory list.
         let predefinedDirs = self.findPredefinedTargetDirectory()
 
@@ -539,12 +539,12 @@ public final class PackageBuilder {
         func findPath(for target: TargetDescription) throws -> AbsolutePath {
             if target.type == .binary {
                 guard let artifact = self.binaryArtifacts[target.name] else {
-                    throw ModuleError.artifactNotFound(targetName: target.name, expectedArtifactName: target.name)
+                    throw ModuleError.artifactNotFound(moduleName: target.name, expectedArtifactName: target.name)
                 }
                 return artifact.path
             } else if let targetPath = target.path, target.type == .providedLibrary {
                 guard let path = try? AbsolutePath(validating: targetPath) else {
-                    throw ModuleError.invalidCustomPath(target: target.name, path: targetPath)
+                    throw ModuleError.invalidCustomPath(moduleName: target.name, path: targetPath)
                 }
 
                 if !self.fileSystem.isDirectory(path) {
@@ -570,7 +570,7 @@ public final class PackageBuilder {
                 if self.fileSystem.isDirectory(path) {
                     return path
                 }
-                throw ModuleError.invalidCustomPath(target: target.name, path: subpath)
+                throw ModuleError.invalidCustomPath(moduleName: target.name, path: subpath)
             }
 
             // Check if target is present in the predefined directory.
@@ -625,7 +625,7 @@ public final class PackageBuilder {
 
         let targets = try createModules(potentialTargets)
 
-        let snippetTargets: [Target]
+        let snippetTargets: [Module]
 
         if self.manifest.packageKind.isRoot {
             // Snippets: depend on all available library targets in the package.
@@ -633,7 +633,7 @@ public final class PackageBuilder {
             let productTargets = Set(manifest.products.flatMap(\.targets))
             let snippetDependencies = targets
                 .filter { $0.type == .library && productTargets.contains($0.name) }
-                .map { Target.Dependency.target($0, conditions: []) }
+                .map { Module.Dependency.module($0, conditions: []) }
             snippetTargets = try createSnippetTargets(dependencies: snippetDependencies)
         } else {
             snippetTargets = []
@@ -643,7 +643,7 @@ public final class PackageBuilder {
     }
 
     // Create targets from the provided potential targets.
-    private func createModules(_ potentialModules: [PotentialModule]) throws -> [Target] {
+    private func createModules(_ potentialModules: [PotentialModule]) throws -> [Module] {
         // Find if manifest references a target which isn't present on disk.
         let allVisibleModuleNames = self.manifest.visibleModuleNames(for: self.productFilter)
         let potentialModulesName = Set(potentialModules.map(\.name))
@@ -717,7 +717,7 @@ public final class PackageBuilder {
         let potentialModules = try topologicalSort(potentialModules, successors: successors)
 
         // The created targets mapped to their name.
-        var targets = [String: Target]()
+        var targets = [String: Module]()
         // If a directory is empty, we don't create a target object for them.
         var emptyModules = Set<String>()
 
@@ -730,14 +730,14 @@ public final class PackageBuilder {
             let manifestTarget = manifest.targetMap[potentialModule.name]
 
             // Get the dependencies of this target.
-            let dependencies: [Target.Dependency] = try manifestTarget.map {
-                try $0.dependencies.compactMap { dependency -> Target.Dependency? in
+            let dependencies: [Module.Dependency] = try manifestTarget.map {
+                try $0.dependencies.compactMap { dependency -> Module.Dependency? in
                     switch dependency {
                     case .target(let name, let condition):
                         // We don't create an object for targets which have no sources.
                         if emptyModules.contains(name) { return nil }
                         guard let target = targets[name] else { return nil }
-                        return .target(target, conditions: buildConditions(from: condition))
+                        return .module(target, conditions: buildConditions(from: condition))
 
                     case .product(let name, let package, let moduleAliases, let condition):
                         try validateModuleAliases(moduleAliases)
@@ -749,7 +749,7 @@ public final class PackageBuilder {
                         // We don't create an object for targets which have no sources.
                         if emptyModules.contains(name) { return nil }
                         if let target = targets[name] {
-                            return .target(target, conditions: buildConditions(from: condition))
+                            return .module(target, conditions: buildConditions(from: condition))
                         } else if potentialModuleMap[name] == nil {
                             return .product(
                                 .init(name: name, package: nil),
@@ -763,17 +763,17 @@ public final class PackageBuilder {
             } ?? []
 
             // Get dependencies from the plugin usages of this target.
-            let pluginUsages: [Target.PluginUsage] = manifestTarget?.pluginUsages.map {
+            let pluginUsages: [Module.PluginUsage] = manifestTarget?.pluginUsages.map {
                 $0.compactMap { usage in
                     switch usage {
                     case .plugin(let name, let package):
                         if let package {
-                            return .product(Target.ProductReference(name: name, package: package), conditions: [])
+                            return .product(Module.ProductReference(name: name, package: package), conditions: [])
                         } else {
                             if let target = targets[name] {
-                                return .target(target, conditions: [])
+                                return .module(target, conditions: [])
                             } else if let targetName = pluginTargetName(for: name), let target = targets[targetName] {
-                                return .target(target, conditions: [])
+                                return .module(target, conditions: [])
                             } else {
                                 self.observabilityScope.emit(.pluginNotFound(name: name))
                                 return nil
@@ -813,7 +813,7 @@ public final class PackageBuilder {
     /// if there's a problem, it throws an error describing what the problem is.
     private func validateModuleName(_ path: AbsolutePath, _ name: String, isTest: Bool) throws {
         if name.isEmpty {
-            throw Target.Error.invalidName(
+            throw Module.Error.invalidName(
                 path: path.relative(to: self.packagePath),
                 problem: .emptyName
             )
@@ -837,8 +837,8 @@ public final class PackageBuilder {
     private func createTarget(
         potentialModule: PotentialModule,
         manifestTarget: TargetDescription?,
-        dependencies: [Target.Dependency]
-    ) throws -> Target? {
+        dependencies: [Module.Dependency]
+    ) throws -> Module? {
         guard let manifestTarget else { return nil }
 
         // Create system library target.
@@ -848,7 +848,7 @@ public final class PackageBuilder {
                 throw ModuleError.invalidLayout(.modulemapMissing(moduleMapPath))
             }
 
-            return SystemLibraryTarget(
+            return SystemLibraryModule(
                 name: potentialModule.name,
                 path: potentialModule.path, isImplicit: false,
                 pkgConfig: manifestTarget.pkgConfig,
@@ -858,15 +858,15 @@ public final class PackageBuilder {
             guard let artifact = self.binaryArtifacts[potentialModule.name] else {
                 throw InternalError("unknown binary artifact for '\(potentialModule.name)'")
             }
-            let artifactOrigin: BinaryTarget.Origin = artifact.originURL.flatMap { .remote(url: $0) } ?? .local
-            return BinaryTarget(
+            let artifactOrigin: BinaryModule.Origin = artifact.originURL.flatMap { .remote(url: $0) } ?? .local
+            return BinaryModule(
                 name: potentialModule.name,
                 kind: artifact.kind,
                 path: potentialModule.path,
                 origin: artifactOrigin
             )
         } else if potentialModule.type == .providedLibrary {
-            return ProvidedLibraryTarget(
+            return ProvidedLibraryModule(
                 name: potentialModule.name,
                 path: potentialModule.path
             )
@@ -882,7 +882,7 @@ public final class PackageBuilder {
                 let dupProductName = name.isEmpty ? dupProductID : name
                 self.observabilityScope.emit(.duplicateProduct(name: dupProductName, package: pkg))
             }
-            let dupTargetNames = dependencies.compactMap { $0.target?.name }.spm_findDuplicates()
+            let dupTargetNames = dependencies.compactMap { $0.module?.name }.spm_findDuplicates()
             for dupTargetName in dupTargetNames {
                 self.observabilityScope.emit(.duplicateTargetDependency(
                     dependency: dupTargetName,
@@ -911,7 +911,7 @@ public final class PackageBuilder {
         )
 
         // Compute the path to public headers directory.
-        let publicHeaderComponent = manifestTarget.publicHeadersPath ?? ClangTarget.defaultPublicHeadersComponent
+        let publicHeaderComponent = manifestTarget.publicHeadersPath ?? ClangModule.defaultPublicHeadersComponent
         let publicHeadersPath = try potentialModule.path.appending(RelativePath(validating: publicHeaderComponent))
         guard publicHeadersPath.isDescendantOfOrEqual(to: potentialModule.path) else {
             throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
@@ -954,7 +954,7 @@ public final class PackageBuilder {
             }
 
             // Create and return an PluginTarget configured with the information from the manifest.
-            return PluginTarget(
+            return PluginModule(
                 name: potentialModule.name,
                 sources: sources,
                 apiVersion: self.manifest.toolsVersion,
@@ -965,7 +965,7 @@ public final class PackageBuilder {
         }
 
         /// Determine the target's type, or leave nil to check the source directory.
-        let targetType: Target.Kind
+        let targetType: Module.Kind
         switch potentialModule.type {
         case .test:
             targetType = .test
@@ -987,7 +987,7 @@ public final class PackageBuilder {
 
         // Create and return the right kind of target depending on what kind of sources we found.
         if sources.hasSwiftSources {
-            return try SwiftTarget(
+            return try SwiftModule(
                 name: potentialModule.name,
                 potentialBundleName: potentialBundleName,
                 type: targetType,
@@ -1030,7 +1030,7 @@ public final class PackageBuilder {
                 throw ModuleError.embedInCodeNotSupported(target: potentialModule.name)
             }
 
-            return try ClangTarget(
+            return try ClangModule(
                 name: potentialModule.name,
                 potentialBundleName: potentialBundleName,
                 cLanguageStandard: self.manifest.cLanguageStandard,
@@ -1278,7 +1278,7 @@ public final class PackageBuilder {
     }
 
     /// Find the test entry point file for the package.
-    private func findTestEntryPoint(in testTargets: [Target]) throws -> AbsolutePath? {
+    private func findTestEntryPoint(in testTargets: [Module]) throws -> AbsolutePath? {
         if let testEntryPointPath {
             return testEntryPointPath
         }
@@ -1303,7 +1303,7 @@ public final class PackageBuilder {
                 }
                 // If we have already searched this path, skip.
                 if !pathsSearched.contains(searchPath) {
-                    for name in SwiftTarget.testEntryPointNames {
+                    for name in SwiftModule.testEntryPointNames {
                         let path = searchPath.appending(component: name)
                         if self.fileSystem.isFile(path) {
                             testEntryPointFiles.insert(path)
@@ -1328,7 +1328,7 @@ public final class PackageBuilder {
     }
 
     /// Collects the products defined by a package.
-    private func constructProducts(_ targets: [Target]) throws -> [Product] {
+    private func constructProducts(_ targets: [Module]) throws -> [Product] {
         var products = OrderedCollections.OrderedSet<KeyedPair<Product, String>>()
 
         /// Helper method to append to products array.
@@ -1344,9 +1344,9 @@ public final class PackageBuilder {
             guard target.type == .test else { return false }
             #if os(Linux)
             // FIXME: Ignore C language test targets on linux for now.
-            if target is ClangTarget {
+            if module is ClangModule {
                 self.observabilityScope
-                    .emit(.unsupportedCTestTarget(package: self.identity.description, target: target.name))
+                    .emit(.unsupportedCTestTarget(package: self.identity.description, module: module.name))
                 return false
             }
             #endif
@@ -1360,7 +1360,7 @@ public final class PackageBuilder {
                     package: self.identity,
                     name: testTarget.name,
                     type: .test,
-                    targets: [testTarget]
+                    modules: [testTarget]
                 )
                 append(product)
             }
@@ -1378,7 +1378,7 @@ public final class PackageBuilder {
                 package: self.identity,
                 name: productName,
                 type: .test,
-                targets: testModules,
+                modules: testModules,
                 testEntryPointPath: testEntryPointPath
             )
             append(product)
@@ -1388,7 +1388,7 @@ public final class PackageBuilder {
         let modulesMap = Dictionary(targets.map { ($0.name, $0) }, uniquingKeysWith: { $1 })
 
         /// Helper method to get targets from target names.
-        func modulesFrom(targetNames names: [String], product: String) throws -> [Target] {
+        func modulesFrom(targetNames names: [String], product: String) throws -> [Module] {
             // Get targets from target names.
             try names.map { targetName in
                 // Ensure we have this target.
@@ -1415,7 +1415,7 @@ public final class PackageBuilder {
             let targets = try modulesFrom(targetNames: product.targets, product: product.name)
             // Perform special validations if this product is exporting
             // a system library target.
-            if targets.contains(where: { $0 is SystemLibraryTarget }) {
+            if targets.contains(where: { $0 is SystemLibraryModule }) {
                 if product.type != .library(.automatic) || targets.count != 1 {
                     self.observabilityScope.emit(.systemPackageProductValidation(product: product.name))
                     continue
@@ -1440,7 +1440,7 @@ public final class PackageBuilder {
                 }
             }
 
-            try append(Product(package: self.identity, name: product.name, type: product.type, targets: targets))
+            try append(Product(package: self.identity, name: product.name, type: product.type, modules: targets))
         }
 
         // Add implicit executables - for root packages and for dependency plugins.
@@ -1491,7 +1491,7 @@ public final class PackageBuilder {
                         package: self.identity,
                         name: target.name,
                         type: .executable,
-                        targets: [target]
+                        modules: [target]
                     )
                     append(product)
                 }
@@ -1509,7 +1509,7 @@ public final class PackageBuilder {
                     package: self.identity,
                     name: self.identity.description + Product.replProductSuffix,
                     type: .library(.dynamic),
-                    targets: libraryTargets
+                    modules: libraryTargets
                 )
                 append(replProduct)
             }
@@ -1518,19 +1518,19 @@ public final class PackageBuilder {
         // Create implicit snippet products
         try targets
             .filter { $0.type == .snippet }
-            .map { try Product(package: self.identity, name: $0.name, type: .snippet, targets: [$0]) }
+            .map { try Product(package: self.identity, name: $0.name, type: .snippet, modules: [$0]) }
             .forEach(append)
 
         // Create implicit macro products
         try targets
             .filter { $0.type == .macro }
-            .map { try Product(package: self.identity, name: $0.name, type: .macro, targets: [$0]) }
+            .map { try Product(package: self.identity, name: $0.name, type: .macro, modules: [$0]) }
             .forEach(append)
 
         return products.map(\.item)
     }
 
-    private func validateLibraryProduct(_ product: ProductDescription, with targets: [Target]) -> Bool {
+    private func validateLibraryProduct(_ product: ProductDescription, with targets: [Module]) -> Bool {
         let pluginTargets = targets.filter { $0.type == .plugin }
         guard pluginTargets.isEmpty else {
             self.observabilityScope.emit(.nonPluginProductWithPluginTargets(
@@ -1554,7 +1554,7 @@ public final class PackageBuilder {
         return true
     }
 
-    private func validateExecutableProduct(_ product: ProductDescription, with targets: [Target]) -> Bool {
+    private func validateExecutableProduct(_ product: ProductDescription, with targets: [Module]) -> Bool {
         let executableTargetCount = targets.executables.count
         guard executableTargetCount == 1 else {
             if executableTargetCount == 0 {
@@ -1581,7 +1581,7 @@ public final class PackageBuilder {
         return true
     }
 
-    private func validatePluginProduct(_ product: ProductDescription, with targets: [Target]) -> Bool {
+    private func validatePluginProduct(_ product: ProductDescription, with targets: [Module]) -> Bool {
         let nonPluginTargets = targets.filter { $0.type != .plugin }
         guard nonPluginTargets.isEmpty else {
             self.observabilityScope
@@ -1685,7 +1685,7 @@ extension Sources {
     }
 
     /// Determine target type based on the sources.
-    fileprivate func computeTargetType() -> Target.Kind {
+    fileprivate func computeTargetType() -> Module.Kind {
         let isLibrary = !relativePaths.contains { path in
             let file = path.basename.lowercased()
             // Look for a main.xxx file avoiding cases like main.xxx.xxx
@@ -1695,10 +1695,10 @@ extension Sources {
     }
 }
 
-extension Target.Dependency {
+extension Module.Dependency {
     fileprivate var nameAndType: String {
         switch self {
-        case .target:
+        case .module:
             "target-\(name)"
         case .product:
             "product-\(name)"
@@ -1709,7 +1709,7 @@ extension Target.Dependency {
 // MARK: - Snippets
 
 extension PackageBuilder {
-    private func createSnippetTargets(dependencies: [Target.Dependency]) throws -> [Target] {
+    private func createSnippetTargets(dependencies: [Module.Dependency]) throws -> [Module] {
         let snippetsDirectory = self.packagePath.appending("Snippets")
         guard self.fileSystem.isDirectory(snippetsDirectory) else {
             return []
@@ -1739,7 +1739,7 @@ extension PackageBuilder {
                     toolsSwiftVersion: self.toolsSwiftVersion()
                 )
 
-                return SwiftTarget(
+                return SwiftModule(
                     name: name,
                     type: .snippet,
                     path: .root,

--- a/Sources/PackageLoading/Target+PkgConfig.swift
+++ b/Sources/PackageLoading/Target+PkgConfig.swift
@@ -62,7 +62,7 @@ public struct PkgConfigResult {
 
 /// Get pkgConfig result for a system library target.
 public func pkgConfigArgs(
-    for target: SystemLibraryTarget,
+    for target: SystemLibraryModule,
     pkgConfigDirectories: [AbsolutePath],
     sdkRootPath: AbsolutePath? = nil,
     brewPrefix: AbsolutePath? = .none,
@@ -334,7 +334,7 @@ extension ObservabilityMetadata {
     public static func pkgConfig(pcFile: String, targetName: String) -> Self {
         var metadata = ObservabilityMetadata()
         metadata.pcFile = "\(pcFile).pc"
-        metadata.targetName = targetName
+        metadata.moduleName = targetName
         return metadata
     }
 }

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -90,7 +90,7 @@ public struct TargetSourcesBuilder {
 
         self.observabilityScope = observabilityScope.makeChildScope(description: "TargetSourcesBuilder") {
             var metadata = ObservabilityMetadata.packageMetadata(identity: packageIdentity, kind: packageKind)
-            metadata.targetName = target.name
+            metadata.moduleName = target.name
             return metadata
         }
 
@@ -215,7 +215,7 @@ public struct TargetSourcesBuilder {
 
         // It's an error to contain mixed language source files.
         if sources.containsMixedLanguage {
-            throw Target.Error.mixedSources(targetPath)
+            throw Module.Error.mixedSources(targetPath)
         }
 
         return (sources, resources, headers, ignored, others)
@@ -793,16 +793,16 @@ extension Basics.Diagnostic {
 }
 
 extension ObservabilityMetadata {
-    public var targetName: String? {
+    public var moduleName: String? {
         get {
-            self[TargetNameKey.self]
+            self[ModuleNameKey.self]
         }
         set {
-            self[TargetNameKey.self] = newValue
+            self[ModuleNameKey.self] = newValue
         }
     }
 
-    enum TargetNameKey: Key {
+    enum ModuleNameKey: Key {
         typealias Value = String
     }
 }

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -28,6 +28,13 @@ add_library(PackageModel
   Manifest/TraitDescription.swift
   ManifestSourceGeneration.swift
   MinimumDeploymentTarget.swift
+  Module/BinaryModule.swift
+  Module/ClangModule.swift
+  Module/PluginModule.swift
+  Module/ProvidedLibraryModule.swift
+  Module/SwiftModule.swift
+  Module/SystemLibraryModule.swift
+  Module/Module.swift
   ModuleMapType.swift
   PackageModel.swift
   PackageIdentity.swift
@@ -49,13 +56,6 @@ add_library(PackageModel
   SwiftSDKs/SwiftSDKConfigurationStore.swift
   SwiftSDKs/SwiftSDKBundle.swift
   SwiftSDKs/SwiftSDKBundleStore.swift
-  Target/BinaryTarget.swift
-  Target/ClangTarget.swift
-  Target/PluginTarget.swift
-  Target/ProvidedLibraryTarget.swift
-  Target/SwiftTarget.swift
-  Target/SystemLibraryTarget.swift
-  Target/Target.swift
   Toolchain.swift
   ToolchainConfiguration.swift
   Toolset.swift

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -484,7 +484,7 @@ public final class Manifest: Sendable {
     }
 
     /// Returns a list of target descriptions whose root source directory is the same as that for the given type.
-    public func targetsWithCommonSourceRoot(type: TargetDescription.TargetType) -> [TargetDescription] {
+    public func targetsWithCommonSourceRoot(type: TargetDescription.TargetKind) -> [TargetDescription] {
         switch type {
         case .test:
             return self.targets.filter { $0.type == .test }
@@ -496,7 +496,7 @@ public final class Manifest: Sendable {
     }
 
     /// Returns true if the tools version is >= 5.9 and the number of targets with a common source root is 1.
-    public func shouldSuggestRelaxedSourceDir(type: TargetDescription.TargetType) -> Bool {
+    public func shouldSuggestRelaxedSourceDir(type: TargetDescription.TargetKind) -> Bool {
         guard self.toolsVersion >= .v5_9 else {
             return false
         }

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -351,7 +351,7 @@ public final class Manifest: Sendable {
     ) -> PackageDependency? {
         self.dependencies.first(where: {
             // rdar://80594761 make sure validation is case insensitive
-            $0.nameForTargetDependencyResolutionOnly.lowercased() == packageName.lowercased()
+            $0.nameForModuleDependencyResolutionOnly.lowercased() == packageName.lowercased()
         })
     }
 

--- a/Sources/PackageModel/Manifest/PackageConditionDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageConditionDescription.swift
@@ -82,7 +82,7 @@ struct PackageConditionWrapper: Codable, Equatable, Hashable {
     }
 }
 
-/// One of possible conditions used in package manifests to restrict targets from being built for certain platforms or
+/// One of possible conditions used in package manifests to restrict modules from being built for certain platforms or
 /// build configurations.
 public enum PackageCondition: Hashable, Sendable {
     case platforms(PlatformsCondition)

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -140,7 +140,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
 
     // FIXME: we should simplify target based dependencies such that this is no longer required
     // A name to be used *only* for target dependencies resolution
-    public var nameForTargetDependencyResolutionOnly: String {
+    public var nameForModuleDependencyResolutionOnly: String {
         switch self {
         case .fileSystem(let settings):
             return settings.nameForTargetDependencyResolutionOnly ?? PackageIdentityParser.computeDefaultName(fromPath: settings.path)
@@ -158,7 +158,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
 
     // FIXME: we should simplify target based dependencies such that this is no longer required
     // A name to be used *only* for target dependencies resolution
-    public var explicitNameForTargetDependencyResolutionOnly: String? {
+    public var explicitNameForModuleDependencyResolutionOnly: String? {
         switch self {
         case .fileSystem(let settings):
             return settings.nameForTargetDependencyResolutionOnly

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The description of an individual target.
+/// The description of an individual module.
 public struct TargetDescription: Hashable, Encodable, Sendable {
     /// The target type.
-    public enum TargetType: String, Hashable, Encodable, Sendable {
+    public enum TargetKind: String, Hashable, Encodable, Sendable {
         case regular
         case executable
         case test
@@ -110,7 +110,7 @@ public struct TargetDescription: Hashable, Encodable, Sendable {
     public let publicHeadersPath: String?
 
     /// The type of target.
-    public let type: TargetType
+    public let type: TargetKind
 
     /// The pkg-config name of a system library target.
     public let pkgConfig: String?
@@ -180,7 +180,7 @@ public struct TargetDescription: Hashable, Encodable, Sendable {
         sources: [String]? = nil,
         resources: [Resource] = [],
         publicHeadersPath: String? = nil,
-        type: TargetType = .regular,
+        type: TargetKind = .regular,
         packageAccess: Bool = true,
         pkgConfig: String? = nil,
         providers: [SystemPackageProviderDescription]? = nil,

--- a/Sources/PackageModel/Manifest/TargetDescription.swift
+++ b/Sources/PackageModel/Manifest/TargetDescription.swift
@@ -12,7 +12,10 @@
 
 /// The description of an individual module.
 public struct TargetDescription: Hashable, Encodable, Sendable {
-    /// The target type.
+    @available(*, deprecated, renamed: "TargetKind")
+    public typealias TargetType = TargetKind
+
+    /// The target kind.
     public enum TargetKind: String, Hashable, Encodable, Sendable {
         case regular
         case executable

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -153,7 +153,7 @@ fileprivate extension SourceCodeFragment {
     /// Instantiates a SourceCodeFragment to represent a single package dependency.
     init(from dependency: PackageDependency, pathAnchor: AbsolutePath) {
         var params: [SourceCodeFragment] = []
-        if let explicitName = dependency.explicitNameForTargetDependencyResolutionOnly {
+        if let explicitName = dependency.explicitNameForModuleDependencyResolutionOnly {
             params.append(SourceCodeFragment(key: "name", string: explicitName))
         }
         switch dependency {

--- a/Sources/PackageModel/Module/BinaryModule.swift
+++ b/Sources/PackageModel/Module/BinaryModule.swift
@@ -12,13 +12,19 @@
 
 import struct Basics.AbsolutePath
 
-public final class BinaryTarget: Target {
+@available(*, deprecated, renamed: "BinaryModule")
+public typealias BinaryTarget = BinaryModule
+
+public final class BinaryModule: Module {
+    /// Description of the module type used in `swift package describe` output. Preserved for backwards compatibility.
+    public override class var typeDescription: String { "BinaryTarget" }
+
     /// The kind of binary artifact.
     public let kind: Kind
-
+    
     /// The original source of the binary artifact.
     public let origin: Origin
-
+    
     /// The binary artifact path.
     public var artifactPath: AbsolutePath {
         return self.sources.root

--- a/Sources/PackageModel/Module/ClangModule.swift
+++ b/Sources/PackageModel/Module/ClangModule.swift
@@ -13,7 +13,13 @@
 import struct Basics.AbsolutePath
 import struct Basics.StringError
 
-public final class ClangTarget: Target {
+@available(*, deprecated, renamed: "ClangModule")
+public typealias ClangTarget = ClangModule
+
+public final class ClangModule: Module {
+    /// Description of the module type used in `swift package describe` output. Preserved for backwards compatibility.
+    public override class var typeDescription: String { "ClangTarget" }
+
     /// The default public include directory component.
     public static let defaultPublicHeadersComponent = "include"
 
@@ -51,7 +57,7 @@ public final class ClangTarget: Target {
         resources: [Resource] = [],
         ignored: [AbsolutePath] = [],
         others: [AbsolutePath] = [],
-        dependencies: [Target.Dependency] = [],
+        dependencies: [Module.Dependency] = [],
         buildSettings: BuildSettings.AssignmentTable = .init(),
         buildSettingsDescription: [TargetBuildSettingDescription.Setting] = [],
         usesUnsafeFlags: Bool

--- a/Sources/PackageModel/Module/Module.swift
+++ b/Sources/PackageModel/Module/Module.swift
@@ -14,17 +14,23 @@ import Basics
 
 import protocol TSCUtility.PolymorphicCodableProtocol
 
-public class Target: PolymorphicCodableProtocol {
+@available(*, deprecated, renamed: "Module")
+public typealias Target = Module
+
+public class Module: PolymorphicCodableProtocol {
+    /// Description of the module type used in `swift package describe` output. Preserved for backwards compatibility.
+    public class var typeDescription: String { fatalError("implement in a subclass") }
+
     public static var implementations: [PolymorphicCodableProtocol.Type] = [
-        SwiftTarget.self,
-        ClangTarget.self,
-        SystemLibraryTarget.self,
-        BinaryTarget.self,
-        PluginTarget.self,
-        ProvidedLibraryTarget.self,
+        SwiftModule.self,
+        ClangModule.self,
+        SystemLibraryModule.self,
+        BinaryModule.self,
+        PluginModule.self,
+        ProvidedLibraryModule.self,
     ]
 
-    /// The target kind.
+    /// The module kind.
     public enum Kind: String, Codable {
         case executable
         case library
@@ -37,14 +43,14 @@ public class Target: PolymorphicCodableProtocol {
         case providedLibrary
     }
 
-    /// A group a target belongs to that allows customizing access boundaries. A target is treated as
+    /// A group a module belongs to that allows customizing access boundaries. A module is treated as
     /// a client outside of the package if `excluded`, inside the package boundary if `package`.
     public enum Group: Codable, Equatable {
         case package
         case excluded
     }
 
-    /// A reference to a product from a target dependency.
+    /// A reference to a product from a module dependency.
     public struct ProductReference: Codable {
         /// The name of the product dependency.
         public let name: String
@@ -63,7 +69,7 @@ public class Target: PolymorphicCodableProtocol {
                 return package.lowercased() + "_" + name
             } else {
                 // this is hit only if this product is referenced `.byName(name)`
-                // which assumes the name of this product, its package, and its target
+                // which assumes the name of this product, its package, and its module
                 // all have the same name
                 return name.lowercased() + "_" + name
             }
@@ -77,17 +83,21 @@ public class Target: PolymorphicCodableProtocol {
         }
     }
 
-    /// A target dependency to a target or product.
+    /// A module dependency to a module or product.
     public enum Dependency {
         /// A dependency referencing another target, with conditions.
-        case target(_ target: Target, conditions: [PackageCondition])
+        case module(_ target: Module, conditions: [PackageCondition])
 
         /// A dependency referencing a product, with conditions.
         case product(_ product: ProductReference, conditions: [PackageCondition])
 
-        /// The target if the dependency is a target dependency.
-        public var target: Target? {
-            if case .target(let target, _) = self {
+
+        @available(*, deprecated, renamed: "module")
+        public var target: Module? { self.module }
+
+        /// The module if the dependency is a target dependency.
+        public var module: Module? {
+            if case .module(let target, _) = self {
                 return target
             } else {
                 return nil
@@ -106,7 +116,7 @@ public class Target: PolymorphicCodableProtocol {
         /// The dependency conditions.
         public var conditions: [PackageCondition] {
             switch self {
-            case .target(_, let conditions):
+            case .module(_, let conditions):
                 return conditions
             case .product(_, let conditions):
                 return conditions
@@ -116,7 +126,7 @@ public class Target: PolymorphicCodableProtocol {
         /// The name of the target or product of the dependency.
         public var name: String {
             switch self {
-            case .target(let target, _):
+            case .module(let target, _):
                 return target.name
             case .product(let product, _):
                 return product.name
@@ -124,20 +134,20 @@ public class Target: PolymorphicCodableProtocol {
         }
     }
 
-    /// A usage of a plugin target or product. Implemented as a dependency
+    /// A usage of a plugin module or product. Implemented as a dependency
     /// for now and added to the `dependencies` array, since they currently
     /// have exactly the same characteristics and to avoid duplicating the
     /// implementation for now.
     public typealias PluginUsage = Dependency
 
-    /// The name of the target.
+    /// The name of the module.
     ///
-    /// NOTE: This name is not the language-level target (i.e., the importable
+    /// NOTE: This name is not the language-level module (i.e., the importable
     /// name) name in many cases, instead use ``Target/c99name`` if you need uniqueness.
     public private(set) var name: String
 
-    /// Module aliases needed to build this target. The key is an original name of a
-    /// dependent target and the value is a new unique name mapped to the name
+    /// Module aliases needed to build this module. The key is an original name of a
+    /// dependent module and the value is a new unique name mapped to the name
     /// of its .swiftmodule binary.
     public private(set) var moduleAliases: [String: String]?
     /// Used to store pre-chained / pre-overriden module aliases
@@ -145,15 +155,15 @@ public class Target: PolymorphicCodableProtocol {
     /// Used to store aliases that should be referenced directly in source code
     public private(set) var directRefAliases: [String: [String]]?
 
-    /// Add module aliases (if applicable) for dependencies of this target.
+    /// Add module aliases (if applicable) for dependencies of this module.
     ///
-    /// For example, adding an alias `Bar` for a target name `Foo` will result in
-    /// compiling references to `Foo` in source code of this target as `Bar.swiftmodule`.
-    /// If the name argument `Foo` is the same as this target's name, this target will be
+    /// For example, adding an alias `Bar` for a module name `Foo` will result in
+    /// compiling references to `Foo` in source code of this module as `Bar.swiftmodule`.
+    /// If the name argument `Foo` is the same as this module's name, this module will be
     /// renamed as `Bar` and the resulting binary will be `Bar.swiftmodule`.
     ///
     /// - Parameters:
-    ///   - name: The original name of a dependent target or this target
+    ///   - name: The original name of a dependent module or this module
     ///   - alias: A new unique name mapped to the resulting binary name
     public func addModuleAlias(for name: String, as alias: String) {
         if moduleAliases == nil {
@@ -187,7 +197,7 @@ public class Target: PolymorphicCodableProtocol {
 
     @discardableResult
     public func applyAlias() -> Bool {
-        // If there's an alias for this target, rename
+        // If there's an alias for this module, rename
         if let alias = moduleAliases?[name] {
             self.name = alias
             self.c99name = alias.spm_mangledToC99ExtendedIdentifier()
@@ -196,10 +206,10 @@ public class Target: PolymorphicCodableProtocol {
         return false
     }
 
-    /// The dependencies of this target.
+    /// The dependencies of this module.
     public let dependencies: [Dependency]
 
-    /// The language-level target name.
+    /// The language-level module name.
     public private(set) var c99name: String
 
     /// The bundle name, if one is being generated.
@@ -211,34 +221,34 @@ public class Target: PolymorphicCodableProtocol {
     /// Suffix that's expected for test targets.
     public static let testModuleNameSuffix = "Tests"
 
-    /// The kind of target.
+    /// The kind of module.
     public let type: Kind
 
-    /// If true, access to package declarations from other targets is allowed.
+    /// If true, access to package declarations from other modules is allowed.
     public let packageAccess: Bool
 
-    /// The path of the target.
+    /// The path of the module.
     public let path: AbsolutePath
 
-    /// The sources for the target.
+    /// The sources for the module.
     public let sources: Sources
 
-    /// The resource files in the target.
+    /// The resource files in the module.
     public let resources: [Resource]
 
     /// Files in the target that were marked as ignored.
     public let ignored: [AbsolutePath]
 
-    /// Other kinds of files in the target.
+    /// Other kinds of files in the module.
     public let others: [AbsolutePath]
 
-    /// The build settings assignments of this target.
+    /// The build settings assignments of this module.
     public let buildSettings: BuildSettings.AssignmentTable
 
     @_spi(SwiftPMInternal)
     public let buildSettingsDescription: [TargetBuildSettingDescription.Setting]
 
-    /// The usages of package plugins by this target.
+    /// The usages of package plugins by this module.
     public let pluginUsages: [PluginUsage]
 
     /// Whether or not this target uses any custom unsafe flags.
@@ -253,7 +263,7 @@ public class Target: PolymorphicCodableProtocol {
         resources: [Resource] = [],
         ignored: [AbsolutePath] = [],
         others: [AbsolutePath] = [],
-        dependencies: [Target.Dependency],
+        dependencies: [Module.Dependency],
         packageAccess: Bool,
         buildSettings: BuildSettings.AssignmentTable,
         buildSettingsDescription: [TargetBuildSettingDescription.Setting],
@@ -299,7 +309,7 @@ public class Target: PolymorphicCodableProtocol {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         // FIXME: dependencies property is skipped on purpose as it points to
-        // the actual target dependency object.
+        // the actual module dependency object.
         try container.encode(name, forKey: .name)
         try container.encode(potentialBundleName, forKey: .potentialBundleName)
         try container.encode(type, forKey: .type)
@@ -312,7 +322,7 @@ public class Target: PolymorphicCodableProtocol {
         try container.encode(buildSettings, forKey: .buildSettings)
         try container.encode(buildSettingsDescription, forKey: .buildSettingsDescription)
         // FIXME: pluginUsages property is skipped on purpose as it points to
-        // the actual target dependency object.
+        // the actual module dependency object.
         try container.encode(usesUnsafeFlags, forKey: .usesUnsafeFlags)
     }
 
@@ -327,7 +337,7 @@ public class Target: PolymorphicCodableProtocol {
         self.ignored = try container.decode([AbsolutePath].self, forKey: .ignored)
         self.others = try container.decode([AbsolutePath].self, forKey: .others)
         // FIXME: dependencies property is skipped on purpose as it points to
-        // the actual target dependency object.
+        // the actual module dependency object.
         self.dependencies = []
         self.c99name = self.name.spm_mangledToC99ExtendedIdentifier()
         self.packageAccess = try container.decode(Bool.self, forKey: .packageAccess)
@@ -337,7 +347,7 @@ public class Target: PolymorphicCodableProtocol {
             forKey: .buildSettingsDescription
         )
         // FIXME: pluginUsages property is skipped on purpose as it points to
-        // the actual target dependency object.
+        // the actual module dependency object.
         self.pluginUsages = []
         self.usesUnsafeFlags = try container.decode(Bool.self, forKey: .usesUnsafeFlags)
     }
@@ -352,28 +362,28 @@ public class Target: PolymorphicCodableProtocol {
     }
 }
 
-extension Target: Hashable {
+extension Module: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(self))
     }
 
-    public static func == (lhs: Target, rhs: Target) -> Bool {
+    public static func == (lhs: Module, rhs: Module) -> Bool {
         ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }
 
-extension Target: CustomStringConvertible {
+extension Module: CustomStringConvertible {
     public var description: String {
         return "<\(Swift.type(of: self)): \(name)>"
     }
 }
 
-public extension Sequence where Iterator.Element == Target {
-    var executables: [Target] {
+public extension Sequence where Iterator.Element == Module {
+    var executables: [Module] {
         return filter {
             switch $0.type {
             case .binary:
-                return ($0 as? BinaryTarget)?.containsExecutable == true
+                return ($0 as? BinaryModule)?.containsExecutable == true
             case .executable, .snippet, .macro:
                 return true
             default:

--- a/Sources/PackageModel/Module/PluginModule.swift
+++ b/Sources/PackageModel/Module/PluginModule.swift
@@ -10,7 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-public final class PluginTarget: Target {
+@available(*, deprecated, renamed: "PluginModule")
+public typealias PluginTarget = PluginModule
+
+public final class PluginModule: Module {
+    /// Description of the module type used in `swift package describe` output. Preserved for backwards compatibility.
+    public override class var typeDescription: String { "PluginTarget" }
 
     /// Declared capability of the plugin.
     public let capability: PluginCapability
@@ -23,7 +28,7 @@ public final class PluginTarget: Target {
         sources: Sources,
         apiVersion: ToolsVersion,
         pluginCapability: PluginCapability,
-        dependencies: [Target.Dependency] = [],
+        dependencies: [Module.Dependency] = [],
         packageAccess: Bool
     ) {
         self.capability = pluginCapability

--- a/Sources/PackageModel/Module/ProvidedLibraryModule.swift
+++ b/Sources/PackageModel/Module/ProvidedLibraryModule.swift
@@ -12,8 +12,11 @@
 
 import struct Basics.AbsolutePath
 
-/// Represents a target library that comes from a toolchain in prebuilt form.
-public final class ProvidedLibraryTarget: Target {
+@available(*, deprecated, renamed: "ProvidedLibraryModule")
+public typealias ProvidedLibraryTarget = ProvidedLibraryModule
+
+/// Represents a library module that comes from a toolchain in prebuilt form.
+public final class ProvidedLibraryModule: Module {
     public init(
         name: String,
         path: AbsolutePath

--- a/Sources/PackageModel/Module/SwiftModule.swift
+++ b/Sources/PackageModel/Module/SwiftModule.swift
@@ -13,7 +13,13 @@
 import struct Basics.AbsolutePath
 import struct Basics.SwiftVersion
 
-public final class SwiftTarget: Target {
+@available(*, deprecated, renamed: "SwiftModule")
+public typealias SwiftTarget = SwiftModule
+
+public final class SwiftModule: Module {
+    /// Description of the module type used in `swift package describe` output. Preserved for backwards compatibility.
+    public override class var typeDescription: String { "SwiftTarget" }
+
     /// The default name for the test entry point file located in a package.
     public static let defaultTestEntryPointName = "XCTMain.swift"
 
@@ -22,7 +28,7 @@ public final class SwiftTarget: Target {
         [defaultTestEntryPointName, "LinuxMain.swift"]
     }
 
-    public init(name: String, dependencies: [Target.Dependency], packageAccess: Bool, testDiscoverySrc: Sources) {
+    public init(name: String, dependencies: [Module.Dependency], packageAccess: Bool, testDiscoverySrc: Sources) {
         self.declaredSwiftVersions = []
 
         super.init(
@@ -51,7 +57,7 @@ public final class SwiftTarget: Target {
         resources: [Resource] = [],
         ignored: [AbsolutePath] = [],
         others: [AbsolutePath] = [],
-        dependencies: [Target.Dependency] = [],
+        dependencies: [Module.Dependency] = [],
         packageAccess: Bool,
         declaredSwiftVersions: [SwiftLanguageVersion] = [],
         buildSettings: BuildSettings.AssignmentTable = .init(),
@@ -81,7 +87,7 @@ public final class SwiftTarget: Target {
     /// Create an executable Swift target from test entry point file.
     public init(
         name: String,
-        dependencies: [Target.Dependency],
+        dependencies: [Module.Dependency],
         packageAccess: Bool,
         testEntryPointPath: AbsolutePath
     ) {
@@ -89,9 +95,9 @@ public final class SwiftTarget: Target {
         // for linux main target. This will need to change if we move to a model
         // where we allow per target swift language version build settings.
         let swiftTestTarget = dependencies.first {
-            guard case .target(let target as SwiftTarget, _) = $0 else { return false }
+            guard case .module(let target as SwiftModule, _) = $0 else { return false }
             return target.type == .test
-        }.flatMap { $0.target as? SwiftTarget }
+        }.flatMap { $0.module as? SwiftModule }
 
         // We need to select the latest Swift language version that can
         // satisfy the current tools version but there is not a good way to

--- a/Sources/PackageModel/Module/SystemLibraryModule.swift
+++ b/Sources/PackageModel/Module/SystemLibraryModule.swift
@@ -12,7 +12,12 @@
 
 import struct Basics.AbsolutePath
 
-public final class SystemLibraryTarget: Target {
+@available(*, deprecated, renamed: "SystemLibraryModule")
+public typealias SystemLibraryTarget = SystemLibraryModule
+
+public final class SystemLibraryModule: Module {
+    /// Description of the module type used in `swift package describe` output. Preserved for backwards compatibility.
+    public override class var typeDescription: String { "SystemLibraryTarget" }
 
     /// The name of pkgConfig file, if any.
     public let pkgConfig: String?
@@ -20,8 +25,7 @@ public final class SystemLibraryTarget: Target {
     /// List of system package providers, if any.
     public let providers: [SystemPackageProviderDescription]?
 
-    /// True if this system library should become implicit target
-    /// dependency of its dependent packages.
+    /// True if this system library should become implicit dependency of its dependent packages.
     public let isImplicit: Bool
 
     public init(

--- a/Sources/PackageModel/PackageModel.swift
+++ b/Sources/PackageModel/PackageModel.swift
@@ -57,7 +57,7 @@ public final class Package: Encodable {
 
     /// The targets contained in the package.
     @PolymorphicCodableArray
-    public var targets: [Target]
+    public var modules: [Module]
 
     /// The products produced by the package.
     public let products: [Product]
@@ -76,7 +76,7 @@ public final class Package: Encodable {
         identity: PackageIdentity,
         manifest: Manifest,
         path: AbsolutePath,
-        targets: [Target],
+        targets: [Module],
         products: [Product],
         targetSearchPath: AbsolutePath,
         testTargetSearchPath: AbsolutePath
@@ -84,7 +84,7 @@ public final class Package: Encodable {
         self.identity = identity
         self.manifest = manifest
         self.path = path
-        self._targets = .init(wrappedValue: targets)
+        self._modules = .init(wrappedValue: targets)
         self.products = products
         self.targetSearchPath = targetSearchPath
         self.testTargetSearchPath = testTargetSearchPath

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -29,7 +29,7 @@ public class Product: Codable {
     /// This is never empty, and is only the targets which are required to be in
     /// the product, but not necessarily their transitive dependencies.
     @PolymorphicCodableArray
-    public var targets: [Target]
+    public var modules: [Module]
 
     /// The path to test entry point file.
     public let testEntryPointPath: AbsolutePath?
@@ -37,12 +37,12 @@ public class Product: Codable {
     /// The suffix for REPL product name.
     public static let replProductSuffix: String = "__REPL"
 
-    public init(package: PackageIdentity, name: String, type: ProductType, targets: [Target], testEntryPointPath: AbsolutePath? = nil) throws {
-        guard !targets.isEmpty else {
+    public init(package: PackageIdentity, name: String, type: ProductType, modules: [Module], testEntryPointPath: AbsolutePath? = nil) throws {
+        guard !modules.isEmpty else {
             throw InternalError("Targets cannot be empty")
         }
         if type == .executable {
-            guard targets.executables.count == 1 else {
+            guard modules.executables.count == 1 else {
                 throw InternalError("Executable products should have exactly one executable target.")
             }
         }
@@ -54,7 +54,7 @@ public class Product: Codable {
         self.name = name
         self.type = type
         self.identity = package.description.lowercased() + "_" + name
-        self._targets = .init(wrappedValue: targets)
+        self._modules = .init(wrappedValue: modules)
         self.testEntryPointPath = testEntryPointPath
     }
 }

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
@@ -88,7 +88,7 @@ public final class SwiftSDKBundleStore {
         get throws {
             // Get absolute paths to available Swift SDK bundles.
             try self.fileSystem.getDirectoryContents(swiftSDKsDirectory).filter {
-                $0.hasSuffix(BinaryTarget.Kind.artifactsArchive.fileExtension)
+                $0.hasSuffix(BinaryModule.Kind.artifactsArchive.fileExtension)
             }.map {
                 self.swiftSDKsDirectory.appending(components: [$0])
             }.compactMap {

--- a/Sources/PackagePlugin/PluginContextDeserializer.swift
+++ b/Sources/PackagePlugin/PluginContextDeserializer.swift
@@ -51,7 +51,7 @@ internal struct PluginContextDeserializer {
     }
 
     /// Returns the `Target` that corresponds to the given ID (a small integer),
-    /// or throws an error if the ID is invalid. The target is deserialized on-
+    /// or throws an error if the ID is invalid. The module is deserialized on-
     /// demand if it hasn't already been deserialized.
     mutating func target(for id: WireInput.Target.Id, pluginGeneratedSources: [URL] = [], pluginGeneratedResources: [URL] = []) throws -> Target {
         if let target = targetsById[id],

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -36,7 +36,7 @@ public struct ExecutableInfo: Equatable {
     public let supportedTriples: [Triple]
 }
 
-extension BinaryTarget {
+extension BinaryModule {
     public func parseXCFrameworks(for triple: Triple, fileSystem: FileSystem) throws -> [LibraryInfo] {
         // At the moment we return at most a single library.
         let metadata = try XCFrameworkMetadata.parse(fileSystem: fileSystem, rootPath: self.artifactPath)

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -28,7 +28,7 @@ public enum PluginAction {
     case performCommand(package: ResolvedPackage, arguments: [String])
 }
 
-extension PluginTarget {
+extension PluginModule {
     public func invoke(
         action: PluginAction,
         buildEnvironment: BuildEnvironment,
@@ -404,14 +404,14 @@ extension ModulesGraph {
         builtToolHandler: (_ name: String, _ path: RelativePath) throws -> AbsolutePath? = { _, _ in return nil }
     ) throws -> [ResolvedModule.ID: (target: ResolvedModule, results: [BuildToolPluginInvocationResult])] {
         var pluginResultsByTarget: [ResolvedModule.ID: (target: ResolvedModule, results: [BuildToolPluginInvocationResult])] = [:]
-        for target in self.allTargets.sorted(by: { $0.name < $1.name }) {
+        for target in self.allModules.sorted(by: { $0.name < $1.name }) {
             // Infer plugins from the declared dependencies, and collect them as well as any regular dependencies. Although usage of build tool plugins is declared separately from dependencies in the manifest, in the internal model we currently consider both to be dependencies.
-            var pluginTargets: [PluginTarget] = []
-            var dependencyTargets: [Target] = []
+            var pluginTargets: [PluginModule] = []
+            var dependencyTargets: [Module] = []
             for dependency in target.dependencies(satisfying: buildParameters.buildEnvironment) {
                 switch dependency {
-                case .target(let target, _):
-                    if let pluginTarget = target.underlying as? PluginTarget {
+                case .module(let target, _):
+                    if let pluginTarget = target.underlying as? PluginModule {
                         assert(pluginTarget.capability == .buildTool)
                         pluginTargets.append(pluginTarget)
                     }
@@ -419,7 +419,7 @@ extension ModulesGraph {
                         dependencyTargets.append(target.underlying)
                     }
                 case .product(let product, _):
-                    pluginTargets.append(contentsOf: product.targets.compactMap{ $0.underlying as? PluginTarget })
+                    pluginTargets.append(contentsOf: product.modules.compactMap{ $0.underlying as? PluginModule })
                 }
             }
 
@@ -658,7 +658,7 @@ public enum PluginAccessibleTool: Hashable {
     case vendedTool(name: String, path: AbsolutePath, supportedTriples: [String])
 }
 
-public extension PluginTarget {
+public extension PluginModule {
 
     func dependencies(satisfying environment: BuildEnvironment) -> [Dependency] {
         return self.dependencies.filter { $0.satisfies(environment) }
@@ -668,15 +668,15 @@ public extension PluginTarget {
     private func accessibleTools(packageGraph: ModulesGraph, fileSystem: FileSystem, environment: BuildEnvironment, for hostTriple: Triple) throws -> Set<PluginAccessibleTool> {
         return try Set(self.dependencies(satisfying: environment).flatMap { dependency -> [PluginAccessibleTool] in
             let builtToolName: String
-            let executableOrBinaryTarget: Target
+            let executableOrBinaryTarget: Module
             switch dependency {
-            case .target(let target, _):
+            case .module(let target, _):
                 builtToolName = target.name
                 executableOrBinaryTarget = target
             case .product(let productRef, _):
                 guard
                     let product = packageGraph.product(for: productRef.name, destination: .tools),
-                    let executableTarget = product.targets.map({ $0.underlying }).executables.spm_only
+                    let executableTarget = product.modules.map({ $0.underlying }).executables.spm_only
                 else {
                     throw StringError("no product named \(productRef.name)")
                 }
@@ -685,7 +685,7 @@ public extension PluginTarget {
             }
 
             // For a binary target we create a `vendedTool`.
-            if let target = executableOrBinaryTarget as? BinaryTarget {
+            if let target = executableOrBinaryTarget as? BinaryModule {
                 // TODO: Memoize this result for the host triple
                 let execInfos = try target.parseArtifactArchives(for: hostTriple, fileSystem: fileSystem)
                 return try execInfos.map{ .vendedTool(name: $0.name, path: $0.executablePath, supportedTriples: try $0.supportedTriples.map{ try $0.withoutVersion().tripleString }) }
@@ -723,10 +723,10 @@ public extension PluginTarget {
     }
 }
 
-fileprivate extension Target.Dependency {
+fileprivate extension Module.Dependency {
     var conditions: [PackageCondition] {
         switch self {
-        case .target(_, let conditions): return conditions
+        case .module(_, let conditions): return conditions
         case .product(_, let conditions): return conditions
         }
     }
@@ -740,7 +740,7 @@ fileprivate extension Target.Dependency {
 /// Represents the result of invoking a build tool plugin for a particular target. The result includes generated build commands and prebuild commands as well as any diagnostics and stdout/stderr output emitted by the plugin.
 public struct BuildToolPluginInvocationResult {
     /// The plugin that produced the results.
-    public var plugin: PluginTarget
+    public var plugin: PluginModule
 
     /// The directory given to the plugin as a place in which it and the commands are allowed to write.
     public var pluginOutputDirectory: AbsolutePath

--- a/Sources/SPMTestSupport/MockPackage.swift
+++ b/Sources/SPMTestSupport/MockPackage.swift
@@ -107,7 +107,7 @@ public struct MockPackage {
                 try MockTarget(name: name),
             ],
             products: [
-                MockProduct(name: name, targets: [name]),
+                MockProduct(name: name, modules: [name]),
             ],
             versions: ["1.0.0"]
         )

--- a/Sources/SPMTestSupport/MockProduct.swift
+++ b/Sources/SPMTestSupport/MockProduct.swift
@@ -12,10 +12,10 @@
 
 public struct MockProduct {
     public let name: String
-    public let targets: [String]
+    public let modules: [String]
 
-    public init(name: String, targets: [String]) {
+    public init(name: String, modules: [String]) {
         self.name = name
-        self.targets = targets
+        self.modules = modules
     }
 }

--- a/Sources/SPMTestSupport/MockWorkspace.swift
+++ b/Sources/SPMTestSupport/MockWorkspace.swift
@@ -223,7 +223,7 @@ public final class MockWorkspace {
                 registryAlternativeURLs = alternativeURLs
             }
 
-            // Create targets on disk.
+            // Create modules on disk.
             let packageToolsVersion = package.toolsVersion ?? .current
             if let specifier = sourceControlSpecifier {
                 let repository = self.repositoryProvider.specifierMap[specifier] ?? .init(path: packagePath, fs: self.fileSystem)
@@ -264,7 +264,7 @@ public final class MockWorkspace {
                     version: v,
                     toolsVersion: packageToolsVersion,
                     dependencies: package.dependencies.map { try $0.convert(baseURL: packagesDir, identityResolver: self.identityResolver) },
-                    products: package.products.map { try ProductDescription(name: $0.name, type: .library(.automatic), targets: $0.targets) },
+                    products: package.products.map { try ProductDescription(name: $0.name, type: .library(.automatic), targets: $0.modules) },
                     targets: try package.targets.map { try $0.convert(identityResolver: self.identityResolver) }
                 )
             }

--- a/Sources/SPMTestSupport/PackageGraphTester.swift
+++ b/Sources/SPMTestSupport/PackageGraphTester.swift
@@ -46,12 +46,12 @@ public final class PackageGraphResult {
         XCTAssertEqual(graph.packages.map {$0.identity }.sorted(), packages.sorted(), file: file, line: line)
     }
 
-    public func check(targets: String..., file: StaticString = #file, line: UInt = #line) {
+    public func check(modules: String..., file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(
-            graph.allTargets
+            graph.allModules
                 .filter { $0.type != .test }
                 .map { $0.name }
-                .sorted(), targets.sorted(), file: file, line: line)
+                .sorted(), modules.sorted(), file: file, line: line)
     }
 
     public func check(products: String..., file: StaticString = #file, line: UInt = #line) {
@@ -59,7 +59,7 @@ public final class PackageGraphResult {
     }
 
     public func check(reachableTargets: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(Set(graph.reachableTargets.map { $0.name }), Set(reachableTargets), file: file, line: line)
+        XCTAssertEqual(Set(graph.reachableModules.map { $0.name }), Set(reachableTargets), file: file, line: line)
     }
 
     public func check(reachableProducts: String..., file: StaticString = #file, line: UInt = #line) {
@@ -93,7 +93,7 @@ public final class PackageGraphResult {
         line: UInt = #line,
         body: (ResolvedTargetResult) -> Void
     ) {
-        let target = graph.target(for: name, destination: destination)
+        let target = graph.module(for: name, destination: destination)
 
         guard let target else {
             return XCTFail("Target \(name) not found", file: file, line: line)
@@ -108,7 +108,7 @@ public final class PackageGraphResult {
         line: UInt = #line,
         body: ([ResolvedTargetResult]) throws -> Void
     ) rethrows {
-        try body(graph.allTargets.filter { $0.name == name }.map(ResolvedTargetResult.init))
+        try body(graph.allModules.filter { $0.name == name }.map(ResolvedTargetResult.init))
     }
 
     public func checkProduct(
@@ -129,7 +129,7 @@ public final class PackageGraphResult {
 
     public func check(testModules: String..., file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(
-            graph.allTargets
+            graph.allModules
                 .filter{ $0.type == .test }
                 .map{ $0.name }
                 .sorted(), testModules.sorted(), file: file, line: line)
@@ -140,17 +140,17 @@ public final class PackageGraphResult {
     }
 
     private func reachableBuildTargets(in environment: BuildEnvironment) throws -> IdentifiableSet<ResolvedModule> {
-        let inputTargets = graph.inputPackages.lazy.flatMap { $0.targets }
+        let inputTargets = graph.inputPackages.lazy.flatMap { $0.modules }
         let recursiveBuildTargetDependencies = try inputTargets
             .flatMap { try $0.recursiveDependencies(satisfying: environment) }
-            .compactMap { $0.target }
+            .compactMap { $0.module }
         return IdentifiableSet(inputTargets).union(recursiveBuildTargetDependencies)
     }
 
     private func reachableBuildProducts(in environment: BuildEnvironment) throws -> IdentifiableSet<ResolvedProduct> {
         let recursiveBuildProductDependencies = try graph.inputPackages
             .lazy
-            .flatMap { $0.targets }
+            .flatMap { $0.modules }
             .flatMap { try $0.recursiveDependencies(satisfying: environment) }
             .compactMap { $0.product }
         return IdentifiableSet(graph.inputPackages.flatMap { $0.products }).union(recursiveBuildProductDependencies)
@@ -184,7 +184,7 @@ public final class ResolvedTargetResult {
         body(ResolvedTargetDependencyResult(dependency))
     }
 
-    public func check(type: Target.Kind, file: StaticString = #file, line: UInt = #line) {
+    public func check(type: Module.Kind, file: StaticString = #file, line: UInt = #line) {
         XCTAssertEqual(type, target.type, file: file, line: line)
     }
 
@@ -246,7 +246,7 @@ public final class ResolvedTargetDependencyResult {
         line: UInt = #line,
         body: (ResolvedTargetResult) -> Void
     ) {
-        guard case let .target(target, _) = self.dependency else {
+        guard case let .module(target, _) = self.dependency else {
             return XCTFail("Dependency \(dependency) is not a target", file: file, line: line)
         }
         body(ResolvedTargetResult(target))
@@ -271,8 +271,8 @@ public final class ResolvedProductResult {
         self.product = product
     }
 
-    public func check(targets: String..., file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(Set(targets), Set(product.targets.map({ $0.name })), file: file, line: line)
+    public func check(modules: String..., file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(Set(modules), Set(product.modules.map({ $0.name })), file: file, line: line)
     }
 
     public func check(type: ProductType, file: StaticString = #file, line: UInt = #line) {
@@ -308,7 +308,7 @@ public final class ResolvedProductResult {
         line: UInt = #line,
         body: (ResolvedTargetResult) -> Void
     ) {
-        guard let target = product.targets.first(where: { $0.name == name }) else {
+        guard let target = product.modules.first(where: { $0.name == name }) else {
             return XCTFail("Target \(name) not found", file: file, line: line)
         }
         body(ResolvedTargetResult(target))
@@ -318,7 +318,7 @@ public final class ResolvedProductResult {
 extension ResolvedModule.Dependency {
     public var name: String {
         switch self {
-        case .target(let target, _):
+        case .module(let target, _):
             return target.name
         case .product(let product, _):
             return product.name

--- a/Sources/SPMTestSupport/ResolvedModule+Mock.swift
+++ b/Sources/SPMTestSupport/ResolvedModule+Mock.swift
@@ -22,7 +22,7 @@ extension ResolvedModule {
     ) -> ResolvedModule {
         ResolvedModule(
             packageIdentity: packageIdentity,
-            underlying: SwiftTarget(
+            underlying: SwiftModule(
                 name: name,
                 type: .library,
                 path: .root,
@@ -31,7 +31,7 @@ extension ResolvedModule {
                 packageAccess: false,
                 usesUnsafeFlags: false
             ),
-            dependencies: deps.map { .target($0, conditions: conditions) },
+            dependencies: deps.map { .module($0, conditions: conditions) },
             defaultLocalization: nil,
             supportedPlatforms: [],
             platformVersionProvider: .init(implementation: .minimumDeploymentTargetDefault)

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -19,8 +19,8 @@ private import SPMBuildCore
 
 // FIXME: should import these module with `private` or `internal` access control
 import class Build.BuildPlan
-import class Build.ClangTargetBuildDescription
-import class Build.SwiftTargetBuildDescription
+import class Build.ClangModuleBuildDescription
+import class Build.SwiftModuleBuildDescription
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ModulesGraph
 import enum PackageGraph.BuildTriple
@@ -42,10 +42,10 @@ public protocol BuildTarget {
 }
 
 private struct WrappedClangTargetBuildDescription: BuildTarget {
-    private let description: ClangTargetBuildDescription
+    private let description: ClangModuleBuildDescription
     let isPartOfRootPackage: Bool
 
-    init(description: ClangTargetBuildDescription, isPartOfRootPackage: Bool) {
+    init(description: ClangModuleBuildDescription, isPartOfRootPackage: Bool) {
         self.description = description
         self.isPartOfRootPackage = isPartOfRootPackage
     }
@@ -71,10 +71,10 @@ private struct WrappedClangTargetBuildDescription: BuildTarget {
 }
 
 private struct WrappedSwiftTargetBuildDescription: BuildTarget {
-    private let description: SwiftTargetBuildDescription
+    private let description: SwiftModuleBuildDescription
     let isPartOfRootPackage: Bool
 
-    init(description: SwiftTargetBuildDescription, isPartOfRootPackage: Bool) {
+    init(description: SwiftModuleBuildDescription, isPartOfRootPackage: Bool) {
         self.description = description
         self.isPartOfRootPackage = isPartOfRootPackage
     }
@@ -138,7 +138,7 @@ public struct BuildDescription {
     /// Returns all targets within the module graph in topological order, starting with low-level targets (that have no
     /// dependencies).
     public func allTargetsInTopologicalOrder(in modulesGraph: ModulesGraph) throws -> [BuildTarget] {
-        try modulesGraph.allTargetsInTopologicalOrder.compactMap {
+        try modulesGraph.allModulesInTopologicalOrder.compactMap {
             getBuildTarget(for: $0, in: modulesGraph)
         }
     }

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -877,7 +877,7 @@ public final class InitPackage {
     }
 
     private func writeTestFileStubs(testsPath: AbsolutePath) throws {
-        let testModule = try AbsolutePath(validating: pkgname + Target.testModuleNameSuffix, relativeTo: testsPath)
+        let testModule = try AbsolutePath(validating: pkgname + Module.testModuleNameSuffix, relativeTo: testsPath)
         progressReporter?("Creating \(testModule.relative(to: destinationPath))/")
         try makeDirectories(testModule)
 

--- a/Sources/Workspace/ManagedArtifact.swift
+++ b/Sources/Workspace/ManagedArtifact.swift
@@ -30,14 +30,14 @@ extension Workspace {
         /// The path of the artifact on disk
         public let path: AbsolutePath
 
-        public let kind: BinaryTarget.Kind
+        public let kind: BinaryModule.Kind
 
         public init(
             packageRef: PackageReference,
             targetName: String,
             source: Source,
             path: AbsolutePath,
-            kind: BinaryTarget.Kind
+            kind: BinaryModule.Kind
         ) {
             self.packageRef = packageRef
             self.targetName = targetName
@@ -53,7 +53,7 @@ extension Workspace {
             url: String,
             checksum: String,
             path: AbsolutePath,
-            kind: BinaryTarget.Kind
+            kind: BinaryModule.Kind
         ) -> ManagedArtifact {
             return ManagedArtifact(
                 packageRef: packageRef,
@@ -69,7 +69,7 @@ extension Workspace {
             packageRef: PackageReference,
             targetName: String,
             path: AbsolutePath,
-            kind: BinaryTarget.Kind,
+            kind: BinaryModule.Kind,
             checksum: String? = nil
         ) -> ManagedArtifact {
             return ManagedArtifact(

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -319,7 +319,7 @@ extension Workspace {
                                                         // strip first level component if needed
                                                         if try self.fileSystem.shouldStripFirstLevel(
                                                             archiveDirectory: tempExtractionDirectory,
-                                                            acceptableExtensions: BinaryTarget.Kind.allCases
+                                                            acceptableExtensions: BinaryModule.Kind.allCases
                                                                 .map(\.fileExtension)
                                                         ) {
                                                             observabilityScope
@@ -467,7 +467,7 @@ extension Workspace {
                                 // strip first level component if needed
                                 if try self.fileSystem.shouldStripFirstLevel(
                                     archiveDirectory: tempExtractionDirectory,
-                                    acceptableExtensions: BinaryTarget.Kind.allCases.map(\.fileExtension)
+                                    acceptableExtensions: BinaryModule.Kind.allCases.map(\.fileExtension)
                                 ) {
                                     observabilityScope
                                         .emit(debug: "stripping first level component from  \(tempExtractionDirectory)")
@@ -720,7 +720,7 @@ extension Workspace.BinaryArtifactsManager {
         fileSystem: FileSystem,
         path: AbsolutePath,
         observabilityScope: ObservabilityScope
-    ) throws -> (AbsolutePath, BinaryTarget.Kind)? {
+    ) throws -> (AbsolutePath, BinaryModule.Kind)? {
         let binaryArtifacts = try Self.deriveBinaryArtifacts(
             fileSystem: fileSystem,
             path: path,
@@ -746,7 +746,7 @@ extension Workspace.BinaryArtifactsManager {
         fileSystem: FileSystem,
         path: AbsolutePath,
         observabilityScope: ObservabilityScope
-    ) throws -> [(AbsolutePath, BinaryTarget.Kind)] {
+    ) throws -> [(AbsolutePath, BinaryModule.Kind)] {
         guard fileSystem.exists(path) else {
             return []
         }
@@ -765,7 +765,7 @@ extension Workspace.BinaryArtifactsManager {
         }
 
         // try to find a matching subdirectory
-        var results = [(AbsolutePath, BinaryTarget.Kind)]()
+        var results = [(AbsolutePath, BinaryModule.Kind)]()
         for subdirectory in subdirectories {
             observabilityScope.emit(debug: "searching for binary artifact in '\(path)'")
             let subdirectoryResults = try Self.deriveBinaryArtifacts(
@@ -783,7 +783,7 @@ extension Workspace.BinaryArtifactsManager {
         fileSystem: FileSystem,
         path: AbsolutePath,
         observabilityScope: ObservabilityScope
-    ) throws -> BinaryTarget.Kind? {
+    ) throws -> BinaryModule.Kind? {
         let files = try fileSystem.getDirectoryContents(path)
             .map { path.appending(component: $0) }
             .filter { fileSystem.isFile($0) }

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -219,7 +219,7 @@ extension Workspace {
                                     info: "swizzling '\(dependency.locationString)' with registry dependency '\(registryIdentity)'."
                                 )
                             targetDependencyPackageNameTransformations[dependency
-                                .nameForTargetDependencyResolutionOnly] = registryIdentity.description
+                                .nameForModuleDependencyResolutionOnly] = registryIdentity.description
                             modifiedDependency = .registry(
                                 identity: registryIdentity,
                                 requirement: requirement,

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -404,7 +404,7 @@ extension WorkspaceStateStorage {
                 case artifactsArchive
                 case unknown
 
-                init(_ underlying: BinaryTarget.Kind) {
+                init(_ underlying: BinaryModule.Kind) {
                     switch underlying {
                     case .xcframework:
                         self = .xcframework
@@ -415,7 +415,7 @@ extension WorkspaceStateStorage {
                     }
                 }
 
-                var underlying: BinaryTarget.Kind {
+                var underlying: BinaryModule.Kind {
                     switch self {
                     case .xcframework:
                         return .xcframework
@@ -1115,7 +1115,7 @@ extension CheckoutState {
 
 // backwards compatibility for older formats
 
-extension BinaryTarget.Kind {
+extension BinaryModule.Kind {
     fileprivate static func forPath(_ path: AbsolutePath) -> Self {
         if let kind = allCases.first(where: { $0.fileExtension == path.extension }) {
             return kind

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1119,7 +1119,7 @@ extension Workspace {
     public func loadPluginImports(
         packageGraph: ModulesGraph
     ) async throws -> [PackageIdentity: [String: [String]]] {
-        let pluginTargets = packageGraph.allTargets.filter { $0.type == .plugin }
+        let pluginTargets = packageGraph.allModules.filter { $0.type == .plugin }
         let scanner = SwiftcImportScanner(
             swiftCompilerEnvironment: hostToolchain.swiftCompilerEnvironment,
             swiftCompilerFlags: self.hostToolchain

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3341,10 +3341,10 @@ final class BuildPlanTests: XCTestCase {
         graphResult.check(reachableTargets: "ATarget", "BTarget1")
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         graphResult.check(products: "aexec", "BLibrary")
-        graphResult.check(moduleBuilders: "ATarget", "BTarget1")
+        graphResult.check(modules: "ATarget", "BTarget1")
         #else
         graphResult.check(products: "BLibrary", "bexec", "aexec", "cexec")
-        graphResult.check(moduleBuilders: "ATarget", "BTarget1", "BTarget2", "CTarget")
+        graphResult.check(modules: "ATarget", "BTarget1", "BTarget2", "CTarget")
         #endif
 
         let planResult = try BuildPlanResult(plan: mockBuildPlan(

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -759,7 +759,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = plan.productsBuildPath
 
-        let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(
             exe,
             [
@@ -777,7 +777,7 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
 
-        let lib = try result.target(for: "lib").swiftTarget().compileArguments()
+        let lib = try result.moduleBuildDescription(for: "lib").swift().compileArguments()
         XCTAssertMatch(
             lib,
             [
@@ -1147,9 +1147,9 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertEqual(Set(result.productMap.keys.map(\.productName)), ["APackageTests"])
         #if os(macOS)
-        XCTAssertEqual(Set(result.targetMap.keys.map(\.targetName)), ["ATarget", "BTarget", "ATargetTests"])
+        XCTAssertEqual(Set(result.targetMap.keys.map(\.moduleName)), ["ATarget", "BTarget", "ATargetTests"])
         #else
-        XCTAssertEqual(Set(result.targetMap.keys.map(\.targetName)), [
+        XCTAssertEqual(Set(result.targetMap.keys.map(\.moduleName)), [
             "APackageTests",
             "APackageDiscoveredTests",
             "ATarget",
@@ -1193,7 +1193,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.destinationBuildParameters.dataPath.appending(components: "release")
 
-        let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(
             exe,
             [
@@ -1287,7 +1287,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.destinationBuildParameters.dataPath.appending(components: "release")
 
-        let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(
             exe,
             [
@@ -1399,7 +1399,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.destinationBuildParameters.dataPath.appending(components: "debug")
 
-        let ext = try result.target(for: "extlib").clangTarget()
+        let ext = try result.moduleBuildDescription(for: "extlib").clang()
         var args: [String] = []
 
         #if os(macOS)
@@ -1426,7 +1426,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try ext.objects, [buildPath.appending(components: "extlib.build", "extlib.c.o")])
         XCTAssertEqual(ext.moduleMap, buildPath.appending(components: "extlib.build", "module.modulemap"))
 
-        let exe = try result.target(for: "exe").clangTarget()
+        let exe = try result.moduleBuildDescription(for: "exe").clang()
         args = []
 
         #if os(macOS)
@@ -1579,11 +1579,11 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             ))
 
-            let exeArguments = try result.target(for: "exe").clangTarget().basicArguments(isCXX: false)
+            let exeArguments = try result.moduleBuildDescription(for: "exe").clang().basicArguments(isCXX: false)
             XCTAssert(exeArguments.contains { $0.contains("PkgLib") })
             XCTAssert(exeArguments.allSatisfy { !$0.contains("ExtLib") })
 
-            let libArguments = try result.target(for: "PkgLib").clangTarget().basicArguments(isCXX: false)
+            let libArguments = try result.moduleBuildDescription(for: "PkgLib").clang().basicArguments(isCXX: false)
             XCTAssert(libArguments.allSatisfy { !$0.contains("ExtLib") })
         }
 
@@ -1598,10 +1598,10 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             ))
 
-            let arguments = try result.target(for: "exe").clangTarget().basicArguments(isCXX: false)
+            let arguments = try result.moduleBuildDescription(for: "exe").clang().basicArguments(isCXX: false)
             XCTAssert(arguments.allSatisfy { !$0.contains("PkgLib") && !$0.contains("ExtLib") })
 
-            let libArguments = try result.target(for: "PkgLib").clangTarget().basicArguments(isCXX: false)
+            let libArguments = try result.moduleBuildDescription(for: "PkgLib").clang().basicArguments(isCXX: false)
             XCTAssert(libArguments.contains { $0.contains("ExtLib") })
         }
     }
@@ -1716,33 +1716,33 @@ final class BuildPlanTests: XCTestCase {
         )
 
         // Assert compile args for swift modules importing cxx modules
-        let swiftInteropLib = try result.target(for: "swiftInteropLib").swiftTarget().compileArguments()
+        let swiftInteropLib = try result.moduleBuildDescription(for: "swiftInteropLib").swift().compileArguments()
         XCTAssertMatch(
             swiftInteropLib,
             [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++1z", .anySequence]
         )
-        let swiftLib = try result.target(for: "swiftLib").swiftTarget().compileArguments()
+        let swiftLib = try result.moduleBuildDescription(for: "swiftLib").swift().compileArguments()
         XCTAssertNoMatch(swiftLib, [.anySequence, "-Xcc", "-std=c++1z", .anySequence])
 
         // Assert symbolgraph-extract args for swift modules importing cxx modules
         do {
-            let swiftInteropLib = try result.target(for: "swiftInteropLib").swiftTarget().compileArguments()
+            let swiftInteropLib = try result.moduleBuildDescription(for: "swiftInteropLib").swift().compileArguments()
             XCTAssertMatch(
                 swiftInteropLib,
                 [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++1z", .anySequence]
             )
-            let swiftLib = try result.target(for: "swiftLib").swiftTarget().compileArguments()
+            let swiftLib = try result.moduleBuildDescription(for: "swiftLib").swift().compileArguments()
             XCTAssertNoMatch(swiftLib, [.anySequence, "-Xcc", "-std=c++1z", .anySequence])
         }
 
         // Assert symbolgraph-extract args for cxx modules
         do {
-            let swiftInteropLib = try result.target(for: "swiftInteropLib").swiftTarget().compileArguments()
+            let swiftInteropLib = try result.moduleBuildDescription(for: "swiftInteropLib").swift().compileArguments()
             XCTAssertMatch(
                 swiftInteropLib,
                 [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++1z", .anySequence]
             )
-            let swiftLib = try result.target(for: "swiftLib").swiftTarget().compileArguments()
+            let swiftLib = try result.moduleBuildDescription(for: "swiftLib").swift().compileArguments()
             XCTAssertNoMatch(swiftLib, [.anySequence, "-Xcc", "-std=c++1z", .anySequence])
         }
     }
@@ -1785,7 +1785,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = plan.productsBuildPath
 
-        let lib = try result.target(for: "lib").clangTarget()
+        let lib = try result.moduleBuildDescription(for: "lib").clang()
         var args: [String] = []
 
         #if os(macOS)
@@ -1813,7 +1813,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
         XCTAssertEqual(lib.moduleMap, buildPath.appending(components: "lib.build", "module.modulemap"))
 
-        let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(
             exe,
             [
@@ -1911,7 +1911,7 @@ final class BuildPlanTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(2)
 
-        let lib = try result.target(for: "lib").clangTarget()
+        let lib = try result.moduleBuildDescription(for: "lib").clang()
         XCTAssertEqual(try lib.objects, [
             AbsolutePath("/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/lib.build/lib.S.o"),
             AbsolutePath("/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/lib.build/lib.c.o"),
@@ -1962,7 +1962,7 @@ final class BuildPlanTests: XCTestCase {
         // Cxx module
         do {
             try XCTAssertMatch(
-                result.target(for: "cxxLib").clangTarget().symbolGraphExtractArguments(),
+                result.moduleBuildDescription(for: "cxxLib").clang().symbolGraphExtractArguments(),
                 [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++20", .anySequence]
             )
         }
@@ -1970,11 +1970,11 @@ final class BuildPlanTests: XCTestCase {
         // Swift module directly importing cxx module
         do {
             try XCTAssertMatch(
-                result.target(for: "swiftLib").swiftTarget().compileArguments(),
+                result.moduleBuildDescription(for: "swiftLib").swift().compileArguments(),
                 [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++20", .anySequence]
             )
             try XCTAssertMatch(
-                result.target(for: "swiftLib").swiftTarget().symbolGraphExtractArguments(),
+                result.moduleBuildDescription(for: "swiftLib").swift().symbolGraphExtractArguments(),
                 [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++20", .anySequence]
             )
         }
@@ -1982,19 +1982,19 @@ final class BuildPlanTests: XCTestCase {
         // Swift module transitively importing cxx module
         do {
             try XCTAssertNoMatch(
-                result.target(for: "swiftLib2").swiftTarget().compileArguments(),
+                result.moduleBuildDescription(for: "swiftLib2").swift().compileArguments(),
                 [.anySequence, "-cxx-interoperability-mode=default", .anySequence]
             )
             try XCTAssertNoMatch(
-                result.target(for: "swiftLib2").swiftTarget().compileArguments(),
+                result.moduleBuildDescription(for: "swiftLib2").swift().compileArguments(),
                 [.anySequence, "-Xcc", "-std=c++20", .anySequence]
             )
             try XCTAssertNoMatch(
-                result.target(for: "swiftLib2").swiftTarget().symbolGraphExtractArguments(),
+                result.moduleBuildDescription(for: "swiftLib2").swift().symbolGraphExtractArguments(),
                 [.anySequence, "-cxx-interoperability-mode=default", .anySequence]
             )
             try XCTAssertNoMatch(
-                result.target(for: "swiftLib2").swiftTarget().symbolGraphExtractArguments(),
+                result.moduleBuildDescription(for: "swiftLib2").swift().symbolGraphExtractArguments(),
                 [.anySequence, "-Xcc", "-std=c++20", .anySequence]
             )
         }
@@ -2070,7 +2070,7 @@ final class BuildPlanTests: XCTestCase {
         // A
         do {
             try XCTAssertMatchesSubSequences(
-                result.target(for: "A").symbolGraphExtractArguments(),
+                result.moduleBuildDescription(for: "A").symbolGraphExtractArguments(),
                 // Swift Module dependencies
                 ["-I", "/path/to/build/\(triple)/debug/Modules"],
                 // C Module dependencies
@@ -2082,7 +2082,7 @@ final class BuildPlanTests: XCTestCase {
         // D
         do {
             try XCTAssertMatchesSubSequences(
-                result.target(for: "D").symbolGraphExtractArguments(),
+                result.moduleBuildDescription(for: "D").symbolGraphExtractArguments(),
                 // Self Module
                 ["-I", "/Pkg/Sources/D/include"],
                 ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/D.build/module.modulemap"],
@@ -2101,7 +2101,7 @@ final class BuildPlanTests: XCTestCase {
 
 #if os(macOS)
             try XCTAssertMatchesSubSequences(
-                result.target(for: "D").symbolGraphExtractArguments(),
+                result.moduleBuildDescription(for: "D").symbolGraphExtractArguments(),
                 // Swift Module dependencies
                 ["-Xcc", "-fmodule-map-file=/path/to/build/\(triple)/debug/B.build/module.modulemap"]
             )
@@ -2186,7 +2186,7 @@ final class BuildPlanTests: XCTestCase {
         let fs = InMemoryFileSystem(
             emptyFiles:
             "/Pkg/Sources/Foo/foo.swift",
-            "/Pkg/Tests/\(SwiftTarget.defaultTestEntryPointName)",
+            "/Pkg/Tests/\(SwiftModule.defaultTestEntryPointName)",
             "/Pkg/Tests/FooTests/foo.swift"
         )
 
@@ -2223,7 +2223,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let foo = try result.target(for: "Foo").swiftTarget().compileArguments()
+        let foo = try result.moduleBuildDescription(for: "Foo").swift().compileArguments()
         XCTAssertMatch(
             foo,
             [
@@ -2242,7 +2242,7 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
 
-        let fooTests = try result.target(for: "FooTests").swiftTarget().compileArguments()
+        let fooTests = try result.moduleBuildDescription(for: "FooTests").swift().compileArguments()
         XCTAssertMatch(
             fooTests,
             [
@@ -2354,7 +2354,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
 
         XCTAssertMatch(
             exe,
@@ -2614,63 +2614,63 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         // single source file not named main, and without @main should not have -parse-as-library.
-        let exe1 = try result.target(for: "exe1").swiftTarget().emitCommandLine()
+        let exe1 = try result.moduleBuildDescription(for: "exe1").swift().emitCommandLine()
         XCTAssertNoMatch(exe1, ["-parse-as-library"])
 
         // single source file named main, and without @main should not have -parse-as-library.
-        let exe2 = try result.target(for: "exe2").swiftTarget().emitCommandLine()
+        let exe2 = try result.moduleBuildDescription(for: "exe2").swift().emitCommandLine()
         XCTAssertNoMatch(exe2, ["-parse-as-library"])
 
         // single source file not named main, with @main should have -parse-as-library.
-        let exe3 = try result.target(for: "exe3").swiftTarget().emitCommandLine()
+        let exe3 = try result.moduleBuildDescription(for: "exe3").swift().emitCommandLine()
         XCTAssertMatch(exe3, ["-parse-as-library"])
 
         // single source file named main, with @main should have -parse-as-library.
-        let exe4 = try result.target(for: "exe4").swiftTarget().emitCommandLine()
+        let exe4 = try result.moduleBuildDescription(for: "exe4").swift().emitCommandLine()
         XCTAssertMatch(exe4, ["-parse-as-library"])
 
         // multiple source files should not have -parse-as-library.
-        let exe5 = try result.target(for: "exe5").swiftTarget().emitCommandLine()
+        let exe5 = try result.moduleBuildDescription(for: "exe5").swift().emitCommandLine()
         XCTAssertNoMatch(exe5, ["-parse-as-library"])
 
         // @main in comment should not have -parse-as-library.
-        let exe6 = try result.target(for: "exe6").swiftTarget().emitCommandLine()
+        let exe6 = try result.moduleBuildDescription(for: "exe6").swift().emitCommandLine()
         XCTAssertNoMatch(exe6, ["-parse-as-library"])
 
         // @main in comment should not have -parse-as-library.
-        let exe7 = try result.target(for: "exe7").swiftTarget().emitCommandLine()
+        let exe7 = try result.moduleBuildDescription(for: "exe7").swift().emitCommandLine()
         XCTAssertNoMatch(exe7, ["-parse-as-library"])
 
         // @main in comment should not have -parse-as-library.
-        let exe8 = try result.target(for: "exe8").swiftTarget().emitCommandLine()
+        let exe8 = try result.moduleBuildDescription(for: "exe8").swift().emitCommandLine()
         XCTAssertNoMatch(exe8, ["-parse-as-library"])
 
         // @main in comment should not have -parse-as-library.
-        let exe9 = try result.target(for: "exe9").swiftTarget().emitCommandLine()
+        let exe9 = try result.moduleBuildDescription(for: "exe9").swift().emitCommandLine()
         XCTAssertNoMatch(exe9, ["-parse-as-library"])
 
         // @main in comment + non-comment should have -parse-as-library.
-        let exe10 = try result.target(for: "exe10").swiftTarget().emitCommandLine()
+        let exe10 = try result.moduleBuildDescription(for: "exe10").swift().emitCommandLine()
         XCTAssertMatch(exe10, ["-parse-as-library"])
 
         // @main in comment + non-comment should have -parse-as-library.
-        let exe11 = try result.target(for: "exe11").swiftTarget().emitCommandLine()
+        let exe11 = try result.moduleBuildDescription(for: "exe11").swift().emitCommandLine()
         XCTAssertMatch(exe11, ["-parse-as-library"])
 
         // @main in comment + non-comment should have -parse-as-library.
-        let exe12 = try result.target(for: "exe12").swiftTarget().emitCommandLine()
+        let exe12 = try result.moduleBuildDescription(for: "exe12").swift().emitCommandLine()
         XCTAssertMatch(exe12, ["-parse-as-library"])
 
         // multiple source files should not have -parse-as-library.
-        let exe13 = try result.target(for: "exe13").swiftTarget().emitCommandLine()
+        let exe13 = try result.moduleBuildDescription(for: "exe13").swift().emitCommandLine()
         XCTAssertNoMatch(exe13, ["-parse-as-library"])
 
         // A snippet with top-level code should not have -parse-as-library.
-        let topLevelCodeSnippet = try result.target(for: "TopLevelCodeSnippet").swiftTarget().emitCommandLine()
+        let topLevelCodeSnippet = try result.moduleBuildDescription(for: "TopLevelCodeSnippet").swift().emitCommandLine()
         XCTAssertNoMatch(topLevelCodeSnippet, ["-parse-as-library"])
 
         // A snippet with @main should have -parse-as-library
-        let atMainSnippet = try result.target(for: "AtMainSnippet").swiftTarget().emitCommandLine()
+        let atMainSnippet = try result.moduleBuildDescription(for: "AtMainSnippet").swift().emitCommandLine()
         XCTAssertMatch(atMainSnippet, ["-parse-as-library"])
     }
 
@@ -2720,7 +2720,7 @@ final class BuildPlanTests: XCTestCase {
         let buildPath = result.plan.productsBuildPath
 
         XCTAssertMatch(
-            try result.target(for: "exe").swiftTarget().compileArguments(),
+            try result.moduleBuildDescription(for: "exe").swift().compileArguments(),
             [
                 "-enable-batch-mode",
                 "-Onone",
@@ -3015,7 +3015,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(
             exe,
             [
@@ -3033,7 +3033,7 @@ final class BuildPlanTests: XCTestCase {
             ]
         )
 
-        let lib = try result.target(for: "lib").swiftTarget().compileArguments()
+        let lib = try result.moduleBuildDescription(for: "lib").swift().compileArguments()
         XCTAssertMatch(
             lib,
             [
@@ -3139,7 +3139,7 @@ final class BuildPlanTests: XCTestCase {
         let triple = result.plan.destinationBuildParameters.triple
         let buildPath = result.plan.productsBuildPath
 
-        let exe = try result.target(for: "exe").clangTarget()
+        let exe = try result.moduleBuildDescription(for: "exe").clang()
 
         var expectedExeBasicArgs = triple.isDarwin() ? ["-fobjc-arc"] : []
         expectedExeBasicArgs += ["-target", defaultTargetTriple]
@@ -3163,7 +3163,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try exe.objects, [buildPath.appending(components: "exe.build", "main.c.o")])
         XCTAssertEqual(exe.moduleMap, nil)
 
-        let lib = try result.target(for: "lib").clangTarget()
+        let lib = try result.moduleBuildDescription(for: "lib").clang()
 
         var expectedLibBasicArgs = triple.isDarwin() ? ["-fobjc-arc"] : []
         expectedLibBasicArgs += ["-target", defaultTargetTriple]
@@ -3341,10 +3341,10 @@ final class BuildPlanTests: XCTestCase {
         graphResult.check(reachableTargets: "ATarget", "BTarget1")
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         graphResult.check(products: "aexec", "BLibrary")
-        graphResult.check(targets: "ATarget", "BTarget1")
+        graphResult.check(moduleBuilders: "ATarget", "BTarget1")
         #else
         graphResult.check(products: "BLibrary", "bexec", "aexec", "cexec")
-        graphResult.check(targets: "ATarget", "BTarget1", "BTarget2", "CTarget")
+        graphResult.check(moduleBuilders: "ATarget", "BTarget1", "BTarget2", "CTarget")
         #endif
 
         let planResult = try BuildPlanResult(plan: mockBuildPlan(
@@ -3595,7 +3595,7 @@ final class BuildPlanTests: XCTestCase {
 
         XCTAssertEqual(diagnostic.message, "couldn't find pc file for BTarget")
         XCTAssertEqual(diagnostic.severity, .warning)
-        XCTAssertEqual(diagnostic.metadata?.targetName, "BTarget")
+        XCTAssertEqual(diagnostic.metadata?.moduleName, "BTarget")
         XCTAssertEqual(diagnostic.metadata?.pcFile, "BTarget.pc")
     }
 
@@ -3636,7 +3636,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.destinationBuildParameters.dataPath.appending(components: "debug")
 
-        let lib = try result.target(for: "lib").clangTarget()
+        let lib = try result.moduleBuildDescription(for: "lib").clang()
         let args = [
             "-target", "x86_64-unknown-windows-msvc",
             "-O0",
@@ -3650,7 +3650,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertEqual(try lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
         XCTAssertEqual(lib.moduleMap, buildPath.appending(components: "lib.build", "module.modulemap"))
 
-        let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(exe, [
             "-enable-batch-mode",
             "-Onone",
@@ -3720,7 +3720,7 @@ final class BuildPlanTests: XCTestCase {
         let supportingTriples: [Basics.Triple] = [.x86_64Linux, .x86_64MacOS]
         for triple in supportingTriples {
             let result = try createResult(for: triple)
-            let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+            let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertMatch(exe, ["-Xfrontend", "-entry-point-function-name", "-Xfrontend", "exe_main"])
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
             XCTAssertMatch(linkExe, [.contains("exe_main")])
@@ -3729,7 +3729,7 @@ final class BuildPlanTests: XCTestCase {
         let unsupportingTriples: [Basics.Triple] = [.wasi, .windows]
         for triple in unsupportingTriples {
             let result = try createResult(for: triple)
-            let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+            let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertNoMatch(exe, ["-entry-point-function-name"])
         }
     }
@@ -3769,7 +3769,7 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             ))
 
-            let lib = try result.target(for: "lib").clangTarget()
+            let lib = try result.moduleBuildDescription(for: "lib").clang()
             let path = StringPattern.equal(result.plan.destinationBuildParameters.indexStore.pathString)
 
             XCTAssertMatch(
@@ -3777,7 +3777,7 @@ final class BuildPlanTests: XCTestCase {
                 [.anySequence, "-index-store-path", path, .anySequence]
             )
 
-            let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+            let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertMatch(exe, [.anySequence, "-index-store-path", path, .anySequence])
         }
 
@@ -3836,7 +3836,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         ))
 
-        let aTarget = try result.target(for: "ATarget").swiftTarget().compileArguments()
+        let aTarget = try result.moduleBuildDescription(for: "ATarget").swift().compileArguments()
         #if os(macOS)
         XCTAssertMatch(
             aTarget,
@@ -3846,7 +3846,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(aTarget, [.equal("-target"), .equal(defaultTargetTriple), .anySequence])
         #endif
 
-        let bTarget = try result.target(for: "BTarget").swiftTarget().compileArguments()
+        let bTarget = try result.moduleBuildDescription(for: "BTarget").swift().compileArguments()
         #if os(macOS)
         XCTAssertMatch(
             bTarget,
@@ -3912,7 +3912,7 @@ final class BuildPlanTests: XCTestCase {
 
         let targetTriple = Triple.arm64iOS
 
-        let aTarget = try result.target(for: "ATarget").swiftTarget().compileArguments()
+        let aTarget = try result.moduleBuildDescription(for: "ATarget").swift().compileArguments()
         let expectedVersion = Platform.iOS.oldestSupportedVersion.versionString
 
         XCTAssertMatch(aTarget, [
@@ -3921,7 +3921,7 @@ final class BuildPlanTests: XCTestCase {
             .anySequence,
         ])
 
-        let bTarget = try result.target(for: "BTarget").swiftTarget().compileArguments()
+        let bTarget = try result.moduleBuildDescription(for: "BTarget").swift().compileArguments()
         XCTAssertMatch(bTarget, [
             .equal("-target"),
             .equal(targetTriple.tripleString(forPlatformVersion: expectedVersion)),
@@ -4230,11 +4230,11 @@ final class BuildPlanTests: XCTestCase {
         do {
             let result = try createResult(for: .x86_64Linux)
 
-            let dep = try result.target(for: "t1").swiftTarget().compileArguments()
+            let dep = try result.moduleBuildDescription(for: "t1").swift().compileArguments()
             XCTAssertMatch(dep, [.anySequence, "-DDEP", .anySequence])
             XCTAssertMatch(dep, [.anySequence, "-swift-version", "4", .anySequence])
 
-            let cbar = try result.target(for: "cbar").clangTarget().basicArguments(isCXX: false)
+            let cbar = try result.moduleBuildDescription(for: "cbar").clang().basicArguments(isCXX: false)
             XCTAssertMatch(
                 cbar,
                 [
@@ -4252,7 +4252,7 @@ final class BuildPlanTests: XCTestCase {
                 ]
             )
 
-            let bar = try result.target(for: "bar").swiftTarget().compileArguments()
+            let bar = try result.moduleBuildDescription(for: "bar").swift().compileArguments()
             XCTAssertMatch(
                 bar,
                 [
@@ -4271,16 +4271,16 @@ final class BuildPlanTests: XCTestCase {
                 ]
             )
 
-            let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+            let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
 
             let linkExe = try result.buildProduct(for: "exe").linkArguments()
             XCTAssertMatch(linkExe, [.anySequence, "-lsqlite3", "-llibz", "-Ilfoo", "-L", "lbar", "-g", .end])
 
-            let testDiscovery = try result.target(for: "APackageDiscoveredTests").swiftTarget().compileArguments()
+            let testDiscovery = try result.moduleBuildDescription(for: "APackageDiscoveredTests").swift().compileArguments()
             XCTAssertMatch(testDiscovery, [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++17"])
 
-            let testEntryPoint = try result.target(for: "APackageTests").swiftTarget().compileArguments()
+            let testEntryPoint = try result.moduleBuildDescription(for: "APackageTests").swift().compileArguments()
             XCTAssertMatch(testEntryPoint, [.anySequence, "-cxx-interoperability-mode=default", "-Xcc", "-std=c++17"])
         }
 
@@ -4294,10 +4294,10 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             ))
 
-            let dep = try result.target(for: "t1").swiftTarget().compileArguments()
+            let dep = try result.moduleBuildDescription(for: "t1").swift().compileArguments()
             XCTAssertMatch(dep, [.anySequence, "-DDEP", .anySequence])
 
-            let cbar = try result.target(for: "cbar").clangTarget().basicArguments(isCXX: false)
+            let cbar = try result.moduleBuildDescription(for: "cbar").clang().basicArguments(isCXX: false)
             XCTAssertMatch(
                 cbar,
                 [
@@ -4315,7 +4315,7 @@ final class BuildPlanTests: XCTestCase {
                 ]
             )
 
-            let bar = try result.target(for: "bar").swiftTarget().compileArguments()
+            let bar = try result.moduleBuildDescription(for: "bar").swift().compileArguments()
             XCTAssertMatch(
                 bar,
                 [
@@ -4335,7 +4335,7 @@ final class BuildPlanTests: XCTestCase {
                 ]
             )
 
-            let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+            let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-g", "-Xcc", "-g", "-Xcc", "-fomit-frame-pointer", .end])
         }
 
@@ -4349,10 +4349,10 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             ))
 
-            let dep = try result.target(for: "t1").swiftTarget().compileArguments()
+            let dep = try result.moduleBuildDescription(for: "t1").swift().compileArguments()
             XCTAssertMatch(dep, [.anySequence, "-DDEP", .anySequence])
 
-            let cbar = try result.target(for: "cbar").clangTarget().basicArguments(isCXX: false)
+            let cbar = try result.moduleBuildDescription(for: "cbar").clang().basicArguments(isCXX: false)
             XCTAssertMatch(
                 cbar,
                 [
@@ -4370,7 +4370,7 @@ final class BuildPlanTests: XCTestCase {
                 ]
             )
 
-            let bar = try result.target(for: "bar").swiftTarget().compileArguments()
+            let bar = try result.moduleBuildDescription(for: "bar").swift().compileArguments()
             XCTAssertMatch(
                 bar,
                 [
@@ -4390,14 +4390,14 @@ final class BuildPlanTests: XCTestCase {
                 ]
             )
 
-            let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+            let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertMatch(exe, [.anySequence, "-swift-version", "5", "-DFOO", "-g", "-Xcc", "-g", "-Xcc", "-fno-omit-frame-pointer", .end])
         }
 
         do {
             let result = try createResult(for: .x86_64MacOS)
 
-            let cbar = try result.target(for: "cbar").clangTarget().basicArguments(isCXX: false)
+            let cbar = try result.moduleBuildDescription(for: "cbar").clang().basicArguments(isCXX: false)
             XCTAssertMatch(
                 cbar,
                 [
@@ -4414,7 +4414,7 @@ final class BuildPlanTests: XCTestCase {
                 ]
             )
 
-            let bar = try result.target(for: "bar").swiftTarget().compileArguments()
+            let bar = try result.moduleBuildDescription(for: "bar").swift().compileArguments()
             XCTAssertMatch(
                 bar,
                 [
@@ -4433,7 +4433,7 @@ final class BuildPlanTests: XCTestCase {
                 ]
             )
 
-            let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+            let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertMatch(
                 exe,
                 [
@@ -4575,7 +4575,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let lib = try result.target(for: "lib").clangTarget()
+        let lib = try result.moduleBuildDescription(for: "lib").clang()
         var args: [StringPattern] = [.anySequence]
         args += ["--sysroot"]
         args += [
@@ -4587,7 +4587,7 @@ final class BuildPlanTests: XCTestCase {
         ]
         XCTAssertMatch(try lib.basicArguments(isCXX: false), args)
 
-        let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(exe, [
             "-module-cache-path", "\(buildPath.appending(components: "ModuleCache"))",
             .anySequence,
@@ -4623,7 +4623,7 @@ final class BuildPlanTests: XCTestCase {
             observabilityScope: observability.topScope
         ))
 
-        let staticExe = try staticResult.target(for: "exe").swiftTarget().compileArguments()
+        let staticExe = try staticResult.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(staticExe, [
             .anySequence,
             "-resource-dir", "\(AbsolutePath("/fake/lib/swift_static"))",
@@ -4732,7 +4732,7 @@ final class BuildPlanTests: XCTestCase {
         }
 
         // Compile C Target
-        let cLibCompileArguments = try result.target(for: "cLib").clangTarget().basicArguments(isCXX: false)
+        let cLibCompileArguments = try result.moduleBuildDescription(for: "cLib").clang().basicArguments(isCXX: false)
         let cLibCompileArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .cCompiler), "-g", cliFlag(tool: .cCompiler),
         ]
@@ -4747,7 +4747,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertCount(0, cLibCompileArguments, cliFlag(tool: .linker))
 
         // Compile Cxx Target
-        let cxxLibCompileArguments = try result.target(for: "cxxLib").clangTarget().basicArguments(isCXX: true)
+        let cxxLibCompileArguments = try result.moduleBuildDescription(for: "cxxLib").clang().basicArguments(isCXX: true)
         let cxxLibCompileArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .cCompiler), "-g", cliFlag(tool: .cCompiler),
             .anySequence,
@@ -4764,7 +4764,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertCount(0, cxxLibCompileArguments, cliFlag(tool: .linker))
 
         // Compile Swift Target
-        let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exeCompileArguments = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         let exeCompileArgumentsPattern: [StringPattern] = [
             jsonFlag(tool: .swiftCompiler),
             "-ld-path=/fake/toolchain/usr/bin/linker",
@@ -4859,12 +4859,12 @@ final class BuildPlanTests: XCTestCase {
         result.checkTargetsCount(2)
 
         // Compile C Target
-        let cLibCompileArguments = try result.target(for: "cLib").clangTarget().basicArguments(isCXX: false)
+        let cLibCompileArguments = try result.moduleBuildDescription(for: "cLib").clang().basicArguments(isCXX: false)
         let cLibCompileArgumentsPattern: [StringPattern] = ["-I", "\(sdkIncludeSearchPath)"]
         XCTAssertMatch(cLibCompileArguments, cLibCompileArgumentsPattern)
 
         // Compile Swift Target
-        let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exeCompileArguments = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         let exeCompileArgumentsPattern: [StringPattern] = ["-I", "\(sdkIncludeSearchPath)"]
         XCTAssertMatch(exeCompileArguments, exeCompileArgumentsPattern)
 
@@ -4993,7 +4993,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let fooTarget = try result.target(for: "Foo").swiftTarget().compileArguments()
+        let fooTarget = try result.moduleBuildDescription(for: "Foo").swift().compileArguments()
         #if os(macOS)
         XCTAssertMatch(
             fooTarget,
@@ -5016,7 +5016,7 @@ final class BuildPlanTests: XCTestCase {
         )
         #endif
 
-        let barTarget = try result.target(for: "Bar").clangTarget().basicArguments(isCXX: false)
+        let barTarget = try result.moduleBuildDescription(for: "Bar").clang().basicArguments(isCXX: false)
         #if os(macOS)
         XCTAssertMatch(
             barTarget,
@@ -5092,7 +5092,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let fooTarget = try result.target(for: "Foo").swiftTarget().compileArguments()
+        let fooTarget = try result.moduleBuildDescription(for: "Foo").swift().compileArguments()
         #if os(macOS)
         XCTAssertMatch(
             fooTarget,
@@ -5117,7 +5117,7 @@ final class BuildPlanTests: XCTestCase {
         )
         #endif
 
-        let barTarget = try result.target(for: "Bar").clangTarget().basicArguments(isCXX: false)
+        let barTarget = try result.moduleBuildDescription(for: "Bar").clang().basicArguments(isCXX: false)
         #if os(macOS)
         XCTAssertMatch(
             barTarget,
@@ -5205,7 +5205,7 @@ final class BuildPlanTests: XCTestCase {
         #endif
         let result = try BuildPlanResult(plan: plan)
 
-        let fooTarget = try result.target(for: "Foo").swiftTarget().compileArguments()
+        let fooTarget = try result.moduleBuildDescription(for: "Foo").swift().compileArguments()
         #if os(macOS)
         XCTAssertMatch(
             fooTarget,
@@ -5230,7 +5230,7 @@ final class BuildPlanTests: XCTestCase {
         )
         #endif
 
-        let barTarget = try result.target(for: "Bar").clangTarget().basicArguments(isCXX: false)
+        let barTarget = try result.moduleBuildDescription(for: "Bar").clang().basicArguments(isCXX: false)
         #if os(macOS)
         XCTAssertMatch(
             barTarget,
@@ -5539,7 +5539,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let fooTarget = try result.target(for: "Foo").swiftTarget()
+        let fooTarget = try result.moduleBuildDescription(for: "Foo").swift()
         XCTAssertEqual(try fooTarget.objects.map(\.pathString), [
             buildPath.appending(components: "Foo.build", "Foo.swift.o").pathString,
             buildPath.appending(components: "Foo.build", "resource_bundle_accessor.swift.o").pathString,
@@ -5553,7 +5553,7 @@ final class BuildPlanTests: XCTestCase {
         // https://github.com/apple/swift-package-manager/pull/2972/files#r623861646
         XCTAssertMatch(contents, .contains("let mainPath = Bundle.main."))
 
-        let barTarget = try result.target(for: "Bar").swiftTarget()
+        let barTarget = try result.moduleBuildDescription(for: "Bar").swift()
         XCTAssertEqual(try barTarget.objects.map(\.pathString), [
             buildPath.appending(components: "Bar.build", "Bar.swift.o").pathString,
         ])
@@ -5607,7 +5607,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let fooTarget = try result.target(for: "Foo").swiftTarget()
+        let fooTarget = try result.moduleBuildDescription(for: "Foo").swift()
         XCTAssertEqual(try fooTarget.objects.map(\.pathString), [
             buildPath.appending(components: "Foo.build", "Foo.swift.o").pathString,
             buildPath.appending(components: "Foo.build", "resource_bundle_accessor.swift.o").pathString,
@@ -5621,7 +5621,7 @@ final class BuildPlanTests: XCTestCase {
         // https://github.com/apple/swift-package-manager/pull/2972/files#r623861646
         XCTAssertMatch(contents, .contains("let mainPath = \""))
 
-        let barTarget = try result.target(for: "Bar").swiftTarget()
+        let barTarget = try result.moduleBuildDescription(for: "Bar").swift()
         XCTAssertEqual(try barTarget.objects.map(\.pathString), [
             buildPath.appending(components: "Bar.build", "Bar.swift.o").pathString,
         ])
@@ -5673,7 +5673,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let fooTarget = try result.target(for: "Foo").clangTarget()
+        let fooTarget = try result.moduleBuildDescription(for: "Foo").clang()
         XCTAssertEqual(try fooTarget.objects.map(\.pathString).sorted(), [
             buildPath.appending(components: "Foo.build", "Foo.m.o").pathString,
             buildPath.appending(components: "Foo.build", "bar.c.o").pathString,
@@ -5739,9 +5739,9 @@ final class BuildPlanTests: XCTestCase {
                 observabilityScope: observability.topScope
             ))
 
-            let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+            let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
             XCTAssertMatch(exe, ["-static-stdlib"])
-            let lib = try result.target(for: "lib").swiftTarget().compileArguments()
+            let lib = try result.moduleBuildDescription(for: "lib").swift().compileArguments()
             XCTAssertMatch(lib, ["-static-stdlib"])
             let link = try result.buildProduct(for: "exe").linkArguments()
             XCTAssertMatch(link, ["-static-stdlib"])
@@ -5870,7 +5870,7 @@ final class BuildPlanTests: XCTestCase {
 
         let buildPath = result.plan.productsBuildPath
 
-        let libraryBasicArguments = try result.target(for: "Library").swiftTarget().compileArguments()
+        let libraryBasicArguments = try result.moduleBuildDescription(for: "Library").swift().compileArguments()
         XCTAssertMatch(libraryBasicArguments, [.anySequence, "-F", "\(buildPath)", .anySequence])
 
         let libraryLinkArguments = try result.buildProduct(for: "Library").linkArguments()
@@ -5878,7 +5878,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(libraryLinkArguments, [.anySequence, "-L", "\(buildPath)", .anySequence])
         XCTAssertMatch(libraryLinkArguments, [.anySequence, "-framework", "Framework", .anySequence])
 
-        let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exeCompileArguments = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(exeCompileArguments, [.anySequence, "-F", "\(buildPath)", .anySequence])
         XCTAssertMatch(
             exeCompileArguments,
@@ -5895,7 +5895,7 @@ final class BuildPlanTests: XCTestCase {
         XCTAssertMatch(exeLinkArguments, [.anySequence, "-L", "\(buildPath)", .anySequence])
         XCTAssertMatch(exeLinkArguments, [.anySequence, "-framework", "Framework", .anySequence])
 
-        let clibraryBasicArguments = try result.target(for: "CLibrary").clangTarget().basicArguments(isCXX: false)
+        let clibraryBasicArguments = try result.moduleBuildDescription(for: "CLibrary").clang().basicArguments(isCXX: false)
         XCTAssertMatch(clibraryBasicArguments, [.anySequence, "-F", "\(buildPath)", .anySequence])
         XCTAssertMatch(
             clibraryBasicArguments,
@@ -6139,13 +6139,13 @@ final class BuildPlanTests: XCTestCase {
         result.checkProductsCount(1)
         result.checkTargetsCount(3)
 
-        let exe = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         XCTAssertMatch(exe, ["-sanitize=\(expectedName)"])
 
-        let lib = try result.target(for: "lib").swiftTarget().compileArguments()
+        let lib = try result.moduleBuildDescription(for: "lib").swift().compileArguments()
         XCTAssertMatch(lib, ["-sanitize=\(expectedName)"])
 
-        let clib = try result.target(for: "clib").clangTarget().basicArguments(isCXX: false)
+        let clib = try result.moduleBuildDescription(for: "clib").clang().basicArguments(isCXX: false)
         XCTAssertMatch(clib, ["-fsanitize=\(expectedName)"])
 
         XCTAssertMatch(try result.buildProduct(for: "exe").linkArguments(), ["-sanitize=\(expectedName)"])
@@ -6190,18 +6190,18 @@ final class BuildPlanTests: XCTestCase {
         result.checkTargetsCount(2)
 
         // Compile C Target
-        let cLibCompileArguments = try result.target(for: "cLib").clangTarget().basicArguments(isCXX: false)
+        let cLibCompileArguments = try result.moduleBuildDescription(for: "cLib").clang().basicArguments(isCXX: false)
         let cLibCompileArgumentsPattern: [StringPattern] = ["-flto=full"]
         XCTAssertMatch(cLibCompileArguments, cLibCompileArgumentsPattern)
 
         // Compile Swift Target
-        let exeCompileArguments = try result.target(for: "exe").swiftTarget().compileArguments()
+        let exeCompileArguments = try result.moduleBuildDescription(for: "exe").swift().compileArguments()
         let exeCompileArgumentsPattern: [StringPattern] = ["-lto=llvm-full"]
         XCTAssertMatch(exeCompileArguments, exeCompileArgumentsPattern)
 
         // Assert the objects built by the Swift Target are actually bitcode
         // files, indicated by the "bc" extension.
-        let exeCompileObjects = try result.target(for: "exe").swiftTarget().objects
+        let exeCompileObjects = try result.moduleBuildDescription(for: "exe").swift().objects
         XCTAssert(exeCompileObjects.allSatisfy { $0.extension == "bc" })
 
         // Assert the objects getting linked contain all the bitcode objects
@@ -6261,7 +6261,7 @@ final class BuildPlanTests: XCTestCase {
 
         switch try XCTUnwrap(
             result.targetMap[.init(
-                targetName: "ExtLib",
+                moduleName: "ExtLib",
                 packageIdentity: "ExtPkg",
                 buildTriple: .destination
             )]
@@ -6513,7 +6513,7 @@ final class BuildPlanTests: XCTestCase {
         result.checkTargetsCount(1)
 
         XCTAssertMatch(
-            try result.target(for: "ATarget").swiftTarget().compileArguments(),
+            try result.moduleBuildDescription(for: "ATarget").swift().compileArguments(),
             [
                 .anySequence,
                 "-I", "/Libraries/C",
@@ -6583,7 +6583,7 @@ final class BuildPlanTests: XCTestCase {
             ))
 
             XCTAssertMatch(
-              try result.target(for: "foo").swiftTarget().compileArguments(),
+              try result.moduleBuildDescription(for: "foo").swift().compileArguments(),
               [
                 "-swift-version", .equal(expectedVersionString)
               ]

--- a/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
+++ b/Tests/BuildTests/ClangTargetBuildDescriptionTests.swift
@@ -51,8 +51,8 @@ final class ClangTargetBuildDescriptionTests: XCTestCase {
         XCTAssertTrue(try targetDescription.basicArguments().contains("-w"))
     }
 
-    private func makeClangTarget() throws -> ClangTarget {
-        try ClangTarget(
+    private func makeClangTarget() throws -> ClangModule {
+        try ClangModule(
             name: "dummy",
             cLanguageStandard: nil,
             cxxLanguageStandard: nil,
@@ -77,7 +77,7 @@ final class ClangTargetBuildDescriptionTests: XCTestCase {
 
     private func makeTargetBuildDescription(_ packageName: String,
                                             buildParameters: BuildParameters? = nil,
-                                            usesSourceControl: Bool = false) throws -> ClangTargetBuildDescription {
+                                            usesSourceControl: Bool = false) throws -> ClangModuleBuildDescription {
         let observability = ObservabilitySystem.makeForTesting(verbose: false)
 
         let manifest: Manifest
@@ -101,12 +101,12 @@ final class ClangTargetBuildDescriptionTests: XCTestCase {
                               targetSearchPath: .root,
                               testTargetSearchPath: .root)
 
-        return try ClangTargetBuildDescription(
+        return try ClangModuleBuildDescription(
             package: .init(underlying: package,
                            defaultLocalization: nil,
                            supportedPlatforms: [],
                            dependencies: [],
-                           targets: .init([target]),
+                           modules: .init([target]),
                            products: [],
                            registryMetadata: nil,
                            platformVersionProvider: .init(implementation: .minimumDeploymentTargetDefault)),

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -14,8 +14,8 @@ import struct Basics.AbsolutePath
 import class Basics.ObservabilitySystem
 import class Build.BuildPlan
 import class Build.ProductBuildDescription
-import enum Build.TargetBuildDescription
-import class Build.SwiftTargetBuildDescription
+import enum Build.ModuleBuildDescription
+import class Build.SwiftModuleBuildDescription
 import struct Basics.Triple
 import enum PackageGraph.BuildTriple
 import class PackageModel.Manifest
@@ -62,7 +62,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
             observabilityScope: observabilityScope
         ))
         result.checkProductsCount(2)
-        // There are two additional targets on non-Apple platforms, for test discovery and
+        // There are two additional modules on non-Apple platforms, for test discovery and
         // test entry point
         result.checkTargetsCount(5)
 
@@ -91,7 +91,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
             observabilityScope: observabilityScope
         ))
         result.checkProductsCount(2)
-        // There are two additional targets on non-Apple platforms, for test discovery and
+        // There are two additional modules on non-Apple platforms, for test discovery and
         // test entry point
         result.checkTargetsCount(5)
 
@@ -158,7 +158,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
             observabilityScope: observabilityScope
         ))
         result.checkProductsCount(2)
-        // There are two additional targets on non-Apple platforms, for test discovery and
+        // There are two additional modules on non-Apple platforms, for test discovery and
         // test entry point
         result.checkTargetsCount(5)
 
@@ -166,7 +166,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
 
         let lib = try XCTUnwrap(
             result.allTargets(named: "lib")
-                .map { try $0.clangTarget() }
+                .map { try $0.clang() }
                 .first { $0.target.buildTriple == .destination }
         )
 
@@ -180,7 +180,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         XCTAssertEqual(try lib.objects, [buildPath.appending(components: "lib.build", "lib.c.o")])
         XCTAssertEqual(lib.moduleMap, buildPath.appending(components: "lib.build", "module.modulemap"))
 
-        let exe = try result.target(for: "app").swiftTarget().compileArguments()
+        let exe = try result.moduleBuildDescription(for: "app").swift().compileArguments()
         XCTAssertMatch(
             exe,
             [
@@ -253,7 +253,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         result.checkTargetsCount(10)
 
         XCTAssertTrue(try result.allTargets(named: "SwiftSyntax")
-            .map { try $0.swiftTarget() }
+            .map { try $0.swift() }
             .contains { $0.target.buildTriple == .tools })
         try result.check(buildTriple: .tools, triple: toolsTriple, for: "MMIOMacros")
         try result.check(buildTriple: .destination, triple: destinationTriple, for: "MMIO")
@@ -265,7 +265,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         let macroProduct = try XCTUnwrap(macroProducts.first)
         XCTAssertEqual(macroProduct.buildParameters.triple, toolsTriple)
 
-        let mmioTargets = try result.allTargets(named: "MMIO").map { try $0.swiftTarget() }
+        let mmioTargets = try result.allTargets(named: "MMIO").map { try $0.swift() }
         XCTAssertEqual(mmioTargets.count, 1)
         let mmioTarget = try XCTUnwrap(mmioTargets.first)
         let compileArguments = try mmioTarget.emitCommandLine()
@@ -305,7 +305,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         result.checkTargetsCount(16)
 
         XCTAssertTrue(try result.allTargets(named: "SwiftSyntax")
-            .map { try $0.swiftTarget() }
+            .map { try $0.swift() }
             .contains { $0.target.buildTriple == .tools })
 
         try result.check(buildTriple: .tools, triple: toolsTriple, for: "swift-mmioPackageTests")
@@ -319,7 +319,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         let macroProduct = try XCTUnwrap(macroProducts.first)
         XCTAssertEqual(macroProduct.buildParameters.triple, toolsTriple)
 
-        let mmioTargets = try result.allTargets(named: "MMIO").map { try $0.swiftTarget() }
+        let mmioTargets = try result.allTargets(named: "MMIO").map { try $0.swift() }
         XCTAssertEqual(mmioTargets.count, 1)
         let mmioTarget = try XCTUnwrap(mmioTargets.first)
         let compileArguments = try mmioTarget.emitCommandLine()
@@ -360,7 +360,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
             result.checkTargetsCount(6)
 
             XCTAssertTrue(try result.allTargets(named: "SwiftSyntax")
-                .map { try $0.swiftTarget() }
+                .map { try $0.swift() }
                 .contains { $0.target.buildTriple == .tools })
 
             try result.check(buildTriple: .tools, triple: toolsTriple, for: "swift-mmioPackageTests")
@@ -385,9 +385,9 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
 }
 
 extension BuildPlanResult {
-    func allTargets(named name: String) throws -> some Collection<TargetBuildDescription> {
+    func allTargets(named name: String) throws -> some Collection<ModuleBuildDescription> {
         self.targetMap
-            .filter { $0.0.targetName == name }
+            .filter { $0.0.moduleName == name }
             .values
     }
 
@@ -405,7 +405,7 @@ extension BuildPlanResult {
         line: UInt = #line
     ) throws {
         let targets = self.targetMap.filter {
-            $0.key.targetName == target && $0.key.buildTriple == buildTriple
+            $0.key.moduleName == target && $0.key.buildTriple == buildTriple
         }
         XCTAssertEqual(targets.count, 1, file: file, line: line)
 
@@ -413,7 +413,7 @@ extension BuildPlanResult {
             targets.first?.value,
             file: file,
             line: line
-        ).swiftTarget()
+        ).swift()
         XCTAssertMatch(try target.emitCommandLine(), [.contains(triple.tripleString)], file: file, line: line)
     }
 }

--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -193,7 +193,7 @@ final class LLBuildManifestBuilderTests: XCTestCase {
         )
     }
     
-    /// Verifies that two targets with the same name but different triples don't share same build manifest keys.
+    /// Verifies that two modules with the same name but different triples don't share same build manifest keys.
     func testToolsBuildTriple() throws {
         let (graph, fs, scope) = try macrosPackageGraph()
         let productsTriple = Triple.x86_64MacOS

--- a/Tests/BuildTests/ModuleAliasingBuildTests.swift
+++ b/Tests/BuildTests/ModuleAliasingBuildTests.swift
@@ -730,9 +730,9 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
         )
 
-        let fooLoggingArgs = try result.target(for: "FooLogging").swiftTarget().compileArguments()
-        let barLoggingArgs = try result.target(for: "BarLogging").swiftTarget().compileArguments()
-        let loggingArgs = try result.target(for: "Logging").swiftTarget().compileArguments()
+        let fooLoggingArgs = try result.moduleBuildDescription(for: "FooLogging").swift().compileArguments()
+        let barLoggingArgs = try result.moduleBuildDescription(for: "BarLogging").swift().compileArguments()
+        let loggingArgs = try result.moduleBuildDescription(for: "Logging").swift().compileArguments()
         #if os(macOS)
         XCTAssertMatch(
             fooLoggingArgs,
@@ -850,8 +850,8 @@ final class ModuleAliasingBuildTests: XCTestCase {
                 .contains { $0.target.name == "Logging" && $0.target.moduleAliases == nil }
         )
 
-        let otherLoggingArgs = try result.target(for: "OtherLogging").swiftTarget().compileArguments()
-        let loggingArgs = try result.target(for: "Logging").swiftTarget().compileArguments()
+        let otherLoggingArgs = try result.moduleBuildDescription(for: "OtherLogging").swift().compileArguments()
+        let loggingArgs = try result.moduleBuildDescription(for: "Logging").swift().compileArguments()
 
         #if os(macOS)
         XCTAssertMatch(

--- a/Tests/BuildTests/PrepareForIndexTests.swift
+++ b/Tests/BuildTests/PrepareForIndexTests.swift
@@ -83,7 +83,7 @@ class PrepareForIndexTests: XCTestCase {
         let manifest = try builder.generatePrepareManifest(at: "/manifest")
 
         // Ensure our C module is here.
-        let lib = try XCTUnwrap(graph.target(for: "lib", destination: .destination))
+        let lib = try XCTUnwrap(graph.module(for: "lib", destination: .destination))
         let name = lib.getLLBuildTargetName(buildParameters: plan.destinationBuildParameters)
         XCTAssertTrue(manifest.targets.keys.contains(name))
     }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -213,7 +213,7 @@ final class TestCommandTests: CommandsTestCase {
 
         // should emit when LinuxMain is not present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftModule.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
             let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }
@@ -225,7 +225,7 @@ final class TestCommandTests: CommandsTestCase {
         }
         // should not emit when LinuxMain is present
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
+            try localFileSystem.writeFileContents(fixturePath.appending(components: "Tests", SwiftModule.defaultTestEntryPointName), bytes: "fatalError(\"boom\")")
             let (_, stderr) = try SwiftPM.Test.execute(["--enable-test-discovery"] + compilerDiagnosticFlags, packagePath: fixturePath)
             XCTAssertNoMatch(stderr, .contains("warning: '--enable-test-discovery' option is deprecated"))
         }

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -455,7 +455,7 @@ final class PluginTests: XCTestCase {
             let package = try XCTUnwrap(packageGraph.rootPackages.first)
             
             // Find the regular target in our test package.
-            let libraryTarget = try XCTUnwrap(package.targets.map(\.underlying).first{ $0.name == "MyLibrary" } as? SwiftTarget)
+            let libraryTarget = try XCTUnwrap(package.modules.map(\.underlying).first{ $0.name == "MyLibrary" } as? SwiftModule)
             XCTAssertEqual(libraryTarget.type, .library)
             
             // Set up a delegate to handle callbacks from the command plugin.
@@ -510,7 +510,7 @@ final class PluginTests: XCTestCase {
                 diagnosticsChecker: (DiagnosticsTestResult) throws -> Void
             ) async {
                 // Find the named plugin.
-                let plugins = package.targets.compactMap{ $0.underlying as? PluginTarget }
+                let plugins = package.modules.compactMap{ $0.underlying as? PluginModule }
                 guard let plugin = plugins.first(where: { $0.name == pluginName }) else {
                     return XCTFail("There is no plugin target named ‘\(pluginName)’")
                 }
@@ -519,7 +519,7 @@ final class PluginTests: XCTestCase {
                 // Find the named input targets to the plugin.
                 var targets: [ResolvedTarget] = []
                 for targetName in targetNames {
-                    guard let target = package.targets.first(where: { $0.underlying.name == targetName }) else {
+                    guard let target = package.modules.first(where: { $0.underlying.name == targetName }) else {
                         return XCTFail("There is no target named ‘\(targetName)’")
                     }
                     XCTAssertTrue(target.type != .plugin, "Target \(target) is a plugin")
@@ -639,7 +639,7 @@ final class PluginTests: XCTestCase {
             XCTAssertNoDiagnostics(observability.diagnostics)
 
             // Make sure that the use of plugins doesn't bleed into the use of plugins by tools.
-            let testTargetMappings = try packageGraph.computeTestTargetsForExecutableTargets()
+            let testTargetMappings = try packageGraph.computeTestModulesForExecutableModules()
             for (target, testTargets) in testTargetMappings {
                 XCTAssertFalse(testTargets.contains{ $0.name == "MySourceGenPluginTests" }, "target: \(target), testTargets: \(testTargets)")
             }
@@ -740,9 +740,9 @@ final class PluginTests: XCTestCase {
             
             // Find the regular target in our test package.
             let libraryTarget = try XCTUnwrap(
-                package.targets
+                package.modules
                     .map(\.underlying)
-                    .first{ $0.name == "MyLibrary" } as? SwiftTarget
+                    .first{ $0.name == "MyLibrary" } as? SwiftModule
             )
             XCTAssertEqual(libraryTarget.type, .library)
             
@@ -796,7 +796,7 @@ final class PluginTests: XCTestCase {
             }
 
             // Find the relevant plugin.
-            let plugins = package.targets.compactMap { $0.underlying as? PluginTarget }
+            let plugins = package.modules.compactMap { $0.underlying as? PluginModule }
             guard let plugin = plugins.first(where: { $0.name == "NeverendingPlugin" }) else {
                 return XCTFail("There is no plugin target named ‘NeverendingPlugin’")
             }

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -73,7 +73,7 @@ class TestDiscoveryTests: XCTestCase {
         #if os(macOS)
         try XCTSkipIf(true)
         #endif
-        try SwiftTarget.testEntryPointNames.forEach { name in
+        try SwiftModule.testEntryPointNames.forEach { name in
             try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 let random = UUID().uuidString
                 let manifestPath = fixturePath.appending(components: "Tests", name)
@@ -93,7 +93,7 @@ class TestDiscoveryTests: XCTestCase {
         try XCTSkipIf(true)
         #endif
         try fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
-            let manifestPath = fixturePath.appending(components: "Tests", SwiftTarget.defaultTestEntryPointName)
+            let manifestPath = fixturePath.appending(components: "Tests", SwiftModule.defaultTestEntryPointName)
             try localFileSystem.writeFileContents(manifestPath, string: "fatalError(\"should not be called\")")
             let (stdout, stderr) = try executeSwiftTest(fixturePath, extraArgs: ["--enable-test-discovery"])
             // in "swift test" build output goes to stderr

--- a/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
+++ b/Tests/PackageGraphPerformanceTests/PackageGraphPerfTests.swift
@@ -175,7 +175,7 @@ final class PackageGraphPerfTests: XCTestCasePerf {
         measure {
             do {
                 for _ in 0..<N {
-                    _ = try resolvedTarget.recursiveTargetDependencies()
+                    _ = try resolvedTarget.recursiveModuleDependencies()
                 }
             } catch {
                 XCTFail("Loading package graph is not expected to fail in this test.")

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -25,7 +25,7 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
         try PackageGraphTester(graph) { result in
             result.check(packages: "Pkg")
             // "SwiftSyntax" is included for both host and target triples and is not pruned on this level
-            result.check(targets: "app", "lib")
+            result.check(modules: "app", "lib")
             result.check(testModules: "test")
             result.checkTarget("app") { result in
                 result.check(buildTriple: .destination)
@@ -48,7 +48,7 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
             result.check(packages: "swift-firmware", "swift-mmio", "swift-syntax")
             // "SwiftSyntax" is included for both host and target triples and is not pruned on this level
             result.check(
-                targets: "Core",
+                modules: "Core",
                 "HAL",
                 "MMIO",
                 "MMIOMacros",
@@ -102,7 +102,7 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
             result.check(packages: "swift-mmio", "swift-syntax")
             // "SwiftSyntax" is included for both host and target triples and is not pruned on this level
             result.check(
-                targets: "MMIO",
+                modules: "MMIO",
                 "MMIOMacros",
                 "MMIOPlugin",
                 "SwiftCompilerPlugin",

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -76,7 +76,7 @@ final class ModulesGraphTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
         PackageGraphTester(g) { result in
             result.check(packages: "Bar", "Foo", "Baz")
-            result.check(targets: "Bar", "Foo", "Baz", "FooDep")
+            result.check(modules: "Bar", "Foo", "Baz", "FooDep")
             result.check(testModules: "BazTests")
             result.checkTarget("Foo") { result in result.check(dependencies: "FooDep") }
             result.checkTarget("Bar") { result in result.check(dependencies: "Foo") }
@@ -84,12 +84,12 @@ final class ModulesGraphTests: XCTestCase {
         }
 
         let fooPackage = try XCTUnwrap(g.package(for: .plain("Foo")))
-        let fooTarget = try XCTUnwrap(g.target(for: "Foo", destination: .destination))
-        let fooDepTarget = try XCTUnwrap(g.target(for: "FooDep", destination: .destination))
+        let fooTarget = try XCTUnwrap(g.module(for: "Foo", destination: .destination))
+        let fooDepTarget = try XCTUnwrap(g.module(for: "FooDep", destination: .destination))
         XCTAssertEqual(g.package(for: fooTarget)?.id, fooPackage.id)
         XCTAssertEqual(g.package(for: fooDepTarget)?.id, fooPackage.id)
         let barPackage = try XCTUnwrap(g.package(for: .plain("Bar")))
-        let barTarget = try XCTUnwrap(g.target(for: "Bar", destination: .destination))
+        let barTarget = try XCTUnwrap(g.module(for: "Bar", destination: .destination))
         XCTAssertEqual(g.package(for: barTarget)?.id, barPackage.id)
     }
 
@@ -131,7 +131,7 @@ final class ModulesGraphTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
         PackageGraphTester(g) { result in
             result.check(packages: "Bar", "Foo")
-            result.check(targets: "Bar", "CBar", "Foo")
+            result.check(modules: "Bar", "CBar", "Foo")
             result.checkTarget("Foo") { result in result.check(dependencies: "Bar", "CBar") }
             result.checkTarget("Bar") { result in result.check(dependencies: "CBar") }
         }
@@ -385,7 +385,7 @@ final class ModulesGraphTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
         PackageGraphTester(graph) { result in
             result.check(packages: "Foo", "Bar")
-            result.check(targets: "Bar", "Baz", "Foo")
+            result.check(modules: "Bar", "Baz", "Foo")
         }
     }
 
@@ -430,7 +430,7 @@ final class ModulesGraphTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
         PackageGraphTester(g) { result in
             result.check(packages: "Bar", "Foo")
-            result.check(targets: "Bar", "Foo")
+            result.check(modules: "Bar", "Foo")
             result.check(testModules: "BarTests")
         }
     }
@@ -467,7 +467,7 @@ final class ModulesGraphTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
         PackageGraphTester(g) { result in
-            result.check(targets: "ExampleApp", "MainLib", "Core")
+            result.check(modules: "ExampleApp", "MainLib", "Core")
             result.check(testModules: "MainLibTests")
             result.checkTarget("MainLib") { result in result.check(dependencies: "Core") }
             result.checkTarget("MainLibTests") { result in result.check(dependencies: "MainLib") }
@@ -927,7 +927,7 @@ final class ModulesGraphTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
         PackageGraphTester(g) { result in
             result.check(packages: "Bar")
-            result.check(targets: "Bar")
+            result.check(modules: "Bar")
         }
     }
 
@@ -1545,13 +1545,13 @@ final class ModulesGraphTests: XCTestCase {
         XCTAssertEqual(observability.diagnostics.count, 3)
         testDiagnostics(observability.diagnostics) { result in
             var expectedMetadata = ObservabilityMetadata()
-            expectedMetadata.targetName = "Foo2"
+            expectedMetadata.moduleName = "Foo2"
             let diagnostic1 = result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'TransitiveBar' contains unsafe build flags"), severity: .error)
-            XCTAssertEqual(diagnostic1?.metadata?.targetName, "Foo2")
+            XCTAssertEqual(diagnostic1?.metadata?.moduleName, "Foo2")
             let diagnostic2 = result.checkUnordered(diagnostic: .contains("the target 'Bar' in product 'Bar' contains unsafe build flags"), severity: .error)
-            XCTAssertEqual(diagnostic2?.metadata?.targetName, "Foo")
+            XCTAssertEqual(diagnostic2?.metadata?.moduleName, "Foo")
             let diagnostic3 = result.checkUnordered(diagnostic: .contains("the target 'Bar2' in product 'Bar' contains unsafe build flags"), severity: .error)
-            XCTAssertEqual(diagnostic3?.metadata?.targetName, "Foo")
+            XCTAssertEqual(diagnostic3?.metadata?.moduleName, "Foo")
         }
     }
 
@@ -1608,7 +1608,7 @@ final class ModulesGraphTests: XCTestCase {
 
         XCTAssertNoDiagnostics(observability.diagnostics)
         PackageGraphTester(graph) { result in
-            result.check(targets: "Foo", "Bar", "Baz", "Biz")
+            result.check(modules: "Foo", "Bar", "Baz", "Biz")
             result.checkTarget("Foo") { result in
                 result.check(dependencies: "Bar", "Baz", "Biz")
                 result.checkDependency("Bar") { result in
@@ -2370,7 +2370,7 @@ final class ModulesGraphTests: XCTestCase {
             ])
         // Make sure aliases are found properly and do not fall back to pre‐5.2 behavior, leaking across onto other dependencies.
         let required = manifest.dependenciesRequired(for: .everything)
-        let unrelated = try XCTUnwrap(required.first(where: { $0.nameForTargetDependencyResolutionOnly == "Unrelated" }))
+        let unrelated = try XCTUnwrap(required.first(where: { $0.nameForModuleDependencyResolutionOnly == "Unrelated" }))
         let requestedProducts = unrelated.productFilter
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         // Unrelated should not have been asked for Product, because it should know Product comes from Identity.

--- a/Tests/PackageGraphTests/ResolvedTargetTests.swift
+++ b/Tests/PackageGraphTests/ResolvedTargetTests.swift
@@ -31,8 +31,8 @@ final class ResolvedModuleDependencyTests: XCTestCase {
         let t2 = ResolvedModule.mock(packageIdentity: "pkg", name: "t2", deps: t1)
         let t3 = ResolvedModule.mock(packageIdentity: "pkg", name: "t3", deps: t2)
 
-        XCTAssertEqualTargetIDs(try t3.recursiveTargetDependencies(), [t2, t1])
-        XCTAssertEqualTargetIDs(try t2.recursiveTargetDependencies(), [t1])
+        XCTAssertEqualTargetIDs(try t3.recursiveModuleDependencies(), [t2, t1])
+        XCTAssertEqualTargetIDs(try t2.recursiveModuleDependencies(), [t1])
     }
 
     func test2() throws {
@@ -41,9 +41,9 @@ final class ResolvedModuleDependencyTests: XCTestCase {
         let t3 = ResolvedModule.mock(packageIdentity: "pkg", name: "t3", deps: t2, t1)
         let t4 = ResolvedModule.mock(packageIdentity: "pkg", name: "t4", deps: t2, t3, t1)
 
-        XCTAssertEqualTargetIDs(try t4.recursiveTargetDependencies(), [t3, t2, t1])
-        XCTAssertEqualTargetIDs(try t3.recursiveTargetDependencies(), [t2, t1])
-        XCTAssertEqualTargetIDs(try t2.recursiveTargetDependencies(), [t1])
+        XCTAssertEqualTargetIDs(try t4.recursiveModuleDependencies(), [t3, t2, t1])
+        XCTAssertEqualTargetIDs(try t3.recursiveModuleDependencies(), [t2, t1])
+        XCTAssertEqualTargetIDs(try t2.recursiveModuleDependencies(), [t1])
     }
 
     func test3() throws {
@@ -52,9 +52,9 @@ final class ResolvedModuleDependencyTests: XCTestCase {
         let t3 = ResolvedModule.mock(packageIdentity: "pkg", name: "t3", deps: t2, t1)
         let t4 = ResolvedModule.mock(packageIdentity: "pkg", name: "t4", deps: t1, t2, t3)
 
-        XCTAssertEqualTargetIDs(try t4.recursiveTargetDependencies(), [t3, t2, t1])
-        XCTAssertEqualTargetIDs(try t3.recursiveTargetDependencies(), [t2, t1])
-        XCTAssertEqualTargetIDs(try t2.recursiveTargetDependencies(), [t1])
+        XCTAssertEqualTargetIDs(try t4.recursiveModuleDependencies(), [t3, t2, t1])
+        XCTAssertEqualTargetIDs(try t3.recursiveModuleDependencies(), [t2, t1])
+        XCTAssertEqualTargetIDs(try t2.recursiveModuleDependencies(), [t1])
     }
 
     func test4() throws {
@@ -63,9 +63,9 @@ final class ResolvedModuleDependencyTests: XCTestCase {
         let t3 = ResolvedModule.mock(packageIdentity: "pkg", name: "t3", deps: t2)
         let t4 = ResolvedModule.mock(packageIdentity: "pkg", name: "t4", deps: t3)
 
-        XCTAssertEqualTargetIDs(try t4.recursiveTargetDependencies(), [t3, t2, t1])
-        XCTAssertEqualTargetIDs(try t3.recursiveTargetDependencies(), [t2, t1])
-        XCTAssertEqualTargetIDs(try t2.recursiveTargetDependencies(), [t1])
+        XCTAssertEqualTargetIDs(try t4.recursiveModuleDependencies(), [t3, t2, t1])
+        XCTAssertEqualTargetIDs(try t3.recursiveModuleDependencies(), [t2, t1])
+        XCTAssertEqualTargetIDs(try t2.recursiveModuleDependencies(), [t1])
     }
 
     func test5() throws {
@@ -77,17 +77,17 @@ final class ResolvedModuleDependencyTests: XCTestCase {
         let t6 = ResolvedModule.mock(packageIdentity: "pkg", name: "t6", deps: t5, t4)
 
         // precise order is not important, but it is important that the following are true
-        let t6rd = try t6.recursiveTargetDependencies().map(\.id)
+        let t6rd = try t6.recursiveModuleDependencies().map(\.id)
         XCTAssertEqual(t6rd.firstIndex(of: t3.id)!, t6rd.index(after: t6rd.firstIndex(of: t4.id)!))
         XCTAssert(t6rd.firstIndex(of: t5.id)! < t6rd.firstIndex(of: t2.id)!)
         XCTAssert(t6rd.firstIndex(of: t5.id)! < t6rd.firstIndex(of: t1.id)!)
         XCTAssert(t6rd.firstIndex(of: t2.id)! < t6rd.firstIndex(of: t1.id)!)
         XCTAssert(t6rd.firstIndex(of: t3.id)! < t6rd.firstIndex(of: t2.id)!)
 
-        XCTAssertEqualTargetIDs(try t5.recursiveTargetDependencies(), [t2, t1])
-        XCTAssertEqualTargetIDs(try t4.recursiveTargetDependencies(), [t3, t2, t1])
-        XCTAssertEqualTargetIDs(try t3.recursiveTargetDependencies(), [t2, t1])
-        XCTAssertEqualTargetIDs(try t2.recursiveTargetDependencies(), [t1])
+        XCTAssertEqualTargetIDs(try t5.recursiveModuleDependencies(), [t2, t1])
+        XCTAssertEqualTargetIDs(try t4.recursiveModuleDependencies(), [t3, t2, t1])
+        XCTAssertEqualTargetIDs(try t3.recursiveModuleDependencies(), [t2, t1])
+        XCTAssertEqualTargetIDs(try t2.recursiveModuleDependencies(), [t1])
     }
 
     func test6() throws {
@@ -104,17 +104,17 @@ final class ResolvedModuleDependencyTests: XCTestCase {
         ) // same as above, but these two swapped
 
         // precise order is not important, but it is important that the following are true
-        let t6rd = try t6.recursiveTargetDependencies().map(\.id)
+        let t6rd = try t6.recursiveModuleDependencies().map(\.id)
         XCTAssertEqual(t6rd.firstIndex(of: t3.id)!, t6rd.index(after: t6rd.firstIndex(of: t4.id)!))
         XCTAssert(t6rd.firstIndex(of: t5.id)! < t6rd.firstIndex(of: t2.id)!)
         XCTAssert(t6rd.firstIndex(of: t5.id)! < t6rd.firstIndex(of: t1.id)!)
         XCTAssert(t6rd.firstIndex(of: t2.id)! < t6rd.firstIndex(of: t1.id)!)
         XCTAssert(t6rd.firstIndex(of: t3.id)! < t6rd.firstIndex(of: t2.id)!)
 
-        XCTAssertEqualTargetIDs(try t5.recursiveTargetDependencies(), [t2, t1])
-        XCTAssertEqualTargetIDs(try t4.recursiveTargetDependencies(), [t3, t2, t1])
-        XCTAssertEqualTargetIDs(try t3.recursiveTargetDependencies(), [t2, t1])
-        XCTAssertEqualTargetIDs(try t2.recursiveTargetDependencies(), [t1])
+        XCTAssertEqualTargetIDs(try t5.recursiveModuleDependencies(), [t2, t1])
+        XCTAssertEqualTargetIDs(try t4.recursiveModuleDependencies(), [t3, t2, t1])
+        XCTAssertEqualTargetIDs(try t3.recursiveModuleDependencies(), [t2, t1])
+        XCTAssertEqualTargetIDs(try t2.recursiveModuleDependencies(), [t1])
     }
 
     func testConditions() throws {

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -118,7 +118,7 @@ class ModuleMapGeneration: XCTestCase {
                     diagnostic: "no include directory found for target \'Foo\'; libraries cannot be imported without public headers",
                     severity: .warning
                 )
-                XCTAssertEqual(diagnostic?.metadata?.targetName, "Foo")
+                XCTAssertEqual(diagnostic?.metadata?.moduleName, "Foo")
             }
         }
 
@@ -139,7 +139,7 @@ class ModuleMapGeneration: XCTestCase {
                     diagnostic: "\(root.appending(components: "include", "F-o-o.h")) should be renamed to \(root.appending(components: "include", "F_o_o.h")) to be used as an umbrella header",
                     severity: .warning
                 )
-                XCTAssertEqual(diagnostic?.metadata?.targetName, "F-o-o")
+                XCTAssertEqual(diagnostic?.metadata?.moduleName, "F-o-o")
             }
         }
     }
@@ -158,7 +158,7 @@ class ModuleMapGeneration: XCTestCase {
                     diagnostic: "target 'Foo' has invalid header layout: umbrella header found at '\(include.appending(components: "Foo", "Foo.h"))', but more than one directory exists next to its parent directory: \(include.appending(components: "Bar")); consider reducing them to one",
                     severity: .error
                 )
-                XCTAssertEqual(diagnostic?.metadata?.targetName, "Foo")
+                XCTAssertEqual(diagnostic?.metadata?.moduleName, "Foo")
             }
         }
 
@@ -173,7 +173,7 @@ class ModuleMapGeneration: XCTestCase {
                     diagnostic: "target 'Foo' has invalid header layout: umbrella header found at '\(include.appending(components: "Foo.h"))', but directories exist next to it: \(include.appending(components: "Bar")); consider removing them",
                     severity: .error
                 )
-                XCTAssertEqual(diagnostic?.metadata?.targetName, "Foo")
+                XCTAssertEqual(diagnostic?.metadata?.moduleName, "Foo")
             }
         }
     }

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -730,7 +730,7 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 )
 
                 XCTAssertEqual(manifest.displayName, "Trivial-\(random)")
-                XCTAssertEqual(manifest.moduleBuilders[0].name, "foo-\(random)")
+                XCTAssertEqual(manifest.targets[0].name, "foo-\(random)")
             }
 
             try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)).count, total)

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -730,7 +730,7 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 )
 
                 XCTAssertEqual(manifest.displayName, "Trivial-\(random)")
-                XCTAssertEqual(manifest.targets[0].name, "foo-\(random)")
+                XCTAssertEqual(manifest.moduleBuilders[0].name, "foo-\(random)")
             }
 
             try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)).count, total)

--- a/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
@@ -90,15 +90,15 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(validationDiagnostics)
 
         XCTAssertEqual(manifest.displayName, "Trivial")
-        XCTAssertEqual(manifest.dependencies[0].nameForTargetDependencyResolutionOnly, "Foo")
-        XCTAssertEqual(manifest.dependencies[1].nameForTargetDependencyResolutionOnly, "Foo2")
-        XCTAssertEqual(manifest.dependencies[2].nameForTargetDependencyResolutionOnly, "Foo3")
-        XCTAssertEqual(manifest.dependencies[3].nameForTargetDependencyResolutionOnly, "Foo4")
-        XCTAssertEqual(manifest.dependencies[4].nameForTargetDependencyResolutionOnly, "Foo5")
-        XCTAssertEqual(manifest.dependencies[5].nameForTargetDependencyResolutionOnly, "bar")
-        XCTAssertEqual(manifest.dependencies[6].nameForTargetDependencyResolutionOnly, "Bar2")
-        XCTAssertEqual(manifest.dependencies[7].nameForTargetDependencyResolutionOnly, "Baz")
-        XCTAssertEqual(manifest.dependencies[8].nameForTargetDependencyResolutionOnly, "swift")
+        XCTAssertEqual(manifest.dependencies[0].nameForModuleDependencyResolutionOnly, "Foo")
+        XCTAssertEqual(manifest.dependencies[1].nameForModuleDependencyResolutionOnly, "Foo2")
+        XCTAssertEqual(manifest.dependencies[2].nameForModuleDependencyResolutionOnly, "Foo3")
+        XCTAssertEqual(manifest.dependencies[3].nameForModuleDependencyResolutionOnly, "Foo4")
+        XCTAssertEqual(manifest.dependencies[4].nameForModuleDependencyResolutionOnly, "Foo5")
+        XCTAssertEqual(manifest.dependencies[5].nameForModuleDependencyResolutionOnly, "bar")
+        XCTAssertEqual(manifest.dependencies[6].nameForModuleDependencyResolutionOnly, "Bar2")
+        XCTAssertEqual(manifest.dependencies[7].nameForModuleDependencyResolutionOnly, "Baz")
+        XCTAssertEqual(manifest.dependencies[8].nameForModuleDependencyResolutionOnly, "swift")
     }
 
     func testTargetDependencyProductInvalidPackage() async throws {
@@ -284,7 +284,7 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
         XCTAssertNoDiagnostics(observability.diagnostics)
         XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let dependencies = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.nameForTargetDependencyResolutionOnly, $0) })
+        let dependencies = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.nameForModuleDependencyResolutionOnly, $0) })
         let dependencyFoobar = dependencies["Foobar"]!
         let dependencyBarfoo = dependencies["Barfoo"]!
         let targetFoo = manifest.targetMap["foo"]!

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -511,7 +511,7 @@ final class PackageBuilderTests: XCTestCase {
     }
 
     func testTestEntryPointFound() throws {
-        try SwiftTarget.testEntryPointNames.forEach { name in
+        try SwiftModule.testEntryPointNames.forEach { name in
             let fs = InMemoryFileSystem(emptyFiles:
                 "/swift/exe/foo.swift",
                 "/\(name)",
@@ -596,7 +596,7 @@ final class PackageBuilderTests: XCTestCase {
     }
 
     func testMultipleTestEntryPointsError() throws {
-        let name = SwiftTarget.defaultTestEntryPointName
+        let name = SwiftModule.defaultTestEntryPointName
         let swift: AbsolutePath = "/swift"
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -769,7 +769,7 @@ final class PackageBuilderTests: XCTestCase {
             package.checkPredefinedPaths(target: Sources, testTarget: Tests)
 
             package.checkModule("Foo") { module in
-                let clangTarget = module.target as? ClangTarget
+                let clangTarget = module.target as? ClangModule
                 XCTAssertEqual(clangTarget?.headers.map{ $0.pathString }, [Sources.appending(components: "Foo", "Foo_private.h").pathString, Sources.appending(components: "Foo", "inc", "Foo.h").pathString])
                 module.check(c99name: "Foo", type: .library)
                 module.checkSources(root: Sources.appending(components: "Foo").pathString, paths: "Foo.c")
@@ -3104,7 +3104,7 @@ final class PackageBuilderTester {
     private let result: Result
 
     /// Contains the targets which have not been checked yet.
-    private var uncheckedModules: Set<PackageModel.Target> = []
+    private var uncheckedModules: Set<PackageModel.Module> = []
 
     /// Contains the products which have not been checked yet.
     private var uncheckedProducts: Set<PackageModel.Product> = []
@@ -3141,7 +3141,7 @@ final class PackageBuilderTester {
             )
             let loadedPackage = try builder.construct()
             self.result = .package(loadedPackage)
-            uncheckedModules = Set(loadedPackage.targets)
+            uncheckedModules = Set(loadedPackage.modules)
             uncheckedProducts = Set(loadedPackage.products)
         } catch {
             let errorString = String(describing: error)
@@ -3178,7 +3178,7 @@ final class PackageBuilderTester {
         guard case .package(let package) = result else {
             return XCTFail("Expected package did not load \(self)", file: file, line: line)
         }
-        guard let target = package.targets.first(where: {$0.name == name}) else {
+        guard let target = package.modules.first(where: {$0.name == name}) else {
             return XCTFail("Module: \(name) not found", file: file, line: line)
         }
         uncheckedModules.remove(target)
@@ -3206,7 +3206,7 @@ final class PackageBuilderTester {
 
         func check(type: PackageModel.ProductType, targets: [String], file: StaticString = #file, line: UInt = #line) {
             XCTAssertEqual(product.type, type, file: file, line: line)
-            XCTAssertEqual(product.targets.map{$0.name}.sorted(), targets.sorted(), file: file, line: line)
+            XCTAssertEqual(product.modules.map{$0.name}.sorted(), targets.sorted(), file: file, line: line)
         }
 
         func check(testEntryPointPath: String?, file: StaticString = #file, line: UInt = #line) {
@@ -3215,27 +3215,27 @@ final class PackageBuilderTester {
     }
 
     final class ModuleResult {
-        let target: PackageModel.Target
+        let target: PackageModel.Module
 
-        fileprivate init(_ target: PackageModel.Target) {
+        fileprivate init(_ target: PackageModel.Module) {
             self.target = target
         }
 
         func check(includeDir: String, file: StaticString = #file, line: UInt = #line) {
-            guard case let target as ClangTarget = target else {
+            guard case let target as ClangModule = target else {
                 return XCTFail("Include directory is being checked on a non clang target", file: file, line: line)
             }
             XCTAssertEqual(target.includeDir.pathString, includeDir, file: file, line: line)
         }
 
         func check(moduleMapType: ModuleMapType, file: StaticString = #file, line: UInt = #line) {
-            guard case let target as ClangTarget = target else {
+            guard case let target as ClangModule = target else {
                 return XCTFail("Module map type is being checked on a non-Clang target", file: file, line: line)
             }
             XCTAssertEqual(target.moduleMapType, moduleMapType, file: file, line: line)
         }
 
-        func check(c99name: String? = nil, type: PackageModel.Target.Kind? = nil, file: StaticString = #file, line: UInt = #line) {
+        func check(c99name: String? = nil, type: PackageModel.Module.Kind? = nil, file: StaticString = #file, line: UInt = #line) {
             if let c99name {
                 XCTAssertEqual(target.c99name, c99name, file: file, line: line)
             }
@@ -3261,11 +3261,11 @@ final class PackageBuilderTester {
         }
 
         func check(targetDependencies depsToCheck: [String], file: StaticString = #file, line: UInt = #line) {
-            XCTAssertEqual(Set(depsToCheck), Set(target.dependencies.compactMap { $0.target?.name }), "unexpected dependencies in \(target.name)", file: file, line: line)
+            XCTAssertEqual(Set(depsToCheck), Set(target.dependencies.compactMap { $0.module?.name }), "unexpected dependencies in \(target.name)", file: file, line: line)
         }
 
         func check(
-            productDependencies depsToCheck: [Target.ProductReference],
+            productDependencies depsToCheck: [Module.ProductReference],
             file: StaticString = #file,
             line: UInt = #line
         ) {
@@ -3304,7 +3304,7 @@ final class PackageBuilderTester {
         }
 
         func check(swiftVersion: String, file: StaticString = #file, line: UInt = #line) {
-            guard case let swiftTarget as SwiftTarget = target else {
+            guard case let swiftTarget as SwiftModule = target else {
                 return XCTFail("\(target) is not a swift target", file: file, line: line)
             }
             let versionAssignments = swiftTarget.buildSettings.assignments[.SWIFT_VERSION]?
@@ -3313,7 +3313,7 @@ final class PackageBuilderTester {
         }
 
         func check(pluginCapability: PluginCapability, file: StaticString = #file, line: UInt = #line) {
-            guard case let target as PluginTarget = target else {
+            guard case let target as PluginModule = target else {
                 return XCTFail("Plugin capability is being checked on a target", file: file, line: line)
             }
             XCTAssertEqual(target.capability, pluginCapability, file: file, line: line)
@@ -3325,9 +3325,9 @@ final class PackageBuilderTester {
     }
 
     final class ModuleDependencyResult {
-        let dependency: PackageModel.Target.Dependency
+        let dependency: PackageModel.Module.Dependency
 
-        fileprivate init(_ dependency: PackageModel.Target.Dependency) {
+        fileprivate init(_ dependency: PackageModel.Module.Dependency) {
             self.dependency = dependency
         }
 

--- a/Tests/PackageLoadingTests/PkgConfigTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 import func TSCTestSupport.withCustomEnv
 
-extension SystemLibraryTarget {
+extension SystemLibraryModule {
     convenience init(pkgConfig: String, providers: [SystemPackageProviderDescription] = []) {
         self.init(
             name: "Foo",
@@ -37,7 +37,7 @@ class PkgConfigTests: XCTestCase {
         // No pkgConfig name.
         do {
             let result = try pkgConfigArgs(
-                for: SystemLibraryTarget(pkgConfig: ""),
+                for: SystemLibraryModule(pkgConfig: ""),
                 pkgConfigDirectories: [],
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -47,7 +47,7 @@ class PkgConfigTests: XCTestCase {
 
         // No pc file.
         do {
-            let target = SystemLibraryTarget(
+            let target = SystemLibraryModule(
                 pkgConfig: "Foo",
                 providers: [
                     .brew(["libFoo"]),
@@ -90,7 +90,7 @@ class PkgConfigTests: XCTestCase {
         // Pc file.
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             for result in try pkgConfigArgs(
-                for: SystemLibraryTarget(pkgConfig: "Foo"),
+                for: SystemLibraryModule(pkgConfig: "Foo"),
                 pkgConfigDirectories: [],
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -107,7 +107,7 @@ class PkgConfigTests: XCTestCase {
         // Pc file with prohibited flags.
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             for result in try pkgConfigArgs(
-                for: SystemLibraryTarget(pkgConfig: "Bar"),
+                for: SystemLibraryModule(pkgConfig: "Bar"),
                 pkgConfigDirectories: [],
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -129,7 +129,7 @@ class PkgConfigTests: XCTestCase {
         // Pc file with -framework Framework flag.
         try withCustomEnv(["PKG_CONFIG_PATH": inputsDir.pathString]) {
             for result in try pkgConfigArgs(
-                for: SystemLibraryTarget(pkgConfig: "Framework"),
+                for: SystemLibraryModule(pkgConfig: "Framework"),
                 pkgConfigDirectories: [],
                 fileSystem: fs,
                 observabilityScope: observability.topScope
@@ -152,7 +152,7 @@ class PkgConfigTests: XCTestCase {
     func testExplicitPkgConfigDirectories() throws {
         // Pc file.
         for result in try pkgConfigArgs(
-            for: SystemLibraryTarget(pkgConfig: "Foo"),
+            for: SystemLibraryModule(pkgConfig: "Foo"),
             pkgConfigDirectories: [inputsDir],
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -167,7 +167,7 @@ class PkgConfigTests: XCTestCase {
 
         // Pc file with prohibited flags.
         for result in try pkgConfigArgs(
-            for: SystemLibraryTarget(pkgConfig: "Bar"),
+            for: SystemLibraryModule(pkgConfig: "Bar"),
             pkgConfigDirectories: [inputsDir],
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -188,7 +188,7 @@ class PkgConfigTests: XCTestCase {
         // Pc file with -framework Framework flag.
         let observability = ObservabilitySystem.makeForTesting()
         for result in try pkgConfigArgs(
-            for: SystemLibraryTarget(pkgConfig: "Framework"),
+            for: SystemLibraryModule(pkgConfig: "Framework"),
             pkgConfigDirectories: [inputsDir],
             fileSystem: fs,
             observabilityScope: observability.topScope

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -291,7 +291,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                     for diagnostic in diagnosticsFound {
                         XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                         XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                        XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                        XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                     }
                 }
             }
@@ -320,7 +320,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                     for diagnostic in diagnosticsFound {
                         XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                         XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                        XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                        XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                     }
                 }
             }
@@ -367,7 +367,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                     for diagnostic in diagnosticsFound {
                         XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                         XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                        XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                        XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                     }
                 }
             }
@@ -396,7 +396,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                     for diagnostic in diagnosticsFound {
                         XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                         XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                        XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                        XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                     }
                 }
             }
@@ -423,7 +423,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                     )
                     XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                     XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                 }
             }
         }
@@ -461,7 +461,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 )
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                 XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
             }
         }
     }
@@ -486,7 +486,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 )
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                 XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
             }
         }
     }
@@ -564,7 +564,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 for diagnostic in diagnosticsFound {
                     XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                     XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                 }
             }
         }
@@ -637,7 +637,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                     )
                     XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                     XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                 }
             }
         }
@@ -659,7 +659,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                     )
                     XCTAssertEqual(diagnostic?.metadata?.packageIdentity, identity)
                     XCTAssertEqual(diagnostic?.metadata?.packageKind, kind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                 }
             }
         }
@@ -706,7 +706,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 for diagnostic in diagnosticsFound {
                     XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
                     XCTAssertEqual(diagnostic?.metadata?.packageKind, builder.packageKind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                 }
             }
         }
@@ -773,7 +773,7 @@ class TargetSourcesBuilderTests: XCTestCase {
                 for diagnostic in diagnosticsFound {
                     XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
                     XCTAssertEqual(diagnostic?.metadata?.packageKind, builder.packageKind)
-                    XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                    XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
                 }
             }
         }
@@ -841,7 +841,7 @@ class TargetSourcesBuilderTests: XCTestCase {
             for diagnostic in diagnosticsFound {
                 XCTAssertEqual(diagnostic?.metadata?.packageIdentity, builder.packageIdentity)
                 XCTAssertEqual(diagnostic?.metadata?.packageKind, builder.packageKind)
-                XCTAssertEqual(diagnostic?.metadata?.targetName, target.name)
+                XCTAssertEqual(diagnostic?.metadata?.moduleName, target.name)
             }
         }
     }

--- a/Tests/PackageLoadingTests/TraitLoadingTests.swift
+++ b/Tests/PackageLoadingTests/TraitLoadingTests.swift
@@ -300,7 +300,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             ]
         )
         XCTAssertEqual(
-            manifest.moduleBuilders.first,
+            manifest.targets.first,
             try .init(
                 name: "Target",
                 dependencies: [

--- a/Tests/PackageLoadingTests/TraitLoadingTests.swift
+++ b/Tests/PackageLoadingTests/TraitLoadingTests.swift
@@ -300,7 +300,7 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             ]
         )
         XCTAssertEqual(
-            manifest.targets.first,
+            manifest.moduleBuilders.first,
             try .init(
                 name: "Target",
                 dependencies: [

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -112,7 +112,7 @@ final class ArtifactsArchiveMetadataTests: XCTestCase {
             ]
         ))
 
-        let binaryTarget = BinaryTarget(
+        let binaryTarget = BinaryModule(
             name: "protoc", kind: .artifactsArchive, path: .root, origin: .local
         )
         // No supportedTriples with binaryTarget should be rejected

--- a/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
+++ b/Tests/SPMBuildCoreTests/PluginInvocationTests.swift
@@ -86,7 +86,7 @@ final class PluginInvocationTests: XCTestCase {
         PackageGraphTester(graph) { graph in
             graph.check(packages: "Foo")
             // "FooTool{Lib}" duplicated as it's present for both build tools and end products triples.
-            graph.check(targets: "Foo", "FooPlugin", "FooTool", "FooTool", "FooToolLib", "FooToolLib")
+            graph.check(modules: "Foo", "FooPlugin", "FooTool", "FooTool", "FooToolLib", "FooToolLib")
             graph.checkTarget("Foo") { target in
                 target.check(dependencies: "FooPlugin")
             }
@@ -324,7 +324,7 @@ final class PluginInvocationTests: XCTestCase {
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
             
             // Find the build tool plugin.
-            let buildToolPlugin = try XCTUnwrap(packageGraph.packages.first?.targets.map(\.underlying).first{ $0.name == "MyPlugin" } as? PluginTarget)
+            let buildToolPlugin = try XCTUnwrap(packageGraph.packages.first?.modules.map(\.underlying).first{ $0.name == "MyPlugin" } as? PluginModule)
             XCTAssertEqual(buildToolPlugin.name, "MyPlugin")
             XCTAssertEqual(buildToolPlugin.capability, .buildTool)
 
@@ -892,7 +892,7 @@ final class PluginInvocationTests: XCTestCase {
             XCTAssert(packageGraph.packages.count == 1, "\(packageGraph.packages)")
 
             // Find the build tool plugin.
-            let buildToolPlugin = try XCTUnwrap(packageGraph.packages.first?.targets.map(\.underlying).filter{ $0.name == "X" }.first as? PluginTarget)
+            let buildToolPlugin = try XCTUnwrap(packageGraph.packages.first?.modules.map(\.underlying).filter{ $0.name == "X" }.first as? PluginModule)
             XCTAssertEqual(buildToolPlugin.name, "X")
             XCTAssertEqual(buildToolPlugin.capability, .buildTool)
 
@@ -1232,10 +1232,10 @@ final class PluginInvocationTests: XCTestCase {
             XCTAssertNoDiagnostics(observability.diagnostics)
 
             // Find the build tool plugin.
-            let buildToolPlugin = try XCTUnwrap(packageGraph.packages.first?.targets
+            let buildToolPlugin = try XCTUnwrap(packageGraph.packages.first?.modules
                 .map(\.underlying)
                 .filter { $0.name == "Foo" }
-                .first as? PluginTarget)
+                .first as? PluginModule)
             XCTAssertEqual(buildToolPlugin.name, "Foo")
             XCTAssertEqual(buildToolPlugin.capability, .buildTool)
 

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -91,7 +91,7 @@ extension SourceKitLSPAPI.BuildDescription {
         partialArguments: [String],
         isPartOfRootPackage: Bool
     ) throws -> Bool {
-        let target = try XCTUnwrap(graph.target(for: targetName, destination: .destination))
+        let target = try XCTUnwrap(graph.module(for: targetName, destination: .destination))
         let buildTarget = try XCTUnwrap(self.getBuildTarget(for: target, in: graph))
 
         guard let file = buildTarget.sources.first else {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -44,7 +44,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTests", dependencies: ["Bar"], type: .test),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo", "Bar"]),
+                        MockProduct(name: "Foo", modules: ["Foo", "Bar"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Baz", requirement: .upToNextMajor(from: "1.0.0")),
@@ -58,7 +58,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -68,7 +68,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Quix"),
                     ],
                     products: [
-                        MockProduct(name: "Quix", targets: ["Quix"]),
+                        MockProduct(name: "Quix", modules: ["Quix"]),
                     ],
                     versions: ["1.0.0", "1.2.0"]
                 ),
@@ -83,7 +83,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo", "Quix")
-                result.check(targets: "Bar", "Baz", "Foo", "Quix")
+                result.check(modules: "Bar", "Baz", "Foo", "Quix")
                 result.check(testModules: "BarTests")
                 result.checkTarget("Foo") { result in result.check(dependencies: "Bar") }
                 result.checkTarget("Bar") { result in result.check(dependencies: "Baz") }
@@ -298,7 +298,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.0.1", "1.0.3", "1.0.5", "1.0.8"]
                 ),
@@ -352,7 +352,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ]
                 ),
             ],
@@ -364,7 +364,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.0.1", "1.0.3", "1.0.5", "1.0.8"]
                 ),
@@ -452,7 +452,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "1.0.1"]
                 ),
@@ -465,7 +465,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "1.0.1"]
                 ),
@@ -517,7 +517,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BazB"),
                     ],
                     products: [
-                        MockProduct(name: "BazAB", targets: ["BazA", "BazB"]),
+                        MockProduct(name: "BazAB", modules: ["BazA", "BazB"]),
                     ]
                 ),
             ],
@@ -528,7 +528,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -539,7 +539,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Baz", "Foo")
                 result.check(packages: "Baz", "Foo")
-                result.check(targets: "BazA", "BazB", "Foo")
+                result.check(modules: "BazA", "BazB", "Foo")
                 result.checkTarget("Foo") { result in result.check(dependencies: "BazAB") }
             }
             XCTAssertNoDiagnostics(diagnostics)
@@ -577,7 +577,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BazB"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["BazA", "BazB"]),
+                        MockProduct(name: "Baz", modules: ["BazA", "BazB"]),
                     ]
                 ),
             ],
@@ -588,7 +588,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -600,7 +600,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo")
-                result.check(targets: "Baz", "Foo")
+                result.check(modules: "Baz", "Foo")
                 result.checkTarget("Foo") { result in result.check(dependencies: "Baz") }
             }
             XCTAssertNoDiagnostics(diagnostics)
@@ -620,7 +620,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Baz", "Foo")
                 result.check(packages: "Baz", "Foo")
-                result.check(targets: "BazA", "BazB", "Foo")
+                result.check(modules: "BazA", "BazB", "Foo")
                 result.checkTarget("Foo") { result in result.check(dependencies: "Baz") }
             }
             XCTAssertNoDiagnostics(diagnostics)
@@ -654,7 +654,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: ["Bar"]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -667,7 +667,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -690,7 +690,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(dependencies: dependencies) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(packages: "Bar", "Foo")
-                result.check(targets: "Bar", "Foo")
+                result.check(modules: "Bar", "Foo")
                 result.checkTarget("Foo") { result in result.check(dependencies: "Bar") }
             }
             XCTAssertNoDiagnostics(diagnostics)
@@ -716,7 +716,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "A", dependencies: ["AA"]),
                     ],
                     products: [
-                        MockProduct(name: "A", targets: ["A"]),
+                        MockProduct(name: "A", modules: ["A"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./AA", requirement: .exact("1.0.0")),
@@ -729,7 +729,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "A", dependencies: ["AA"]),
                     ],
                     products: [
-                        MockProduct(name: "A", targets: ["A"]),
+                        MockProduct(name: "A", modules: ["A"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./AA", requirement: .exact("2.0.0")),
@@ -742,7 +742,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "AA"),
                     ],
                     products: [
-                        MockProduct(name: "AA", targets: ["AA"]),
+                        MockProduct(name: "AA", modules: ["AA"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -757,7 +757,7 @@ final class WorkspaceTests: XCTestCase {
             try workspace.checkPackageGraph(deps: deps) { graph, diagnostics in
                 PackageGraphTester(graph) { result in
                     result.check(packages: "A", "AA")
-                    result.check(targets: "A", "AA")
+                    result.check(modules: "A", "AA")
                     result.checkTarget("A") { result in result.check(dependencies: "AA") }
                 }
                 XCTAssertNoDiagnostics(diagnostics)
@@ -818,7 +818,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "A", dependencies: ["AA"]),
                     ],
                     products: [
-                        MockProduct(name: "A", targets: ["A"]),
+                        MockProduct(name: "A", modules: ["A"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./AA", requirement: .exact("1.0.0")),
@@ -831,7 +831,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "B", dependencies: ["AA"]),
                     ],
                     products: [
-                        MockProduct(name: "B", targets: ["B"]),
+                        MockProduct(name: "B", modules: ["B"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./AA", requirement: .exact("2.0.0")),
@@ -844,7 +844,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "AA"),
                     ],
                     products: [
-                        MockProduct(name: "AA", targets: ["AA"]),
+                        MockProduct(name: "AA", modules: ["AA"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -934,13 +934,13 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "B",
                     targets: [MockTarget(name: "B")],
-                    products: [MockProduct(name: "B", targets: ["B"])],
+                    products: [MockProduct(name: "B", modules: ["B"])],
                     versions: ["1.0.0"]
                 ),
                 MockPackage(
                     name: "C",
                     targets: [MockTarget(name: "C")],
-                    products: [MockProduct(name: "C", targets: ["C"])],
+                    products: [MockProduct(name: "C", modules: ["C"])],
                     versions: ["1.0.0"]
                 ),
             ]
@@ -997,13 +997,13 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "B",
                     targets: [MockTarget(name: "B")],
-                    products: [MockProduct(name: "B", targets: ["B"])],
+                    products: [MockProduct(name: "B", modules: ["B"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
                 MockPackage(
                     name: "C",
                     targets: [MockTarget(name: "C")],
-                    products: [MockProduct(name: "C", targets: ["C"])],
+                    products: [MockProduct(name: "C", modules: ["C"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
             ]
@@ -1061,7 +1061,7 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "C",
                     targets: [MockTarget(name: "C")],
-                    products: [MockProduct(name: "C", targets: ["C"])],
+                    products: [MockProduct(name: "C", modules: ["C"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
             ]
@@ -1115,13 +1115,13 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "B",
                     targets: [MockTarget(name: "B")],
-                    products: [MockProduct(name: "B", targets: ["B"])],
+                    products: [MockProduct(name: "B", modules: ["B"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
                 MockPackage(
                     name: "C",
                     targets: [MockTarget(name: "C")],
-                    products: [MockProduct(name: "C", targets: ["C"])],
+                    products: [MockProduct(name: "C", modules: ["C"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
             ]
@@ -1182,13 +1182,13 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "B",
                     targets: [MockTarget(name: "B")],
-                    products: [MockProduct(name: "B", targets: ["B"])],
+                    products: [MockProduct(name: "B", modules: ["B"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
                 MockPackage(
                     name: "C",
                     targets: [MockTarget(name: "C")],
-                    products: [MockProduct(name: "C", targets: ["C"])],
+                    products: [MockProduct(name: "C", modules: ["C"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
             ]
@@ -1250,13 +1250,13 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "B",
                     targets: [MockTarget(name: "B")],
-                    products: [MockProduct(name: "B", targets: ["B"])],
+                    products: [MockProduct(name: "B", modules: ["B"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
                 MockPackage(
                     name: "C",
                     targets: [MockTarget(name: "C")],
-                    products: [MockProduct(name: "C", targets: ["C"])],
+                    products: [MockProduct(name: "C", modules: ["C"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
             ]
@@ -1318,13 +1318,13 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "B",
                     targets: [MockTarget(name: "B")],
-                    products: [MockProduct(name: "B", targets: ["B"])],
+                    products: [MockProduct(name: "B", modules: ["B"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
                 MockPackage(
                     name: "C",
                     targets: [MockTarget(name: "C")],
-                    products: [MockProduct(name: "C", targets: ["C"])],
+                    products: [MockProduct(name: "C", modules: ["C"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
             ]
@@ -1388,13 +1388,13 @@ final class WorkspaceTests: XCTestCase {
                 MockPackage(
                     name: "B",
                     targets: [MockTarget(name: "B")],
-                    products: [MockProduct(name: "B", targets: ["B"])],
+                    products: [MockProduct(name: "B", modules: ["B"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
                 MockPackage(
                     name: "C",
                     targets: [MockTarget(name: "C")],
-                    products: [MockProduct(name: "C", targets: ["C"])],
+                    products: [MockProduct(name: "C", modules: ["C"])],
                     versions: [nil, "1.0.0", "1.0.5", "2.0.0"]
                 ),
             ]
@@ -1443,7 +1443,7 @@ final class WorkspaceTests: XCTestCase {
         try workspace.checkPackageGraph(roots: ["A", "B", "C"]) { graph, diagnostics in
             PackageGraphTester(graph) { result in
                 result.check(packages: "A", "B", "C")
-                result.check(targets: "A", "B", "C")
+                result.check(modules: "A", "B", "C")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -1463,7 +1463,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Root", dependencies: ["Foo"]),
                     ],
                     products: [
-                        MockProduct(name: "Root", targets: ["Root"]),
+                        MockProduct(name: "Root", modules: ["Root"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1477,7 +1477,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: ["Bar"]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1490,7 +1490,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.5.0"]
                 ),
@@ -1500,7 +1500,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1564,7 +1564,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Root", dependencies: ["Foo"]),
                     ],
                     products: [
-                        MockProduct(name: "Root", targets: ["Root"]),
+                        MockProduct(name: "Root", modules: ["Root"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1578,7 +1578,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1588,7 +1588,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.5.0"]
                 ),
@@ -1659,7 +1659,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Root", dependencies: ["Foo"]),
                     ],
                     products: [
-                        MockProduct(name: "Root", targets: ["Root"]),
+                        MockProduct(name: "Root", modules: ["Root"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1673,7 +1673,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: ["Bar"]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1686,7 +1686,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: ["Bar"]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMinor(from: "1.0.0")),
@@ -1699,7 +1699,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.2.0"]
                 ),
@@ -1763,7 +1763,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Root", dependencies: ["Foo"]),
                     ],
                     products: [
-                        MockProduct(name: "Root", targets: ["Root"]),
+                        MockProduct(name: "Root", modules: ["Root"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1777,7 +1777,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -1936,7 +1936,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: ["Bar", "Baz"]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -1951,7 +1951,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz", dependencies: ["Bam"]),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bam", requirement: .upToNextMajor(from: "1.0.0")),
@@ -2002,7 +2002,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["develop"]
                 ),
@@ -2012,7 +2012,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["boo"]
                 ),
@@ -2066,7 +2066,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.2.3"]
                 ),
@@ -2185,7 +2185,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v3
@@ -2306,7 +2306,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -2316,7 +2316,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -2413,7 +2413,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -2465,7 +2465,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -2551,7 +2551,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.2.0", "1.3.2"]
                 ),
@@ -2561,7 +2561,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -2671,7 +2671,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -2681,7 +2681,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: ["Bar"]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -2694,7 +2694,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -2744,7 +2744,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: ["Bar"]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .exact("1.0.0")),
@@ -2758,7 +2758,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -2842,7 +2842,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -2852,7 +2852,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -2926,7 +2926,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: [nil, "1.0.0", "1.1.0"]
                 ),
@@ -2937,7 +2937,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0"]
                 ),
@@ -3001,7 +3001,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Root", dependencies: ["Foo"]),
                     ],
                     products: [
-                        MockProduct(name: "Root", targets: ["Root"]),
+                        MockProduct(name: "Root", modules: ["Root"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -3015,7 +3015,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.5.0"]
                 ),
@@ -3064,7 +3064,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0", nil]
                 ),
@@ -3074,7 +3074,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz", dependencies: ["Bar"]),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -3088,7 +3088,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Bar", "Baz", "Foo")
-                result.check(targets: "Bar", "Baz", "Foo")
+                result.check(modules: "Bar", "Baz", "Foo")
                 result.check(testModules: "FooTests")
                 result.checkTarget("Baz") { result in result.check(dependencies: "Bar") }
                 result.checkTarget("Foo") { result in result.check(dependencies: "Baz", "Bar") }
@@ -3141,7 +3141,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar", dependencies: ["Baz"]),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     dependencies: [
                         .fileSystem(path: "./Baz"),
@@ -3154,7 +3154,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.5.0", nil]
                 ),
@@ -3165,7 +3165,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Foo")
-                result.check(targets: "Foo")
+                result.check(modules: "Foo")
             }
             testDiagnostics(diagnostics) { result in
                 result.check(
@@ -3202,7 +3202,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0", nil]
                 ),
@@ -3267,7 +3267,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Foo")
-                result.check(targets: "Foo")
+                result.check(modules: "Foo")
             }
             testDiagnostics(diagnostics) { result in
                 result.check(
@@ -3304,7 +3304,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["develop", "1.0.0"]
                 ),
@@ -3373,7 +3373,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["develop", "1.0.0", nil]
                 ),
@@ -3442,7 +3442,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: [nil]
                 ),
@@ -3453,7 +3453,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: [nil]
                 ),
@@ -3514,7 +3514,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: [nil]
                 ),
@@ -3525,7 +3525,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: [nil]
                 ),
@@ -3592,7 +3592,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -3603,7 +3603,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "OtherFoo"),
                     ],
                     products: [
-                        MockProduct(name: "OtherFoo", targets: ["OtherFoo"]),
+                        MockProduct(name: "OtherFoo", modules: ["OtherFoo"]),
                     ],
                     versions: ["1.1.0"]
                 ),
@@ -3667,7 +3667,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -3743,7 +3743,7 @@ final class WorkspaceTests: XCTestCase {
                             MockTarget(name: "Foo"),
                         ],
                         products: [
-                            MockProduct(name: "Foo", targets: ["Foo"]),
+                            MockProduct(name: "Foo", modules: ["Foo"]),
                         ],
                         versions: ["1.0.0"]
                     ),
@@ -3791,7 +3791,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.1.0"],
                     revisionProvider: { version in version } // stable revisions
@@ -3803,7 +3803,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.1.0"],
                     revisionProvider: { version in version } // stable revisions
@@ -3815,7 +3815,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.1.0"],
                     revisionProvider: { version in version } // stable revisions
@@ -3827,7 +3827,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.1.0"],
                     revisionProvider: { version in version } // stable revisions
@@ -3839,7 +3839,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.1.0"],
                     revisionProvider: { version in version } // stable revisions
@@ -4027,7 +4027,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.0.1", "1.1.0", "1.1.1", "1.2.0", "1.2.1", "1.3.0", "1.3.1"]
                 ),
@@ -4038,7 +4038,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.0.1", "1.1.0", "1.1.1", "1.2.0", "1.2.1", "1.3.0", "1.3.1"]
                 ),
@@ -4049,7 +4049,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.0.1", "1.1.0", "1.1.1", "1.2.0", "1.2.1", "1.3.0", "1.3.1"]
                 ),
@@ -4286,7 +4286,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Dep", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4303,7 +4303,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Dep", targets: ["Dep"]),
+                        MockProduct(name: "Dep", modules: ["Dep"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4317,7 +4317,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -4327,7 +4327,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
                 ),
@@ -4339,7 +4339,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "BazMirror", "Foo", "Dep")
-                result.check(targets: "Bar", "Baz", "Foo", "Dep")
+                result.check(modules: "Bar", "Baz", "Foo", "Dep")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -4378,7 +4378,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Dep", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4394,7 +4394,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Dep", targets: ["Dep"]),
+                        MockProduct(name: "Dep", modules: ["Dep"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4407,7 +4407,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -4417,7 +4417,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
                 ),
@@ -4427,7 +4427,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -4443,7 +4443,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "Foo", "Dep")
-                result.check(targets: "Bar", "Foo", "Dep")
+                result.check(modules: "Bar", "Foo", "Dep")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -4475,7 +4475,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://scm.com/org/dep", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4493,7 +4493,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Dep", targets: ["Dep"]),
+                        MockProduct(name: "Dep", modules: ["Dep"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://scm.com/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4508,7 +4508,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -4519,7 +4519,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
                 ),
@@ -4531,7 +4531,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "BazMirror", "Foo", "Dep")
-                result.check(targets: "Bar", "Baz", "Foo", "Dep")
+                result.check(modules: "Bar", "Baz", "Foo", "Dep")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -4564,7 +4564,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://scm.com/org/dep", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4581,7 +4581,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Dep", targets: ["Dep"]),
+                        MockProduct(name: "Dep", modules: ["Dep"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://scm.com/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4595,7 +4595,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -4606,7 +4606,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
                 ),
@@ -4617,7 +4617,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -4637,7 +4637,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "Foo", "Dep")
-                result.check(targets: "Bar", "Foo", "Dep")
+                result.check(modules: "Bar", "Foo", "Dep")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -4669,7 +4669,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://scm.com/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4685,7 +4685,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -4696,7 +4696,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
                 ),
@@ -4708,7 +4708,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "Baz", "Foo")
-                result.check(targets: "Bar", "Baz", "Foo")
+                result.check(modules: "Bar", "Baz", "Foo")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -4739,7 +4739,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4755,7 +4755,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "1.5.0"]
                 ),
@@ -4766,7 +4766,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.6.0"]
                 ),
@@ -4778,7 +4778,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "BarMirror", "Baz", "Foo")
-                result.check(targets: "Bar", "Baz", "Foo")
+                result.check(modules: "Bar", "Baz", "Foo")
             }
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -4833,7 +4833,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://scm.com/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4852,7 +4852,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://scm.com/other/foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -4867,7 +4867,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"],
                     revisionProvider: { _ in fooRevision }
@@ -4879,7 +4879,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "OtherFoo"),
                     ],
                     products: [
-                        MockProduct(name: "OtherFoo", targets: ["OtherFoo"]),
+                        MockProduct(name: "OtherFoo", modules: ["OtherFoo"]),
                     ],
                     versions: ["1.0.0"],
                     revisionProvider: { _ in fooRevision }
@@ -4966,7 +4966,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.2.0", "1.3.2"]
                 ),
@@ -4976,7 +4976,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "develop"]
                 ),
@@ -5087,7 +5087,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ]
                 ),
             ],
@@ -5098,7 +5098,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.2.0", "1.3.2"]
                 ),
@@ -5140,7 +5140,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.2.0", "1.3.2"]
                 ),
@@ -5150,7 +5150,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", "develop"]
                 ),
@@ -5196,7 +5196,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: [nil]
                 ),
@@ -5235,7 +5235,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: [nil]
                 ),
@@ -5336,7 +5336,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: ["Local"]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .fileSystem(path: "./Local"),
@@ -5349,7 +5349,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Local"),
                     ],
                     products: [
-                        MockProduct(name: "Local", targets: ["Local"]),
+                        MockProduct(name: "Local", modules: ["Local"]),
                     ],
                     versions: [nil]
                 ),
@@ -5383,7 +5383,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ]
                 ),
             ],
@@ -5395,7 +5395,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -5451,7 +5451,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://localhost/org/Baz", requirement: .upToNextMajor(from: "1.0.0")),
@@ -5465,7 +5465,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -5476,7 +5476,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -5526,7 +5526,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar", settings: [.init(tool: .swift, kind: .unsafeFlags(["-F", "/tmp"]))]),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -5549,7 +5549,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar", settings: [.init(tool: .swift, kind: .unsafeFlags(["-F", "/tmp"]))]),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["1.0.0", nil]
                 ),
@@ -5563,7 +5563,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -5581,13 +5581,13 @@ final class WorkspaceTests: XCTestCase {
                     severity: .error
                 )
                 XCTAssertEqual(diagnostic1?.metadata?.packageIdentity, .plain("foo"))
-                XCTAssertEqual(diagnostic1?.metadata?.targetName, "Foo")
+                XCTAssertEqual(diagnostic1?.metadata?.moduleName, "Foo")
                 let diagnostic2 = result.checkUnordered(
                     diagnostic: .equal("the target 'Bar' in product 'Baz' contains unsafe build flags"),
                     severity: .error
                 )
                 XCTAssertEqual(diagnostic2?.metadata?.packageIdentity, .plain("foo"))
-                XCTAssertEqual(diagnostic2?.metadata?.targetName, "Foo")
+                XCTAssertEqual(diagnostic2?.metadata?.moduleName, "Foo")
             }
         }
     }
@@ -5622,7 +5622,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foundation", settings: [.init(tool: .swift, kind: .unsafeFlags(["-F", "/tmp"]))]),
                     ],
                     products: [
-                        MockProduct(name: "Foundation", targets: ["Foundation"])
+                        MockProduct(name: "Foundation", modules: ["Foundation"])
                     ],
                     versions: ["1.0.0", nil]
                 )
@@ -5661,7 +5661,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo", dependencies: ["Bar"]),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .branch("master")),
@@ -5674,7 +5674,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["master", "1.0.0", nil]
                 ),
@@ -5684,7 +5684,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz", dependencies: ["Bar"]),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./Bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -5742,12 +5742,12 @@ final class WorkspaceTests: XCTestCase {
         let barProducts: [MockProduct]
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         barProducts = [
-            MockProduct(name: "Bar", targets: ["Bar"]),
-            MockProduct(name: "BarUnused", targets: ["BarUnused"]),
+            MockProduct(name: "Bar", moduleBuilders: ["Bar"]),
+            MockProduct(name: "BarUnused", moduleBuilders: ["BarUnused"]),
         ]
         #else
         // Whether a product is being used does not affect dependency resolution in this case, so we omit the unused product.
-        barProducts = [MockProduct(name: "Bar", targets: ["Bar"])]
+        barProducts = [MockProduct(name: "Bar", moduleBuilders: ["Bar"])]
         #endif
 
         let workspace = try MockWorkspace(
@@ -5778,7 +5778,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTests", dependencies: ["TestHelper2"], type: .test),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo1"]),
+                        MockProduct(name: "Foo", modules: ["Foo1"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./TestHelper2", requirement: .upToNextMajor(from: "1.0.0")),
@@ -5808,7 +5808,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5_2
@@ -5819,7 +5819,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "TestHelper1"),
                     ],
                     products: [
-                        MockProduct(name: "TestHelper1", targets: ["TestHelper1"]),
+                        MockProduct(name: "TestHelper1", modules: ["TestHelper1"]),
                     ],
                     versions: ["1.0.0"],
                     toolsVersion: .v5_2
@@ -5903,8 +5903,8 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "A1", targets: ["A1"]),
-                        MockProduct(name: "A2", targets: ["A2"]),
+                        MockProduct(name: "A1", modules: ["A1"]),
+                        MockProduct(name: "A2", modules: ["A2"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -5918,7 +5918,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "B", targets: ["B"]),
+                        MockProduct(name: "B", modules: ["B"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -6129,10 +6129,10 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "A1", targets: ["A1"]),
-                        MockProduct(name: "A2", targets: ["A2"]),
-                        MockProduct(name: "A3", targets: ["A3"]),
-                        MockProduct(name: "A4", targets: ["A4"]),
+                        MockProduct(name: "A1", modules: ["A1"]),
+                        MockProduct(name: "A2", modules: ["A2"]),
+                        MockProduct(name: "A3", modules: ["A3"]),
+                        MockProduct(name: "A4", modules: ["A4"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -6878,8 +6878,8 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "A1", targets: ["A1"]),
-                        MockProduct(name: "A2", targets: ["A2"]),
+                        MockProduct(name: "A1", modules: ["A1"]),
+                        MockProduct(name: "A2", modules: ["A2"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -6894,7 +6894,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "B", targets: ["B"]),
+                        MockProduct(name: "B", modules: ["B"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -7099,11 +7099,11 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "A1", targets: ["A1"]),
-                        MockProduct(name: "A2", targets: ["A2"]),
-                        MockProduct(name: "A3", targets: ["A3"]),
-                        MockProduct(name: "A4", targets: ["A4"]),
-                        MockProduct(name: "A7", targets: ["A7"]),
+                        MockProduct(name: "A1", modules: ["A1"]),
+                        MockProduct(name: "A2", modules: ["A2"]),
+                        MockProduct(name: "A3", modules: ["A3"]),
+                        MockProduct(name: "A4", modules: ["A4"]),
+                        MockProduct(name: "A7", modules: ["A7"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -7118,7 +7118,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "B", targets: ["B"]),
+                        MockProduct(name: "B", modules: ["B"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -8427,7 +8427,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "A", type: .binary, url: "https://a.com/a.zip", checksum: "0a"),
                     ],
                     products: [
-                        MockProduct(name: "A", targets: ["A"]),
+                        MockProduct(name: "A", modules: ["A"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -8440,7 +8440,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "B", targets: ["B"]),
+                        MockProduct(name: "B", modules: ["B"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./C", requirement: .exact("1.0.0")),
@@ -8456,7 +8456,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "C", targets: ["C"]),
+                        MockProduct(name: "C", modules: ["C"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./A", requirement: .exact("1.0.0")),
@@ -8471,7 +8471,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "D", targets: ["D"]),
+                        MockProduct(name: "D", modules: ["D"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "./A", requirement: .exact("1.0.0")),
@@ -8696,7 +8696,7 @@ final class WorkspaceTests: XCTestCase {
                     ),
                 ],
                 products: [
-                    MockProduct(name: "binary\(index)", targets: ["binary\(index)"]),
+                    MockProduct(name: "binary\(index)", modules: ["binary\(index)"]),
                 ],
                 versions: ["1.0.0"]
             )
@@ -9233,8 +9233,8 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "A1", targets: ["A1"]),
-                        MockProduct(name: "A2", targets: ["A2"]),
+                        MockProduct(name: "A1", modules: ["A1"]),
+                        MockProduct(name: "A2", modules: ["A2"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -9249,7 +9249,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "B", targets: ["B"]),
+                        MockProduct(name: "B", modules: ["B"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -9801,7 +9801,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -9813,7 +9813,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -9862,7 +9862,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -9874,7 +9874,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -9931,7 +9931,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -9943,7 +9943,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -9992,7 +9992,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10003,7 +10003,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10047,7 +10047,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10058,7 +10058,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10102,7 +10102,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10113,7 +10113,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10157,7 +10157,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10168,7 +10168,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10221,7 +10221,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10232,7 +10232,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10280,7 +10280,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10291,7 +10291,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10344,7 +10344,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10355,7 +10355,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -10412,7 +10412,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooUtilityTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooUtilityProduct", targets: ["FooUtilityTarget"]),
+                        MockProduct(name: "FooUtilityProduct", modules: ["FooUtilityTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10425,7 +10425,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControlWithDeprecatedName(
@@ -10444,7 +10444,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "OtherUtilityTarget"),
                     ],
                     products: [
-                        MockProduct(name: "OtherUtilityProduct", targets: ["OtherUtilityTarget"]),
+                        MockProduct(name: "OtherUtilityProduct", modules: ["OtherUtilityTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10493,7 +10493,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooUtilityTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooUtilityProduct", targets: ["FooUtilityTarget"]),
+                        MockProduct(name: "FooUtilityProduct", modules: ["FooUtilityTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10506,7 +10506,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "other-foo/utility", requirement: .upToNextMajor(from: "1.0.0")),
@@ -10521,7 +10521,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "OtherUtilityTarget"),
                     ],
                     products: [
-                        MockProduct(name: "OtherUtilityProduct", targets: ["OtherUtilityTarget"]),
+                        MockProduct(name: "OtherUtilityProduct", modules: ["OtherUtilityTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10578,7 +10578,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10591,7 +10591,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -10609,7 +10609,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10656,7 +10656,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10669,7 +10669,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "http://github.com/foo/foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -10684,7 +10684,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10731,7 +10731,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10744,7 +10744,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "git@github.com:foo/foo.git", requirement: .upToNextMajor(from: "1.0.0")),
@@ -10759,7 +10759,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10806,7 +10806,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10819,7 +10819,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -10837,7 +10837,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10884,7 +10884,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10897,7 +10897,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -10915,7 +10915,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10977,7 +10977,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -10991,7 +10991,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -11009,7 +11009,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BazTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BazProduct", targets: ["BazTarget"]),
+                        MockProduct(name: "BazProduct", modules: ["BazTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11021,7 +11021,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11033,7 +11033,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BazTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BazProduct", targets: ["BazTarget"]),
+                        MockProduct(name: "BazProduct", modules: ["BazTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11092,7 +11092,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "FooUtilityProduct", targets: ["FooUtilityTarget"]),
+                        MockProduct(name: "FooUtilityProduct", modules: ["FooUtilityTarget"]),
                     ],
                     dependencies: [
                         .sourceControlWithDeprecatedName(
@@ -11112,7 +11112,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControlWithDeprecatedName(
@@ -11131,7 +11131,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "OtherUtilityTarget"),
                     ],
                     products: [
-                        MockProduct(name: "OtherUtilityProduct", targets: ["OtherUtilityTarget"]),
+                        MockProduct(name: "OtherUtilityProduct", modules: ["OtherUtilityTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11182,7 +11182,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "FooUtilityProduct", targets: ["FooUtilityTarget"]),
+                        MockProduct(name: "FooUtilityProduct", modules: ["FooUtilityTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "bar", requirement: .upToNextMajor(from: "1.0.0")),
@@ -11199,7 +11199,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(path: "other/utility", requirement: .upToNextMajor(from: "1.0.0")),
@@ -11215,7 +11215,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "OtherUtilityTarget"),
                     ],
                     products: [
-                        MockProduct(name: "OtherUtilityProduct", targets: ["OtherUtilityTarget"]),
+                        MockProduct(name: "OtherUtilityProduct", modules: ["OtherUtilityTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11271,7 +11271,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControlWithDeprecatedName(
@@ -11290,7 +11290,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11352,7 +11352,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -11369,7 +11369,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11382,7 +11382,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BazProduct", targets: ["BazTarget"]),
+                        MockProduct(name: "BazProduct", modules: ["BazTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -11399,7 +11399,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11412,7 +11412,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "QuxProduct", targets: ["QuxTarget"]),
+                        MockProduct(name: "QuxProduct", modules: ["QuxTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -11429,7 +11429,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11506,7 +11506,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11519,7 +11519,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -11536,7 +11536,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11549,7 +11549,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BazProduct", targets: ["BazTarget"]),
+                        MockProduct(name: "BazProduct", modules: ["BazTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -11566,7 +11566,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -11652,7 +11652,7 @@ final class WorkspaceTests: XCTestCase {
                          MockTarget(name: "FooTarget"),
                      ],
                      products: [
-                         MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                         MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                      ],
                      versions: ["1.0.0", "1.1.0"],
                      revisionProvider: { _ in "foo" } // we need this to be consistent for fingerprints check to work
@@ -11664,7 +11664,7 @@ final class WorkspaceTests: XCTestCase {
                          MockTarget(name: "FooTarget"),
                      ],
                      products: [
-                         MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                         MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                      ],
                      versions: ["1.0.0", "1.1.0"],
                      revisionProvider: { _ in "foo" } // we need this to be consistent for fingerprints check to work
@@ -11678,7 +11678,7 @@ final class WorkspaceTests: XCTestCase {
                          ]),
                      ],
                      products: [
-                         MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                         MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                      ],
                      dependencies: [
                          .sourceControl(
@@ -11698,7 +11698,7 @@ final class WorkspaceTests: XCTestCase {
                          ]),
                      ],
                      products: [
-                         MockProduct(name: "BazProduct", targets: ["BazTarget"]),
+                         MockProduct(name: "BazProduct", modules: ["BazTarget"]),
                      ],
                      dependencies: [
                          .sourceControl(
@@ -11803,7 +11803,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"],
                     revisionProvider: { _ in "foo" } // we need this to be consistent for fingerprints check to work
@@ -11815,7 +11815,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"],
                     revisionProvider: { _ in "foo" } // we need this to be consistent for fingerprints check to work
@@ -11918,7 +11918,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"],
                     revisionProvider: { _ in "foo" } // we need this to be consistent for fingerprints check to work
@@ -11932,7 +11932,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -11949,7 +11949,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"],
                     revisionProvider: { _ in "foo" } // we need this to be consistent for fingerprints check to work
@@ -11961,7 +11961,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"],
                     revisionProvider: { _ in "foo" } // we need this to be consistent for fingerprints check to work
@@ -12039,7 +12039,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        .init(name: "Root1Product", targets: ["Root1Target"])
+                        .init(name: "Root1Product", modules: ["Root1Target"])
                     ],
                     dependencies: [
                         .sourceControl(
@@ -12057,7 +12057,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        .init(name: "Root2Product", targets: ["Root2Target"])
+                        .init(name: "Root2Product", modules: ["Root2Target"])
                     ],
                     dependencies: [
                         .sourceControl(
@@ -12077,7 +12077,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        .init(name: "FooProduct", targets: ["FooTarget"]),
+                        .init(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -12096,7 +12096,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        .init(name: "BarProduct", targets: ["BarTarget"]),
+                        .init(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -12115,7 +12115,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        .init(name: "BazProduct", targets: ["BazTarget"]),
+                        .init(name: "BazProduct", modules: ["BazTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(
@@ -12170,7 +12170,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "experiment"]
                 ),
@@ -12183,7 +12183,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "http://localhost/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12198,7 +12198,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Root")
                 result.check(packages: "BarPackage", "FooPackage", "Root")
-                result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                 result.checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
             }
         }
@@ -12375,7 +12375,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
+                        MockProduct(name: "MyProduct", modules: ["MyTarget1", "MyTarget2"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "http://localhost/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12391,7 +12391,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.5.1"]
                 ),
@@ -12402,7 +12402,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["2.0.0", "2.1.0", "2.2.0"]
                 ),
@@ -12414,7 +12414,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "MyPackage")
                 result.check(packages: "Bar", "Foo", "MyPackage")
-                result.check(targets: "Foo", "Bar", "MyTarget1", "MyTarget2")
+                result.check(modules: "Foo", "Bar", "MyTarget1", "MyTarget2")
                 result.checkTarget("MyTarget1") { result in result.check(dependencies: "Foo") }
                 result.checkTarget("MyTarget2") { result in result.check(dependencies: "Bar") }
             }
@@ -12481,7 +12481,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
+                        MockProduct(name: "MyProduct", modules: ["MyTarget1", "MyTarget2"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "http://localhost/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12502,7 +12502,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "http://localhost/org/baz", requirement: .range("2.0.0" ..< "4.0.0")),
@@ -12521,7 +12521,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "http://localhost/org/baz", requirement: .upToNextMajor(from: "3.0.0")),
@@ -12535,7 +12535,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "2.0.0", "2.1.0", "3.0.0", "3.1.0"]
                 ),
@@ -12547,7 +12547,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "MyPackage")
                 result.check(packages: "Bar", "Baz", "Foo", "MyPackage")
-                result.check(targets: "Foo", "Bar", "Baz", "MyTarget1", "MyTarget2")
+                result.check(modules: "Foo", "Bar", "Baz", "MyTarget1", "MyTarget2")
                 result.checkTarget("MyTarget1") { result in result.check(dependencies: "Foo") }
                 result.checkTarget("MyTarget2") { result in result.check(dependencies: "Bar") }
                 result.checkTarget("Foo") { result in result.check(dependencies: "Baz") }
@@ -12625,7 +12625,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
+                        MockProduct(name: "MyProduct", modules: ["MyTarget1", "MyTarget2"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12641,7 +12641,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.5.1"]
                 ),
@@ -12652,7 +12652,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["2.0.0", "2.1.0", "2.2.0"]
                 ),
@@ -12664,7 +12664,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "MyPackage")
                 result.check(packages: "Bar", "Foo", "MyPackage")
-                result.check(targets: "Foo", "Bar", "MyTarget1", "MyTarget2")
+                result.check(modules: "Foo", "Bar", "MyTarget1", "MyTarget2")
                 result.checkTarget("MyTarget1") { result in result.check(dependencies: "Foo") }
                 result.checkTarget("MyTarget2") { result in result.check(dependencies: "Bar") }
             }
@@ -12731,7 +12731,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
+                        MockProduct(name: "MyProduct", modules: ["MyTarget1", "MyTarget2"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -12752,7 +12752,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.baz", requirement: .range("2.0.0" ..< "4.0.0")),
@@ -12771,7 +12771,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.baz", requirement: .upToNextMajor(from: "3.0.0")),
@@ -12785,7 +12785,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "2.0.0", "2.1.0", "3.0.0", "3.1.0"]
                 ),
@@ -12797,7 +12797,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "MyPackage")
                 result.check(packages: "Bar", "Baz", "Foo", "MyPackage")
-                result.check(targets: "Foo", "Bar", "Baz", "MyTarget1", "MyTarget2")
+                result.check(modules: "Foo", "Bar", "Baz", "MyTarget1", "MyTarget2")
                 result.checkTarget("MyTarget1") { result in result.check(dependencies: "Foo") }
                 result.checkTarget("MyTarget2") { result in result.check(dependencies: "Bar") }
                 result.checkTarget("Foo") { result in result.check(dependencies: "Baz") }
@@ -12884,7 +12884,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0"]
                 ),
@@ -12895,7 +12895,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0"]
                 ),
@@ -12907,7 +12907,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0"]
                 ),
@@ -12922,7 +12922,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -12945,7 +12945,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -12968,7 +12968,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -13014,7 +13014,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -13026,7 +13026,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -13111,7 +13111,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "2.0.0", "2.1.0"]
                 ),
@@ -13124,7 +13124,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -13139,7 +13139,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "2.0.0", "2.1.0"]
                 ),
@@ -13179,7 +13179,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -13203,7 +13203,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -13226,7 +13226,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -13274,7 +13274,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0"]
                 ),
@@ -13287,7 +13287,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.2.0")),
@@ -13302,7 +13302,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0"]
                 ),
@@ -13341,7 +13341,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -13364,7 +13364,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -13412,7 +13412,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -13425,7 +13425,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "2.0.0")),
@@ -13440,7 +13440,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -13538,7 +13538,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0"]
                 ),
@@ -13551,7 +13551,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://git/org/foo", requirement: .upToNextMajor(from: "1.2.0")),
@@ -13565,7 +13565,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0"]
                 ),
@@ -13612,7 +13612,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -13635,7 +13635,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -13684,7 +13684,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -13697,7 +13697,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://git/org/foo", requirement: .upToNextMajor(from: "2.0.0")),
@@ -13711,7 +13711,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -13810,7 +13810,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://git/org/baz", requirement: .upToNextMajor(from: "1.1.0")),
@@ -13826,7 +13826,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.baz", requirement: .upToNextMajor(from: "1.0.0")),
@@ -13840,7 +13840,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BazTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BazProduct", targets: ["BazTarget"]),
+                        MockProduct(name: "BazProduct", modules: ["BazTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0"]
                 ),
@@ -13852,7 +13852,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BazTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BazProduct", targets: ["BazTarget"]),
+                        MockProduct(name: "BazProduct", modules: ["BazTarget"]),
                     ],
                     versions: ["1.0.0", "1.1.0"]
                 ),
@@ -13899,7 +13899,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "BazPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "BazTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "BazTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                     if ToolsVersion.current < .v5_8 {
@@ -13927,7 +13927,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "BazPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "BazTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "BazTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                     result.checkTarget("FooTarget") { result in result.check(dependencies: "BazProduct") }
@@ -13980,7 +13980,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     dependencies: [
                         .sourceControl(url: "https://git/org/baz", requirement: .upToNextMajor(from: "1.0.0")),
@@ -13996,7 +13996,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.baz", requirement: .upToNextMajor(from: "2.0.0")),
@@ -14010,7 +14010,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BazTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BazProduct", targets: ["BazTarget"]),
+                        MockProduct(name: "BazProduct", modules: ["BazTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14022,7 +14022,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BazTarget"),
                     ],
                     products: [
-                        MockProduct(name: "BazProduct", targets: ["BazTarget"]),
+                        MockProduct(name: "BazProduct", modules: ["BazTarget"]),
                     ],
                     versions: ["1.0.0", "2.0.0"]
                 ),
@@ -14119,7 +14119,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["experiment"]
                 ),
@@ -14132,7 +14132,7 @@ final class WorkspaceTests: XCTestCase {
                         ]),
                     ],
                     products: [
-                        MockProduct(name: "BarProduct", targets: ["BarTarget"]),
+                        MockProduct(name: "BarProduct", modules: ["BarTarget"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -14147,7 +14147,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "FooTarget"),
                     ],
                     products: [
-                        MockProduct(name: "FooProduct", targets: ["FooTarget"]),
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14186,7 +14186,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -14216,7 +14216,7 @@ final class WorkspaceTests: XCTestCase {
                 PackageGraphTester(graph) { result in
                     result.check(roots: "Root")
                     result.check(packages: "BarPackage", "FooPackage", "Root")
-                    result.check(targets: "FooTarget", "BarTarget", "RootTarget")
+                    result.check(modules: "FooTarget", "BarTarget", "RootTarget")
                     result
                         .checkTarget("RootTarget") { result in result.check(dependencies: "BarProduct", "FooProduct") }
                 }
@@ -14279,7 +14279,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "BarTests", dependencies: ["Bar"], type: .test),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo", "Bar"]),
+                        MockProduct(name: "Foo", modules: ["Foo", "Bar"]),
                     ],
                     dependencies: [
                         .sourceControl(url: bazURL, requirement: .upToNextMajor(from: "1.0.0")),
@@ -14294,7 +14294,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Baz"),
                     ],
                     products: [
-                        MockProduct(name: "Baz", targets: ["Baz"]),
+                        MockProduct(name: "Baz", modules: ["Baz"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14309,7 +14309,7 @@ final class WorkspaceTests: XCTestCase {
             PackageGraphTester(graph) { result in
                 result.check(roots: "Foo")
                 result.check(packages: "Baz", "Foo")
-                result.check(targets: "Bar", "Baz", "Foo")
+                result.check(modules: "Bar", "Baz", "Foo")
                 result.check(testModules: "BarTests")
                 result.checkTarget("Foo") { result in result.check(dependencies: "Bar") }
                 result.checkTarget("Bar") { result in result.check(dependencies: "Baz") }
@@ -14360,7 +14360,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14406,7 +14406,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14491,7 +14491,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14578,7 +14578,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14663,7 +14663,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14759,7 +14759,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14815,7 +14815,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "MyProduct", targets: ["MyTarget"]),
+                        MockProduct(name: "MyProduct", modules: ["MyTarget"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -14904,7 +14904,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0"]
                 ),
@@ -14951,7 +14951,7 @@ final class WorkspaceTests: XCTestCase {
                         ),
                     ],
                     products: [
-                        MockProduct(name: "MyProduct", targets: ["MyTarget1", "MyTarget2"]),
+                        MockProduct(name: "MyProduct", modules: ["MyTarget1", "MyTarget2"]),
                     ],
                     dependencies: [
                         .registry(identity: "org.foo", requirement: .upToNextMajor(from: "1.0.0")),
@@ -14968,7 +14968,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Foo"),
                     ],
                     products: [
-                        MockProduct(name: "Foo", targets: ["Foo"]),
+                        MockProduct(name: "Foo", modules: ["Foo"]),
                     ],
                     versions: ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.5.1"]
                 ),
@@ -14980,7 +14980,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["2.0.0", "2.1.0", "2.2.0"]
                 ),
@@ -14991,7 +14991,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["2.0.0", "2.1.0", "2.2.0"]
                 ),
@@ -15003,7 +15003,7 @@ final class WorkspaceTests: XCTestCase {
                         MockTarget(name: "Bar"),
                     ],
                     products: [
-                        MockProduct(name: "Bar", targets: ["Bar"]),
+                        MockProduct(name: "Bar", modules: ["Bar"]),
                     ],
                     versions: ["2.0.0", "2.1.0", "2.2.0"]
                 ),

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5742,12 +5742,12 @@ final class WorkspaceTests: XCTestCase {
         let barProducts: [MockProduct]
         #if ENABLE_TARGET_BASED_DEPENDENCY_RESOLUTION
         barProducts = [
-            MockProduct(name: "Bar", moduleBuilders: ["Bar"]),
-            MockProduct(name: "BarUnused", moduleBuilders: ["BarUnused"]),
+            MockProduct(name: "Bar", modules: ["Bar"]),
+            MockProduct(name: "BarUnused", modules: ["BarUnused"]),
         ]
         #else
         // Whether a product is being used does not affect dependency resolution in this case, so we omit the unused product.
-        barProducts = [MockProduct(name: "Bar", moduleBuilders: ["Bar"])]
+        barProducts = [MockProduct(name: "Bar", modules: ["Bar"])]
         #endif
 
         let workspace = try MockWorkspace(

--- a/Tests/XCBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/XCBuildSupportTests/PIFBuilderTests.swift
@@ -2431,7 +2431,7 @@ class PIFBuilderTests: XCTestCase {
         )
 
         let toolsVersion: ToolsVersion = if isPackageAccessModifierSupported { .v5_9 } else { .v5 }
-        let mainTargetType: TargetDescription.TargetType = if toolsVersion >= .v5_9 { .executable } else { .regular }
+        let mainTargetType: TargetDescription.TargetKind = if toolsVersion >= .v5_9 { .executable } else { .regular }
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadModulesGraph(
             fileSystem: fs,


### PR DESCRIPTION
Cleaning up `PackageGraph` and `Build` code naming inconsistencies after `ResolvedTarget` to `ResolvedModule` renaming. User-visible strings and symbols still reference it as "target", but at least it's easier to navigate for contributors. `public` symbols gained deprecation notices where this was possible and easy to add.