### PR TITLE
Remove triple from SwiftBuild system output path

### DIFF
--- a/Sources/SPMBuildCore/Triple+Extensions.swift
+++ b/Sources/SPMBuildCore/Triple+Extensions.swift
@@ -32,7 +32,9 @@ extension Triple {
             // can be used to build for any Apple platform and it has its own
             // conventions for build subpaths based on platforms.
             return "apple"
-        case .swiftbuild, .native:
+        case .swiftbuild:
+            return "out"
+        case .native:
             return self.platformBuildPathComponent
         }
     }

--- a/Sources/_InternalTestSupport/BuildSystemProvider+Configuration.swift
+++ b/Sources/_InternalTestSupport/BuildSystemProvider+Configuration.swift
@@ -66,7 +66,7 @@ extension BuildSystemProvider.Kind {
         case .native:
             return scratchPath + [tripleString, "\(config)".lowercased()]
         case .swiftbuild:
-            return scratchPath + [tripleString, "Products", "\(config)".capitalized + suffix]
+            return scratchPath + ["out", "Products", "\(config)".capitalized + suffix]
         case .xcode:
             return scratchPath + ["apple", "Products", "\(config)".capitalized + suffix]
         }

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -846,6 +846,23 @@ struct BuildCommandTestCases {
         }
     }
 
+    @Test
+    func pifManifestFileIsCreatedInTheRootScratchPathDirectory() async throws {
+        try await fixture(name: "Miscellaneous/ParseableInterfaces") { fixturePath in
+            try await withTemporaryDirectory { tmpDir in
+                try await executeSwiftBuild(
+                    fixturePath,
+                    extraArgs: [
+                        "--scratch-path",
+                        tmpDir.pathString,
+                    ],
+                    buildSystem: .swiftbuild
+                )
+                expectFileExists(at: tmpDir.appending("manifest.pif"))
+            }
+        }
+    }
+
     @Test(
         .tags(
             .Feature.BuildCache,
@@ -857,47 +874,43 @@ struct BuildCommandTestCases {
         data: BuildData,
     ) async throws {
         let buildSystem = data.buildSystem
-        try await withKnownIssue {
-            try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
-                let buildCompleteRegex = try Regex(#"Build complete!\s?(\([0-9]*\.[0-9]*\s*s(econds)?\))?"#)
-                do {
-                    let result = try await execute(
-                        packagePath: fixturePath,
-                        configuration: data.config,
-                        buildSystem: buildSystem,
-                    )
-                    // This test fails to match the 'Compiling' regex; rdar://101815761
-                    // XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
-                    let lines = result.stdout.split(whereSeparator: { $0.isNewline })
-                    let lastLine = try #require(lines.last)
-                    #expect(lastLine.contains(buildCompleteRegex))
-                }
-
-                do {
-                    // test second time, to stabilize the cache
-                    try await execute(
-                        packagePath: fixturePath,
-                        configuration: data.config,
-                        buildSystem: buildSystem,
-                    )
-                }
-
-                do {
-                    // test third time, to make sure message is presented even when nothing to build (cached)
-                    let result = try await execute(
-                        packagePath: fixturePath,
-                        configuration: data.config,
-                        buildSystem: buildSystem,
-                    )
-                    // This test fails to match the 'Compiling' regex; rdar://101815761
-                    // XCTAssertNoMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
-                    let lines = result.stdout.split(whereSeparator: { $0.isNewline })
-                    let lastLine = try #require(lines.last)
-                    #expect(lastLine.contains(buildCompleteRegex))
-                }
+        try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
+            let buildCompleteRegex = try Regex(#"Build complete!\s?(\([0-9]*\.[0-9]*\s*s(econds)?\))?"#)
+            do {
+                let result = try await execute(
+                    packagePath: fixturePath,
+                    configuration: data.config,
+                    buildSystem: buildSystem,
+                )
+                // This test fails to match the 'Compiling' regex; rdar://101815761
+                // XCTAssertMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
+                let lines = result.stdout.split(whereSeparator: { $0.isNewline })
+                let lastLine = try #require(lines.last)
+                #expect(lastLine.contains(buildCompleteRegex))
             }
-        } when: {
-            buildSystem == .swiftbuild && (ProcessInfo.hostOperatingSystem == .windows)
+
+            do {
+                // test second time, to stabilize the cache
+                try await execute(
+                    packagePath: fixturePath,
+                    configuration: data.config,
+                    buildSystem: buildSystem,
+                )
+            }
+
+            do {
+                // test third time, to make sure message is presented even when nothing to build (cached)
+                let result = try await execute(
+                    packagePath: fixturePath,
+                    configuration: data.config,
+                    buildSystem: buildSystem,
+                )
+                // This test fails to match the 'Compiling' regex; rdar://101815761
+                // XCTAssertNoMatch(result.stdout, .regex("\\[[1-9][0-9]*\\/[1-9][0-9]*\\] Compiling"))
+                let lines = result.stdout.split(whereSeparator: { $0.isNewline })
+                let lastLine = try #require(lines.last)
+                #expect(lastLine.contains(buildCompleteRegex))
+            }
         }
     }
 
@@ -1135,31 +1148,24 @@ struct BuildCommandTestCases {
     func swiftDriverRawOutputGetsNewlines(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-         try await withKnownIssue(
-            "error produced for this fixture",
-            isIntermittent: ProcessInfo.hostOperatingSystem == .linux,
-        ) {
-            try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
-                // Building with `-wmo` should result in a `remark: Incremental compilation has been disabled: it is not
-                // compatible with whole module optimization` message, which should have a trailing newline.  Since that
-                // message won't be there at all when the legacy compiler driver is used, we gate this check on whether the
-                // remark is there in the first place.
-                let result = try await execute(
-                    ["-Xswiftc", "-wmo"],
-                    packagePath: fixturePath,
-                    configuration: .release,
-                    buildSystem: buildSystem,
-                )
-                if result.stdout.contains(
-                    "remark: Incremental compilation has been disabled: it is not compatible with whole module optimization"
-                ) {
-                    #expect(result.stdout.contains("optimization\n"))
-                    #expect(!result.stdout.contains("optimization["))
-                    #expect(!result.stdout.contains("optimizationremark"))
-                }
+        try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
+            // Building with `-wmo` should result in a `remark: Incremental compilation has been disabled: it is not
+            // compatible with whole module optimization` message, which should have a trailing newline.  Since that
+            // message won't be there at all when the legacy compiler driver is used, we gate this check on whether the
+            // remark is there in the first place.
+            let result = try await execute(
+                ["-Xswiftc", "-wmo"],
+                packagePath: fixturePath,
+                configuration: .release,
+                buildSystem: buildSystem,
+            )
+            if result.stdout.contains(
+                "remark: Incremental compilation has been disabled: it is not compatible with whole module optimization"
+            ) {
+                #expect(result.stdout.contains("optimization\n"))
+                #expect(!result.stdout.contains("optimization["))
+                #expect(!result.stdout.contains("optimizationremark"))
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -5640,7 +5640,7 @@ struct PackageCommandTests {
             data: BuildData,
         ) async throws {
             // Plugin arguments: check-testability <targetName> <config> <shouldTestable>
-            try await withKnownIssue {
+            try await withKnownIssue(isIntermittent: true) {
                 // Overall configuration: debug, plugin build request: debug -> without testability
                 try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
                     let _ = await #expect(throws: Never.self) {
@@ -5668,7 +5668,7 @@ struct PackageCommandTests {
         func commandPluginBuildTestabilityInternalModule_Release_False(
             data: BuildData,
         ) async throws {
-            try await withKnownIssue {
+            try await withKnownIssue(isIntermittent: true) {
                 // Overall configuration: debug, plugin build request: release -> without testability
                 try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
                     let _ = await #expect(throws: Never.self) {

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -53,7 +53,7 @@ struct RunCommandTests {
         buildSystem: BuildSystemProvider.Kind
     ) async throws {
         let stdout = try await execute(["-help"], buildSystem: buildSystem).stdout
-        
+
         #expect(stdout.contains("USAGE: swift run <options>") || stdout.contains("USAGE: swift run [<options>]"), "got stdout:\n \(stdout)")
     }
 
@@ -106,7 +106,6 @@ struct RunCommandTests {
     func toolsetDebugger(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue {
         try await fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
             #if os(Windows)
                 let win32 = ".win32"
@@ -135,10 +134,6 @@ struct RunCommandTests {
                 buildSystem == .swiftbuild
             }
         }
-        } when: {
-            (.swiftbuild == buildSystem && ProcessInfo.hostOperatingSystem == .windows)
-            || (.native == buildSystem && ProcessInfo.hostOperatingSystem == .windows && CiEnvironment.runningInSmokeTestPipeline)
-        }
     }
 
     @Test(
@@ -152,34 +147,29 @@ struct RunCommandTests {
     func productArgumentPassing(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue {
-            try await fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
-                let (stdout, stderr) = try await execute(
-                    ["secho", "1", "--hello", "world"],
-                    packagePath: fixturePath,
-                    buildSystem: buildSystem,
-                )
+        try await fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
+            let (stdout, stderr) = try await execute(
+                ["secho", "1", "--hello", "world"],
+                packagePath: fixturePath,
+                buildSystem: buildSystem,
+            )
 
-                // We only expect tool's output on the stdout stream.
-                #expect(stdout.contains("""
-                    "1" "--hello" "world"
-                    """))
+            // We only expect tool's output on the stdout stream.
+            #expect(stdout.contains("""
+                "1" "--hello" "world"
+                """))
 
-                // swift-build-tool output should go to stderr.
-                withKnownIssue {
-                    #expect(stderr.contains("Compiling"))
-                } when: {
-                    buildSystem == .swiftbuild
-                }
-                withKnownIssue {
-                    #expect(stderr.contains("Linking"))
-                } when: {
-                    buildSystem == .swiftbuild
-                }
+            // swift-build-tool output should go to stderr.
+            withKnownIssue {
+                #expect(stderr.contains("Compiling"))
+            } when: {
+                buildSystem == .swiftbuild
             }
-        } when: {
-            (.windows == ProcessInfo.hostOperatingSystem && buildSystem == .swiftbuild)
-            || (.windows == ProcessInfo.hostOperatingSystem && buildSystem == .native && CiEnvironment.runningInSmokeTestPipeline)
+            withKnownIssue {
+                #expect(stderr.contains("Linking"))
+            } when: {
+                buildSystem == .swiftbuild
+            }
         }
     }
 
@@ -220,7 +210,6 @@ struct RunCommandTests {
     func multipleExecutableAndExplicitExecutable(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue {
         try await fixture(name: "Miscellaneous/MultipleExecutables") { fixturePath in
 
             let error = await #expect(throws: SwiftPMError.self ) {
@@ -241,10 +230,6 @@ struct RunCommandTests {
 
             (runOutput, _) = try await execute(["exec2"], packagePath: fixturePath, buildSystem: buildSystem)
             #expect(runOutput.contains("2"))
-        }
-        } when: {
-            ([.windows].contains(ProcessInfo.hostOperatingSystem) && buildSystem == .swiftbuild && CiEnvironment.runningInSelfHostedPipeline)
-            || (.windows == ProcessInfo.hostOperatingSystem && [.native, .swiftbuild].contains(buildSystem) && CiEnvironment.runningInSmokeTestPipeline)
         }
     }
 

--- a/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/Tests/IntegrationTests/SwiftPMTests.swift
@@ -152,7 +152,10 @@ private struct SwiftPMTests {
         }
     }
 
-    @Test(.requireHostOS(.macOS), arguments: [BuildSystemProvider.Kind.native, .swiftbuild])
+    @Test(
+        .requireHostOS(.macOS),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
     func testArchCustomization(buildSystem: BuildSystemProvider.Kind) async throws {
         try await  withTemporaryDirectory { tmpDir in
             let packagePath = tmpDir.appending(component: "foo")
@@ -192,7 +195,7 @@ private struct SwiftPMTests {
                     )
                 case .swiftbuild:
                     fooPath = try AbsolutePath(
-                        validating: ".build/\(arch)-apple-macosx/Products/Debug/foo",
+                        validating: ".build/out/Products/Debug/foo",
                         relativeTo: packagePath
                     )
                 default:
@@ -225,7 +228,7 @@ private struct SwiftPMTests {
                 )
             case .swiftbuild:
                 fooPath = try AbsolutePath(
-                    validating: ".build/\(hostArch)-apple-macosx/Products/Debug/foo",
+                    validating: ".build/out/Products/Debug/foo",
                     relativeTo: packagePath
                 )
             default:

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -180,7 +180,7 @@ struct PIFBuilderTests {
             let releaseConfig = try pif.workspace
                 .project(named: "BasicExecutable")
                 .target(named: "Executable")
-                .buildConfig(named: "Release")
+                .buildConfig(named: .release)
 
             for platform in ProjectModel.BuildSettings.Platform.allCases {
                 let search_paths = releaseConfig.impartedBuildProperties.settings[.LIBRARY_SEARCH_PATHS, platform]


### PR DESCRIPTION
The triple name in the SwiftBuild build system is redundant.  Remove the triple from the output path.
