### PR TITLE
Revert "Add SwiftBuildSupport to the primary libSwiftPM product"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,7 +80,6 @@ let swiftPMProduct = (
         "LLBuildManifest",
         "SourceKitLSPAPI",
         "SPMLLBuild",
-        "SwiftBuildSupport",
     ]
 )
 


### PR DESCRIPTION
Reverts swiftlang/swift-package-manager#8780. We're going to expose this through a BSP server rather than in-process.