### PR TITLE
[6.2] Cherry-pick: Remove animated progress bar from SwiftBuild output

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -291,11 +291,9 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         try await withService(connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint)) { service in
             let derivedDataPath = self.buildParameters.dataPath
 
-            let progressAnimation = ProgressAnimation.percent(
+            let progressAnimation = ProgressAnimation.ninja(
                 stream: self.outputStream,
-                verbose: self.logLevel.isVerbose,
-                header: "",
-                isColorized: self.buildParameters.outputParameters.isColorized
+                verbose: self.logLevel.isVerbose
             )
 
             do {


### PR DESCRIPTION
This change removes the progress bar from the output generated when we use the SwiftBuild build system in SwiftPM. The progress bar tears and affects the format of the emitted logs and diagnostics.
