### PR TITLE
Explicitly set the Swift language mode on package init

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -35,14 +35,19 @@ public final class InitPackage {
         /// Note: This should only contain Apple platforms right now.
         public var platforms: [SupportedPlatform]
 
+        /// The swiftLanguageModes to include
+        public var swiftLanguageModes: [SwiftLanguageVersion]
+
         public init(
             packageType: PackageType,
             supportedTestingLibraries: Set<TestingLibrary>,
-            platforms: [SupportedPlatform] = []
+            platforms: [SupportedPlatform] = [],
+            swiftLanguageModes: [SwiftLanguageVersion] = [SwiftLanguageVersion.v6]
         ) {
             self.packageType = packageType
             self.supportedTestingLibraries = supportedTestingLibraries
             self.platforms = platforms
+            self.swiftLanguageModes = swiftLanguageModes
         }
     }
 
@@ -430,6 +435,12 @@ public final class InitPackage {
                 }
 
                 pkgParams.append(param)
+            }
+
+            if (!options.swiftLanguageModes.isEmpty) {
+                pkgParams.append("""
+                    swiftLanguageModes: [\(options.swiftLanguageModes.map { ".v\($0)" }.joined(separator: ", "))]
+                """)
             }
 
             stream.send("\(pkgParams.joined(separator: ",\n"))\n)\n")

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -666,11 +666,12 @@ extension InitPackage {
         packageType: PackageType,
         supportedTestingLibraries: Set<TestingLibrary> = [.swiftTesting],
         destinationPath: AbsolutePath,
-        fileSystem: FileSystem
+        fileSystem: FileSystem,
+        swiftLanguageModes: [SwiftLanguageVersion] = []
     ) throws {
         try self.init(
             name: name,
-            options: InitPackageOptions(packageType: packageType, supportedTestingLibraries: supportedTestingLibraries),
+            options: InitPackageOptions(packageType: packageType, supportedTestingLibraries: supportedTestingLibraries, swiftLanguageModes: swiftLanguageModes),
             destinationPath: destinationPath,
             installedSwiftPMConfiguration: .default,
             fileSystem: fileSystem

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -510,6 +510,31 @@ final class InitTests: XCTestCase {
         }
     }
 
+    func testInitPackageIncludesSwiftLanguageMode() throws {
+        try testWithTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("testInitPackageIncludesSwiftLanguageMode")
+            let name = path.basename
+            try fs.createDirectory(path)
+
+            // Create a library package
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: .library,
+                supportedTestingLibraries: [],
+                destinationPath: path,
+                installedSwiftPMConfiguration: .default,
+                fileSystem: localFileSystem
+            )
+            try initPackage.writePackageStructure()
+
+            // Verify the manifest includes Swift language mode
+            let manifest = path.appending("Package.swift")
+            let manifestContents: String = try localFileSystem.readFileContents(manifest)
+            XCTAssertMatch(manifestContents, .contains("swiftLanguageModes: [.v6]"))
+        }
+    }
+
     private func packageWithNameOnly(named name: String) -> String {
         return """
         let package = Package(


### PR DESCRIPTION
Explicitly set the Swift language mode on package init

### Motivation:

When a package is created using `swift package init` no language mode is specified and defaults to using Swift 5.

New packages should be written in Swift 6, so explicitly set the language mode to 6 on package init.

### Modifications:

Include a language mode on package init

### Result:

New packages created using `swift package init` will include the following by default: swiftLanguageModes: [.v6]

```
let package = Package(
    name: "tmp",
    products: [
        // Products define the executables and libraries a package produces, making them visible to other packages.
        .library(
            name: "tmp",
            targets: ["tmp"]
        ),
    ],
    targets: [
        // Targets are the basic building blocks of a package, defining a module or a test suite.
        // Targets can depend on other targets in this package and products from dependencies.
        .target(
            name: "tmp"
        ),
        .testTarget(
            name: "tmpTests",
            dependencies: ["tmp"]
        ),
    ],
    swiftLanguageModes: [.v6]
)
```