### PR TITLE
Fix artifactPath used for binary targets in PIF

### DIFF
--- a/Fixtures/BinaryTargets/Inputs/SwiftFramework/SwiftFramework.xcodeproj/xcshareddata/xcschemes/SwiftFramework.xcscheme
+++ b/Fixtures/BinaryTargets/Inputs/SwiftFramework/SwiftFramework.xcodeproj/xcshareddata/xcschemes/SwiftFramework.xcscheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "63A1B3E323FB4B26001B7732"
+               BuildableName = "SwiftFramework.framework"
+               BlueprintName = "SwiftFramework"
+               ReferencedContainer = "container:SwiftFramework.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "63A1B3E323FB4B26001B7732"
+            BuildableName = "SwiftFramework.framework"
+            BlueprintName = "SwiftFramework"
+            ReferencedContainer = "container:SwiftFramework.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -21,6 +21,7 @@ import struct Basics.SourceControlURL
 
 import class PackageModel.Manifest
 import class PackageModel.Module
+import class PackageModel.BinaryModule
 import class PackageModel.Product
 import class PackageModel.SystemLibraryModule
 
@@ -629,8 +630,12 @@ extension PackagePIFProjectBuilder {
                     }
 
                 case .binary:
+                    guard let binaryModule = moduleDependency.underlying as? BinaryModule else {
+                        log(.error, "'\(moduleDependency.name)' is a binary dependency, but its underlying module was not")
+                        break
+                    }
                     let binaryReference = self.binaryGroup.addFileReference { id in
-                        FileReference(id: id, path: moduleDependency.path.pathString)
+                        FileReference(id: id, path: (binaryModule.artifactPath.pathString))
                     }
                     if shouldLinkProduct {
                         self.project[keyPath: sourceModuleTargetKeyPath].addLibrary { id in

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -339,8 +339,12 @@ extension PackagePIFProjectBuilder {
 
                 switch moduleDependency.type {
                 case .binary:
+                    guard let binaryModule = moduleDependency.underlying as? BinaryModule else {
+                        log(.error, "'\(moduleDependency.name)' is a binary dependency, but its underlying module was not")
+                        break
+                    }
                     let binaryFileRef = self.binaryGroup.addFileReference { id in
-                        FileReference(id: id, path: moduleDependency.path.pathString)
+                        FileReference(id: id, path: binaryModule.artifactPath.pathString)
                     }
                     let toolsVersion = self.package.manifest.toolsVersion
                     self.project[keyPath: mainModuleTargetKeyPath].addLibrary { id in
@@ -720,7 +724,7 @@ extension PackagePIFProjectBuilder {
 
                 if let binaryTarget = moduleDependency.underlying as? BinaryModule {
                     let binaryFileRef = self.binaryGroup.addFileReference { id in
-                        FileReference(id: id, path: binaryTarget.path.pathString)
+                        FileReference(id: id, path: binaryTarget.artifactPath.pathString)
                     }
                     let toolsVersion = package.manifest.toolsVersion
                     self.project[keyPath: libraryUmbrellaTargetKeyPath].addLibrary { id in

--- a/Sources/_IntegrationTestSupport/Helpers.swift
+++ b/Sources/_IntegrationTestSupport/Helpers.swift
@@ -113,7 +113,7 @@ package func _sh(
 }
 
 public func binaryTargetsFixture(_ closure: (AbsolutePath) async throws -> Void) async throws {
-    try await fixture(name: "BinaryTargets") { fixturePath in
+    try await fixture(name: "BinaryTargets", removeFixturePathOnDeinit: false) { fixturePath in
         let inputsPath = fixturePath.appending(component: "Inputs")
         let packagePath = fixturePath.appending(component: "TestBinary")
 
@@ -157,7 +157,7 @@ public func binaryTargetsFixture(_ closure: (AbsolutePath) async throws -> Void)
             let projectPath = subpath.appending(component: "SwiftFramework.xcodeproj")
             try sh(
                 xcodebuild, "-project", projectPath, "-scheme", "SwiftFramework",
-                "-derivedDataPath", tmpDir, "COMPILER_INDEX_STORE_ENABLE=NO"
+                "-derivedDataPath", tmpDir, "COMPILER_INDEX_STORE_ENABLE=NO", "DEPLOYMENT_LOCATION=NO"
             )
             let frameworkPath = try AbsolutePath(
                 validating: "Build/Products/Debug/SwiftFramework.framework",


### PR DESCRIPTION
The path of a binary module is always the root, whereas the artifactPath points to the artifact bundle / xcframework. Ensure we use the latter when generating file references in PIF so that we can link binary artifacts properly.