### PR TITLE
Disable failing test on Amazon Linux 2

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
@@ -75,4 +75,11 @@ extension Trait where Self == Testing.Bug {
             relationship: .defect,
         )
     }
+
+    public static var IssueLdFailsUnexpectedly : Self {
+        .issue(
+            "https://github.com/swiftlang/swift-package-manager/issues/9249",
+            relationship: .defect,
+        )
+    }
 }

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -162,6 +162,7 @@ struct DependencyResolutionTests {
 
     @Test(
         .IssueWindowsLongPath,
+        .IssueLdFailsUnexpectedly,
         .tags(
             Tag.Feature.Command.Build,
         ),
@@ -188,7 +189,8 @@ struct DependencyResolutionTests {
                 #expect(output == "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
             }
         } when: {
-            ProcessInfo.hostOperatingSystem == .windows // due to long path isues
+            ProcessInfo.hostOperatingSystem == .windows // due to long path issues
+            || (ProcessInfo.isHostAmazonLinux2() && buildSystem == .swiftbuild) // Linker ld throws an unexpected error.
         }
     }
 


### PR DESCRIPTION
* Disable the 'externalComplex' test on Amazon Linux 2 as this is blocking the nightly toolchain.
