### PR TITLE
Run EnvironmentTests serially as it is testing the non thread-safe global state of Environment

### DIFF
--- a/Tests/BasicsTests/Environment/EnvironmentTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentTests.swift
@@ -18,6 +18,7 @@ import Basics
 import Testing
 import _InternalTestSupport
 
+@Suite(.serialized)
 struct EnvironmentTests {
     @Test
     func initialize() {


### PR DESCRIPTION
Run EnvironmentTests serially as it is testing the non thread-safe global state of Environment

### Motivation:

Address a crash due to concurrent read/write of Environment during test execution.

See: https://ci.swift.org/job/oss-swift-package-debian-12/1535/

### Modifications:

Run EnvironmentTests serially