### PR TITLE
Fix linking error on linux

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -500,9 +500,9 @@ extension PackagePIFProjectBuilder {
                 // darwin & freebsd
                 switch platform {
                     case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
-                        settings[.OTHER_LDFLAGS, platform] = ["-lc++", "$(inherited)"]
+                        impartedSettings[.OTHER_LDFLAGS, platform] = ["-lc++", "$(inherited)"]
                     case .android, .linux, .wasi, .openbsd:
-                        settings[.OTHER_LDFLAGS, platform] = ["-lstdc++", "$(inherited)"]
+                        impartedSettings[.OTHER_LDFLAGS, platform] = ["-lstdc++", "$(inherited)"]
                     case .windows, ._iOSDevice:
                         break
                 }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -163,7 +163,7 @@ struct PIFBuilderTests {
                 .buildConfig(named: "Release")
 
             for platform in ProjectModel.BuildSettings.Platform.allCases {
-                let ld_flags = releaseConfig.settings[.OTHER_LDFLAGS, platform]
+                let ld_flags = releaseConfig.impartedBuildProperties.settings[.OTHER_LDFLAGS, platform]
                 switch platform {
                     case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
                          #expect(ld_flags == ["-lc++", "$(inherited)"], "for platform \(platform)")


### PR DESCRIPTION
- libstdc++ needs to be added when linking if any dependency has a cpp dependency
