### PR TITLE
Fix testIncorrectDependencies failure on linux due to merge race

### DIFF
--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1173,7 +1173,7 @@ final class PluginTests: XCTestCase {
             XCTAssert(stdout.contains("Build complete!"), "output:\n\(stderr)\n\(stdout)")
         }
 
-#if !os(Windows) // https://github.com/swiftlang/swift-package-manager/issues/8774
+#if os(macOS) // https://github.com/swiftlang/swift-package-manager/issues/8774
         // Try again with the Swift Build build system
         try await fixture(name: "Miscellaneous/Plugins") { path in
             let (stdout, stderr) = try await executeSwiftBuild(path.appending("IncorrectDependencies"), extraArgs: ["--build-system", "swiftbuild", "--build-tests"])


### PR DESCRIPTION
https://github.com/swiftlang/swift-build/pull/558 and https://github.com/swiftlang/swift-package-manager/pull/8767 had a test/merge race which caused a failure in this test on linux. Add a narrow skip to this brand new test until these changes are working together