### PR TITLE
Pass the correct toolchain path to SwiftBuild on Windows and FreeBSD

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(Basics
   Netrc.swift
   Observability.swift
   OSSignpost.swift
+  Process.swift
   ProgressAnimation/NinjaProgressAnimation.swift
   ProgressAnimation/PercentProgressAnimation.swift
   ProgressAnimation/ProgressAnimationProtocol.swift

--- a/Sources/Basics/Process.swift
+++ b/Sources/Basics/Process.swift
@@ -15,19 +15,24 @@ public enum OperatingSystem: Hashable, Sendable {
     case windows
     case linux
     case android
+    case freebsd
     case unknown
 }
 
 extension ProcessInfo {
-    #if os(macOS)
-    public static let hostOperatingSystem = OperatingSystem.macOS
-    #elseif os(Linux)
-    public static let hostOperatingSystem = OperatingSystem.linux
-    #elseif os(Windows)
-    public static let hostOperatingSystem = OperatingSystem.windows
-    #else
-    public static let hostOperatingSystem = OperatingSystem.unknown
-    #endif
+    public static var hostOperatingSystem: OperatingSystem {
+        #if os(macOS)
+        .macOS
+        #elseif os(Linux)
+        .linux
+        #elseif os(Windows)
+        .windows
+        #elseif os(FreeBSD)
+        .freebsd
+        #else
+        .unknown
+        #endif
+    }
 
     #if os(Windows)
     public static let EOL = "\r\n"

--- a/Sources/_InternalTestSupport/SkippedTestSupport.swift
+++ b/Sources/_InternalTestSupport/SkippedTestSupport.swift
@@ -11,6 +11,7 @@
 
 import class Foundation.FileManager
 import class Foundation.ProcessInfo
+import Basics
 import Testing
 
 extension Trait where Self == Testing.ConditionTrait {


### PR DESCRIPTION
Amendment to #8696 which computes the correct path on Windows and FreeBSD, which use different install layouts from the other platforms.