### PR TITLE
Test: mark test withKnownIssue

### DIFF
--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -220,13 +220,17 @@ struct TestCommandTests {
     }
 
     @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/8955", relationship: .defect),
         arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
     )
     func enableDisableTestabilityDefaultShouldRunWithTestability(
         buildSystem: BuildSystemProvider.Kind,
         configuration: BuildConfiguration,
     ) async throws {
-        try await withKnownIssue("fails to build the package") {
+        try await withKnownIssue(
+            "fails to build the package",
+            isIntermittent: (CiEnvironment.runningInSmokeTestPipeline),
+        ) {
             // default should run with testability
             try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
                 let result = try await execute(
@@ -238,7 +242,7 @@ struct TestCommandTests {
                 #expect(result.stderr.contains("-enable-testing"))
             }
         } when: {
-            (buildSystem == .swiftbuild && .linux == ProcessInfo.hostOperatingSystem && CiEnvironment.runningInSelfHostedPipeline)
+            (buildSystem == .swiftbuild && .linux == ProcessInfo.hostOperatingSystem)
             || (buildSystem == .swiftbuild && .windows == ProcessInfo.hostOperatingSystem && CiEnvironment.runningInSelfHostedPipeline)
         }
     }


### PR DESCRIPTION
A test is failing when building an Ubuntu 22.04 toolchain.  The failing test runs against SwiftBuild build system.

Mark the test as withKnownIssues until and track a GitHub to fix this' properly.