### PR TITLE
Fix build of host&target destination products with `--static-swift-stdlib`

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -66,7 +66,8 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
     /// Path to the temporary directory for this product.
     var tempsPath: AbsolutePath {
-        self.buildParameters.buildPath.appending(component: self.product.name + ".product")
+        let suffix = buildParameters.suffix
+        return self.buildParameters.buildPath.appending(component: "\(self.product.name)\(suffix).product")
     }
 
     /// Path to the link filelist file.

--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -218,5 +218,7 @@ final class LLBuildManifestBuilderTests: XCTestCase {
         let manifest = try builder.generateManifest(at: "/manifest")
 
         XCTAssertNotNil(manifest.commands["C.SwiftSyntax-aarch64-unknown-linux-gnu-debug-tool.module"])
+        // Ensure that Objects.LinkFileList is -tool suffixed.
+        XCTAssertNotNil(manifest.commands["/path/to/build/aarch64-unknown-linux-gnu/debug/MMIOMacros-tool.product/Objects.LinkFileList"])
     }
 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1574,6 +1574,14 @@ final class PackageCommandTests: CommandsTestCase {
     }
 
     func testBuildToolPlugin() async throws {
+        try await testBuildToolPlugin(staticStdlib: false)
+    }
+
+    func testBuildToolPluginWithStaticStdlib() async throws {
+        try await testBuildToolPlugin(staticStdlib: true)
+    }
+
+    func testBuildToolPlugin(staticStdlib: Bool) async throws {
         // Only run the test if the environment in which we're running actually supports Swift concurrency (which the plugin APIs require).
         try XCTSkipIf(!UserToolchain.default.supportsSwiftConcurrency(), "skipping because test environment doesn't support concurrency")
 
@@ -1647,7 +1655,8 @@ final class PackageCommandTests: CommandsTestCase {
             )
 
             // Invoke it, and check the results.
-            let (stdout, stderr) = try await SwiftPM.Build.execute(packagePath: packageDir)
+            let args = staticStdlib ? ["--static-swift-stdlib"] : []
+            let (stdout, stderr) = try await SwiftPM.Build.execute(args, packagePath: packageDir)
             XCTAssert(stdout.contains("Build complete!"))
 
             // We expect a warning about `library.bar` but not about `library.foo`.

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1578,6 +1578,22 @@ final class PackageCommandTests: CommandsTestCase {
     }
 
     func testBuildToolPluginWithStaticStdlib() async throws {
+        // Skip if the toolchain cannot compile a simple program with static stdlib.
+        do {
+            let args = try [
+                UserToolchain.default.swiftCompilerPath.pathString,
+                "-static-stdlib", "-emit-executable", "-o", "/dev/null", "-"
+            ]
+            let process = AsyncProcess(arguments: args)
+            let stdin = try process.launch()
+            stdin.write(sequence: "".utf8)
+            try stdin.close()
+            let result = try await process.waitUntilExit()
+            try XCTSkipIf(
+                result.exitStatus != .terminated(code: 0),
+                "skipping because static stdlib is not supported by the toolchain"
+            )
+        }
         try await testBuildToolPlugin(staticStdlib: true)
     }
 


### PR DESCRIPTION
### Motivation:

Given the following conditions:
- `--static-swift-stdlib` is enabled (it only affects "target" destination products, "host" destination products are always dynamic)
- the building subset contains both "host" and "target" destination products derived from the same product.
- the product imports `Foundation` (that has private dependency libs)

then the build randomly failed due to the race condition of the Objects.LinkFileList creation.

Reproducible project https://github.com/kateinoigakukun/swift-autolink-issue-repro

### Modifications:

This commit fixes the issue by distinguishing the temporary link file list response file name by the `-tool` suffix.

I think it would be better to add assertions in `LLBuildManifest` to avoid such unintentional target overwrites later.

### Result:

Fix the build for the above case.