### PR TITLE
Stop using mergeable-symbols in embedded

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -475,12 +475,6 @@ public final class SwiftModuleBuildDescription {
             args.append("-enable-batch-mode")
         }
 
-        // Workaround for https://github.com/swiftlang/swift-package-manager/issues/8648
-        if self.useMergeableSymbols {
-            args.append("-Xfrontend")
-            args.append("-mergeable-symbols")
-        }
-
         args += ["-serialize-diagnostics"]
 
         args += self.buildParameters.indexStoreArguments(for: self.target)
@@ -1067,12 +1061,6 @@ public final class SwiftModuleBuildDescription {
         case .release:
             return true
         }
-    }
-
-    // Workaround for https://github.com/swiftlang/swift-package-manager/issues/8648
-    /// Whether to build Swift code with -Xfrontend -mergeable-symbols.
-    package var useMergeableSymbols: Bool {
-        return self.isEmbeddedSwift
     }
 }
 

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -2146,7 +2146,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         )
         XCTAssertNoDiagnostics(observability.diagnostics)
 
-        // -Xfrontend -mergeable symbols should be passed with Embedded
+        // -wmo should be passed with Embedded
         let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             fileSystem: fs,
@@ -2160,47 +2160,6 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         let aCompileArgumentsNegativePattern: [StringPattern] = ["-wmo"]
         XCTAssertMatch(aCompileArguments, aCompileArgumentsPattern)
         XCTAssertNoMatch(aCompileArguments, aCompileArgumentsNegativePattern)
-    }
-
-    // Workaround for: https://github.com/swiftlang/swift-package-manager/issues/8648
-    func test_mergeableSymbols_enabledInEmbedded() async throws {
-        let Pkg: AbsolutePath = "/Pkg"
-        let fs: FileSystem = InMemoryFileSystem(
-            emptyFiles:
-                Pkg.appending(components: "Sources", "A", "A.swift").pathString
-        )
-
-        let observability = ObservabilitySystem.makeForTesting()
-        let graph = try loadModulesGraph(
-            fileSystem: fs,
-            manifests: [
-                Manifest.createRootManifest(
-                    displayName: "Pkg",
-                    path: .init(validating: Pkg.pathString),
-                    targets: [
-                        TargetDescription(
-                            name: "A",
-                            settings: [.init(tool: .swift, kind: .enableExperimentalFeature("Embedded"))]
-                        ),
-                    ]
-                ),
-            ],
-            observabilityScope: observability.topScope
-        )
-        XCTAssertNoDiagnostics(observability.diagnostics)
-
-        // -Xfrontend -mergeable symbols should be passed with Embedded
-        let result = try await BuildPlanResult(plan: mockBuildPlan(
-            graph: graph,
-            fileSystem: fs,
-            observabilityScope: observability.topScope
-        ))
-        result.checkTargetsCount(1)
-
-        // Compile Swift Target
-        let aCompileArguments = try result.moduleBuildDescription(for: "A").swift().compileArguments()
-        let aCompileArgumentsPattern: [StringPattern] = ["-Xfrontend", "-mergeable-symbols"]
-        XCTAssertMatch(aCompileArguments, aCompileArgumentsPattern)
     }
 
     func testREPLArguments() async throws {


### PR DESCRIPTION
This flag is now a no-op and isn't needed after recent changes to the embedded swift linkage model.

Fixes: #8653
