### PR TITLE
Enable newly passing tests after fixing Swift Build response file format issues

### DIFF
--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -48,7 +48,7 @@ fileprivate func expectDirectoryContainsFile(
 )
 struct CFamilyTargetTestCase {
     @Test(
-        .issue("https://github.com/swiftlang/swift-build/issues/333", relationship: .defect),
+        .IssueWindowsLongPath,
         .tags(
             .Feature.Command.Build,
             .Feature.SpecialCharacters,
@@ -73,7 +73,7 @@ struct CFamilyTargetTestCase {
                 }
             }
         } when: {
-            data.buildSystem == .swiftbuild
+            ProcessInfo.hostOperatingSystem == .windows && data.buildSystem == .swiftbuild
         }
     }
 

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -96,7 +96,7 @@ struct TestDiscoveryTests {
                 #expect(stdout.contains("Executed 1 test"))
             }
         } when: {
-            buildSystem == .swiftbuild && [.windows, .macOS].contains(ProcessInfo.hostOperatingSystem)
+            buildSystem == .swiftbuild && [.windows].contains(ProcessInfo.hostOperatingSystem)
         }
     }
 


### PR DESCRIPTION
Depends on https://github.com/swiftlang/swift-build/pull/921