### PR TITLE
Test: disable environment test in self hosted

### DIFF
--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -147,7 +147,9 @@ struct EnvironmentTests {
 
     /// Important: This test is inherently race-prone, if it is proven to be
     /// flaky, it should run in a singled threaded environment/removed entirely.
-    @Test(.disabled(if: isInCiEnvironment, "This test can disrupt other tests running in parallel."))
+    @Test(
+        .disabled(if: isInCiEnvironment || isSelfHostedCiEnvironment, "This test can disrupt other tests running in parallel."),
+    )
     func makeCustomPathEnv() async throws {
         let customEnvironment: Environment = .current
         let origPath = customEnvironment[.path]


### PR DESCRIPTION
There is a test which runs in self hosted pipelines, which, when run in parallel, is prone to impacting other tests as it modifies the `PATH` environment variable.

Modify the test trait to also disable the tests when it's run in self hosted environment.