### PR TITLE
Remove the forward slash '/' in the output

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -567,7 +567,7 @@ public final class InitPackage {
         guard self.fileSystem.exists(sources) == false else {
             return
         }
-        progressReporter?("Creating \(sources.relative(to: destinationPath))/")
+        progressReporter?("Creating \(sources.relative(to: destinationPath))")
         try makeDirectories(sources)
 
         let moduleDir: AbsolutePath


### PR DESCRIPTION
Not all platforms use `/` for example Windows.