### PR TITLE
Specify the platform version as the fixtures depend on swift concurrency

### DIFF
--- a/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Package.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "ExistentialAnyMigration",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     targets: [
         .target(name: "Library", dependencies: ["CommonLibrary"], plugins: [.plugin(name: "Plugin")]),
         .plugin(name: "Plugin", capability: .buildTool, dependencies: ["Tool"]),

--- a/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Package.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyWithPluginMigration/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "ExistentialAnyMigration",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     targets: [
         .target(name: "Library", plugins: [.plugin(name: "Plugin")]),
         .plugin(name: "Plugin", capability: .buildTool, dependencies: ["Tool"]),


### PR DESCRIPTION
Specify the platform version as the fixtures depend on swift concurrency.

Motivation:

Tests failing locally due to code in the fixtures depending on Swift Concurrency features.

Modifications:

Specify the platform version in the fixtures.

Result:

Tests pass