### PR TITLE
Make sure we don't get backslashes in the Prebuilts Manifest

### DIFF
--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -54,7 +54,7 @@ extension Workspace {
             public let name: String
             public var products: [String]
             public var cModules: [String]?
-            public var includePath: [RelativePath]?
+            public var includePath: [String]?
             public var artifacts: [Artifact]?
 
             public var id: String { name }
@@ -81,7 +81,7 @@ extension Workspace {
                 self.name = name
                 self.products = products
                 self.cModules = cModules
-                self.includePath = includePath
+                self.includePath = includePath?.map({ $0.pathString.replacingOccurrences(of: "\\", with: "/") })
                 self.artifacts = artifacts
             }
         }
@@ -640,7 +640,7 @@ extension Workspace {
                             path: path,
                             checkoutPath: checkoutPath,
                             products: library.products,
-                            includePath: library.includePath,
+                            includePath: try library.includePath?.map({ try RelativePath(validating: $0) }),
                             cModules: library.cModules ?? []
                         )
                         addedPrebuilts.add(managedPrebuilt)


### PR DESCRIPTION
We are running into cases where, if the Windows prebuilts build runs last, it's the one producing the prebuilts manifest. Since we're using RelativePath to for the library include paths, it's resulting in Windows paths being used and that fails on the other platforms. This change makes sure we always use forward slashes which will work on all platforms.

Note to do this we're copying over the manifest types to the BuildPrebuilts script temporarily to so we don't need to make changes in 6.2.0. We'll revisit this for the next release where we probably should use per platform JSON files.
