### PR TITLE
Remove externalComplex test completely.

### DIFF
--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -160,39 +160,43 @@ struct DependencyResolutionTests {
         }
     }
 
-    @Test(
-        .IssueWindowsLongPath,
-        .IssueLdFailsUnexpectedly,
-        .tags(
-            Tag.Feature.Command.Build,
-        ),
-        arguments: SupportedBuildSystemOnAllPlatforms,
-        BuildConfiguration.allCases,
-    )
-    func externalComplex(
-        buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
-    ) async throws {
-        try await withKnownIssue(isIntermittent: ProcessInfo.hostOperatingSystem == .windows){
-            try await fixture(name: "DependencyResolution/External/Complex") { fixturePath in
-                let packageRoot = fixturePath.appending("app")
-                try await executeSwiftBuild(
-                    packageRoot,
-                    configuration: configuration,
-                    buildSystem: buildSystem,
-                )
-                let binPath = try packageRoot.appending(components: buildSystem.binPath(for: configuration))
-                let executablePath = binPath.appending(components: "Dealer")
-                expectFileExists(at: executablePath)
-                let output = try await AsyncProcess.checkNonZeroExit(args: executablePath.pathString)
-                    .withSwiftLineEnding
-                #expect(output == "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
-            }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows // due to long path issues
-            || (ProcessInfo.isHostAmazonLinux2() && buildSystem == .swiftbuild) // Linker ld throws an unexpected error.
-        }
-    }
+    // Remove test completely until root issues are resolved
+    // has caused trouble in multiple ways for weeks.
+    // https://github.com/swiftlang/swift-package-manager/issues/9249
+    
+    // @Test(
+    //     .IssueWindowsLongPath,
+    //     .IssueLdFailsUnexpectedly,
+    //     .tags(
+    //         Tag.Feature.Command.Build,
+    //     ),
+    //     arguments: SupportedBuildSystemOnAllPlatforms,
+    //     BuildConfiguration.allCases,
+    // )
+    // func externalComplex(
+    //     buildSystem: BuildSystemProvider.Kind,
+    //     configuration: BuildConfiguration,
+    // ) async throws {
+    //     try await withKnownIssue(isIntermittent: ProcessInfo.hostOperatingSystem == .windows){
+    //         try await fixture(name: "DependencyResolution/External/Complex") { fixturePath in
+    //             let packageRoot = fixturePath.appending("app")
+    //             try await executeSwiftBuild(
+    //                 packageRoot,
+    //                 configuration: configuration,
+    //                 buildSystem: buildSystem,
+    //             )
+    //             let binPath = try packageRoot.appending(components: buildSystem.binPath(for: configuration))
+    //             let executablePath = binPath.appending(components: "Dealer")
+    //             expectFileExists(at: executablePath)
+    //             let output = try await AsyncProcess.checkNonZeroExit(args: executablePath.pathString)
+    //                 .withSwiftLineEnding
+    //             #expect(output == "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
+    //         }
+    //     } when: {
+    //         ProcessInfo.hostOperatingSystem == .windows // due to long path issues
+    //         || (ProcessInfo.isHostAmazonLinux2() && buildSystem == .swiftbuild) // Linker ld throws an unexpected error.
+    //     }
+    // }
 
     @Test(
         .IssueProductTypeForObjectLibraries,


### PR DESCRIPTION
Comment out test as it has caused CI issues for weeks now.

https://github.com/swiftlang/swift-package-manager/issues/9249