### PR TITLE
Tests: Augment TraitTests to support SwiftBuild

### DIFF
--- a/Sources/_InternalTestSupport/SkippedTestSupport.swift
+++ b/Sources/_InternalTestSupport/SkippedTestSupport.swift
@@ -84,6 +84,7 @@ extension Tag.Feature {
     @Tag public static var CodeCoverage: Tag
     @Tag public static var Resource: Tag
     @Tag public static var SpecialCharacters: Tag
+    @Tag public static var Traits: Tag
 }
 
 
@@ -96,6 +97,9 @@ extension Tag.Feature.Command {
 
 extension Tag.Feature.Command.Package {
     @Tag public static var Init: Tag
+    @Tag public static var DumpPackage: Tag
+    @Tag public static var DumpSymbolGraph: Tag
+    @Tag public static var Plugin: Tag
 }
 extension Tag.Feature.PackageType {
     @Tag public static var Library: Tag

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -321,7 +321,7 @@ public func executeSwiftRun(
     Xld: [String] = [],
     Xswiftc: [String] = [],
     env: Environment? = nil,
-    buildSystem: BuildSystemProvider.Kind = .native
+    buildSystem: BuildSystemProvider.Kind
 ) async throws -> (stdout: String, stderr: String) {
     var args = swiftArgs(
         configuration: configuration,

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -34,7 +34,7 @@ final class ResourcesTests: XCTestCase {
             #endif
 
             for execName in executables {
-                let (output, _) = try await executeSwiftRun(fixturePath, execName)
+                let (output, _) = try await executeSwiftRun(fixturePath, execName, buildSystem: .native)
                 XCTAssertTrue(output.contains("foo"), output)
             }
         }

--- a/Tests/FunctionalTests/StaticBinaryLibrary.swift
+++ b/Tests/FunctionalTests/StaticBinaryLibrary.swift
@@ -27,7 +27,8 @@ struct StaticBinaryLibraryTests {
                 let (stdout, stderr) = try await executeSwiftRun(
                     fixturePath.appending("Static").appending("Package1"),
                     "Example",
-                    extraArgs: ["--experimental-prune-unused-dependencies"]
+                    extraArgs: ["--experimental-prune-unused-dependencies"],
+                    buildSystem: .native,
                 )
                 #expect(stdout == """
                 42


### PR DESCRIPTION
In the process of updating the TraitTests to add test support for the Swift Build build system, migrate the test Suite to Swift Testing, making use of parameterized tests to reduce duplication and use `withKnownIssue` to get signal when tests have been fixed.

Depends on: #8714 