### PR TITLE
OpenBSD uses versioned triples for imports.

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -741,7 +741,10 @@ public final class UserToolchain: Toolchain {
             // targetInfo from the compiler
             let targetInfo = try customTargetInfo ?? Self.getTargetInfo(swiftCompiler: swiftCompilers.compile)
             self._targetInfo = targetInfo
-            triple = try swiftSDK.targetTriple ?? Self.getHostTriple(targetInfo: targetInfo, versioned: false)
+            triple = try Self.getHostTriple(targetInfo: targetInfo, versioned: false)
+            if !triple.isDarwin() {
+                triple = try Self.getHostTriple(targetInfo: targetInfo, versioned: true)
+            }
         }
 
         // Change the triple to the specified arch if there's exactly one of them.


### PR DESCRIPTION
Without this change, the build will fail to find modules since the import path on OpenBSD currently uses versioned triples.

### Motivation:

After #9271, bootstrap failures still occurred on OpenBSD.

### Modifications:

Used the versioned triple as the default, if the unversioned triple was OpenBSD.

### Result:

swiftpm bootstraps properly on OpenBSD.
