### PR TITLE
extending the docs to explain how to use embedInCode

### DIFF
--- a/Sources/Runtimes/PackageDescription/Resource.swift
+++ b/Sources/Runtimes/PackageDescription/Resource.swift
@@ -97,7 +97,7 @@ public struct Resource: Sendable {
 
     /// Applies the embed rule to a resource at the given path.
     ///
-    /// Use the embed rule to embed the bytes that represents the contents of a resource into executable code.
+    /// Use the embed rule to embed the bytes that represent the contents of a resource into executable code.
     /// For example,  if you embed the file `identifier.txt` that has the contents:
     /// ```
     /// Hello Swift


### PR DESCRIPTION
Extends the PackageDescription documentation to explain how to use the .embedInCode rule for a resource.

### Motivation:

The changelog originally included some detail, but it's missing from the documentation, so updating the 
API reference for PackageDescription to provide information about how to use .embedInCode.

### Modifications:

Updated the .embedInCode documentation to show code blocks with an example of usage to illustrate how to use it.

### Result:

Improved documentation for PackageDescription and the embedInCode resource rule
