### PR TITLE
Include out-of-target sources

### DIFF
--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -3477,6 +3477,33 @@ final class PackageBuilderTests: XCTestCase {
             }
         }
     }
+
+    func testOutOfTargetSource() throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/Sources/foo/foo.swift",
+            "/Sources/foo/foobar/foobar.swift",
+
+            "/Sources/bar/bar.swift"
+        )
+
+        let manifest = try Manifest.createRootManifest(
+            displayName: "pkg",
+            toolsVersion: .vNext,
+            targets: [
+                TargetDescription(
+                    name: "foo",
+                    sources: ["../bar/bar.swift", "foobar"]
+                ),
+            ]
+        )
+
+        PackageBuilderTester(manifest, in: fs) { package, _ in
+            package.checkModule("foo") { module in
+                module.checkSources(sources: ["foobar/foobar.swift","../bar/bar.swift"])
+            }
+        }
+    }
 }
 
 final class PackageBuilderTester {


### PR DESCRIPTION
Add support for out-of-target declared sources and headers in TargetSourcesBuilder for tools version vNext

### Motivation:

Since out-of-target resources are already supported, this change extends similar support to out-of-target declared sources and headers, enabling consistent handling of external source files in package loading for tools versions >= vNext.

### Modifications:

Updated TargetSourcesBuilder to process declaredSources, categorizing unhandled sources as headers or additional sources based on file extensions. Added logic to integrate these sources and headers for tools versions >= vNext.

### Result:

TargetSourcesBuilder now supports out-of-target declared sources and headers, allowing seamless inclusion of external source files in package loading for tools versions >= vNext.