### PR TITLE
[6.2] Bump swift-syntax in template to 620.0.0-latest

### DIFF
--- a/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
+++ b/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
@@ -37,7 +37,7 @@ public struct InstalledSwiftPMConfiguration {
         return .init(
             version: 0,
             swiftSyntaxVersionForMacroTemplate: .init(
-                major: 620,
+                major: 602,
                 minor: 0,
                 patch: 0,
                 prereleaseIdentifier: "latest"

--- a/Utilities/config.json
+++ b/Utilities/config.json
@@ -1,3 +1,3 @@
 {"version":1,
-  "swiftSyntaxVersionForMacroTemplate":{"major":620,"minor":0,"patch":0, "prereleaseIdentifier":"latest"},
+  "swiftSyntaxVersionForMacroTemplate":{"major":602,"minor":0,"patch":0, "prereleaseIdentifier":"latest"},
   "swiftTestingVersionForTestTemplate":{"major":0,"minor":8,"patch":0}}


### PR DESCRIPTION
`swift package init --type macro` still points to swift-syntax version 6.0.0 although main has moved on to 6.2.0.

### Motivation:

`swift package init --type macro` is outdated

### Modifications:

Locally verified that `swift package init --type macro` uses the updated version.

### Result:

`swift package init --type macro` will output the latest version
