### PR TITLE
Fix libraryEvolutionLinuxXCFramework test on arm

### DIFF
--- a/Tests/FunctionalTests/LibraryEvolutionXCFLinuxTests.swift
+++ b/Tests/FunctionalTests/LibraryEvolutionXCFLinuxTests.swift
@@ -32,7 +32,7 @@ private struct SwiftPMTests {
                 )
 
                 #if arch(arm64)
-                let arch = "arm64"
+                let arch = "aarch64"
                 #elseif arch(x86_64)
                 let arch = "x86_64"
                 #endif


### PR DESCRIPTION
Fix tests on arm.

```
swift test --filter "FunctionalTests.SwiftPMTests/libraryEvolutionLinuxXCFramework()"
```

In main there is: https://github.com/swiftlang/swift-package-manager/pull/9375

Fixes https://github.com/swiftlang/swift-package-manager/issues/9372
