### PR TITLE
Mark new test as withKnownIssue on some linux distro

### DIFF
--- a/Sources/_InternalTestSupport/ProcessInfo+hostutils.swift
+++ b/Sources/_InternalTestSupport/ProcessInfo+hostutils.swift
@@ -10,7 +10,7 @@
 import Foundation
 
 extension ProcessInfo {
-    public static func isHostAmazonLinux2(_ content: String? = nil) -> Bool {
+    package static func isHostOs(prettyName: String, content: String? = nil) -> Bool {
         let contentString: String
         if let content {
             contentString = content
@@ -22,8 +22,16 @@ extension ProcessInfo {
                 return false
             }
         }
-        let al2_name = "PRETTY_NAME=\"Amazon Linux 2\""
-        return contentString.contains(al2_name)
+        let name = "PRETTY_NAME=\"\(prettyName)\""
+        return contentString.contains(name)
+
+    }
+    public static func isHostAmazonLinux2() -> Bool {
+        return Self.isHostOs(prettyName: "Amazon Linux 2")
+    }
+
+    public static func isHostDebian12() -> Bool {
+        return Self.isHostOs(prettyName: "Debian GNU/Linux 12 (bookworm)")
     }
 
 }

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -40,6 +40,7 @@ extension Tag.Feature {
     @Tag public static var CodeCoverage: Tag
     @Tag public static var CTargets: Tag
     @Tag public static var DependencyResolution: Tag
+    @Tag public static var LibraryEvolution: Tag
     @Tag public static var ModuleAliasing: Tag
     @Tag public static var Mirror: Tag
     @Tag public static var NetRc: Tag

--- a/Tests/FunctionalTests/LibraryEvolutionXCFLinuxTests.swift
+++ b/Tests/FunctionalTests/LibraryEvolutionXCFLinuxTests.swift
@@ -10,16 +10,25 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import _InternalTestSupport
 import Basics
 import Testing
+import PackageLoading
 
 private struct SwiftPMTests {
     @Test(
         .requireSwift6_2,
-        .requireHostOS(.linux)
+        .requireHostOS(.linux),
+        .tags(
+            .TestSize.large,
+            .Feature.Command.Run,
+            .Feature.LibraryEvolution,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9372", relationship: .defect),
     )
     func libraryEvolutionLinuxXCFramework() async throws {
+        try await withKnownIssue {
         try await fixture(name: "Miscellaneous/LibraryEvolutionLinuxXCF") { fixturePath in
             let swiftFramework = "SwiftFramework"
             try await withTemporaryDirectory(removeTreeOnDeinit: false) { tmpDir in
@@ -104,6 +113,9 @@ private struct SwiftPMTests {
             )
             #expect(!runOutput.stderr.contains("error:"))
             #expect(runOutput.stdout.contains("Latest Framework with LibraryEvolution version: v2"))
+        }
+        } when: {
+            ProcessInfo.isHostAmazonLinux2() || ProcessInfo.isHostDebian12()
         }
     }
 }


### PR DESCRIPTION
A new test was added in #7239, however this test failed in the Amazon Linux 2 and Debian 12 OSS Toolchain CI builds.  Mark this test as `withKnownIssue` on these platforms until we can investigate the rooot cause.

Also, include tag information on the test.

Relates to: #7239
Issue: rdar://164634849
