### PR TITLE
Disable optimization to work around a compiler bug

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -202,15 +202,15 @@ extension ManifestLoaderProtocol {
     ) async throws -> Manifest {
         // find the manifest path and parse it's tools-version
         let manifestPath = try ManifestLoader.findManifest(
-            packagePath: packagePath, 
-            fileSystem: fileSystem, 
+            packagePath: packagePath,
+            fileSystem: fileSystem,
             currentToolsVersion: currentToolsVersion
         )
         let manifestToolsVersion = try ToolsVersionParser.parse(manifestPath: manifestPath, fileSystem: fileSystem)
         // validate the manifest tools-version against the toolchain tools-version
         try manifestToolsVersion.validateToolsVersion(
-            currentToolsVersion, 
-            packageIdentity: packageIdentity, 
+            currentToolsVersion,
+            packageIdentity: packageIdentity,
             packageVersion: packageVersion?.version?.description ?? packageVersion?.revision
         )
 
@@ -259,7 +259,7 @@ actor ManifestCacheActor {
 /// `atexit()` handler) which is then deserialized and loaded.
 public final class ManifestLoader: ManifestLoaderProtocol {
     public typealias Delegate = ManifestLoaderDelegate
-    
+
     private let toolchain: UserToolchain
     private let serializedDiagnostics: Bool
     private let isManifestSandboxEnabled: Bool
@@ -298,7 +298,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         self.databaseCacheDir = try? cacheDir.map(resolveSymlinks)
         self.pruneDependencies = pruneDependencies
     }
-    
+
     public func load(
         manifestPath: AbsolutePath,
         manifestToolsVersion: ToolsVersion,
@@ -476,7 +476,6 @@ public final class ManifestLoader: ManifestLoaderProtocol {
         delegate: Delegate?,
         delegateQueue: DispatchQueue?
     ) async throws -> ManifestJSONParser.Result {
-        
         let key = try CacheKey(
             packageIdentity: packageIdentity,
             packageLocation: packageLocation,
@@ -677,10 +676,14 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
             return result
         }
-        
     }
 
     /// Helper method for evaluating the manifest.
+    // TODO: Optimizations are disabled to work around a compiler bug. Remove this attribute when the bug is fixed.
+    // See https://github.com/swiftlang/llvm-project/issues/11377 for details.
+    #if os(Windows)
+    @_optimize(none)
+    #endif
     func evaluateManifest(
         at manifestPath: AbsolutePath,
         vfsOverlayPath: AbsolutePath? = nil,

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -461,6 +461,11 @@ enum PackageArchiveSigner {
 }
 
 enum PackageArchiver {
+    // TODO: Optimizations are disabled to work around a compiler bug. Remove this attribute when the bug is fixed.
+    // See https://github.com/swiftlang/llvm-project/issues/11377 for details.
+    #if os(Windows)
+    @_optimize(none)
+    #endif
     static func archive(
         packageIdentity: PackageIdentity,
         packageVersion: Version,

--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -422,6 +422,11 @@ extension Workspace {
             return hash == checksum
         }
 
+        // TODO: Optimizations are disabled to work around a compiler bug. Remove this attribute when the bug is fixed.
+        // See https://github.com/swiftlang/llvm-project/issues/11377 for details.
+        #if os(Windows)
+        @_optimize(none)
+        #endif
         func downloadPrebuilt(
             workspace: Workspace,
             package: PrebuiltPackage,


### PR DESCRIPTION
Temporarily disable optimizations for some functions.

### Motivation:

There is a bug in the Swift rebranch that prevents some functions from being optimized in a way that the assembler can handle. This temporarily disables optimizations for these functions until a permanent solution is implemented.

Bug: swiftlang/llvm-project#11377

### Modifications:

Disable optimizations on Windows for problematic functions.

### Result:

The project builds for the Swift rebranch.