### PR TITLE
[native] Add toolchain span back deployment rpaths when required

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -318,12 +318,12 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
                 throw InternalError("unexpectedly asked to generate linker arguments for a plugin product")
             }
 
-            // When deploying to macOS prior to macOS 12, add an rpath to the
-            // back-deployed concurrency libraries.
             if useStdlibRpath, triple.isMacOSX {
                 let macOSSupportedPlatform = self.package.getSupportedPlatform(for: .macOS, usingXCTest: product.isLinkingXCTest)
 
                 if macOSSupportedPlatform.version.major < 12 {
+                    // When deploying to macOS prior to macOS 12, add an rpath to the
+                    // back-deployed concurrency libraries.
                     let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
                         .parentDirectory
                         .parentDirectory
@@ -331,6 +331,21 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
                         .appending("macosx")
                     args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
                 }
+
+                if macOSSupportedPlatform.version.major < 26 {
+                    // When deploying to macOS prior to macOS 26, add an rpath to the
+                    // back-deployed Span library.
+                    let backDeployedStdlib = try buildParameters.toolchain.macosSwiftStdlib
+                        .parentDirectory
+                        .parentDirectory
+                        .appending("swift-6.2")
+                        .appending("macosx")
+                    args += ["-Xlinker", "-rpath", "-Xlinker", backDeployedStdlib.pathString]
+                }
+
+                // If either back deployment library is used, the driver is responsible for injecting
+                // a /usr/lib/swift -rpath at the front to ensure OS content is preferred when
+                // available.
             }
         } else {
             // Don't link runtime compatibility patch libraries if there are no

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -835,6 +835,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path", "-Xlinker",
             buildPath.appending(components: "Modules", "lib.swiftmodule").pathString,
@@ -1150,6 +1151,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-g",
         ])
@@ -1244,6 +1246,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-g",
         ])
@@ -1794,6 +1797,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path", "-Xlinker", "/path/to/build/\(result.plan.destinationBuildParameters.triple)/debug/exe.build/exe.swiftmodule",
             "-g",
@@ -2353,11 +2357,12 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
 
         #if os(macOS)
         let version = MinimumDeploymentTarget.computeXCTestMinimumDeploymentTarget(for: .macOS).versionString
-        let rpathsForBackdeployment: [String]
+        var rpathsForBackdeployment: [String] = []
         if let version = try? Version(string: version, lenient: true), version.major < 12 {
-            rpathsForBackdeployment = ["-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx"]
-        } else {
-            rpathsForBackdeployment = []
+            rpathsForBackdeployment += ["-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx"]
+        }
+        if let version = try? Version(string: version, lenient: true), version.major < 26 {
+            rpathsForBackdeployment += ["-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx"]
         }
         XCTAssertEqual(
             try result.buildProduct(for: "PkgPackageTests").linkArguments(),
@@ -2475,6 +2480,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-dead_strip",
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", hostTriple.tripleString(forPlatformVersion: "12.0"),
             "-g",
         ])
@@ -2846,6 +2852,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path",
             "-Xlinker", buildPath.appending(components: "exe.build", "exe.swiftmodule").pathString,
@@ -2992,6 +2999,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "Foo.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path",
             "-Xlinker", buildPath.appending(components: "Foo.build", "Foo.swiftmodule").pathString,
@@ -3009,6 +3017,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "Bar-Baz.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path",
             "-Xlinker", buildPath.appending(components: "Modules", "Bar.swiftmodule").pathString,
@@ -3165,6 +3174,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-Xlinker", "-rpath", "-Xlinker", "@loader_path",
             "@\(buildPath.appending(components: "lib.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path", "-Xlinker",
             buildPath.appending(components: "Modules", "lib.swiftmodule").pathString,
@@ -7295,6 +7305,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             "-emit-executable",
             "@\(buildPath.appending(components: "exe.product", "Objects.LinkFileList"))",
             "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-5.5/macosx",
+            "-Xlinker", "-rpath", "-Xlinker", "/fake/path/lib/swift-6.2/macosx",
             "-target", defaultTargetTriple,
             "-Xlinker", "-add_ast_path",
             "-Xlinker", buildPath.appending(components: "Modules", "lib.swiftmodule").pathString,


### PR DESCRIPTION
SwiftPM's native build system does not have the concept of embedding the compatibility libraries for distribution, so add rpaths to the span back deploy library in the toolchain when targeting macOS < 26. Ensure we always insert /usr/lib/swift ahead of the added rpaths to prefer the OS content when available. this mirrors the handling of the concurrency compat lib

Closes https://github.com/swiftlang/swift-package-manager/issues/9163