### PR TITLE
[🍒]Allow auditing of uncompressed artifact bundles (#9297)

### DIFF
--- a/Sources/Commands/PackageCommands/AuditBinaryArtifact.swift
+++ b/Sources/Commands/PackageCommands/AuditBinaryArtifact.swift
@@ -99,6 +99,11 @@ struct AuditBinaryArtifact: AsyncSwiftCommand {
     {
         let archiver = UniversalArchiver(fileSystem)
 
+        if let lastPathComponent = path.components.last,
+            lastPathComponent.hasSuffix("artifactbundle") {
+            return path
+        }
+
         guard let lastPathComponent = path.components.last,
             archiver.isFileSupported(lastPathComponent)
         else {


### PR DESCRIPTION
- **Explanation**:  Improves the usability of the `experimental-audit-binary-artifact` command. 
- **Scope**: The cherry picked change is entirely scoped to the `experimental-audit-binary-artifact` command and has no changes in other parts of the Swift PM code. This command is also Linux only so it doesn't affect the other platforms.
- **Issues**: This came up when trying to use the `experimental-audit-binary-artifact` in `swift-temporal-sdk`.
- **Original PRs**: #9297 
- **Risk**: Low since it only touches the experimental command
- **Testing**: I just tested this on the latest nightly main toolchain and it works now.
- **Reviewers**: @owenv @jakepetroules  @FranzBusch 