### PR TITLE
fix deprecation to introduction for publicHeadersDirectoryURL property

### DIFF
--- a/Sources/PackagePlugin/PackageModel.swift
+++ b/Sources/PackagePlugin/PackageModel.swift
@@ -366,6 +366,7 @@ public struct ClangSourceModuleTarget: SourceModuleTarget {
 
     /// The directory containing public C headers, if applicable. This will
     /// only be set for targets that have a directory of a public headers.
+    @available(_PackageDescription, introduced: 6.0)
     public let publicHeadersDirectoryURL: URL?
 
     /// Any custom linked libraries required by the module, as specified in the


### PR DESCRIPTION
Deprecation looks "incorrect" as it was added and deprecated at the same as the property `publicHeadersDirectory`, which I believe this was meant to replace.

### Motivation:

While updating the documentation, this stood out as added and deprecated, which seemed like a mistake.

### Modifications:

reverted the deprecation of the publicHeadersDirectoryURL property

### Result:

property is undeprecated
