### PR TITLE
Link Swift Testing documentation in its test template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -549,7 +549,7 @@ public final class InitPackage {
                     func createBuildCommand(for inputPath: URL, in outputDirectoryPath: URL, with generatorToolPath: URL) -> Command? {
                         // Skip any file that doesn't have the extension we're looking for (replace this with the actual one).
                         guard inputPath.pathExtension == "my-input-suffix" else { return .none }
-                        
+
                         // Return a command that will run during the build to generate the output file.
                         let inputName = inputPath.lastPathComponent
                         let outputName = inputPath.deletingPathExtension().lastPathComponent + ".swift"
@@ -644,7 +644,7 @@ public final class InitPackage {
             content = """
             // The Swift Programming Language
             // https://docs.swift.org/swift-book
-            // 
+            //
             // Swift Argument Parser
             // https://swiftpackageindex.com/apple/swift-argument-parser/documentation
 
@@ -731,6 +731,8 @@ public final class InitPackage {
 
                 @Test func example() async throws {
                     // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+                    // Swift Testing Documentation
+                    // https://swiftpackageindex.com/swiftlang/swift-testing/documentation
                 }
 
                 """


### PR DESCRIPTION
Link Swift Testing documentation in its test template

### Motivation:

This hopefully makes it easier for new users to find relevant documentation for our test framework!

It also matches the existing pattern where XCTest documentation is linked in its respective test template.

### Modifications:

- Add a link to Swift Testing documentation in the test template.
- Trims some trailing whitespace. Realistically, I don't have much control over this since my editor is respecting the project's .editorconfig's `trim_trailing_whitespace = true` directive. I can manually put them back if that would be better.

### Result:

Default Swift Testing template will include a comment linking to the developer docs.

Testing it locally:
```
~/scraps/autogen/xx.ZtJsA ❯ /Users/jerrychen/workspace/opensource/swift-package-manager/.build/arm64-apple-macosx/debug/swift-package init
Creating library package: xx.ZtJsA
Creating Package.swift
Creating .gitignore
Creating Sources
Creating Sources/xx.ZtJsA/xx_ZtJsA.swift
Creating Tests/
Creating Tests/xx.ZtJsATests/
Creating Tests/xx.ZtJsATests/xx_ZtJsATests.swift
~/scraps/autogen/xx.ZtJsA ❯ /bin/cat Tests/xx.ZtJsATests/xx_ZtJsATests.swift
import Testing
@testable import xx_ZtJsA

@Test func example() async throws {
    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
    // Swift Testing Documentation
    // https://developer.apple.com/documentation/testing
}
```