### PR TITLE
Mark commandPluginCompilation as intermittent

### DIFF
--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -7208,7 +7208,7 @@ struct PackageCommandTests {
                                 "iteration \(num) failed.  stderr: \(stderr)",
                             )
                         } when: {
-                            data.config == .release && data.buildSystem == .native
+                            data.buildSystem == .native
                         }
                         #expect(
                             !stdout.contains("Building for \(data.config.buildFor)..."),


### PR DESCRIPTION
Mark it as intermittent for the native build system debug configuration.
Some CI environments are encountering an intermittent failure in this
configuration in addition to the release.