### PR TITLE
[6.2] SwiftModuleBuildDescription: Fix diagnostic file paths for WMO builds

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -1126,10 +1126,22 @@ extension SwiftModuleBuildDescription {
 
 extension SwiftModuleBuildDescription {
     package var diagnosticFiles: [AbsolutePath] {
-        self.sources.compactMap { self.diagnosticFile(sourceFile: $0) }
+        // WMO builds have a single frontend invocation and produce a single
+        // diagnostic file named after the module.
+        if self.useWholeModuleOptimization {
+            return [
+                self.diagnosticFile(name: self.target.name)
+            ]
+        }
+
+        return self.sources.map(self.diagnosticFile(sourceFile:))
+    }
+
+    private func diagnosticFile(name: String) -> AbsolutePath {
+        self.tempsPath.appending(component: "\(name).dia")
     }
 
     private func diagnosticFile(sourceFile: AbsolutePath) -> AbsolutePath {
-        self.tempsPath.appending(component: "\(sourceFile.basenameWithoutExt).dia")
+        self.diagnosticFile(name: sourceFile.basenameWithoutExt)
     }
 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2158,7 +2158,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         }
     }
 
-    func testMigrateCommand() async throws {
+    func _testMigrateCommand(configuration: BuildConfiguration) async throws {
         try XCTSkipIf(
             !UserToolchain.default.supportesSupportedFeatures,
             "skipping because test environment compiler doesn't support `-print-supported-features`"
@@ -2186,7 +2186,7 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
                 }
 
                 let (stdout, _) = try await self.execute(
-                    ["migrate", "--to-feature", featureName],
+                    ["migrate", "-c", configuration.rawValue, "--to-feature", featureName],
                     packagePath: fixturePath
                 )
 
@@ -2208,6 +2208,14 @@ class PackageCommandTestCase: CommandsBuildProviderTestCase {
         try await doMigration(featureName: "ExistentialAny", expectedSummary: "Applied 5 fix-its in 1 file")
         try await doMigration(featureName: "StrictMemorySafety", expectedSummary: "Applied 1 fix-it in 1 file")
         try await doMigration(featureName: "InferIsolatedConformances", expectedSummary: "Applied 3 fix-its in 2 files")
+    }
+
+    func testMigrateCommandDebug() async throws {
+        try await _testMigrateCommand(configuration: .debug)
+    }
+
+    func testMigrateCommandRelease() async throws {
+        try await _testMigrateCommand(configuration: .release)
     }
 
     func testMigrateCommandWithBuildToolPlugins() async throws {
@@ -4288,7 +4296,11 @@ class PackageCommandSwiftBuildTests: PackageCommandTestCase {
         throw XCTSkip("SWBINTTODO: Test fails as plugins are not currenty supported")
     }
 
-    override func testMigrateCommand() async throws {
+    override func testMigrateCommandDebug() async throws {
+        throw XCTSkip("SWBINTTODO: Build plan is not currently supported")
+    }
+
+    override func testMigrateCommandRelease() async throws {
         throw XCTSkip("SWBINTTODO: Build plan is not currently supported")
     }
 


### PR DESCRIPTION
- **Explanation**: WMO builds have a single frontend invocation and produce a single diagnostic file named after the module as opposed to one diagnostic file per source file. 
- **Scope**: `swift package migrate` when run with release configuration.
- **Issues**: https://github.com/swiftlang/swift-package-manager/issues/9006
- **Original PRs**: https://github.com/swiftlang/swift-package-manager/pull/9020
- **Risk**: Low.
- **Testing**: Regression test added.
- **Reviewers**: @bkhouri @dschaefer2 @jakepetroules 