### PR TITLE
dump-pif: Add support for the swift-build PIFBuilder

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -903,6 +903,10 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         }
         return true
     }
+
+    public func generatePIF(preserveStructure: Bool) async throws -> String {
+        throw StringError("PIF generation is not applicable to the native build system.")
+    }
 }
 
 public struct PluginConfiguration {

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -183,13 +183,8 @@ struct DumpPIF: AsyncSwiftCommand {
     var preserveStructure: Bool = false
 
     func run(_ swiftCommandState: SwiftCommandState) async throws {
-        let graph = try await swiftCommandState.loadPackageGraph()
-        let pif = try PIFBuilder.generatePIF(
-            buildParameters: swiftCommandState.productsBuildParameters,
-            packageGraph: graph,
-            fileSystem: swiftCommandState.fileSystem,
-            observabilityScope: swiftCommandState.observabilityScope,
-            preservePIFModelStructure: preserveStructure)
+        let buildSystem = try await swiftCommandState.createBuildSystem()
+        let pif = try await buildSystem.generatePIF(preserveStructure: preserveStructure)
         print(pif)
     }
 

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -116,6 +116,8 @@ public protocol BuildSystem: Cancellable {
     func build(subset: BuildSubset, buildOutputs: [BuildOutput]) async throws -> BuildResult
 
     var hasIntegratedAPIDigesterSupport: Bool { get }
+
+    func generatePIF(preserveStructure: Bool) async throws -> String
 }
 
 extension BuildSystem {

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -945,13 +945,16 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         }
     }
 
-    public func writePIF(buildParameters: BuildParameters) async throws {
-        let pifBuilder = try await getPIFBuilder()
-        let pif = try await pifBuilder.generatePIF(
+    public func generatePIF(preserveStructure: Bool) async throws -> String {
+        return try await getPIFBuilder().generatePIF(
+            preservePIFModelStructure: preserveStructure,
             printPIFManifestGraphviz: buildParameters.printPIFManifestGraphviz,
-            buildParameters: buildParameters,
+            buildParameters: buildParameters
         )
+    }
 
+    public func writePIF(buildParameters: BuildParameters) async throws {
+        let pif = try await generatePIF(preserveStructure: false)
         try self.fileSystem.writeIfChanged(path: buildParameters.pifManifest, string: pif)
     }
 

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -357,6 +357,17 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
             try await packageGraphLoader()
         }
     }
+
+    public func generatePIF(preserveStructure: Bool) async throws -> String {
+        let graph = try await getPackageGraph()
+        return try PIFBuilder.generatePIF(
+            buildParameters: buildParameters,
+            packageGraph: graph,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope,
+            preservePIFModelStructure: preserveStructure
+        )
+    }
 }
 
 struct XCBBuildParameters: Encodable {


### PR DESCRIPTION
Respect --build-system when dumping PIF, and error if invoked with the native build system