### PR TITLE
Unconditionally add test targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1032,23 +1032,7 @@ let package = Package(
             name: "package-info",
             dependencies: ["Workspace"],
             path: "Examples/package-info/Sources/package-info"
-        )
-    ],
-    swiftLanguageModes: [.v5]
-)
-
-#if canImport(Darwin)
-package.targets.append(contentsOf: [
-    .executableTarget(
-        name: "swiftpm-testing-helper"
-    )
-])
-#endif
-
-// rdar://101868275 "error: cannot find 'XCTAssertEqual' in scope" can affect almost any functional test, so we flat out
-// disable them all until we know what is going on
-if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] == nil {
-    package.targets.append(contentsOf: [
+        ),
         .testTarget(
             name: "FunctionalTests",
             dependencies: [
@@ -1098,9 +1082,17 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
                 "_InternalTestSupport",
             ] + swiftToolsProtocolsDeps
         ),
-    ])
-}
+    ],
+    swiftLanguageModes: [.v5]
+)
 
+#if canImport(Darwin)
+package.targets.append(contentsOf: [
+    .executableTarget(
+        name: "swiftpm-testing-helper"
+    )
+])
+#endif
 
 func swiftSyntaxDependencies(_ names: [String]) -> [Target.Dependency] {
   /// Whether swift-syntax is being built as a single dynamic library instead of as a separate library per module.

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -87,8 +87,17 @@ extension Trait where Self == Testing.ConditionTrait {
 
     // Enabled if the toolchain has supported features
     public static var supportsSupportedFeatures: Self {
-        enabled("skipping because test environment compiler doesn't support `-print-supported-features`") {
-            (try? UserToolchain.default)!.supportsSupportedFeatures
+        let isEnabled: Bool
+        let errorInfo: String
+        do {
+            isEnabled = try UserToolchain.default.supportsSupportedFeatures
+            errorInfo = ""
+        } catch {
+            isEnabled = false
+            errorInfo = "Error: \(error)"
+        }
+        return enabled("Skipping because test environment compiler doesn't support `-print-supported-features`.\(errorInfo)") {
+            isEnabled
         }
     }
 


### PR DESCRIPTION
Since some test targets were being "guarded" behind an environment variable, they were not being executed and were hiding an issue in CI as these tests were being excluded from the Package manifest in the smoke tests pipelies, and were being skipped in the self-hosted pipelines.

Since the impacted tests run an end-to-end tests, and the smoke tests pipeline does a partial toolchain build, let's ensure these tests are executed as part of the smoke tests.

Requires: #9318