### PR TITLE
Fix warning - Sending value of non-Sendable type '() async -> ()' risks causing data races

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -26,7 +26,7 @@ public enum Concurrency {
 }
 
 @available(*, noasync, message: "This method blocks the current thread indefinitely. Calling it from the concurrency pool can cause deadlocks")
-public func unsafe_await<T>(_ body: @Sendable @escaping () async -> T) -> T {
+public func unsafe_await<T: Sendable>(_ body: @Sendable @escaping () async -> T) -> T {
     let semaphore = DispatchSemaphore(value: 0)
 
     let box = ThreadSafeBox<T>()


### PR DESCRIPTION
### Motivation:

Warning: Sending value of non-Sendable type '() async -> ()' risks causing data races; this is an error in the Swift 6 language mode

### Modifications:

Require template type to inherit from Sendable
