### PR TITLE
Deprecate `--use-integrated-swift-driver` option

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -526,6 +526,7 @@ public struct BuildOptions: ParsableArguments {
     /// Whether to use the integrated Swift driver rather than shelling out
     /// to a separate process.
     @Flag()
+    /// This flag is deprecated but cannot indicate so in Swift Argument Parser until https://github.com/apple/swift-argument-parser/issues/656
     public var useIntegratedSwiftDriver: Bool = false
 
     /// A flag that indicates this build should check whether targets only import

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -854,6 +854,11 @@ public final class SwiftCommandState {
         observabilityScope: ObservabilityScope? = .none,
         delegate: BuildSystemDelegate? = nil
     ) async throws -> BuildSystem {
+
+        if self.options.build.useIntegratedSwiftDriver && self.options.build.buildSystem == .native {
+            self.observabilityScope.emit(warning: "`--use-integrated-swift-driver` option is deprecated as the feature is not fully functional.")
+        }
+
         guard let buildSystemProvider else {
             fatalError("build system provider not initialized")
         }


### PR DESCRIPTION
The Native Build system supports a `--use-integrated-swift-driver` command line argument.  The feature is not fully funtional.  With the transition to SwiftBuild, mark this option as deprecated.

Fixes: #9323
Issue: rdar://163962023
