### PR TITLE
Adopt swift-subprocess when running unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ if(FIND_PM_DEPS)
   find_package(SwiftCertificates CONFIG REQUIRED)
   find_package(SwiftCrypto CONFIG REQUIRED)
   find_package(SwiftBuild CONFIG REQUIRED)
+  find_package(SwiftSubprocess CONFIG REQUIRED)
 endif()
 
 find_package(dispatch QUIET)

--- a/Package.swift
+++ b/Package.swift
@@ -239,6 +239,7 @@ let package = Package(
             dependencies: [
                 "_AsyncFileSystem",
                 .target(name: "SPMSQLite3", condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS, .macCatalyst, .linux, .openbsd, .custom("freebsd")])),
+                .product(name: "Subprocess", package: "swift-subprocess"),
                 .product(name: "SwiftToolchainCSQLite", package: "swift-toolchain-sqlite", condition: .when(platforms: [.windows, .android])),
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
@@ -575,6 +576,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
+                .product(name: "Subprocess", package: "swift-subprocess"),
                 "Basics",
                 "BinarySymbols",
                 "Build",
@@ -1113,6 +1115,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-system.git", revision: "1.5.0"),
         .package(url: "https://github.com/apple/swift-collections.git", revision: "1.1.6"),
         .package(url: "https://github.com/apple/swift-certificates.git", revision: "1.10.1"),
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", revision: "1.0.7"),
         // Not in toolchain, used for use in previewing documentation
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
@@ -1131,6 +1134,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-system"),
         .package(path: "../swift-collections"),
         .package(path: "../swift-certificates"),
+        .package(path: "../swift-subprocess"),
         .package(path: "../swift-toolchain-sqlite"),
     ]
     if !swiftDriverDeps.isEmpty {

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(Basics
   Serialization/SerializedJSON.swift
   SwiftVersion.swift
   SQLiteBackedCache.swift
+  Subprocess+Extensions.swift
   TestingLibrary.swift
   Triple+Basics.swift
   URL.swift
@@ -83,6 +84,7 @@ add_library(Basics
 target_link_libraries(Basics PUBLIC
   _AsyncFileSystem
   SwiftCollections::OrderedCollections
+  SwiftSubprocess::Subprocess
   TSCBasic
   TSCUtility)
 target_link_libraries(Basics PRIVATE

--- a/Sources/Basics/Subprocess+Extensions.swift
+++ b/Sources/Basics/Subprocess+Extensions.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Subprocess
+import TSCBasic
+
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
+
+extension Subprocess.Environment {
+    public init(_ env: Basics.Environment) {
+        var newEnv: [Subprocess.Environment.Key: String] = [:]
+        for (key, value) in env {
+            newEnv[.init(rawValue: key.rawValue)!] = value
+        }
+        self = Subprocess.Environment.custom(newEnv)
+    }
+}
+
+extension Subprocess.Configuration {
+    public init(commandLine: [String], environment: Subprocess.Environment) throws {
+        guard let arg0 = commandLine.first else {
+            throw StringError("command line was unexpectedly empty")
+        }
+        self.init(.path(FilePath(arg0)), arguments: .init(Array(commandLine.dropFirst())), environment: environment)
+    }
+}

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(Commands
 target_link_libraries(Commands PUBLIC
   SwiftCollections::OrderedCollections
   SwiftSyntax::SwiftRefactor
+  SwiftSubprocess::Subprocess
   ArgumentParser
   Basics
   BinarySymbols

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -288,7 +288,7 @@ final class PluginDelegate: PluginInvocationDelegate {
 
                         // Run the test — for now we run the sequentially so we can capture accurate timing results.
                         let startTime = DispatchTime.now()
-                        let result = testRunner.test(outputHandler: { _ in }) // this drops the tests output
+                        let result = await testRunner.test(outputHandler: { _ in }) // this drops the tests output
                         let duration = Double(startTime.distance(to: .now()).milliseconds() ?? 0) / 1000.0
                         numFailedTests += (result != .failure) ? 0 : 1
                         testResults.append(

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -248,6 +248,7 @@ def parse_global_args(args):
     args.source_dirs["swift-asn1"]            = os.path.join(args.project_root, "..", "swift-asn1")
     args.source_dirs["swift-syntax"]          = os.path.join(args.project_root, "..", "swift-syntax")
     args.source_dirs["swift-build"]           = os.path.join(args.project_root, "..", "swift-build")
+    args.source_dirs["swift-subprocess"]      = os.path.join(args.project_root, "..", "swift-subprocess")
     args.source_root                          = os.path.join(args.project_root, "Sources")
 
     if platform.system() == 'Darwin':
@@ -447,6 +448,8 @@ def build(args):
         build_dependency(args, "swift-certificates",
             ["-DSwiftASN1_DIR=" + os.path.join(args.build_dirs["swift-asn1"], "cmake/modules"),
              "-DSwiftCrypto_DIR=" + os.path.join(args.build_dirs["swift-crypto"], "cmake/modules")])
+        build_dependency(args, "swift-subprocess",
+            ["-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules")])
         swift_build_cmake_flags = [
             get_llbuild_cmake_arg(args),
             "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
@@ -732,6 +735,7 @@ def build_swiftpm_with_cmake(args):
 
     cmake_flags = [
         get_llbuild_cmake_arg(args),
+        "-DSwiftSubprocess_DIR="   + os.path.join(args.build_dirs["swift-subprocess"],      "cmake/modules"),
         "-DTSC_DIR="               + os.path.join(args.build_dirs["tsc"],                   "cmake/modules"),
         "-DArgumentParser_DIR="    + os.path.join(args.build_dirs["swift-argument-parser"], "cmake/modules"),
         "-DSwiftDriver_DIR="       + os.path.join(args.build_dirs["swift-driver"],          "cmake/modules"),
@@ -765,6 +769,7 @@ def build_swiftpm_with_cmake(args):
         add_rpath_for_cmake_build(args, args.build_dirs["llbuild"])
 
     if platform.system() == "Darwin":
+        add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-subprocess"],      "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-argument-parser"], "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-crypto"],          "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-driver"],          "lib"))
@@ -772,7 +777,7 @@ def build_swiftpm_with_cmake(args):
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-collections"],     "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-asn1"],            "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-certificates"],    "lib"))
-        add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-build"],          "lib"))
+        add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-build"],           "lib"))
 
         # rpaths for compatibility libraries
         for lib_path in get_swift_backdeploy_library_paths(args):
@@ -901,6 +906,7 @@ def get_swiftpm_env_cmd(args):
     if args.bootstrap:
         libs = [
             os.path.join(args.bootstrap_dir,                       "lib"),
+            os.path.join(args.build_dirs["swift-subprocess"],      "lib"),
             os.path.join(args.build_dirs["tsc"],                   "lib"),
             os.path.join(args.build_dirs["llbuild"],               "lib"),
             os.path.join(args.build_dirs["swift-argument-parser"], "lib"),


### PR DESCRIPTION
Alternative to https://github.com/swiftlang/swift-package-manager/pull/9191

Begin adopting swift-subprocess, beginning with test execution, in an effort to standardize on one implementation for process output streaming across platforms.

This required a bit of additional refactoring of the parallel test runner to make it async

Depends on https://github.com/swiftlang/swift/pull/84947
Fixes: #8928 