### PR TITLE
Use new common object product type in PIF

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -358,7 +358,7 @@ public final class PackagePIFBuilder {
         // Products.
         case application
         case staticArchive
-        case objectFile
+        case commonObject
         case dynamicLibrary
         case framework
         case executable
@@ -382,7 +382,7 @@ public final class PackagePIFBuilder {
             self = switch pifProductType {
             case .application: .application
             case .staticArchive: .staticArchive
-            case .objectFile: .objectFile
+            case .commonObject: .commonObject
             case .dynamicLibrary: .dynamicLibrary
             case .framework: .framework
             case .executable: .executable

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -249,11 +249,7 @@ extension PackagePIFProjectBuilder {
             }
 
         case .staticLibrary, .executable:
-            #if os(Windows) // Temporary until we get a new productType in swift-build
-            productType = .staticArchive
-            #else
-            productType = .objectFile
-            #endif
+            productType = .commonObject
 
         case .macro:
             productType = .hostBuildTool


### PR DESCRIPTION
Use a common object type that can deal with the differences between Windows and Darwin/Linux leaving the PIF platform agnostic and pushing the platform differences down into swift-build 
https://github.com/swiftlang/swift-build/issues/610