### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,7 +26,6 @@
 
 * @jakepetroules @dschaefer2 @shawnhyam @bripeticca @plemarquand @owenv @bkhouri @cmcgee1024 @daveyc123
 
-Sources/XCBuildSupport/* @jakepetroules
 Sources/Commands/PackageCommands/Migrate.swift @AnthonyLatsis @bnbarham @xedin @jakepetroules @dschaefer2 @shawnhyam @bripeticca @plemarquand @owenv @bkhouri @cmcgee1024 @daveyc123
 Sources/SwiftFixIt/* @AnthonyLatsis @bnbarham @xedin @jakepetroules @dschaefer2 @shawnhyam @bripeticca @plemarquand @owenv @bkhouri @cmcgee1024 @daveyc123
 Tests/SwiftFixItTests/* @AnthonyLatsis @bnbarham @xedin @jakepetroules @dschaefer2 @shawnhyam @bripeticca @plemarquand @owenv @bkhouri @cmcgee1024 @daveyc123


### PR DESCRIPTION
Remove myself from CODEOWNERS for XCBuildSupport. CODEOWNERS doesn't stack, so this blocks others on the team from approving PRs that change these files and makes me single serialization point.