### PR TITLE
Add `binary` type for binary targets to `add-target` command.

### DIFF
--- a/Sources/Commands/PackageCommands/AddTarget.swift
+++ b/Sources/Commands/PackageCommands/AddTarget.swift
@@ -31,6 +31,7 @@ extension SwiftPackageCommand {
             case executable
             case test
             case macro
+            case binary
         }
 
         package static let configuration = CommandConfiguration(
@@ -95,6 +96,7 @@ extension SwiftPackageCommand {
                 case .executable: .executable
                 case .test: .test
                 case .macro: .macro
+                case .binary: .binary
             }
 
             // Map dependencies

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1067,6 +1067,65 @@ final class PackageCommandTests: CommandsTestCase {
             XCTAssertMatch(contents, .contains(#""OtherLib""#))
         }
     }
+    
+    func testPackageAddRemoteBinaryTarget() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("PackageB")
+            try fs.createDirectory(path)
+
+            try fs.writeFileContents(path.appending("Package.swift"), string:
+                """
+                // swift-tools-version: 5.9
+                import PackageDescription
+                let package = Package(
+                    name: "client"
+                )
+                """
+            )
+
+            _ = try await execute(["add-target", "client", "--url", "https://example.com/client.xcframework.zip", "--checksum", "abcdef1234567890", "--type", "binary"], packagePath: path)
+
+            let manifest = path.appending("Package.swift")
+            XCTAssertFileExists(manifest)
+            let contents: String = try fs.readFileContents(manifest)
+
+            XCTAssertMatch(contents, .contains(#"targets:"#))
+            XCTAssertMatch(contents, .contains(#".binaryTarget"#))
+            XCTAssertMatch(contents, .contains(#"name: "client""#))
+            XCTAssertMatch(contents, .contains(#"url: "https://example.com/client.xcframework.zip""#))
+            XCTAssertMatch(contents, .contains(#"checksum: "abcdef1234567890""#))
+        }
+    }
+    
+    func testPackageAddLocalBinaryTarget() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("PackageB")
+            try fs.createDirectory(path)
+
+            try fs.writeFileContents(path.appending("Package.swift"), string:
+                """
+                // swift-tools-version: 5.9
+                import PackageDescription
+                let package = Package(
+                    name: "client"
+                )
+                """
+            )
+
+            _ = try await execute(["add-target", "client", "--path", "Artifacts/client.xcframework", "--type", "binary"], packagePath: path)
+
+            let manifest = path.appending("Package.swift")
+            XCTAssertFileExists(manifest)
+            let contents: String = try fs.readFileContents(manifest)
+
+            XCTAssertMatch(contents, .contains(#"targets:"#))
+            XCTAssertMatch(contents, .contains(#".binaryTarget"#))
+            XCTAssertMatch(contents, .contains(#"name: "client""#))
+            XCTAssertMatch(contents, .contains(#"path: "Artifacts/client.xcframework""#))
+        }
+    }
 
     func testPackageAddTargetDependency() async throws {
         try await testWithTemporaryDirectory { tmpPath in


### PR DESCRIPTION
Updates the `add-target` subcommand to allow creating a target that references a remote or local binary artifact.

### Motivation:

The `add-target` command currently accepts a set of arguments that make it seem like it should be able to create a `.binaryTarget` in the package's manifest. However, when trying to use the command in this way, you'll either get an error because of validation if trying to create a target for a remote binary artifact, or a regular source target will be created if trying to create a target for a local binary artifact. Issue #8277 has the full details.

### Modifications:

This PR adds `.binary` as a new value for the `TargetType` enum (which is used for parsing the `--type` argument of the `add-target` command). This value gets mapped to `TargetDescription.TargetKind.binary` when actually creating the target in the manifest.

### Result:

By specifying `--type binary` for the `add-target` command and providing a value for `--url` or `--path`, a `.binaryTarget` will be added to the package's manifest, with the appropriate configuration depending on if the binary artifact is sourced from a remote URL or a local path.