### PR TITLE
Tests: Migrate BuildSystemDelegateTests to Swift Testing and augment

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -79,6 +79,13 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    /// Enabled if toolsupm suported SDK Dependent Tests
+    public static var requiresSDKDependentTestsSupport: Self {
+        enabled("skipping because test environment doesn't support this test") {
+            (try? UserToolchain.default)!.supportsSDKDependentTests()
+        }
+    }
+
     // Enabled if the toolchain has supported features
     public static var supportsSupportedFeatures: Self {
         enabled("skipping because test environment compiler doesn't support `-print-supported-features`") {

--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -2,50 +2,94 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import Foundation
 
 import PackageModel
 import _InternalTestSupport
-import XCTest
+import Testing
 
 import var TSCBasic.localFileSystem
 
-final class BuildSystemDelegateTests: XCTestCase {
-    func testDoNotFilterLinkerDiagnostics() async throws {
-        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
-        try await fixtureXCTest(name: "Miscellaneous/DoNotFilterLinkerDiagnostics") { fixturePath in
-            #if !os(macOS)
-            // These linker diagnostics are only produced on macOS.
-            try XCTSkipIf(true, "test is only supported on macOS")
-            #endif
-            let (fullLog, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
-            XCTAssertTrue(fullLog.contains("ld: warning: search path 'foobar' not found"), "log didn't contain expected linker diagnostics")
+@Suite(
+    .tags(
+        .TestSize.large,
+    )
+)
+struct BuildSystemDelegateTests {
+    @Test(
+        .requiresSDKDependentTestsSupport,
+        .requireHostOS(.macOS),  // These linker diagnostics are only produced on macOS.
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+    )
+    func doNotFilterLinkerDiagnostics(
+        data: BuildData,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/DoNotFilterLinkerDiagnostics") { fixturePath in
+            let (stdout, stderr) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: data.config,
+                // extraArgs: ["--verbose"],
+                buildSystem: data.buildSystem,
+            )
+            switch data.buildSystem {
+            case .native:
+                #expect(
+                    stdout.contains("ld: warning: search path 'foobar' not found"),
+                    "log didn't contain expected linker diagnostics.  stderr: '\(stderr)')",
+                )
+            case .swiftbuild:
+                #expect(
+                    stderr.contains("warning: Search path 'foobar' not found"),
+                    "log didn't contain expected linker diagnostics. stderr: '\(stdout)",
+                )
+                #expect(
+                    !stdout.contains("warning: Search path 'foobar' not found"),
+                    "log didn't contain expected linker diagnostics.  stderr: '\(stderr)')",
+                )
+            case .xcode:
+                Issue.record("Test expectation has not be implemented")
+            }
         }
     }
 
-    func testFilterNonFatalCodesignMessages() async throws {
-        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8540: Package fails to build when the test is being executed")
-
-        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
-        // Note: we can re-use the `TestableExe` fixture here since we just need an executable.
-        #if os(Windows)
-        let executableExt = ".exe"
-        #else
-        let executableExt = ""
-        #endif
-        try await fixtureXCTest(name: "Miscellaneous/TestableExe") { fixturePath in
-            _ = try await executeSwiftBuild(fixturePath, buildSystem: .native)
-            let execPath = fixturePath.appending(components: ".build", "debug", "TestableExe1\(executableExt)")
-            XCTAssertTrue(localFileSystem.exists(execPath), "executable not found at '\(execPath)'")
-            try localFileSystem.removeFileTree(execPath)
-            let (fullLog, _) = try await executeSwiftBuild(fixturePath, buildSystem: .native)
-            XCTAssertFalse(fullLog.contains("replacing existing signature"), "log contained non-fatal codesigning messages")
+    @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/8540", relationship: .defect),  // Package fails to build when the test is being executed"
+        .requiresSDKDependentTestsSupport,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+    )
+    func filterNonFatalCodesignMessages(
+        data: BuildData,
+    ) async throws {
+        try await withKnownIssue(isIntermittent: true) {
+            // Note: we can re-use the `TestableExe` fixture here since we just need an executable.
+            try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
+                _ = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: data.config,
+                    buildSystem: data.buildSystem,
+                )
+                let execPath = try fixturePath.appending(
+                    components: data.buildSystem.binPath(for: data.config) + [executableName("TestableExe1")]
+                )
+                expectFileExists(at: execPath)
+                try localFileSystem.removeFileTree(execPath)
+                let (stdout, stderr) = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: data.config,
+                    buildSystem: data.buildSystem,
+                )
+                #expect(!stdout.contains("replacing existing signature"), "log contained non-fatal codesigning messages stderr: '\(stderr)'")
+                #expect(!stderr.contains("replacing existing signature"), "log contained non-fatal codesigning messages. stdout: '\(stdout)'")
+            }
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 }

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -39,7 +39,7 @@ struct ModuleAliasingFixtureTests {
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "ModuleAliasing/DirectDeps1") { fixturePath in
                 let pkgPath = fixturePath.appending(components: "AppPkg")
-                let buildPath = pkgPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration))
+                let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
                 try await executeSwiftBuild(
                     pkgPath,
                     configuration: configuration,
@@ -82,7 +82,7 @@ struct ModuleAliasingFixtureTests {
         try await withKnownIssue {
         try await fixture(name: "ModuleAliasing/DirectDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration))
+            let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
             try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,
@@ -117,7 +117,7 @@ struct ModuleAliasingFixtureTests {
         try await withKnownIssue {
         try await fixture(name: "ModuleAliasing/NestedDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration))
+            let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
             try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,
@@ -156,7 +156,7 @@ struct ModuleAliasingFixtureTests {
         try await withKnownIssue {
         try await fixture(name: "ModuleAliasing/NestedDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
-            let buildPath = pkgPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration))
+            let buildPath = try pkgPath.appending(components: buildSystem.binPath(for: configuration))
             try await executeSwiftBuild(
                 pkgPath,
                 configuration: configuration,

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -124,7 +124,8 @@ struct ToolsVersionTests {
                     configuration: configuration,
                     buildSystem: buildSystem,
                 )
-                let exe: String = primaryPath.appending(components: [".build", try UserToolchain.default.targetTriple.platformBuildPathComponent] + buildSystem.binPathSuffixes(for: configuration) + ["Primary"]).pathString
+                let binPath = try primaryPath.appending(components: buildSystem.binPath(for: configuration))
+                let exe: String = binPath.appending(components: "Primary").pathString
                 // v1 should get selected because v1.0.1 depends on a (way) higher set of tools.
                 try await withKnownIssue {
                     let executableActualOutput = try await AsyncProcess.checkNonZeroExit(args: exe).spm_chomp()


### PR DESCRIPTION
Migrate the `BuildSystemDelegateTests` test to Swift Testing and augment the test to run against both the Native and SwiftBUild build system, in addition to the `debug` and `release` build configuration.

Depends on: #9012
Relates to: #8997
issue: rdar://157669245