### PR TITLE
Tests: APIDiff Tests - mark known issues on AL2

### DIFF
--- a/Sources/_InternalTestSupport/CombinationsWithRepetition.swift
+++ b/Sources/_InternalTestSupport/CombinationsWithRepetition.swift
@@ -1,0 +1,59 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import Foundation
+package  struct CombinationsWithRepetition<C: Collection> : Sequence {
+
+    let base: C
+    let length: Int
+
+    init(of base: C, length: Int) {
+        self.base = base
+        self.length = length
+    }
+
+    package struct Iterator : IteratorProtocol {
+        let base: C
+
+        var firstIteration = true
+        var finished: Bool
+        var positions: [C.Index]
+
+        package init(of base: C, length: Int) {
+            self.base = base
+            finished = base.isEmpty
+            positions = Array(repeating: base.startIndex, count: length)
+        }
+
+        package mutating func next() -> [C.Element]? {
+            if firstIteration {
+                firstIteration = false
+            } else {
+                // Update indices for next combination.
+                finished = true
+                for i in positions.indices.reversed() {
+                    base.formIndex(after: &positions[i])
+                    if positions[i] != base.endIndex {
+                        finished = false
+                        break
+                    } else {
+                        positions[i] = base.startIndex
+                    }
+                }
+
+            }
+            return finished ? nil : positions.map { base[$0] }
+        }
+    }
+
+    package func makeIterator() -> Iterator {
+        return Iterator(of: base, length: length)
+    }
+}

--- a/Sources/_InternalTestSupport/ProcessInfo+hostutils.swift
+++ b/Sources/_InternalTestSupport/ProcessInfo+hostutils.swift
@@ -1,0 +1,37 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2025 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+import Foundation
+
+extension ProcessInfo {
+    public static func isHostAmazonLinux2(_ content: String? = nil) -> Bool {
+        let contentString: String
+        if let content {
+            contentString = content
+        } else {
+            let osReleasePath = "/etc/os-release"
+            do {
+                contentString = try String(contentsOfFile: osReleasePath, encoding: .utf8)
+            } catch {
+                return false
+            }
+        }
+        let lines = contentString.components(separatedBy: .newlines)
+        for line in lines {
+            if line.starts(with: "ID=") {
+                let id = line.replacingOccurrences(of: "ID=", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+                if id == "amzn" { // ID for Amazon Linux is "amzn"
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+}

--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -148,7 +148,7 @@ struct EnvironmentTests {
     /// Important: This test is inherently race-prone, if it is proven to be
     /// flaky, it should run in a singled threaded environment/removed entirely.
     @Test(
-        .disabled(if: isInCiEnvironment || CiEnvironment.runningInSelfHostedPipeline, "This test can disrupt other tests running in parallel."),
+        .disabled(if: CiEnvironment.runningInSmokeTestPipeline || CiEnvironment.runningInSelfHostedPipeline, "This test can disrupt other tests running in parallel."),
     )
     func makeCustomPathEnv() async throws {
         let customEnvironment: Environment = .current

--- a/Tests/BasicsTests/ProcessInfoTests.swift
+++ b/Tests/BasicsTests/ProcessInfoTests.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import Basics
+import Testing
+@testable import struct _InternalTestSupport.CombinationsWithRepetition
+
+fileprivate let d = [
+            [],
+            [""],
+            ["line1"],
+            ["line1", "line2"],
+            ["line1", "line2", "line3"],
+        ]
+fileprivate let prefixAndSuffixData = CombinationsWithRepetition(of: d, length: 2).map( {data in
+    // Content(prefix: data.0, suffix: data.1)
+    Content(prefix: data[0], suffix: data[1])
+})
+
+fileprivate struct Content {
+    let prefix: [String]
+    let suffix: [String]
+
+    init(prefix pre: [String], suffix: [String]) {
+        self.prefix = pre
+        self.suffix = suffix
+    }
+
+    func getContent(_ value: String) -> String {
+        let contentArray: [String] = self.prefix + [value] + self.suffix
+        let content = contentArray.joined(separator: "\n")
+        return content
+    }
+}
+
+@Suite
+struct ProcessInfoExtensionTests {
+
+    @Suite
+    struct isAmazonLinux2 {
+        @Test(
+            arguments: [
+                (contentUT: "", expected: false),
+                (contentUT: "ID=", expected: false),
+                (contentUT: "ID=foo", expected: false),
+                (contentUT: "ID=amzn", expected: true),
+                (contentUT: " ID=amzn", expected: false),
+            ], prefixAndSuffixData,
+        )
+        fileprivate func isAmazonLinux2ReturnsExpectedValue(
+            data: (contentUT: String, expected: Bool),
+            content: Content,
+        ) async throws {
+            let content = content.getContent(data.contentUT)
+
+            let actual = ProcessInfo.isHostAmazonLinux2(content)
+
+            #expect(actual == data.expected, "Content is: '\(content)'")
+        }
+
+        @Test(
+            "isHostAmazonLinux2 returns false when not executed on Linux",
+            .skipHostOS(.linux),
+            .tags(Tag.TestSize.medium),
+        )
+        func isAmazonLinux2ReturnsFalseWhenNotRunOnLinux() {
+            let actual = ProcessInfo.isHostAmazonLinux2()
+
+            #expect(actual == false)
+        }
+    }
+}


### PR DESCRIPTION
Change #8857 added SwiftBUild support for diagnose-api-breaking-changs. However, it appears that some test expectation are failing on Amazon Linux 2.

Mark these a known issues until they can be fixed.