### PR TITLE
Updates to get executables building and running on windows

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -1000,18 +1000,16 @@ extension ProjectModel.BuildSettings {
     mutating func configureDynamicSettings(
         productName: String,
         targetName: String,
-        executableName: String,
         packageIdentity: PackageIdentity,
         packageName: String?,
         createDylibForDynamicProducts: Bool,
         installPath: String,
-        delegate: PackagePIFBuilder.BuildDelegate
+        delegate: PackagePIFBuilder.BuildDelegate,
     ) {
         self[.TARGET_NAME] = targetName
-        self[.PRODUCT_NAME] = createDylibForDynamicProducts ? productName : executableName
+        self[.PRODUCT_NAME] = productName
         self[.PRODUCT_MODULE_NAME] = productName
         self[.PRODUCT_BUNDLE_IDENTIFIER] = "\(packageIdentity).\(productName)".spm_mangledToBundleIdentifier()
-        self[.EXECUTABLE_NAME] = executableName
         self[.CLANG_ENABLE_MODULES] = "YES"
         self[.SWIFT_PACKAGE_NAME] = packageName ?? nil
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -77,7 +77,7 @@ extension PackagePIFProjectBuilder {
                 id: product.pifTargetGUID,
                 productType: pifProductType,
                 name: product.targetName(),
-                productName: product.name
+                productName: "$(EXECUTABLE_NAME)"
             )
         }
         do {
@@ -115,7 +115,6 @@ extension PackagePIFProjectBuilder {
         settings[.PRODUCT_MODULE_NAME] = product.c99name
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(product.name)"
             .spm_mangledToBundleIdentifier()
-        settings[.EXECUTABLE_NAME] = product.name
         settings[.CLANG_ENABLE_MODULES] = "YES"
         settings[.SWIFT_PACKAGE_NAME] = mainModule.packageName
 
@@ -596,35 +595,15 @@ extension PackagePIFProjectBuilder {
 
         // FIXME: Cleanup this mess with <rdar://56889224>
 
-        let pifProductName: String
-        let executableName: String
         let productType: ProjectModel.Target.ProductType
 
         if desiredProductType == .dynamic {
             if pifBuilder.createDylibForDynamicProducts {
-                pifProductName = "lib\(product.name).dylib"
-                executableName = pifProductName
                 productType = .dynamicLibrary
             } else {
-                // If a product is explicitly declared dynamic, we preserve its name,
-                // otherwise we will compute an automatic one.
-                if product.libraryType == .dynamic {
-                    if let customExecutableName = pifBuilder.delegate
-                        .customExecutableName(product: product.underlying)
-                    {
-                        executableName = customExecutableName
-                    } else {
-                        executableName = product.name
-                    }
-                } else {
-                    executableName = PackagePIFBuilder.computePackageProductFrameworkName(productName: product.name)
-                }
-                pifProductName = "\(executableName).framework"
                 productType = .framework
             }
         } else {
-            pifProductName = "lib\(product.name).a"
-            executableName = pifProductName
             productType = .packageProduct
         }
 
@@ -637,7 +616,7 @@ extension PackagePIFProjectBuilder {
                 id: product.pifTargetGUID(suffix: targetSuffix),
                 productType: productType,
                 name: product.targetName(suffix: targetSuffix),
-                productName: pifProductName
+                productName: product.name
             )
         }
         do {
@@ -706,7 +685,6 @@ extension PackagePIFProjectBuilder {
             settings.configureDynamicSettings(
                 productName: product.name,
                 targetName: product.targetName(),
-                executableName: executableName,
                 packageIdentity: package.identity,
                 packageName: package.identity.c99name,
                 createDylibForDynamicProducts: pifBuilder.createDylibForDynamicProducts,
@@ -1037,7 +1015,6 @@ extension PackagePIFProjectBuilder {
         settings[.PRODUCT_MODULE_NAME] = moduleName
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(name)"
             .spm_mangledToBundleIdentifier()
-        settings[.EXECUTABLE_NAME] = name
         settings[.SKIP_INSTALL] = "NO"
         settings[.SWIFT_VERSION] = "5.0"
         // This should eventually be set universally for all package targets/products.

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -211,7 +211,6 @@ struct PackagePIFProjectBuilder {
         settings[.PRODUCT_MODULE_NAME] = bundleName
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(module.name).resources"
             .spm_mangledToBundleIdentifier()
-        settings[.EXECUTABLE_NAME] = ""
         settings[.GENERATE_INFOPLIST_FILE] = "YES"
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "resource"
 

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -727,16 +727,19 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
         settings["LIBRARY_SEARCH_PATHS"] = try "$(inherited) \(buildParameters.toolchain.toolchainLibDir.pathString)"
         settings["OTHER_CFLAGS"] = (
+            verboseFlag +
             ["$(inherited)"]
                 + buildParameters.toolchain.extraFlags.cCompilerFlags.map { $0.shellEscaped() }
                 + buildParameters.flags.cCompilerFlags.map { $0.shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_CPLUSPLUSFLAGS"] = (
+            verboseFlag +
             ["$(inherited)"]
                 + buildParameters.toolchain.extraFlags.cxxCompilerFlags.map { $0.shellEscaped() }
                 + buildParameters.flags.cxxCompilerFlags.map { $0.shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_SWIFT_FLAGS"] = (
+            verboseFlag +
             ["$(inherited)"]
                 + buildParameters.toolchain.extraFlags.swiftCompilerFlags.map { $0.shellEscaped() }
                 + buildParameters.flags.swiftCompilerFlags.map { $0.shellEscaped() }

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -554,19 +554,14 @@ struct BuildCommandTestCases {
     func nonReachableProductsAndTargetsFunctional(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        // skipped on Xcode
-        try await withKnownIssue {
-            try await fixture(name: "Miscellaneous/UnreachableTargets") { fixturePath in
-                let aPath = fixturePath.appending("A")
+        try await fixture(name: "Miscellaneous/UnreachableTargets") { fixturePath in
+            let aPath = fixturePath.appending("A")
 
-                let result = try await build([], packagePath: aPath, buildSystem: buildSystem)
-                #expect(!result.binContents.contains("bexec"))
-                #expect(!result.binContents.contains("BTarget2.build"))
-                #expect(!result.binContents.contains("cexec"))
-                #expect(!result.binContents.contains("CTarget.build"))
-            }
-        } when: {
-            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
+            let result = try await build([], packagePath: aPath, buildSystem: buildSystem)
+            #expect(!result.binContents.contains("bexec"))
+            #expect(!result.binContents.contains("BTarget2.build"))
+            #expect(!result.binContents.contains("cexec"))
+            #expect(!result.binContents.contains("CTarget.build"))
         }
     }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2722,7 +2722,7 @@ struct PackageCommandTests {
                 #expect(try localFileSystem.readFileContents(bazTotPackageFile) == content)
             }
         } when: {
-            [.windows, .linux].contains(ProcessInfo.hostOperatingSystem) && data.buildSystem == .swiftbuild
+            ProcessInfo.hostOperatingSystem == .linux && data.buildSystem == .swiftbuild
         }
 
     }
@@ -2738,40 +2738,36 @@ struct PackageCommandTests {
     func packageClean(
         data: BuildData,
     ) async throws {
-        try await withKnownIssue {
-            try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-                let packageRoot = fixturePath.appending("Bar")
+        try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+            let packageRoot = fixturePath.appending("Bar")
 
-                // Build it.
-                try await executeSwiftBuild(
-                    packageRoot,
-                    configuration: data.config,
-                    buildSystem: data.buildSystem,
-                )
-                let buildPath = packageRoot.appending(".build")
-                let binPath = try buildPath.appending(components: data.buildSystem.binPath(for: data.config, scratchPath: []))
-                let binFile = binPath.appending(executableName("Bar"))
-                expectFileExists(at: binFile)
-                #expect(localFileSystem.isDirectory(buildPath))
+            // Build it.
+            try await executeSwiftBuild(
+                packageRoot,
+                configuration: data.config,
+                buildSystem: data.buildSystem,
+            )
+            let buildPath = packageRoot.appending(".build")
+            let binPath = try buildPath.appending(components: data.buildSystem.binPath(for: data.config, scratchPath: []))
+            let binFile = binPath.appending(executableName("Bar"))
+            expectFileExists(at: binFile)
+            #expect(localFileSystem.isDirectory(buildPath))
 
-                // Clean, and check for removal of the build directory but not Packages.
-                _ = try await execute(
-                    ["clean"],
-                    packagePath: packageRoot,
-                    configuration: data.config,
-                    buildSystem: data.buildSystem,
-                )
-                expectFileDoesNotExists(at: binFile)
-                // Clean again to ensure we get no error.
-                _ = try await execute(
-                    ["clean"],
-                    packagePath: packageRoot,
-                    configuration: data.config,
-                    buildSystem: data.buildSystem,
-                )
-            }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && data.buildSystem == .swiftbuild
+            // Clean, and check for removal of the build directory but not Packages.
+            _ = try await execute(
+                ["clean"],
+                packagePath: packageRoot,
+                configuration: data.config,
+                buildSystem: data.buildSystem,
+            )
+            expectFileDoesNotExists(at: binFile)
+            // Clean again to ensure we get no error.
+            _ = try await execute(
+                ["clean"],
+                packagePath: packageRoot,
+                configuration: data.config,
+                buildSystem: data.buildSystem,
+            )
         }
     }
 
@@ -2787,53 +2783,49 @@ struct PackageCommandTests {
     func packageReset(
         data: BuildData,
     ) async throws {
-        try await withKnownIssue {
-            try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
-                let packageRoot = fixturePath.appending("Bar")
+        try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+            let packageRoot = fixturePath.appending("Bar")
 
-                // Build it.
-                try await executeSwiftBuild(
-                    packageRoot,
-                    configuration: data.config,
-                    buildSystem: data.buildSystem
-                )
-                let buildPath = packageRoot.appending(".build")
-                let binPath = try buildPath.appending(components: data.buildSystem.binPath(for: data.config, scratchPath: [], ))
-                let binFile = binPath.appending(executableName("Bar"))
-                expectFileExists(at: binFile)
-                #expect(localFileSystem.isDirectory(buildPath))
-                // Clean, and check for removal of the build directory but not Packages.
+            // Build it.
+            try await executeSwiftBuild(
+                packageRoot,
+                configuration: data.config,
+                buildSystem: data.buildSystem
+            )
+            let buildPath = packageRoot.appending(".build")
+            let binPath = try buildPath.appending(components: data.buildSystem.binPath(for: data.config, scratchPath: [], ))
+            let binFile = binPath.appending(executableName("Bar"))
+            expectFileExists(at: binFile)
+            #expect(localFileSystem.isDirectory(buildPath))
+            // Clean, and check for removal of the build directory but not Packages.
 
-                _ = try await execute(
-                    ["clean"],
-                    packagePath: packageRoot,
-                    configuration: data.config,
-                    buildSystem: data.buildSystem,
-                )
-                expectFileDoesNotExists(at: binFile)
-                try #expect(
-                    !localFileSystem.getDirectoryContents(buildPath.appending("repositories")).isEmpty
-                )
+            _ = try await execute(
+                ["clean"],
+                packagePath: packageRoot,
+                configuration: data.config,
+                buildSystem: data.buildSystem,
+            )
+            expectFileDoesNotExists(at: binFile)
+            try #expect(
+                !localFileSystem.getDirectoryContents(buildPath.appending("repositories")).isEmpty
+            )
 
-                // Fully clean.
-                _ = try await execute(
-                    ["reset"],
-                    packagePath: packageRoot,
-                    configuration: data.config,
-                    buildSystem: data.buildSystem,
-                )
-                #expect(!localFileSystem.isDirectory(buildPath))
+            // Fully clean.
+            _ = try await execute(
+                ["reset"],
+                packagePath: packageRoot,
+                configuration: data.config,
+                buildSystem: data.buildSystem,
+            )
+            #expect(!localFileSystem.isDirectory(buildPath))
 
-                // Test that we can successfully run reset again.
-                _ = try await execute(
-                    ["reset"],
-                    packagePath: packageRoot,
-                    configuration: data.config,
-                    buildSystem: data.buildSystem,
-                )
-            }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && data.buildSystem == .swiftbuild
+            // Test that we can successfully run reset again.
+            _ = try await execute(
+                ["reset"],
+                packagePath: packageRoot,
+                configuration: data.config,
+                buildSystem: data.buildSystem,
+            )
         }
     }
 
@@ -3071,7 +3063,7 @@ struct PackageCommandTests {
                 }
             }
         } when: {
-            [.windows, .linux].contains(ProcessInfo.hostOperatingSystem) && data.buildSystem == .swiftbuild
+            ProcessInfo.hostOperatingSystem == .linux && data.buildSystem == .swiftbuild
         }
     }
 

--- a/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/Tests/IntegrationTests/SwiftPMTests.swift
@@ -122,8 +122,7 @@ private struct SwiftPMTests {
                 #expect(!runOutput.stderr.contains("error:"))
                 #expect(runOutput.stdout.contains("Hello, world!"))
             } when: {
-                (buildSystemProvider == .swiftbuild && .windows == ProcessInfo.hostOperatingSystem)
-                || (buildSystemProvider == .swiftbuild && .linux == ProcessInfo.hostOperatingSystem && CiEnvironment.runningInSelfHostedPipeline)
+                (buildSystemProvider == .swiftbuild && .linux == ProcessInfo.hostOperatingSystem && CiEnvironment.runningInSelfHostedPipeline)
             }
         }
     }


### PR DESCRIPTION
- the also changes the source modules on Windows to be a static lib since pre-linked .o is not supported.

depends on: https://github.com/swiftlang/swift-build/pull/795