### PR TITLE
Resolve traits on top level manifests explicitly

### DIFF
--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -598,8 +598,10 @@ extension Workspace {
             // Resolve and flatten the list of traits on top level manifests. This handles
             // the case where a package is being loaded in a wrapper project (not package),
             // where there are no root packages but there are dependencies.
-            let topLevelManifestTraits = try manifest.enabledTraits(using: parentEnabledTraits, nil)
-            self.enabledTraitsMap[manifest.packageIdentity] = topLevelManifestTraits
+            if root.packages.isEmpty {
+                let topLevelManifestTraits = try manifest.enabledTraits(using: parentEnabledTraits, nil)
+                self.enabledTraitsMap[manifest.packageIdentity] = topLevelManifestTraits
+            }
 
             return try manifest.dependencies.filter { dep in
                 let explicitlyEnabledTraits = dep.traits?.filter({


### PR DESCRIPTION
If a package is contained in a wrapper project it will have a top level manifest with no root packages. In this case, we weren't resolving default traits on the dependencies within this top level manifest.