### PR TITLE
fix: remove preceding `-Xcc` instead of the argument following `-Werror` or `-Wwarning`

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -611,26 +611,21 @@ public final class SwiftModuleBuildDescription {
         // suppress warnings if the package is remote
         if self.package.isRemote {
             // suppress-warnings and the other warning control flags are mutually exclusive
-            var removeNextArg = false
-            args = Array(args.lazy.reversed().filter { arg in
-                if removeNextArg {
-                    removeNextArg = false
-                    return false
-                }
+            var filteredArgs = [String]()
+            for arg in args {
                 switch arg {
                 case "-warnings-as-errors", "-no-warnings-as-errors":
-                    return false
+                    // Skip this flag
+                    continue
                 case "-Wwarning", "-Werror":
-                    removeNextArg = true
-                    return false
+                    // Remove preceding -Xcc and skip this flag
+                    filteredArgs.removeLast()
                 default:
-                    return true
+                    filteredArgs.append(arg)
                 }
-            }.reversed())
-            guard !removeNextArg else {
-                throw InternalError("Unexpected '-Wwarning' or '-Werror' at the end of args")
             }
-            args += ["-suppress-warnings"]
+            args = filteredArgs
+            args.append("-suppress-warnings")
         }
 
         // Pass `-user-module-version` for versioned packages that aren't pre-releases.


### PR DESCRIPTION
When suppressing warnings in remote packages, `SwiftModuleBuildDescription.compileArguments` removes the flag following `-Werror` / `-Wwarning` instead of the preceding `-Xcc` (issue: https://github.com/swiftlang/swift-package-manager/issues/9192). This is a proposed fix to that issue by reversing the arguments before filtering.

### Motivation:
The problem is described in this issue: https://github.com/swiftlang/swift-package-manager/issues/9192 .
This was most likely introduced in this PR https://github.com/swiftlang/swift-package-manager/pull/8315 .
It looks like the originally submitted code was filtering on the reversed args, in which case the preceding `-Xcc` would have been removed. But the final iteration does not reverse the args.

### Modifications:
Instead of filtering with a closure with side-effects, initialize an empty array and while iterating over `args` append to new array/skip/skip+remove last as needed.
#### Stale
Reverse `args` before filtering, reverse again after filtering to recover original order. Use `Array.lazy` to avoid materializing intermediate arrays.
Edit: I'm not completely sure if lazy will play well with the side-effect of mutating the captured `removeNextArg`.

### Result:
Given `swift build -Xcc -Werror <other flags>`, remote packages should now build equivalently as `swift build -suppress-warnings <other flags>` and not throw the internal error.
