### PR TITLE
Detect system GNU ld script pretending to be system libraries

### DIFF
--- a/Sources/Commands/PackageCommands/AuditBinaryArtifact.swift
+++ b/Sources/Commands/PackageCommands/AuditBinaryArtifact.swift
@@ -50,7 +50,10 @@ struct AuditBinaryArtifact: AsyncSwiftCommand {
         var hostDefaultSymbols = ReferencedSymbols()
         let symbolProvider = LLVMObjdumpSymbolProvider(objdumpPath: objdump)
         for binary in try await detectDefaultObjects(
-            clang: clang, fileSystem: fileSystem, hostTriple: hostTriple)
+            clang: clang, fileSystem: fileSystem, hostTriple: hostTriple,
+            observabilityScope:
+                swiftCommandState.observabilityScope.makeChildScope(
+                    description: "DefaultObjectsDetector"))
         {
             try await symbolProvider.symbols(
                 for: binary, symbols: &hostDefaultSymbols, recordUndefined: false)


### PR DESCRIPTION
When a system library is shimmed with a GNU ld script, pull in the required libraries when auditing binary artifacts

### Motivation:

Basic C runtime libraries appear to sometimes be replaced by a GNU ld script that pulls it some other libraries as a backwards compatibility mechanism on certain Linux distros. This makes it difficult for the binary auditing tool to find all required libraries. The only previously known case of this was libgcc_s so we used to just special case for it, but now that Ubuntu does this for splitting up libm, a more general solution is required.

### Modifications:

Add basic support for detecting such GNU ld script and parsing out libraries they pull in. The subset of features supported is consistent with how we have seen libraries being repackaged.

### Result:

Binary auditing tool will be more resilient.