### PR TITLE
Add -F flag for xcframework dependency

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "FooKit",
+    products: [
+        .library(name: "FooKit", type: .dynamic, targets: ["FooKit"]),
+    ],
+    targets: [
+        .target(name: "FooKit"),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Scripts/archive_xcframework.sh
+++ b/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Scripts/archive_xcframework.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See http://swift.org/LICENSE.txt for license information
+## See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+##===----------------------------------------------------------------------===##
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd -P)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd $PROJECT_ROOT
+
+PROJECT_BUILD_DIR="${PROJECT_BUILD_DIR:-"${PROJECT_ROOT}/.build"}"
+XCODEBUILD_BUILD_DIR="$PROJECT_BUILD_DIR/xcodebuild"
+XCODEBUILD_DERIVED_DATA_PATH="$XCODEBUILD_BUILD_DIR/DerivedData"
+
+PACKAGE_NAME=$1
+if [ -z "$PACKAGE_NAME" ]; then
+    echo "No package name provided. Using the first scheme found in the Package.swift."
+    PACKAGE_NAME=$(xcodebuild -list | awk 'schemes && NF>0 { print $1; exit } /Schemes:$/ { schemes = 1 }')
+    echo "Using: $PACKAGE_NAME"
+fi
+
+build_framework() {
+    local sdk="$1"
+    local destination="$2"
+    local scheme="$3"
+
+    local XCODEBUILD_ARCHIVE_PATH="$PROJECT_BUILD_DIR/$scheme-$sdk.xcarchive"
+
+    rm -rf "$XCODEBUILD_ARCHIVE_PATH"
+
+    PROTOBUFKIT_LIBRARY_TYPE=dynamic xcodebuild archive \
+        -scheme $scheme \
+        -archivePath $XCODEBUILD_ARCHIVE_PATH \
+        -derivedDataPath "$XCODEBUILD_DERIVED_DATA_PATH" \
+        -sdk "$sdk" \
+        -destination "$destination" \
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+        INSTALL_PATH='Library/Frameworks' \
+        OTHER_SWIFT_FLAGS=-no-verify-emitted-module-interface
+
+    if [ "$sdk" = "macosx" ]; then
+        FRAMEWORK_MODULES_PATH="$XCODEBUILD_ARCHIVE_PATH/Products/Library/Frameworks/$scheme.framework/Versions/Current/Modules"
+        mkdir -p "$FRAMEWORK_MODULES_PATH"
+        cp -r \
+        "$XCODEBUILD_DERIVED_DATA_PATH/Build/Intermediates.noindex/ArchiveIntermediates/$scheme/BuildProductsPath/Release/$scheme.swiftmodule" \
+        "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule"
+        rm -rf "$XCODEBUILD_ARCHIVE_PATH/Products/Library/Frameworks/$scheme.framework/Modules"
+        ln -s Versions/Current/Modules "$XCODEBUILD_ARCHIVE_PATH/Products/Library/Frameworks/$scheme.framework/Modules"
+    else
+        FRAMEWORK_MODULES_PATH="$XCODEBUILD_ARCHIVE_PATH/Products/Library/Frameworks/$scheme.framework/Modules"
+        mkdir -p "$FRAMEWORK_MODULES_PATH"
+        cp -r \
+        "$XCODEBUILD_DERIVED_DATA_PATH/Build/Intermediates.noindex/ArchiveIntermediates/$scheme/BuildProductsPath/Release-$sdk/$scheme.swiftmodule" \
+        "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule"
+    fi
+
+    # Delete private and package swiftinterface
+    rm -f "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule/*.package.swiftinterface"
+    rm -f "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule/*.private.swiftinterface"
+}
+
+build_framework "macosx" "generic/platform=macOS" "$PACKAGE_NAME"
+
+echo "Builds completed successfully."
+
+cd $PROJECT_BUILD_DIR
+
+XCFRAMEWORK_DESTINATION="$PROJECT_ROOT/../$PACKAGE_NAME.xcframework"
+
+rm -rf $XCFRAMEWORK_DESTINATION
+xcodebuild -create-xcframework  \
+    -framework $PACKAGE_NAME-macosx.xcarchive/Products/Library/Frameworks/$PACKAGE_NAME.framework \
+    -output $XCFRAMEWORK_DESTINATION

--- a/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Scripts/archive_xcframework.sh
+++ b/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Scripts/archive_xcframework.sh
@@ -22,14 +22,17 @@ PROJECT_BUILD_DIR="${PROJECT_BUILD_DIR:-"${PROJECT_ROOT}/.build"}"
 XCODEBUILD_BUILD_DIR="$PROJECT_BUILD_DIR/xcodebuild"
 XCODEBUILD_DERIVED_DATA_PATH="$XCODEBUILD_BUILD_DIR/DerivedData"
 
-# SwiftPM CI runs tests with SWIFT_EXEC pointing at the just-built compiler. Do not let xcodebuild
-# inherit those overrides while resolving this fixture package; it should use the selected Xcode
-# toolchain to create the xcframework input for the SwiftPM command under test.
+# SwiftPM CI runs tests with compiler and library overrides pointing at the just-built toolchain and
+# in-tree SwiftPM libraries. Do not let xcodebuild inherit those while resolving this fixture package;
+# it should use the selected Xcode toolchain to create the xcframework input for the command under test.
 run_xcodebuild() {
     env \
+        -u DYLD_LIBRARY_PATH \
         -u SWIFT_EXEC \
         -u SWIFT_DRIVER_SWIFT_EXEC \
         -u SWIFT_EXEC_MANIFEST \
+        -u SWIFTCI_USE_LOCAL_DEPS \
+        -u SWIFTPM_CUSTOM_LIBS_DIR \
         xcodebuild "$@"
 }
 

--- a/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Scripts/archive_xcframework.sh
+++ b/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Scripts/archive_xcframework.sh
@@ -22,10 +22,21 @@ PROJECT_BUILD_DIR="${PROJECT_BUILD_DIR:-"${PROJECT_ROOT}/.build"}"
 XCODEBUILD_BUILD_DIR="$PROJECT_BUILD_DIR/xcodebuild"
 XCODEBUILD_DERIVED_DATA_PATH="$XCODEBUILD_BUILD_DIR/DerivedData"
 
+# SwiftPM CI runs tests with SWIFT_EXEC pointing at the just-built compiler. Do not let xcodebuild
+# inherit those overrides while resolving this fixture package; it should use the selected Xcode
+# toolchain to create the xcframework input for the SwiftPM command under test.
+run_xcodebuild() {
+    env \
+        -u SWIFT_EXEC \
+        -u SWIFT_DRIVER_SWIFT_EXEC \
+        -u SWIFT_EXEC_MANIFEST \
+        xcodebuild "$@"
+}
+
 PACKAGE_NAME=$1
 if [ -z "$PACKAGE_NAME" ]; then
     echo "No package name provided. Using the first scheme found in the Package.swift."
-    PACKAGE_NAME=$(xcodebuild -list | awk 'schemes && NF>0 { print $1; exit } /Schemes:$/ { schemes = 1 }')
+    PACKAGE_NAME=$(run_xcodebuild -list | awk 'schemes && NF>0 { print $1; exit } /Schemes:$/ { schemes = 1 }')
     echo "Using: $PACKAGE_NAME"
 fi
 
@@ -38,7 +49,7 @@ build_framework() {
 
     rm -rf "$XCODEBUILD_ARCHIVE_PATH"
 
-    PROTOBUFKIT_LIBRARY_TYPE=dynamic xcodebuild archive \
+    PROTOBUFKIT_LIBRARY_TYPE=dynamic run_xcodebuild archive \
         -scheme $scheme \
         -archivePath $XCODEBUILD_ARCHIVE_PATH \
         -derivedDataPath "$XCODEBUILD_DERIVED_DATA_PATH" \
@@ -78,6 +89,6 @@ cd $PROJECT_BUILD_DIR
 XCFRAMEWORK_DESTINATION="$PROJECT_ROOT/../$PACKAGE_NAME.xcframework"
 
 rm -rf $XCFRAMEWORK_DESTINATION
-xcodebuild -create-xcframework  \
+run_xcodebuild -create-xcframework  \
     -framework $PACKAGE_NAME-macosx.xcarchive/Products/Library/Frameworks/$PACKAGE_NAME.framework \
     -output $XCFRAMEWORK_DESTINATION

--- a/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Sources/FooKit/FooKit.swift
+++ b/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/FooKit/Sources/FooKit/FooKit.swift
@@ -1,0 +1,4 @@
+/// print "foo"
+public func foo() {
+    print("foo")
+}

--- a/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.8
+import PackageDescription
+
+let package = Package(
+    name: "DemoKit",
+    products: [
+        .library(name: "DemoKit", targets: ["DemoKit"]),
+    ],
+    targets: [
+        .plugin(
+            name: "GenerateSymbolGraphPlugin",
+            capability: .command(
+                intent: .custom(
+                    verb: "generate-symbol-graph",
+                    description: "Generate symbol graph for all Swift source targets."
+                )
+            )
+        ),
+        .binaryTarget(name: "FooKit", path: "FooKit.xcframework"),
+        .target(
+            name: "DemoKit",
+            dependencies: ["FooKit"]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/Plugins/GenerateSymbolGraphPlugin/GenerateSymbolGraphPlugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/Plugins/GenerateSymbolGraphPlugin/GenerateSymbolGraphPlugin.swift
@@ -1,0 +1,19 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+import Foundation
+import PackagePlugin
+
+@main
+struct GenerateSymbolGraphPlugin: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) throws {
+        for target in context.package.targets where target is SwiftSourceModuleTarget {
+            let _ = try packageManager.getSymbolGraph(for: target, options: .init())
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/Sources/DemoKit/DemoKit.swift
+++ b/Fixtures/Miscellaneous/Plugins/SymbolGraphForBinaryDependency/Sources/DemoKit/DemoKit.swift
@@ -1,0 +1,6 @@
+import FooKit
+
+public func greeting(_ name: String) {
+    FooKit.foo()
+    print("Hello \(name)")
+}

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -172,6 +172,9 @@ public final class SwiftModuleBuildDescription {
     /// over to the build output directory so executables that use them can find them.
     var windowsDLLBinaryPaths: Set<AbsolutePath> = []
 
+    /// Paths to search when importing binary frameworks.
+    var frameworkSearchPaths: Set<AbsolutePath> = []
+
     /// Any addition flags to be added. These flags are expected to be computed during build planning.
     var additionalFlags: [String] = []
 
@@ -561,10 +564,7 @@ public final class SwiftModuleBuildDescription {
             args += ["-static"]
         }
 
-        // Only add the build path to the framework search path if there are binary frameworks to link against.
-        if !self.libraryBinaryPaths.isEmpty {
-            args += ["-F", BuildOperation.buildProductsPath(for: self.buildParameters).pathString]
-        }
+        args += self.frameworkSearchPathArguments()
 
         // Emit the ObjC compatibility header if enabled.
         if self.shouldEmitObjCCompatibilityHeader {
@@ -696,6 +696,8 @@ public final class SwiftModuleBuildDescription {
         // Include search paths for swift module dependencies.
         args += ["-I", self.modulesPath.pathString]
 
+        args += self.frameworkSearchPathArguments()
+
         // FIXME: Only include valid args
         // This condition should instead only include args which are known to be
         // compatible instead of filtering out specific unknown args.
@@ -704,6 +706,17 @@ public final class SwiftModuleBuildDescription {
         // will silently error failing the operation.
         args = args.filter { !$0.starts(with: "-use-ld=") }
         return args
+    }
+
+    private func frameworkSearchPathArguments() -> [String] {
+        var frameworkSearchPaths = self.frameworkSearchPaths
+        if !self.libraryBinaryPaths.isEmpty {
+            frameworkSearchPaths.insert(BuildOperation.buildProductsPath(for: self.buildParameters))
+        }
+
+        return frameworkSearchPaths.map(\.pathString).sorted().flatMap {
+            ["-F", $0, "-Xcc", "-F", "-Xcc", $0]
+        }
     }
 
     // FIXME: this function should operation on a strongly typed buildSetting

--- a/Sources/Build/BuildPlan/BuildPlan+Swift.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Swift.swift
@@ -92,6 +92,9 @@ extension BuildPlan {
                         library.headersPaths.forEach {
                             swiftTarget.additionalFlags += ["-I", $0.pathString, "-Xcc", "-I", "-Xcc", $0.pathString]
                         }
+                        if library.libraryPath.extension == "framework", swiftTarget.buildParameters.triple.isDarwin() {
+                            swiftTarget.frameworkSearchPaths.insert(library.libraryPath.parentDirectory)
+                        }
                         swiftTarget.libraryBinaryPaths.insert(library.libraryPath)
                     }
                 }

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -180,8 +180,11 @@ struct PluginsBuildPlanTests {
             .Feature.Command.Package.Plugin,
         ),
         .requireHostOS(.macOS),
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
-    func docCPluginForBinaryDependency() async throws {
+    func docCPluginForBinaryDependency(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
         try await fixture(name: "Miscellaneous/Plugins/SymbolGraphForBinaryDependency") { fixturePath in
             let result = try await AsyncProcess.popen(arguments: [
                 fixturePath.appending(RelativePath("FooKit/Scripts/archive_xcframework.sh")).pathString,
@@ -191,14 +194,12 @@ struct PluginsBuildPlanTests {
             try print(result.utf8stderrOutput())
             #expect(result.exitStatus == .terminated(code: 0))
             // Before we add -F support for xcframework, this call will throw since the command will abort with a non-zero exit code
-            do {
+            await #expect(throws: Never.self) {
                 _ = try await executeSwiftPackage(
                     fixturePath,
                     extraArgs: ["generate-symbol-graph"],
-                    buildSystem: .native
+                    buildSystem: buildSystem
                 )
-            } catch {
-                Issue.record("Expected symbol graph generation for an xcframework dependency to succeed, but failed with \(error)")
             }
         }
     }

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -175,5 +175,31 @@ struct PluginsBuildPlanTests {
             expectFileExists(at: pluginToolBinPath.appending(pluginToolName))
         }
     }
-
+    @Test(
+        .tags(
+            .Feature.Command.Package.Plugin,
+        ),
+        .requireHostOS(.macOS),
+    )
+    func docCPluginForBinaryDependency() async throws {
+        try await fixture(name: "Miscellaneous/Plugins/SymbolGraphForBinaryDependency") { fixturePath in
+            let result = try await AsyncProcess.popen(arguments: [
+                fixturePath.appending(RelativePath("FooKit/Scripts/archive_xcframework.sh")).pathString,
+                "FooKit"
+            ])
+            try print(result.utf8Output())
+            try print(result.utf8stderrOutput())
+            #expect(result.exitStatus == .terminated(code: 0))
+            // Before we add -F support for xcframework, this call will throw since the command will abort with a non-zero exit code
+            do {
+                _ = try await executeSwiftPackage(
+                    fixturePath,
+                    extraArgs: ["generate-symbol-graph"],
+                    buildSystem: .native
+                )
+            } catch {
+                Issue.record("Expected symbol graph generation for an xcframework dependency to succeed, but failed with \(error)")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Close #7580

### Motivation:

If a target has a dependency on binaryTarget. Then the call of `PackageManager.getSymbolGraph` to that target will get a directory contains no symbol graph.

It will break `PackageManager.getSymbolGraph`'s client such as swift-docc-plugin.

The downstream user can generate doc using `swift build` and call `docc convert` to generate documentation. But if they migrate to swift-docc-plugin or swift-docc-plugin based service like SwiftPackageIndex, the documentation build will fail.

```
// ✅ Build Package Documentation via Xcode GUI

// ✅ Build Package Documentation manually
swift build --target DemoKit \
  -Xswiftc -emit-symbol-graph \
  -Xswiftc -emit-symbol-graph-dir -Xswiftc "./symbol-graph"

docc convert --additional-symbol-graph-dir ./symbol-graph ...

// ❌ Build Package Documentation via swift-docc-plugin
swift package generate-documentation --target DemoKit
```

The underlying issue is that xcframework dependencies are being passed to swift-symbolgraph-extract with -I paths, rather than -F paths. (Thanks @QuietMisdreavus)

### Modifications:

Adding -F related additionalFlag for binary swift target.

> Replace -I with -F is enough to fix the issue. Keeping -I for compatibility reason in case there are other cases where -I is needed