### PR TITLE
Tests: Only test debug build configuration on Windows

### DIFF
--- a/Tests/_InternalTestSupportTests/BuildSystemProviderSupportedTests.swift
+++ b/Tests/_InternalTestSupportTests/BuildSystemProviderSupportedTests.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import _InternalTestSupport
+import Testing
+import struct SPMBuildCore.BuildSystemProvider
+import enum PackageModel.BuildConfiguration
+import struct Basics.Environment
+
+@Suite(
+    .tags(
+        .TestSize.small,
+    )
+)
+struct BuildSystemProviderSupportedTests {
+
+    @Test(
+        .serialized,
+        arguments: [
+            [BuildSystemProvider.Kind.native],
+            [BuildSystemProvider.Kind.native, .xcode],
+            [BuildSystemProvider.Kind.native, .xcode, .swiftbuild],
+        ], [true, false],
+    )
+    func getBuildDataReturnsExpectedTests(
+        buildSystemsUT: [BuildSystemProvider.Kind],
+        setEnvironmantVariable: Bool,
+    ) async throws {
+        let expectedCount: Int
+        let customEnv: Environment
+
+        if setEnvironmantVariable {
+            expectedCount = buildSystemsUT.count
+            customEnv = [TEST_ONLY_DEBUG_ENV_VAR : "true"]
+        } else {
+            expectedCount = buildSystemsUT.count * BuildConfiguration.allCases.count
+            customEnv = [:]
+        }
+
+        try Environment.makeCustom(customEnv) {
+            let actual = getBuildData(for: buildSystemsUT)
+
+            #expect(actual.count == expectedCount)
+        }
+
+    }
+}

--- a/Tests/_InternalTestSupportTests/String+ExtensionTests.swift
+++ b/Tests/_InternalTestSupportTests/String+ExtensionTests.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import _InternalTestSupport
+import Testing
+
+@Suite(
+    .tags(
+        .TestSize.small,
+    )
+)
+struct StringExtensionTests {
+
+    @Test(
+        arguments: [
+            (value: "", expected: false),
+            (value: " ", expected: false),
+            (value: "0", expected: false),
+            (value: "1", expected: true),
+            (value: "true", expected: true),
+            (value: "True", expected: true),
+            (value: "TrUe", expected: true),
+            (value: "ftrue", expected: false),
+            (value: "truef", expected: false),
+            (value: "ftruef", expected: false),
+            (value: "YES", expected: true),
+            (value: "YEs", expected: true),
+            (value: "yEs", expected: true),
+            (value: "yes", expected: true),
+            (value: "fyes", expected: false),
+            (value: "yesf", expected: false),
+            (value: "fyesf", expected: false),
+            (value: "11", expected: false),
+        ],
+    )
+    func isTruthyReturnsCorrectValue(
+        valueUT: String,
+        expected: Bool,
+    ) async throws {
+        let actual = valueUT.isTruthy
+
+        #expect(actual == expected, "Value \(valueUT) should be \(expected)")
+    }
+}

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -136,6 +136,10 @@ def is_on_darwin() -> bool:
     return platform.system() == "Darwin"
 
 
+def is_on_windows() -> bool:
+    return platform.system() == "Windows"
+
+
 def set_environment(
     *,
     swiftpm_bin_dir: pathlib.Path,
@@ -147,6 +151,10 @@ def set_environment(
         sdk_root = call_output(shlex.split("xcrun --show-sdk-path --sdk macosx"))
         logging.debug("macos sdk root = %r", sdk_root)
         os.environ["SDKROOT"] = sdk_root
+
+    if is_on_windows():
+        # GH #9159: Temprorarily set this environment until we figure out why the Windows internal CI is hanging
+        os.environ["SWIFTPM_TEST_ONLY_DEBUG_BUILD_CONFIGURATION"] = "true"
     log_environment()
 
 


### PR DESCRIPTION
With the recent changes to the automated test, which augmented the Tests to run against the Native and Swift Build build system, in addition to the debug and release build configuraiton, and with `swift test` buffer the output on Windows (#8928), the theory is the Windows self hosted pipeline is failing due to the number of automated test, which causes Jenkins to hit the "Build Timeout" algorithim, causing Jenkins to abort the build as there is no output to the console.

I norer to unblock development, a change was made to run test against the Debug build configuration on Windows until a proper solution is availabe.

Related to #9159
Issue: rdar://160936699
