### PR TITLE
[6.2] Make sure we don't get backslashes in the Prebuilts Manifest

### DIFF
--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -54,7 +54,7 @@ extension Workspace {
             public let name: String
             public var products: [String]
             public var cModules: [String]?
-            public var includePath: [RelativePath]?
+            public var includePath: [String]?
             public var artifacts: [Artifact]?
 
             public var id: String { name }
@@ -81,7 +81,7 @@ extension Workspace {
                 self.name = name
                 self.products = products
                 self.cModules = cModules
-                self.includePath = includePath
+                self.includePath = includePath?.map({ $0.pathString.replacingOccurrences(of: "\\", with: "/") })
                 self.artifacts = artifacts
             }
         }
@@ -628,7 +628,7 @@ extension Workspace {
                             path: path,
                             checkoutPath: checkoutPath,
                             products: library.products,
-                            includePath: library.includePath,
+                            includePath: try library.includePath?.map({ try RelativePath(validating: $0) }),
                             cModules: library.cModules ?? []
                         )
                         addedPrebuilts.add(managedPrebuilt)

--- a/Sources/swift-build-prebuilts/BuildPrebuilts.swift
+++ b/Sources/swift-build-prebuilts/BuildPrebuilts.swift
@@ -30,7 +30,7 @@ struct Artifact: Codable {
     var checksum: String
     var libraryName: String?
     var products: [String]?
-    var includePath: [RelativePath]?
+    var includePath: [String]?
     var cModules: [String]? // deprecated, includePath is the way forward
     var swiftVersion: String?
 }
@@ -222,7 +222,7 @@ struct BuildPrebuilts: AsyncParsableCommand {
                     checksum: checksum,
                     libraryName: libraryName,
                     products: package.products.map(\.name),
-                    includePath: cModules.map({ $0.includeDir.relative(to: repoDir ) }),
+                    includePath: cModules.map({ $0.includeDir.relative(to: repoDir ).pathString.replacingOccurrences(of: "\\", with: "/") }),
                     swiftVersion: swiftVersion
                 )
 


### PR DESCRIPTION
Cherry pick of #9112 from main.

We are running into cases where, if the Windows prebuilts build runs last, it's the one producing the prebuilts manifest. Since we're using RelativePath to for the library include paths, it's resulting in Windows paths being used and that fails on the other platforms. This change makes sure we always use forward slashes which will work on all platforms. We use strings for the manifest and correct the slashes before writing them in the generator. We then convert them back to RelativePaths on the client side.
