### PR TITLE
Remove withKnownIssue Amazon Linux 2 clauses

### DIFF
--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -103,15 +103,11 @@ struct APIDiffTests {
                 string: "public class Qux<T, U> { private let x = 1 }"
             )
             await expectThrowsCommandExecutionError(try await execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot, buildSystem: buildSystem)) { error in
-                withKnownIssue {
-                    #expect(error.stdout.contains("2 breaking changes detected in Qux"))
-                    #expect(error.stdout.contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                    #expect(error.stdout.contains("💔 API breakage: var Qux.x has been removed"))
-                    #expect(error.stdout.contains("1 breaking change detected in Baz"))
-                    #expect(error.stdout.contains("💔 API breakage: func bar() has been removed"))
-                } when: {
-                    buildSystem == .swiftbuild && ProcessInfo.isHostAmazonLinux2()
-                }
+                #expect(error.stdout.contains("2 breaking changes detected in Qux"))
+                #expect(error.stdout.contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
+                #expect(error.stdout.contains("💔 API breakage: var Qux.x has been removed"))
+                #expect(error.stdout.contains("1 breaking change detected in Baz"))
+                #expect(error.stdout.contains("💔 API breakage: func bar() has been removed"))
             }
         }
     }
@@ -142,16 +138,11 @@ struct APIDiffTests {
                             packagePath: packageRoot, buildSystem: buildSystem)
             ) { error in
                 #expect(!error.stdout.contains("💔 API breakage: class Qux has generic signature change from <T> to <T, U>"))
-                withKnownIssue {
-                    #expect(error.stdout.contains("1 breaking change detected in Qux"))
-                    #expect(error.stdout.contains("💔 API breakage: var Qux.x has been removed"))
-                    #expect(error.stdout.contains("1 breaking change detected in Baz"))
-                    #expect(error.stdout.contains("💔 API breakage: func bar() has been removed"))
-                } when: {
-                    buildSystem == .swiftbuild && ProcessInfo.isHostAmazonLinux2()
-                }
+                #expect(error.stdout.contains("1 breaking change detected in Qux"))
+                #expect(error.stdout.contains("💔 API breakage: var Qux.x has been removed"))
+                #expect(error.stdout.contains("1 breaking change detected in Baz"))
+                #expect(error.stdout.contains("💔 API breakage: func bar() has been removed"))
             }
-
         }
     }
 
@@ -180,16 +171,11 @@ struct APIDiffTests {
                 string: "public class Qux<T, U> { private let x = 1 }"
             )
             try await expectThrowsCommandExecutionError(try await execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot, buildSystem: buildSystem)) { error in
-                try withKnownIssue {
-                    #expect(error.stdout.contains("💔 API breakage"))
-                    let regex = try Regex("\\d+ breaking change(s?) detected in Foo")
-                    #expect(error.stdout.contains(regex))
-                    #expect(error.stdout.contains(regex))
-                    #expect(error.stdout.contains(regex))
-                } when: {
-                    buildSystem == .swiftbuild && ProcessInfo.isHostAmazonLinux2()
-                }
-
+                #expect(error.stdout.contains("💔 API breakage"))
+                let regex = try Regex("\\d+ breaking change(s?) detected in Foo")
+                #expect(error.stdout.contains(regex))
+                #expect(error.stdout.contains(regex))
+                #expect(error.stdout.contains(regex))
                 // Qux is not part of a library product, so any API changes should be ignored
                 #expect(!error.stdout.contains("Qux"))
             }
@@ -226,18 +212,10 @@ struct APIDiffTests {
             try await expectThrowsCommandExecutionError(
                 try await execute(["diagnose-api-breaking-changes", "1.2.3", "--products", "One", "--targets", "Bar"], packagePath: packageRoot, buildSystem: buildSystem)
             ) { error in
-                withKnownIssue {
-                    #expect(error.stdout.contains("💔 API breakage"))
-                } when: {
-                    buildSystem == .swiftbuild && ProcessInfo.isHostAmazonLinux2()
-                }
+                #expect(error.stdout.contains("💔 API breakage"))
                 let regex = try Regex("\\d+ breaking change(s?) detected in Foo")
 
-                withKnownIssue {
-                    #expect(error.stdout.contains(regex))
-                } when: {
-                    buildSystem == .swiftbuild && ProcessInfo.isHostAmazonLinux2()
-                }
+                #expect(error.stdout.contains(regex))
 
                 // Baz and Qux are not included in the filter, so any API changes should be ignored.
                 #expect(!error.stdout.contains("Baz"))
@@ -248,14 +226,9 @@ struct APIDiffTests {
             try await expectThrowsCommandExecutionError(
                 try await execute(["diagnose-api-breaking-changes", "1.2.3", "--targets", "Baz"], packagePath: packageRoot, buildSystem: buildSystem)
             ) { error in
-                try withKnownIssue {
-                    #expect(error.stdout.contains("💔 API breakage"))
-                    let regex = try Regex("\\d+ breaking change(s?) detected in Baz")
-                    #expect(error.stdout.contains(regex))
-                } when: {
-                    buildSystem == .swiftbuild && ProcessInfo.isHostAmazonLinux2()
-                }
-
+                #expect(error.stdout.contains("💔 API breakage"))
+                let regex = try Regex("\\d+ breaking change(s?) detected in Baz")
+                #expect(error.stdout.contains(regex))
                 // Only Baz is included, we should not see any other API changes.
                 #expect(!error.stdout.contains("Foo"))
                 #expect(!error.stdout.contains("Bar"))
@@ -279,7 +252,7 @@ struct APIDiffTests {
         .tags(
             .Feature.Command.Run,
         ),
-        .requiresAPIDigester, 
+        .requiresAPIDigester,
         arguments: SupportedBuildSystemOnAllPlatforms
     )
     func testAPIDiffOfModuleWithCDependency(buildSystem: BuildSystemProvider.Kind) async throws {
@@ -341,20 +314,16 @@ struct APIDiffTests {
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testNoBreakingChanges(buildSystem: BuildSystemProvider.Kind) async throws {
-        try await withKnownIssue {
-            try await fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
-                let packageRoot = fixturePath.appending("Bar")
-                // Introduce an API-compatible change
-                try localFileSystem.writeFileContents(
-                    packageRoot.appending(components: "Sources", "Baz", "Baz.swift"),
-                    string: "public func bar() -> Int { 100 }"
-                )
-                let (output, _) = try await execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot, buildSystem: buildSystem)
-                #expect(output.contains("No breaking changes detected in Baz"))
-                #expect(output.contains("No breaking changes detected in Qux"))
-            }
-        } when : {
-            buildSystem == .swiftbuild && ProcessInfo.isHostAmazonLinux2()
+        try await fixture(name: "Miscellaneous/APIDiff/") { fixturePath in
+            let packageRoot = fixturePath.appending("Bar")
+            // Introduce an API-compatible change
+            try localFileSystem.writeFileContents(
+                packageRoot.appending(components: "Sources", "Baz", "Baz.swift"),
+                string: "public func bar() -> Int { 100 }"
+            )
+            let (output, _) = try await execute(["diagnose-api-breaking-changes", "1.2.3"], packagePath: packageRoot, buildSystem: buildSystem)
+            #expect(output.contains("No breaking changes detected in Baz"))
+            #expect(output.contains("No breaking changes detected in Qux"))
         }
     }
 


### PR DESCRIPTION
These issues no longer occur as a fix for linking was submitted that affects AL2 and the gold linker.
https://github.com/swiftlang/swift-build/pull/892

Tests are no longer recording known issues causing test failures.

* Remove the withKnownIssue clauses for AL2 On failing tests.
