### PR TITLE
Add experimental max parallelization width option for Swift Testing.

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -162,6 +162,12 @@ struct TestCommandOptions: ParsableArguments {
             help: "Number of tests to execute in parallel.")
     var numberOfWorkers: Int?
 
+    /// Width of task group used by Swift Testing.
+    ///
+    /// This argument is consumed by Swift Testing and is passed through verbatim by SwiftPM.
+    @Option(help: .hidden)
+    var experimentalMaximumParallelizationWidth: Int? = nil
+
     /// List the tests and exit.
     @Flag(name: [.customLong("list-tests"), .customShort("l")],
           help: "Lists test methods in specifier format.")


### PR DESCRIPTION
Adds `swift test --experimental-maximum-parallelization-width`. This flag passes through to Swift Testing. We may end up just reusing `--num-workers` but as it's not exactly the same feature, I'm keeping it separate for now pending discussion and review.