### PR TITLE
[Traits] Encode all trait information for package dump

### DIFF
--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -524,7 +524,7 @@ extension Manifest: Encodable {
     private enum CodingKeys: CodingKey {
         case name, path, url, version, targetMap, toolsVersion,
              pkgConfig, providers, cLanguageStandard, cxxLanguageStandard, swiftLanguageVersions,
-             dependencies, products, targets, platforms, packageKind, revision,
+             dependencies, products, targets, experimentalTraits, platforms, packageKind, revision,
              defaultLocalization
     }
 
@@ -555,6 +555,7 @@ extension Manifest: Encodable {
         try container.encode(self.dependencies, forKey: .dependencies)
         try container.encode(self.products, forKey: .products)
         try container.encode(self.targets, forKey: .targets)
+        try container.encode(self.traits, forKey: .experimentalTraits)
         try container.encode(self.platforms, forKey: .platforms)
         try container.encode(self.packageKind, forKey: .packageKind)
     }

--- a/Sources/PackageModel/Manifest/TraitDescription.swift
+++ b/Sources/PackageModel/Manifest/TraitDescription.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct TraitDescription: Sendable, Hashable, ExpressibleByStringLiteral {
+public struct TraitDescription: Sendable, Hashable, Codable, ExpressibleByStringLiteral {
     /// The trait's canonical name.
     ///
     /// This is used when enabling the trait or when referring to it from other modifiers in the manifest.

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -13,6 +13,7 @@
 import DriverSupport
 import SPMTestSupport
 import PackageModel
+import TSCBasic
 import XCTest
 
 final class TraitTests: XCTestCase {
@@ -161,5 +162,17 @@ final class TraitTests: XCTestCase {
             """)
         }
     }
+
+    func testTraits_dumpPackage() async throws {
+        try await fixture(name: "Traits") { fixturePath in
+            let packageRoot = fixturePath.appending("Example")
+            let (dumpOutput, _) = try await SwiftPM.Package.execute(["dump-package"], packagePath: packageRoot)
+            let json = try JSON(bytes: ByteString(encodingAsUTF8: dumpOutput))
+            guard case let .dictionary(contents) = json else { XCTFail("unexpected result"); return }
+            guard case let .array(traits)? = contents["experimentalTraits"] else { XCTFail("unexpected result"); return }
+            XCTAssertEqual(traits.count, 11)
+        }
+    }
+
 }
 #endif


### PR DESCRIPTION
# Motivation

We need to encode all trait related package manifest configuration so that it shows up in the `dump-package` output.

# Modification

This PR encodes the missing `traits` property of the manifest.