### PR TITLE
swift-package-migrate: Miscellaneous low-risk improvements and more tests

### DIFF
--- a/Fixtures/SwiftMigrate/UpdateManifest/Package.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+var swiftSettings: [SwiftSetting] = []
+
+let package = Package(
+    name: "WithErrors",
+    targets: [
+        .target(
+            name: "CannotFindSettings",
+            swiftSettings: swiftSettings
+        ),
+        .target(name: "A"),
+        .target(name: "B"),
+    ]
+)
+
+package.targets.append(
+    .target(
+        name: "CannotFindTarget",
+        swiftSettings: swiftSettings
+    ),
+)

--- a/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-A-B.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-A-B.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+var swiftSettings: [SwiftSetting] = []
+
+let package = Package(
+    name: "WithErrors",
+    targets: [
+        .target(
+            name: "CannotFindSettings",
+            swiftSettings: swiftSettings
+        ),
+        .target(name: "A",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+        .target(name: "B",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+    ]
+)
+
+package.targets.append(
+    .target(
+        name: "CannotFindTarget",
+        swiftSettings: swiftSettings
+    ),
+)

--- a/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-A.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-A.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+var swiftSettings: [SwiftSetting] = []
+
+let package = Package(
+    name: "WithErrors",
+    targets: [
+        .target(
+            name: "CannotFindSettings",
+            swiftSettings: swiftSettings
+        ),
+        .target(name: "A",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+        .target(name: "B"),
+    ]
+)
+
+package.targets.append(
+    .target(
+        name: "CannotFindTarget",
+        swiftSettings: swiftSettings
+    ),
+)

--- a/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-all.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Package.updated.targets-all.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.8
+
+import PackageDescription
+
+var swiftSettings: [SwiftSetting] = []
+
+let package = Package(
+    name: "WithErrors",
+    targets: [
+        .target(
+            name: "CannotFindSettings",
+            swiftSettings: swiftSettings
+        ),
+        .target(name: "A",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+        .target(name: "B",swiftSettings: [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InferIsolatedConformances"),]),
+    ]
+)
+
+package.targets.append(
+    .target(
+        name: "CannotFindTarget",
+        swiftSettings: swiftSettings
+    ),
+)

--- a/Fixtures/SwiftMigrate/UpdateManifest/Sources/A/File.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Sources/A/File.swift
@@ -1,0 +1,1 @@
+public func foo() {}

--- a/Fixtures/SwiftMigrate/UpdateManifest/Sources/B/File.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Sources/B/File.swift
@@ -1,0 +1,1 @@
+public func foo() {}

--- a/Fixtures/SwiftMigrate/UpdateManifest/Sources/CannotFindSettings/File.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Sources/CannotFindSettings/File.swift
@@ -1,0 +1,1 @@
+public func foo() {}

--- a/Fixtures/SwiftMigrate/UpdateManifest/Sources/CannotFindTarget/File.swift
+++ b/Fixtures/SwiftMigrate/UpdateManifest/Sources/CannotFindTarget/File.swift
@@ -1,0 +1,1 @@
+public func foo() {}

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2250,6 +2250,100 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         }
     }
 
+    func testMigrateCommandUpdateManifestSingleTarget() async throws {
+        try XCTSkipIf(
+            !UserToolchain.default.supportesSupportedFeatures,
+            "skipping because test environment compiler doesn't support `-print-supported-features`"
+        )
+
+        try await fixture(name: "SwiftMigrate/UpdateManifest") { fixturePath in
+            _ = try await self.execute(
+                [
+                    "migrate",
+                    "--to-feature",
+                    "ExistentialAny,InferIsolatedConformances",
+                    "--target",
+                    "A",
+                ],
+                packagePath: fixturePath
+            )
+
+            let updatedManifest = try localFileSystem.readFileContents(
+                fixturePath.appending(components: "Package.swift")
+            )
+            let expectedManifest = try localFileSystem.readFileContents(
+                fixturePath.appending(components: "Package.updated.targets-A.swift")
+            )
+            XCTAssertEqual(updatedManifest, expectedManifest)
+        }
+
+    }
+
+    func testMigrateCommandUpdateManifest2Targets() async throws {
+        try XCTSkipIf(
+            !UserToolchain.default.supportesSupportedFeatures,
+            "skipping because test environment compiler doesn't support `-print-supported-features`"
+        )
+
+        try await fixture(name: "SwiftMigrate/UpdateManifest") { fixturePath in
+            _ = try await self.execute(
+                [
+                    "migrate",
+                    "--to-feature",
+                    "ExistentialAny,InferIsolatedConformances",
+                    "--target",
+                    "A,B",
+                ],
+                packagePath: fixturePath
+            )
+
+            let updatedManifest = try localFileSystem.readFileContents(
+                fixturePath.appending(components: "Package.swift")
+            )
+            let expectedManifest = try localFileSystem.readFileContents(
+                fixturePath.appending(components: "Package.updated.targets-A-B.swift")
+            )
+            XCTAssertEqual(updatedManifest, expectedManifest)
+        }
+    }
+
+    func testMigrateCommandUpdateManifestWithErrors() async throws {
+        try XCTSkipIf(
+            !UserToolchain.default.supportesSupportedFeatures,
+            "skipping because test environment compiler doesn't support `-print-supported-features`"
+        )
+
+        try await fixture(name: "SwiftMigrate/UpdateManifest") { fixturePath in
+            try await XCTAssertThrowsCommandExecutionError(
+                await self.execute(
+                    ["migrate", "--to-feature", "ExistentialAny,InferIsolatedConformances,StrictMemorySafety"],
+                    packagePath: fixturePath
+                )
+            ) { error in
+                // 'SwiftMemorySafety.strictMemorySafety' was introduced in 6.2.
+                XCTAssertMatch(
+                    error.stderr,
+                    .contains(
+                        """
+                        error: Could not update manifest to enable requested features for target 'A' (package manifest version 5.8.0 is too old: please update to manifest version 6.2.0 or newer). Please enable them manually by adding the following Swift settings to the target: '.enableUpcomingFeature("ExistentialAny"), .enableUpcomingFeature("InferIsolatedConformances"), .strictMemorySafety()'
+                        error: Could not update manifest to enable requested features for target 'B' (package manifest version 5.8.0 is too old: please update to manifest version 6.2.0 or newer). Please enable them manually by adding the following Swift settings to the target: '.enableUpcomingFeature("ExistentialAny"), .enableUpcomingFeature("InferIsolatedConformances"), .strictMemorySafety()'
+                        error: Could not update manifest to enable requested features for target 'CannotFindSettings' (unable to find array literal for 'swiftSettings' argument). Please enable them manually by adding the following Swift settings to the target: '.enableUpcomingFeature("ExistentialAny"), .enableUpcomingFeature("InferIsolatedConformances"), .strictMemorySafety()'
+                        error: Could not update manifest to enable requested features for target 'CannotFindTarget' (unable to find target named 'CannotFindTarget' in package). Please enable them manually by adding the following Swift settings to the target: '.enableUpcomingFeature("ExistentialAny"), .enableUpcomingFeature("InferIsolatedConformances"), .strictMemorySafety()'
+                        """
+                    )
+                )
+            }
+
+            let updatedManifest = try localFileSystem.readFileContents(
+                fixturePath.appending(components: "Package.swift")
+            )
+            let expectedManifest = try localFileSystem.readFileContents(
+                fixturePath.appending(components: "Package.updated.targets-all.swift")
+            )
+            XCTAssertEqual(updatedManifest, expectedManifest)
+        }
+    }
+
     func testBuildToolPlugin() async throws {
         try await testBuildToolPlugin(staticStdlib: false)
     }


### PR DESCRIPTION
### Modifications:

* Improve command-line option descriptions. Be clear that both options accept a comma-separated list, which is not at all obvious, and also state the default for `--target`.
* Add tests for feature resolution errors. This change also extracts feature resolution into a method and removes a superfluous colon from the 'unsupported feature' error message.
* Emit feature validation errors through the diagnostic emitter. These errors do not represent issues with parsing command-line arguments, so throwing a `ValidationError` is not suitable — we don't want to present the user with a command usage hint in these cases.
* Add more clarity to manifest update error message along with some tests for it.
