### PR TITLE
[Traits] Add experimental flags to enable specific or all traits, disable default traits

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -213,7 +213,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                         // return the build description that's on disk.
                         let buildDescription = try BuildDescription.load(fileSystem: self.fileSystem, path: buildDescriptionPath)
 
-                        // We need to check that the build traits enabled for the cached build operation
+                        // We need to check that the build has same traits enabled for the cached build operation
                         // match otherwise we have to re-plan.
                         if buildDescription.traitConfiguration == self.traitConfiguration {
                             return buildDescription

--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -67,6 +67,9 @@ struct APIDiff: SwiftCommand {
             help: "One or more targets to include in the API comparison. If present, only the specified targets (and any products specified using `--products`) will be compared.")
     var targets: [String] = []
 
+    @OptionGroup(visibility: .hidden)
+    package var traits: TraitOptions
+
     @Option(name: .customLong("baseline-dir"),
             help: "The path to a directory used to store API baseline files. If unspecified, a temporary directory will be used.")
     var overrideBaselineDir: AbsolutePath?
@@ -83,7 +86,11 @@ struct APIDiff: SwiftCommand {
         let baselineRevision = try repository.resolveRevision(identifier: treeish)
 
         // We turn build manifest caching off because we need the build plan.
-        let buildSystem = try swiftCommandState.createBuildSystem(explicitBuildSystem: .native, cacheBuildManifest: false)
+        let buildSystem = try swiftCommandState.createBuildSystem(
+            explicitBuildSystem: .native,
+            traitConfiguration: .init(traitOptions: self.traits),
+            cacheBuildManifest: false
+        )
 
         let packageGraph = try buildSystem.getPackageGraph()
         let modulesToDiff = try determineModulesToDiff(

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -47,7 +47,12 @@ struct DumpSymbolGraph: SwiftCommand {
         // Build the current package.
         //
         // We turn build manifest caching off because we need the build plan.
-        let buildSystem = try swiftCommandState.createBuildSystem(explicitBuildSystem: .native, cacheBuildManifest: false)
+        let buildSystem = try swiftCommandState.createBuildSystem(
+            explicitBuildSystem: .native,
+            // We are enabling all traits for dumping the symbol graph.
+            traitConfiguration: .init(enableAllTraits: true),
+            cacheBuildManifest: false
+        )
         try buildSystem.build()
 
         // Configure the symbol graph extractor.

--- a/Sources/Commands/PackageCommands/InstalledPackages.swift
+++ b/Sources/Commands/PackageCommands/InstalledPackages.swift
@@ -80,7 +80,7 @@ extension SwiftPackageCommand {
                 throw StringError("\(productToInstall.name) is already installed at \(existingPkg.path)")
             }
 
-            try tool.createBuildSystem(explicitProduct: productToInstall.name)
+            try tool.createBuildSystem(explicitProduct: productToInstall.name, traitConfiguration: .init())
                 .build(subset: .product(productToInstall.name))
 
             let binPath = try tool.productsBuildParameters.buildPath.appending(component: productToInstall.name)

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -321,6 +321,7 @@ struct PluginCommand: SwiftCommand {
         // Build or bring up-to-date any executable host-side tools on which this plugin depends. Add them and any binary dependencies to the tool-names-to-path map.
         let buildSystem = try swiftCommandState.createBuildSystem(
             explicitBuildSystem: .native,
+            traitConfiguration: .init(),
             cacheBuildManifest: false,
             productsBuildParameters: swiftCommandState.productsBuildParameters,
             toolsBuildParameters: buildParameters,

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -93,7 +93,7 @@ struct SnippetCard: Card {
 
     func runExample() throws {
         print("Building '\(snippet.path)'\n")
-        let buildSystem = try swiftCommandState.createBuildSystem(explicitProduct: snippet.name)
+        let buildSystem = try swiftCommandState.createBuildSystem(explicitProduct: snippet.name, traitConfiguration: .init())
         try buildSystem.build(subset: .product(snippet.name))
         let executablePath = try swiftCommandState.productsBuildParameters.buildPath.appending(component: snippet.name)
         if let exampleTarget = try buildSystem.getPackageGraph().module(for: snippet.name, destination: .destination) {

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -97,6 +97,10 @@ struct BuildCommandOptions: ParsableArguments {
     @Option(help: "Build the specified product")
     var product: String?
 
+    /// Specifies the traits to build.
+    @OptionGroup(visibility: .hidden)
+    package var traits: TraitOptions
+
     /// If should link the Swift stdlib statically.
     @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically")
     public var shouldLinkStaticSwiftStdlib: Bool = false
@@ -140,7 +144,10 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
 
         if options.printManifestGraphviz {
             // FIXME: Doesn't seem ideal that we need an explicit build operation, but this concretely uses the `LLBuildManifest`.
-            guard let buildOperation = try swiftCommandState.createBuildSystem(explicitBuildSystem: .native) as? BuildOperation else {
+            guard let buildOperation = try swiftCommandState.createBuildSystem(
+                explicitBuildSystem: .native,
+                traitConfiguration: .init(traitOptions: self.options.traits)
+            ) as? BuildOperation else {
                 throw StringError("asked for native build system but did not get it")
             }
             let buildManifest = try buildOperation.getBuildManifest()
@@ -198,6 +205,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
     ) throws {
         let buildSystem = try swiftCommandState.createBuildSystem(
             explicitProduct: options.product,
+            traitConfiguration: .init(traitOptions: self.options.traits),
             shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib,
             productsBuildParameters: productsBuildParameters,
             toolsBuildParameters: toolsBuildParameters,

--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -83,6 +83,10 @@ struct RunCommandOptions: ParsableArguments {
     @Argument(help: "The executable to run", completion: .shellCommand("swift package completion-tool list-executables"))
     var executable: String?
 
+    /// Specifies the traits to build the product with.
+    @OptionGroup(visibility: .hidden)
+    package var traits: TraitOptions
+
     /// The arguments to pass to the executable.
     @Argument(parsing: .captureForPassthrough,
               help: "The arguments to pass to the executable")
@@ -130,6 +134,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
             // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the REPL. rdar://86112934
             let buildSystem = try swiftCommandState.createBuildSystem(
                 explicitBuildSystem: .native,
+                traitConfiguration: .init(traitOptions: self.options.traits),
                 cacheBuildManifest: false,
                 packageGraphLoader: graphLoader
             )
@@ -149,7 +154,10 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
 
         case .debugger:
             do {
-                let buildSystem = try swiftCommandState.createBuildSystem(explicitProduct: options.executable)
+                let buildSystem = try swiftCommandState.createBuildSystem(
+                    explicitProduct: options.executable,
+                    traitConfiguration: .init(traitOptions: self.options.traits)
+                )
                 let productName = try findProductName(in: buildSystem.getPackageGraph())
                 if options.shouldBuildTests {
                     try buildSystem.build(subset: .allIncludingTests)
@@ -191,7 +199,10 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
             }
 
             do {
-                let buildSystem = try swiftCommandState.createBuildSystem(explicitProduct: options.executable)
+                let buildSystem = try swiftCommandState.createBuildSystem(
+                    explicitProduct: options.executable,
+                    traitConfiguration: .init(traitOptions: self.options.traits)
+                )
                 let productName = try findProductName(in: buildSystem.getPackageGraph())
                 if options.shouldBuildTests {
                     try buildSystem.build(subset: .allIncludingTests)

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1377,6 +1377,8 @@ private func buildTestsIfNeeded(
     testProduct: String?
 ) throws -> [BuiltTestProduct] {
     let buildSystem = try swiftCommandState.createBuildSystem(
+        // TODO: Will support traits in test in a follow up PR
+        traitConfiguration: .init(),
         productsBuildParameters: productsBuildParameters,
         toolsBuildParameters: toolsBuildParameters
     )

--- a/Sources/Commands/Utilities/APIDigester.swift
+++ b/Sources/Commands/Utilities/APIDigester.swift
@@ -139,6 +139,7 @@ struct APIDigesterBaselineDumper {
         // FIXME: We need to implement the build tool invocation closure here so that build tool plugins work with the APIDigester. rdar://86112934
         let buildSystem = try swiftCommandState.createBuildSystem(
             explicitBuildSystem: .native,
+            traitConfiguration: .init(),
             cacheBuildManifest: false,
             productsBuildParameters: productsBuildParameters,
             toolsBuildParameters: toolsBuildParameters,

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -161,6 +161,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         let buildSystem = try swiftCommandState.createBuildSystem(
             explicitBuildSystem: .native,
             explicitProduct: explicitProduct,
+            traitConfiguration: .init(),
             cacheBuildManifest: false,
             productsBuildParameters: buildParameters,
             outputStream: outputStream,
@@ -223,7 +224,10 @@ final class PluginDelegate: PluginInvocationDelegate {
         var toolsBuildParameters = try swiftCommandState.toolsBuildParameters
         toolsBuildParameters.testingParameters.enableTestability = true
         toolsBuildParameters.testingParameters.enableCodeCoverage = parameters.enableCodeCoverage
-        let buildSystem = try swiftCommandState.createBuildSystem(toolsBuildParameters: toolsBuildParameters)
+        let buildSystem = try swiftCommandState.createBuildSystem(
+            traitConfiguration: .init(),
+            toolsBuildParameters: toolsBuildParameters
+        )
         try buildSystem.build(subset: .allIncludingTests)
 
         // Clean out the code coverage directory that may contain stale `profraw` files from a previous run of
@@ -381,7 +385,11 @@ final class PluginDelegate: PluginInvocationDelegate {
         // while building.
 
         // Create a build system for building the target., skipping the the cache because we need the build plan.
-        let buildSystem = try swiftCommandState.createBuildSystem(explicitBuildSystem: .native, cacheBuildManifest: false)
+        let buildSystem = try swiftCommandState.createBuildSystem(
+            explicitBuildSystem: .native,
+            traitConfiguration: .init(),
+            cacheBuildManifest: false
+        )
 
         // Find the target in the build operation's package graph; it's an error if we don't find it.
         let packageGraph = try buildSystem.getPackageGraph()

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -13,6 +13,7 @@
 import Build
 import SPMBuildCore
 import XCBuildSupport
+import PackageGraph
 
 import class Basics.ObservabilityScope
 import struct PackageGraph.ModulesGraph
@@ -24,6 +25,7 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
 
     func makeBuildSystem(
         explicitProduct: String?,
+        traitConfiguration: TraitConfiguration,
         cacheBuildManifest: Bool,
         productsBuildParameters: BuildParameters?,
         toolsBuildParameters: BuildParameters?,
@@ -41,6 +43,7 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
             packageGraphLoader: packageGraphLoader ?? {
                 try self.swiftCommandState.loadPackageGraph(
                     explicitProduct: explicitProduct,
+                    traitConfiguration: traitConfiguration,
                     testEntryPointPath: testEntryPointPath
                 )
             },
@@ -50,6 +53,7 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
                 disableSandbox: self.swiftCommandState.shouldDisableSandbox
             ),
             scratchDirectory: self.swiftCommandState.scratchDirectory,
+            traitConfiguration: traitConfiguration,
             additionalFileRules: FileRuleDescription.swiftpmFileTypes,
             pkgConfigDirectories: self.swiftCommandState.options.locations.pkgConfigDirectories,
             dependenciesByRootPackageIdentity: rootPackageInfo.dependencies,
@@ -66,6 +70,7 @@ private struct XcodeBuildSystemFactory: BuildSystemFactory {
 
     func makeBuildSystem(
         explicitProduct: String?,
+        traitConfiguration: TraitConfiguration,
         cacheBuildManifest: Bool,
         productsBuildParameters: BuildParameters?,
         toolsBuildParameters: BuildParameters?,

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -615,6 +615,24 @@ public final class SwiftCommandState {
         explicitProduct: String? = nil,
         testEntryPointPath: AbsolutePath? = nil
     ) throws -> ModulesGraph {
+        try self.loadPackageGraph(
+            explicitProduct: explicitProduct,
+            traitConfiguration: nil,
+            testEntryPointPath: testEntryPointPath
+        )
+    }
+
+    /// Fetch and load the complete package graph.
+    ///
+    /// - Parameters:
+    ///   - explicitProduct: The product specified on the command line to a “swift run” or “swift build” command. This
+    /// allows executables from dependencies to be run directly without having to hook them up to any particular target.
+    @discardableResult
+    package func loadPackageGraph(
+        explicitProduct: String? = nil,
+        traitConfiguration: TraitConfiguration? = nil,
+        testEntryPointPath: AbsolutePath? = nil
+    ) throws -> ModulesGraph {
         do {
             let workspace = try getActiveWorkspace()
 
@@ -622,6 +640,7 @@ public final class SwiftCommandState {
             let graph = try workspace.loadPackageGraph(
                 rootInput: getWorkspaceRoot(),
                 explicitProduct: explicitProduct,
+                traitConfiguration: traitConfiguration,
                 forceResolvedVersions: options.resolver.forceResolvedVersions,
                 testEntryPointPath: testEntryPointPath,
                 observabilityScope: self.observabilityScope
@@ -699,6 +718,7 @@ public final class SwiftCommandState {
     public func createBuildSystem(
         explicitBuildSystem: BuildSystemProvider.Kind? = .none,
         explicitProduct: String? = .none,
+        traitConfiguration: TraitConfiguration,
         cacheBuildManifest: Bool = true,
         shouldLinkStaticSwiftStdlib: Bool = false,
         productsBuildParameters: BuildParameters? = .none,
@@ -718,6 +738,7 @@ public final class SwiftCommandState {
         let buildSystem = try buildSystemProvider.createBuildSystem(
             kind: explicitBuildSystem ?? options.build.buildSystem,
             explicitProduct: explicitProduct,
+            traitConfiguration: traitConfiguration,
             cacheBuildManifest: cacheBuildManifest,
             productsBuildParameters: productsParameters,
             toolsBuildParameters: toolsBuildParameters,

--- a/Sources/PackageGraph/CMakeLists.txt
+++ b/Sources/PackageGraph/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(PackageGraph
   PackageModel+Extensions.swift
   PackageRequirement.swift
   PinsStore.swift
+  TraitConfiguration.swift
   Resolution/PubGrub/Assignment.swift
   Resolution/PubGrub/ContainerProvider.swift
   Resolution/PubGrub/DiagnosticReportBuilder.swift

--- a/Sources/PackageGraph/TraitConfiguration.swift
+++ b/Sources/PackageGraph/TraitConfiguration.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The trait configuration.
+public struct TraitConfiguration: Codable, Hashable {
+    /// The traits to enable for the package.
+    package var enabledTraits: Set<String>?
+
+    /// Enables all traits of the package.
+    package var enableAllTraits: Bool
+
+    package init(
+        enabledTraits: Set<String>? = nil,
+        enableAllTraits: Bool = false
+    ) {
+        self.enabledTraits = enabledTraits
+        self.enableAllTraits = enableAllTraits
+    }
+}

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -101,6 +101,7 @@ public protocol BuildPlan {
 public protocol BuildSystemFactory {
     func makeBuildSystem(
         explicitProduct: String?,
+        traitConfiguration: TraitConfiguration,
         cacheBuildManifest: Bool,
         productsBuildParameters: BuildParameters?,
         toolsBuildParameters: BuildParameters?,
@@ -127,6 +128,7 @@ public struct BuildSystemProvider {
     public func createBuildSystem(
         kind: Kind,
         explicitProduct: String? = .none,
+        traitConfiguration: TraitConfiguration,
         cacheBuildManifest: Bool = true,
         productsBuildParameters: BuildParameters? = .none,
         toolsBuildParameters: BuildParameters? = .none,
@@ -140,6 +142,7 @@ public struct BuildSystemProvider {
         }
         return try buildSystemFactory.makeBuildSystem(
             explicitProduct: explicitProduct,
+            traitConfiguration: traitConfiguration,
             cacheBuildManifest: cacheBuildManifest,
             productsBuildParameters: productsBuildParameters,
             toolsBuildParameters: toolsBuildParameters,

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -891,6 +891,29 @@ extension Workspace {
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
         observabilityScope: ObservabilityScope
     ) throws -> ModulesGraph {
+        try self.loadPackageGraph(
+            rootInput: root,
+            explicitProduct: explicitProduct,
+            traitConfiguration: nil,
+            forceResolvedVersions: forceResolvedVersions,
+            customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
+            testEntryPointPath: testEntryPointPath,
+            expectedSigningEntities: expectedSigningEntities,
+            observabilityScope: observabilityScope
+        )
+    }
+
+    @discardableResult
+    package func loadPackageGraph(
+        rootInput root: PackageGraphRootInput,
+        explicitProduct: String? = nil,
+        traitConfiguration: TraitConfiguration? = nil,
+        forceResolvedVersions: Bool = false,
+        customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
+        testEntryPointPath: AbsolutePath? = nil,
+        expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
+        observabilityScope: ObservabilityScope
+    ) throws -> ModulesGraph {
         let start = DispatchTime.now()
         self.delegate?.willLoadGraph()
         defer {
@@ -931,6 +954,7 @@ extension Workspace {
             binaryArtifacts: binaryArtifacts,
             shouldCreateMultipleTestProducts: self.configuration.shouldCreateMultipleTestProducts,
             createREPLProduct: self.configuration.createREPLProduct,
+            traitConfiguration: traitConfiguration,
             customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
             testEntryPointPath: testEntryPointPath,
             fileSystem: self.fileSystem,
@@ -952,8 +976,24 @@ extension Workspace {
         observabilityScope: ObservabilityScope
     ) throws -> ModulesGraph {
         try self.loadPackageGraph(
+            rootPath: rootPath,
+            explicitProduct: explicitProduct,
+            traitConfiguration: nil,
+            observabilityScope: observabilityScope
+        )
+    }
+
+    @discardableResult
+    package func loadPackageGraph(
+        rootPath: AbsolutePath,
+        explicitProduct: String? = nil,
+        traitConfiguration: TraitConfiguration? = nil,
+        observabilityScope: ObservabilityScope
+    ) throws -> ModulesGraph {
+        try self.loadPackageGraph(
             rootInput: PackageGraphRootInput(packages: [rootPath]),
             explicitProduct: explicitProduct,
+            traitConfiguration: traitConfiguration,
             observabilityScope: observabilityScope
         )
     }

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -324,6 +324,8 @@ struct SwiftBootstrapBuildTool: ParsableCommand {
                     cacheBuildManifest: false,
                     packageGraphLoader: packageGraphLoader,
                     scratchDirectory: scratchDirectory,
+                    // When bootrapping no special trait build configuration is used
+                    traitConfiguration: nil,
                     additionalFileRules: [],
                     pkgConfigDirectories: [],
                     dependenciesByRootPackageIdentity: [:],

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -31,5 +31,136 @@ final class TraitTests: XCTestCase {
             """)
         }
     }
+
+    func testTraits_whenTraitUnification() throws {
+        try fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "defaults,Package9,Package10"])
+            XCTAssertEqual(stdout, """
+            Package1Library1 trait1 enabled
+            Package2Library1 trait2 enabled
+            Package3Library1 trait3 enabled
+            Package4Library1 trait1 disabled
+            Package10Library1 trait1 enabled
+            Package10Library1 trait2 enabled
+            Package10Library1 trait1 enabled
+            Package10Library1 trait2 enabled
+            DEFINE1 enabled
+            DEFINE2 disabled
+            DEFINE3 disabled
+
+            """)
+        }
+    }
+
+    func testTraits_whenTraitUnification_whenSecondTraitNotEnabled() throws {
+        try fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "defaults,Package9"])
+            XCTAssertEqual(stdout, """
+            Package1Library1 trait1 enabled
+            Package2Library1 trait2 enabled
+            Package3Library1 trait3 enabled
+            Package4Library1 trait1 disabled
+            Package10Library1 trait1 enabled
+            Package10Library1 trait2 enabled
+            DEFINE1 enabled
+            DEFINE2 disabled
+            DEFINE3 disabled
+
+            """)
+        }
+    }
+
+    func testTraits_whenIndividualTraitsEnabled_andDefaultTraits() throws {
+        try fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "defaults,Package5,Package7,BuildCondition3"])
+            XCTAssertEqual(stdout, """
+            Package1Library1 trait1 enabled
+            Package2Library1 trait2 enabled
+            Package3Library1 trait3 enabled
+            Package4Library1 trait1 disabled
+            Package5Library1 trait1 enabled
+            Package6Library1 trait1 enabled
+            Package7Library1 trait1 disabled
+            DEFINE1 enabled
+            DEFINE2 disabled
+            DEFINE3 enabled
+
+            """)
+        }
+    }
+
+    func testTraits_whenDefaultTraitsDisabled() throws {
+        try fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-disable-default-traits"])
+            XCTAssertEqual(stdout, """
+            DEFINE1 disabled
+            DEFINE2 disabled
+            DEFINE3 disabled
+
+            """)
+        }
+    }
+
+    func testTraits_whenIndividualTraitsEnabled_andDefaultTraitsDisabled() throws {
+        try fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-traits", "Package5,Package7"])
+            XCTAssertEqual(stdout, """
+            Package5Library1 trait1 enabled
+            Package6Library1 trait1 enabled
+            Package7Library1 trait1 disabled
+            DEFINE1 disabled
+            DEFINE2 disabled
+            DEFINE3 disabled
+
+            """)
+        }
+    }
+
+    func testTraits_whenAllTraitsEnabled() throws {
+        try fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-enable-all-traits"])
+            XCTAssertEqual(stdout, """
+            Package1Library1 trait1 enabled
+            Package2Library1 trait2 enabled
+            Package3Library1 trait3 enabled
+            Package4Library1 trait1 disabled
+            Package5Library1 trait1 enabled
+            Package6Library1 trait1 enabled
+            Package7Library1 trait1 disabled
+            Package10Library1 trait1 enabled
+            Package10Library1 trait2 enabled
+            Package10Library1 trait1 enabled
+            Package10Library1 trait2 enabled
+            DEFINE1 enabled
+            DEFINE2 enabled
+            DEFINE3 enabled
+
+            """)
+        }
+    }
+
+    func testTraits_whenAllTraitsEnabled_andDefaultTraitsDisabled() throws {
+        try fixture(name: "Traits") { fixturePath in
+            let (stdout, _) = try executeSwiftRun(fixturePath.appending("Example"), "Example", extraArgs: ["--experimental-enable-all-traits", "--experimental-disable-default-traits"])
+            XCTAssertEqual(stdout, """
+            Package1Library1 trait1 enabled
+            Package2Library1 trait2 enabled
+            Package3Library1 trait3 enabled
+            Package4Library1 trait1 disabled
+            Package5Library1 trait1 enabled
+            Package6Library1 trait1 enabled
+            Package7Library1 trait1 disabled
+            Package10Library1 trait1 enabled
+            Package10Library1 trait2 enabled
+            Package10Library1 trait1 enabled
+            Package10Library1 trait2 enabled
+            DEFINE1 enabled
+            DEFINE2 enabled
+            DEFINE3 enabled
+
+            """)
+        }
+    }
+
 }
 #endif


### PR DESCRIPTION
# Motivation
When building, testing or running a root package we want users to be able to change the traits enabled in the packages. This allows them to build binaries with different traits enabled or run tests with different traits.

# Modification
This PR adds trait options to a few commands and wires them through to the ModuleGraph loading and the build description caching. The latter is important to trigger rebuilds when the trait configuration has changed. Along the way I refactored the `GraphLoadingNode` and externalised the logic to calculate traits since I need slightly different logic for the root nodes and for the dependency nodes.

# Result
`swift build/run` now support passing trait configuration.
