### PR TITLE
Allow auditing of uncompressed artifact bundles

### DIFF
--- a/Sources/Commands/PackageCommands/AuditBinaryArtifact.swift
+++ b/Sources/Commands/PackageCommands/AuditBinaryArtifact.swift
@@ -99,6 +99,11 @@ struct AuditBinaryArtifact: AsyncSwiftCommand {
     {
         let archiver = UniversalArchiver(fileSystem)
 
+        if let lastPathComponent = path.components.last,
+            lastPathComponent.hasSuffix("artifactbundle") {
+            return path
+        }
+
         guard let lastPathComponent = path.components.last,
             archiver.isFileSupported(lastPathComponent)
         else {


### PR DESCRIPTION
This is useful for debugging scenarios where artifact bundle authors want to iterate over their artifacts without having to compress them first.