### PR TITLE
Bootstrap: Use computed module triple

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -727,9 +727,8 @@ def build_swiftpm_with_cmake(args):
     """Builds SwiftPM using CMake."""
     logging.info("Building SwiftPM (with CMake)")
 
-    module_triple = get_build_target(args)
-    if platform.system() == 'Darwin':
-        module_triple = module_triple.replace('macosx', 'macos')
+    get_build_target(args)
+    module_triple = args.target_info["target"]["moduleTriple"]
 
     cmake_flags = [
         get_llbuild_cmake_arg(args),


### PR DESCRIPTION

Use the `moduleTriple` field to compute the module triple.

### Motivation:

Neither the unversioned target triple or target triple are the module triple. They are often similar, but not guaranteed to be the same, which can cause issues.

```
[2025-10-16T00:39:26.676Z] 11 | //===----------------------------------------------------------------------===//
[2025-10-16T00:39:26.676Z] 12 | 
[2025-10-16T00:39:26.676Z] 13 | @_spi(PackageDescriptionInternal) import PackageDescription
[2025-10-16T00:39:26.676Z]    |                                          `- error: could not find module 'PackageDescription' for target 'x86_64-unknown-freebsd'; found: x86_64-unknown-freebsd14.3, at: /home/ec2-user/jenkins/workspace/oss-swift-package-freebsd-14/build/buildbot_freebsd/swiftpm-freebsd-x86_64/x86_64-unknown-freebsd/bootstrap/Sources/Runtimes/PackageDescription/PackageDescription.swiftmodule/x86_64-unknown-freebsd
```
https://github.com/swiftlang/swift-package-manager/issues/9255

### Modifications:

Updated the cmake bootstrap build to use the module triple instead of the unversioned triple or full target triple.

### Result:

We will use the module triple as computed by the Swift compiler to set the module triple that SwiftPM will generate to emit the swiftmodule instead of either the unversioned target triple or full target triple. Neither of which are guaranteed to align with the expected module triple used on the file name.