### PR TITLE
[6.2] Cherry Pick - Build fat packages when shouldPackagesBuildForARM64e is set

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -584,7 +584,7 @@ public final class PackagePIFBuilder {
                 default:
                     .init(from: arm64ePlatform)
                 }
-                settings.platformSpecificSettings[pifPlatform]![.ARCHS] = ["arm64e"]
+                settings.platformSpecificSettings[pifPlatform]![.ARCHS, default: []].append(contentsOf: ["arm64e"])
             }
         }
 


### PR DESCRIPTION
### Motivation:

I extended arm64e support for macOS & visionOS apps in my previous PR #8837. When enabled, that patch *only* produced the arm64e slice but...

The App Store will now accept arm64e for macOS, iOS, and visionOS — arm64e is optional and off by default. But when you turn on arm64e support for packages (ie, using `shouldPackagesBuildForARM64e` PIF builder delegate method) we expect *both* slices in the binary now.

### Modifications:

Changes the PIF builder to update the ARCHS settings without overriding it completely, ensuring we get all required slices (ie, a so called fat binary).

### Result:

PIF builder nows has the capability of building packages for arm64 and arm64e. (Note, for now, that this is currently disabled in SwiftPM.)

I validated this by building a simple macOS executable for arm64e (and force enabling it in SwifPM):

    $ swift package init --type executable --name HelloWorld
    $ swift run swift-build --package-path HelloWorld --build-system swiftbuild --configuration release

...and then I inspected the generated binary:

    $ lipo -archs HelloWorld/.build/arm64-apple-macosx/Products/Release/HelloWorld 
    x86_64 arm64 arm64e

Debug builds. With ONLY_ACTIVE_ARCH = "YES" in debug builds, even though you specify multiple architectures in ARCHS, it will still only build for the active architecture during development. This is set to "NO" for release builds.
