### PR TITLE
Tests: Convert Run Command Tests to Swift Testing

### DIFF
--- a/IntegrationTests/Sources/IntegrationTestSupport/Helpers.swift
+++ b/IntegrationTests/Sources/IntegrationTestSupport/Helpers.swift
@@ -123,7 +123,7 @@ public let swiftTest: AbsolutePath = swiftpmBinaryDirectory.appending(component:
 
 public let swiftRun: AbsolutePath = swiftpmBinaryDirectory.appending(component: "swift-run")
 
-public let isSelfHosted: Bool = {
+public let runningInSelfHostedPipeline: Bool = {
     ProcessInfo.processInfo.environment["SWIFTCI_IS_SELF_HOSTED"] != nil
 }()
 

--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -48,7 +48,7 @@ public func XCTAssertEqual<T:Equatable, U:Equatable> (_ lhs:(T,U), _ rhs:(T,U), 
 
 public func XCTSkipIfPlatformCI(because reason: String? = nil, file: StaticString = #filePath, line: UInt = #line) throws {
     // TODO: is this actually the right variable now?
-    if isInCiEnvironment {
+    if CiEnvironment.runningInSmokeTestPipeline {
         let failureCause = reason ?? "Skipping because the test is being run on CI"
         throw XCTSkip(failureCause, file: file, line: line)
     }

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -63,6 +63,14 @@ public let isRealSigningIdentitTestDefined = {
     #endif
 }()
 
+public let duplicateSymbolRegex: Regex<AnyRegexOutput>? = {
+    do {
+        return try Regex(".*One of the duplicates must be removed or renamed.")
+    } catch {
+        return nil
+    }
+}()
+
 /// Test helper utility for executing a block with a temporary directory.
 public func testWithTemporaryDirectory(
     function: StaticString = #function,

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -193,7 +193,7 @@ struct BuildCommandTestCases {
         arguments: SupportedBuildSystemOnPlatform,
     )
     func commandDoesNotEmitDuplicateSymbols(buildSystem: BuildSystemProvider.Kind) async throws {
-        let duplicateSymbolRegex = try Regex(".*One of the duplicates must be removed or renamed.")
+        let duplicateSymbolRegex = try #require(duplicateSymbolRegex)
         let (stdout, stderr) = try await execute(["--help"], buildSystem: buildSystem)
         #expect(!stdout.contains(duplicateSymbolRegex))
         #expect(!stderr.contains(duplicateSymbolRegex))


### PR DESCRIPTION
    
Convert the Run Command Tests to Swift Testing.
    
Make use of parameterized tests to reduce duplication and use `withKnownIssue` to get signal when tests have been fixed.

Depends on: #8714 