### PR TITLE
Remove unused options from `add-product` subcommand

### DIFF
--- a/Sources/Commands/PackageCommands/AddProduct.swift
+++ b/Sources/Commands/PackageCommands/AddProduct.swift
@@ -51,15 +51,6 @@ extension SwiftPackageCommand {
         )
         var targets: [String] = []
 
-        @Option(help: "The URL for a remote binary target")
-        var url: String?
-
-        @Option(help: "The path to a local binary target")
-        var path: String?
-
-        @Option(help: "The checksum for a remote binary target")
-        var checksum: String?
-
         func run(_ swiftCommandState: SwiftCommandState) throws {
             let workspace = try swiftCommandState.getActiveWorkspace()
 


### PR DESCRIPTION
Remove unused options from `add-product` subcommand.

### Motivation:

There are options (url, path, checksum) being used in the `add-product` subcommand that are not defined in [SE-0301 proposal](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0301-package-editing-commands.md#detailed-design).
I suspect these options were mistakenly implemented in `add-product` when they are actually used in the `add-target` subcommand. They appear in the command's help text but are not actually utilized, which could potentially confuse users. Therefore, I believe they should be removed to avoid misleading users.

Here is the current output of the `add-product` help:

```
OVERVIEW: Add a new product to the manifest

USAGE: swift package add-product <name> [--type <type>] [--targets <targets> ...] [--url <url>] [--path <path>] [--checksum <checksum>]

ARGUMENTS:
  <name>                  The name of the new product

OPTIONS:
  --type <type>           The type of target to add, which can be one of 'executable', 'library', 'static-library', 'dynamic-library', or 'plugin' (default:
                          library)
  --targets <targets>     A list of targets that are part of this product
  --url <url>             The URL for a remote binary target
  --path <path>           The path to a local binary target
  --checksum <checksum>   The checksum for a remote binary target
  --version               Show the version.
  -h, -help, --help       Show help information.
```

### Modifications:

Remove the `url`, `path`, and `checksum` options from the `add-product` subcommand.

### Result:

Here is the updated output of the `add-product` help:
The `url`, `path`, and `checksum` options have been removed from the help text.

```
OVERVIEW: Add a new product to the manifest

USAGE: swift package add-product <name> [--type <type>] [--targets <targets> ...]

ARGUMENTS:
  <name>                  The name of the new product

OPTIONS:
  --type <type>           The type of target to add, which can be one of 'executable', 'library', 'static-library', 'dynamic-library', or 'plugin' (default:
                          library)
  --targets <targets>     A list of targets that are part of this product
  --version               Show the version.
  -h, -help, --help       Show help information.
```
