### PR TITLE
Cherry-pick Disable check for unsafe flags. (#8896)

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -2024,7 +2024,8 @@ extension Sequence {
 
 extension TargetDescription {
     fileprivate var usesUnsafeFlags: Bool {
-        settings.filter(\.kind.isUnsafeFlags).isEmpty == false
+        // We no longer restrict unsafe flags
+        false
     }
 
     fileprivate func isMacroTest(in manifest: Manifest) -> Bool {

--- a/Tests/PackageGraphTests/ModulesGraphTests.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests.swift
@@ -2127,26 +2127,8 @@ final class ModulesGraphTests: XCTestCase {
             observabilityScope: observability.topScope
         )
 
-        XCTAssertEqual(observability.diagnostics.count, 3)
-        testDiagnostics(observability.diagnostics) { result in
-            var expectedMetadata = ObservabilityMetadata()
-            expectedMetadata.moduleName = "Foo2"
-            let diagnostic1 = result.checkUnordered(
-                diagnostic: .contains("the target 'Bar2' in product 'TransitiveBar' contains unsafe build flags"),
-                severity: .error
-            )
-            XCTAssertEqual(diagnostic1?.metadata?.moduleName, "Foo2")
-            let diagnostic2 = result.checkUnordered(
-                diagnostic: .contains("the target 'Bar' in product 'Bar' contains unsafe build flags"),
-                severity: .error
-            )
-            XCTAssertEqual(diagnostic2?.metadata?.moduleName, "Foo")
-            let diagnostic3 = result.checkUnordered(
-                diagnostic: .contains("the target 'Bar2' in product 'Bar' contains unsafe build flags"),
-                severity: .error
-            )
-            XCTAssertEqual(diagnostic3?.metadata?.moduleName, "Foo")
-        }
+        // We have turned off the unsafe flags check
+        XCTAssertEqual(observability.diagnostics.count, 0)
     }
 
     func testConditionalTargetDependency() throws {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5793,20 +5793,8 @@ final class WorkspaceTests: XCTestCase {
 
         // We should only see errors about use of unsafe flag in the version-based dependency.
         try await workspace.checkPackageGraph(roots: ["Foo", "Bar"]) { _, diagnostics in
-            testDiagnostics(diagnostics) { result in
-                let diagnostic1 = result.checkUnordered(
-                    diagnostic: .equal("the target 'Baz' in product 'Baz' contains unsafe build flags"),
-                    severity: .error
-                )
-                XCTAssertEqual(diagnostic1?.metadata?.packageIdentity, .plain("foo"))
-                XCTAssertEqual(diagnostic1?.metadata?.moduleName, "Foo")
-                let diagnostic2 = result.checkUnordered(
-                    diagnostic: .equal("the target 'Bar' in product 'Baz' contains unsafe build flags"),
-                    severity: .error
-                )
-                XCTAssertEqual(diagnostic2?.metadata?.packageIdentity, .plain("foo"))
-                XCTAssertEqual(diagnostic2?.metadata?.moduleName, "Foo")
-            }
+            // We have disabled the check so there shouldn't be any errors.
+            XCTAssert(diagnostics.filter({ $0.severity == .error }).isEmpty)
         }
     }
 


### PR DESCRIPTION
Cherry-pick #8896 

As discussed in the Swift forums below, a number of projects require the use of "unsafe" flags. A common example is the use of absolute header include paths set via an environment variable that project consumers agree to use. As such, the flags can be safely used under those circumstances.

This change disables the one line that was doing the check.

We will further study the issue and come up with other mechanisms to ensure the challenges some flags have on quality of the package ecosystem are mitigated.


https://forums.swift.org/t/pitch-disable-checks-for-unsafe-flags-in-swiftpm/80698