### PR TITLE
initial, simple SDK documentation

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftSDKCommands.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftSDKCommands.md
@@ -10,14 +10,14 @@ Perform operations on Swift SDKs.
 ## Overview
 
 By default, Swift Package Manager compiles code for the host platform on which you run it.
-Swift 6.1 introduced SDKs to support cross-compilation.
+Swift 6.1 introduced SDKs (through
+[SE-0387](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md))
+to support cross-compilation.
 
 SDKs are tightly coupled with the toolchain used to create them.
 Supported SDKs are distributed by the Swift project with links on the [installation page](https://www.swift.org/install/) for macOS and Linux, and included in the distribution for Windows.
 
-Additionally, the Swift project provides a tooling repository called [swift-sdk-generator](https://github.com/swiftlang/swift-sdk-generator) that you can use to create a custom SDK for your preferred platform.
-
-For more information on the introduction of Swift SDKs, refer to the Swift evolution proposal [SE-0387](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md).
+Additionally, the Swift project provides the tooling repository [swift-sdk-generator](https://github.com/swiftlang/swift-sdk-generator) that you can use to create a custom SDK for your preferred platform.
 
 ## Topics 
 


### PR DESCRIPTION
Provides some basic detail for Swift cross-compilation SDKs, referencing the installation links on swift.org, the evolution proposal, and the SDK generator code.

resolves #8864, to finalize the documentation of the CLI commands