### PR TITLE
Add some extra conditionals for swift-build on OpenBSD.

### DIFF
--- a/Sources/Basics/Process.swift
+++ b/Sources/Basics/Process.swift
@@ -16,6 +16,7 @@ public enum OperatingSystem: Hashable, Sendable {
     case linux
     case android
     case freebsd
+    case openbsd
     case unknown
 }
 
@@ -30,6 +31,8 @@ extension ProcessInfo {
         .windows
         #elseif os(FreeBSD)
         .freebsd
+        #elseif os(OpenBSD)
+        .openbsd
         #else
         .unknown
         #endif

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -110,7 +110,7 @@ extension Toolchain {
                     .parentDirectory // bin
                     .parentDirectory // usr
                     .parentDirectory // <toolchain>
-            case .freebsd:
+            case .freebsd, .openbsd:
                 return compilerPath
                     .parentDirectory // bin
                     .parentDirectory // local


### PR DESCRIPTION
Despite the toolchain path being specified swift-build is still not initializing a toolchain properly. I have my suspicions, but I believe they can be addressed on the swift-build side, and this change on the swiftpm side is nonetheless correct.

### Motivation:

When attempting to use swift-build, errors are raised.

### Modifications:

Provide the correct platform conditionals to suppress these errors.

### Result:

swift-build is not properly working, but I believe these changes will still be necessary.
