### PR TITLE
Add `swift package add-target-plugin` command

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(Commands
   PackageCommands/AddTarget.swift
   PackageCommands/AddTargetDependency.swift
   PackageCommands/AddSetting.swift
+  PackageCommands/AddTargetPlugin.swift
   PackageCommands/APIDiff.swift
   PackageCommands/ArchiveSource.swift
   PackageCommands/AuditBinaryArtifact.swift

--- a/Sources/Commands/PackageCommands/AddTargetPlugin.swift
+++ b/Sources/Commands/PackageCommands/AddTargetPlugin.swift
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import CoreCommands
+import Foundation
+import PackageGraph
+import PackageModel
+import SwiftParser
+@_spi(PackageRefactor) import SwiftRefactor
+import SwiftSyntax
+import TSCBasic
+import TSCUtility
+import Workspace
+
+extension SwiftPackageCommand {
+    struct AddTargetPlugin: SwiftCommand {
+        package static let configuration = CommandConfiguration(
+            abstract: "Add a new target plugin to the manifest"
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        @Argument(help: "The name of the new plugin")
+        var pluginName: String
+
+        @Argument(help: "The name of the target to update")
+        var targetName: String
+
+        @Option(help: "The package in which the plugin resides")
+        var package: String?
+
+        func run(_ swiftCommandState: SwiftCommandState) throws {
+            let workspace = try swiftCommandState.getActiveWorkspace()
+
+            guard let packagePath = try swiftCommandState.getWorkspaceRoot().packages.first else {
+                throw StringError("unknown package")
+            }
+
+            // Load the manifest file
+            let fileSystem = workspace.fileSystem
+            let manifestPath = packagePath.appending("Package.swift")
+            let manifestContents: ByteString
+            do {
+                manifestContents = try fileSystem.readFileContents(manifestPath)
+            } catch {
+                throw StringError("cannot find package manifest in \(manifestPath)")
+            }
+
+            // Parse the manifest.
+            let manifestSyntax = manifestContents.withData { data in
+                data.withUnsafeBytes { buffer in
+                    buffer.withMemoryRebound(to: UInt8.self) { buffer in
+                        Parser.parse(source: buffer)
+                    }
+                }
+            }
+
+            let pluginUsage: PackageTarget.PluginUsage = .plugin(name: pluginName, package: package)
+
+            let editResult = try SwiftRefactor.AddPluginUsage.textRefactor(
+                syntax: manifestSyntax,
+                in: .init(
+                    targetName: targetName,
+                    pluginUsage: pluginUsage
+                )
+            )
+
+            try editResult.applyEdits(
+                to: fileSystem,
+                manifest: manifestSyntax,
+                manifestPath: manifestPath,
+                verbose: !globalOptions.logging.quiet
+            )
+        }
+    }
+}
+

--- a/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
+++ b/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
@@ -39,6 +39,7 @@ public struct SwiftPackageCommand: AsyncParsableCommand {
             AddTargetDependency.self,
             AddSetting.self,
             AuditBinaryArtifact.self,
+            AddTargetPlugin.self,
             Clean.self,
             PurgeCache.self,
             Reset.self,

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -55,6 +55,7 @@ extension Tag.Feature.Command.Package {
     @Tag public static var AddSetting: Tag
     @Tag public static var AddTarget: Tag
     @Tag public static var AddTargetDependency: Tag
+    @Tag public static var AddTargetPlugin: Tag
     @Tag public static var BuildPlugin: Tag
     @Tag public static var Clean: Tag
     @Tag public static var CommandPlugin: Tag


### PR DESCRIPTION
Adds `swift package add-target-plugin` command for adding plugins to target from CLI

### Motivation:
Featured requested in #8169 

Allows users to add package plugins to targets via command line. 

[Forums Discussion](https://forums.swift.org/t/proposal-swift-package-add-target-plugin-command-to-swiftpm/77930)

### Modifications:
Add new `add-target-plugin` command which aligns with the existing `add-target-dependency` command


```bash
> swift package add-target-plugin --help
OVERVIEW: Add a new target plugin to the manifest

USAGE: swift package add-target-plugin <plugin-name> <target-name> [--package <package>]

ARGUMENTS:
  <plugin-name>           The name of the new plugin
  <target-name>           The name of the target to update

OPTIONS:
  --package <package>     The package in which the plugin resides
  --version               Show the version.
  -h, -help, --help       Show help information.
```


### Result:
After running the following command:

```bash
swift package add-target-plugin OpenAPIGenerator myTarget --package swift-openapi-generator
```

The following addition will be made to the `Package.swift` manifest:

```swift
.target(
  name: "myTarget",
  plugins: [
    .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")
  ]
)
```
