### PR TITLE
Basics: internalise `Deque` usage

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -79,11 +79,11 @@ add_library(Basics
   Vendor/Triple+Platforms.swift)
 target_link_libraries(Basics PUBLIC
   _AsyncFileSystem
-  SwiftCollections::DequeModule
   SwiftCollections::OrderedCollections
   TSCBasic
   TSCUtility)
 target_link_libraries(Basics PRIVATE
+  SwiftCollections::DequeModule
   SPMSQLite3
   TSCclibc)
 

--- a/Sources/Basics/Concurrency/TokenBucket.swift
+++ b/Sources/Basics/Concurrency/TokenBucket.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import _Concurrency
-import DequeModule
+private import DequeModule
 
 /// Type modeled after a "token bucket" pattern, which is similar to a semaphore, but is built with
 /// Swift Concurrency primitives.

--- a/Sources/Basics/Graph/DirectedGraph.swift
+++ b/Sources/Basics/Graph/DirectedGraph.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct DequeModule.Deque
+private import DequeModule
 
 /// Directed graph that stores edges in [adjacency lists](https://en.wikipedia.org/wiki/Adjacency_list).
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)

--- a/Sources/Basics/Graph/UndirectedGraph.swift
+++ b/Sources/Basics/Graph/UndirectedGraph.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct DequeModule.Deque
+private import DequeModule
 
 /// Undirected graph that stores edges in an [adjacency matrix](https://en.wikipedia.org/wiki/Adjacency_matrix).
 @_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)

--- a/Sources/Basics/HTTPClient/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient/HTTPClient.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import _Concurrency
-import DequeModule
 import Foundation
 
 /// `async`-friendly wrapper for HTTP clients. It allows a specific client implementation (either Foundation or


### PR DESCRIPTION
This module is not part of the public interface. Mark this is as an `internal` import which helps reduce the spread of this dependency into SourceKit-LSP.