### PR TITLE
Fix setting SPECIALIZATION_SDK_OPTIONS, .ARCHS

### DIFF
--- a/Fixtures/PIFBuilder/PackageWithSDKSpecialization/Package.swift
+++ b/Fixtures/PIFBuilder/PackageWithSDKSpecialization/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "PackageWithSDKSpecialization",
+    platforms: [ .macOS("10.15.foo") ],
+    products: [
+        .library(
+            name: "PackageWithSDKSpecialization",
+            targets: ["PackageWithSDKSpecialization"]),
+    ],
+    targets: [
+        .target(
+            name: "PackageWithSDKSpecialization",
+            dependencies: []
+        ),
+        .target(
+            name: "Executable",
+            dependencies: ["PackageWithSDKSpecialization"]
+        ),
+    ]
+)

--- a/Fixtures/PIFBuilder/PackageWithSDKSpecialization/Sources/Executable/main.swift
+++ b/Fixtures/PIFBuilder/PackageWithSDKSpecialization/Sources/Executable/main.swift
@@ -1,0 +1,1 @@
+print("Hello, world!")

--- a/Fixtures/PIFBuilder/PackageWithSDKSpecialization/Sources/PackageWithSDKSpecialization/PackageWithSDKSpecialization.swift
+++ b/Fixtures/PIFBuilder/PackageWithSDKSpecialization/Sources/PackageWithSDKSpecialization/PackageWithSDKSpecialization.swift
@@ -1,0 +1,3 @@
+struct PackageWithSDKSpecialization {
+    var text = "Hello, World!"
+}

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -581,7 +581,7 @@ public final class PackagePIFBuilder {
                 log(.warning, "Ignoring options '\(platformOptions.joined(separator: " "))' specified for unknown platform \(platform.name)")
                 continue
             }
-            settings[.SPECIALIZATION_SDK_OPTIONS, pifPlatform]?.append(contentsOf: platformOptions)
+            settings[.SPECIALIZATION_SDK_OPTIONS, pifPlatform] = (settings[.SPECIALIZATION_SDK_OPTIONS, pifPlatform] ?? []) + platformOptions
         }
 
         let deviceFamilyIDs: Set<Int> = self.delegate.deviceFamilyIDs()
@@ -607,7 +607,7 @@ public final class PackagePIFBuilder {
                 } catch {
                     preconditionFailure("Unhandled arm64e platform: \(error)")
                 }
-                settings[.ARCHS, pifPlatform]?.append(contentsOf: ["arm64e"])
+                settings[.ARCHS, pifPlatform] = (settings[.ARCHS, pifPlatform] ?? []) + ["arm64e"]
             }
         }
 


### PR DESCRIPTION
The code to build up the SPECIALIZATION_SDK_OPTIONS list was appending to the existing list, but the list is not guarenteed to be initialized. If it isn't initialized, the append never happens and the setting is dropped.
