### PR TITLE
[🍒] Detect system GNU ld script pretending to be system libraries (#9296)

### DIFF
--- a/Sources/Commands/PackageCommands/AuditBinaryArtifact.swift
+++ b/Sources/Commands/PackageCommands/AuditBinaryArtifact.swift
@@ -50,7 +50,10 @@ struct AuditBinaryArtifact: AsyncSwiftCommand {
         var hostDefaultSymbols = ReferencedSymbols()
         let symbolProvider = LLVMObjdumpSymbolProvider(objdumpPath: objdump)
         for binary in try await detectDefaultObjects(
-            clang: clang, fileSystem: fileSystem, hostTriple: hostTriple)
+            clang: clang, fileSystem: fileSystem, hostTriple: hostTriple,
+            observabilityScope:
+                swiftCommandState.observabilityScope.makeChildScope(
+                    description: "DefaultObjectsDetector"))
         {
             try await symbolProvider.symbols(
                 for: binary, symbols: &hostDefaultSymbols, recordUndefined: false)


### PR DESCRIPTION
- **Explanation**:  The `experimental-audit-binary-artifact` command fails in certain distributions since it doesn't account for `ld` scripts.
- **Scope**: The cherry picked change is entirely scoped to the `experimental-audit-binary-artifact` command and has no changes in other parts of the Swift PM code. This command is also Linux only so it doesn't affect the other platforms.
- **Issues**: This came up when trying to use the `experimental-audit-binary-artifact` in `swift-temporal-sdk`.
- **Original PRs**: #9296
- **Risk**: Low since it only touches the experimental command
- **Testing**: I just tested this on the latest nightly main toolchain and it works now.
- **Reviewers**: @dschaefer2 @FranzBusch 