### PR TITLE
SwiftBuild: Add index store support

### DIFF
--- a/Fixtures/PIFBuilder/Simple/.gitignore
+++ b/Fixtures/PIFBuilder/Simple/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Fixtures/PIFBuilder/Simple/Package.swift
+++ b/Fixtures/PIFBuilder/Simple/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Simple",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Simple",
+            targets: ["Simple"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "Simple"
+        ),
+        .testTarget(
+            name: "SimpleTests",
+            dependencies: ["Simple"]
+        ),
+    ]
+)

--- a/Fixtures/PIFBuilder/Simple/Sources/Simple/Simple.swift
+++ b/Fixtures/PIFBuilder/Simple/Sources/Simple/Simple.swift
@@ -1,0 +1,25 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+public struct Person {
+    public let name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}
+extension Person: CustomStringConvertible {
+    public var description: String {
+        return name
+    }
+}
+
+public func greet(person: Person? = nil) -> String {
+    let name = if let person {
+        person.name
+    } else {
+        "World"
+    }
+
+    return "Hello, \(name)!"
+}

--- a/Fixtures/PIFBuilder/Simple/Tests/SimpleTests/SimpleTests.swift
+++ b/Fixtures/PIFBuilder/Simple/Tests/SimpleTests/SimpleTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import XCTest
+
+import Simple
+
+
+final public class XCTesting: XCTestCase {
+    func testGreetWithEmptyArgument() {
+        let actual = greet()
+        XCTAssertEqual(actual, "Hello, World!")
+    }
+
+    func testGreetWithNonEmptyArgument() {
+        let name = "MyName"
+        let person = Person(name: name)
+        let actual = greet(person: person)
+        XCTAssertEqual(actual, "Hello, \(name)!")
+    }
+}
+
+@Suite
+struct STTestTests {
+    @Test("STTest tests")
+    func testGreetWithEmptyArgument() {
+        let actual = greet()
+        #expect(actual == "Hello, World!")
+    }
+
+    @Test("STTest tests")
+    func testGreetWithNonEmptyArgument() {
+        let name = "MyName"
+        let person = Person(name: name)
+        let actual = greet(person: person)
+        #expect(actual == "Hello, \(name)!")
+    }
+}

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -29,7 +29,7 @@ public struct BuildParameters: Encodable {
     }
 
     /// Mode for the indexing-while-building feature.
-    public enum IndexStoreMode: String, Encodable {
+    public enum IndexStoreMode: String, Encodable, CaseIterable {
         /// Index store should be enabled.
         case on
         /// Index store should be disabled.

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -32,6 +32,8 @@ import struct PackageGraph.ModulesGraph
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 
+import struct SPMBuildCore.BuildParameters
+
 import enum SwiftBuild.ProjectModel
 
 typealias GUID = SwiftBuild.ProjectModel.GUID
@@ -203,7 +205,7 @@ public final class PackagePIFBuilder {
         addLocalRpaths: Bool = true,
         packageDisplayVersion: String?,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
     ) {
         self.package = resolvedPackage
         self.packageManifest = packageManifest
@@ -227,7 +229,7 @@ public final class PackagePIFBuilder {
         addLocalRpaths: Bool = true,
         packageDisplayVersion: String?,
         fileSystem: FileSystem,
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
     ) {
         self.package = resolvedPackage
         self.packageManifest = packageManifest
@@ -438,7 +440,7 @@ public final class PackagePIFBuilder {
         //
 
         self.log(.debug, "Processing \(package.products.count) products:")
-        
+
         // For each of the **products** in the package we create a corresponding `PIFTarget` of the appropriate type.
         for product in self.package.products {
             switch product.type {
@@ -561,8 +563,8 @@ public final class PackagePIFBuilder {
         // We currently deliberately do not support Swift ObjC interface headers.
         settings[.SWIFT_INSTALL_OBJC_HEADER] = "NO"
         settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME] = ""
-        
-        // rdar://47937899 (Don't try to link frameworks to object files) 
+
+        // rdar://47937899 (Don't try to link frameworks to object files)
         //  - looks like this defaults to OTHER_LDFLAGS (via xcspec) which can result in linking frameworks to mh_objects which is unwanted.
         settings[.OTHER_LDRFLAGS] = []
 
@@ -622,6 +624,7 @@ public final class PackagePIFBuilder {
         debugSettings[.ENABLE_TESTABILITY] = "YES"
         debugSettings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS, default: []].append(contentsOf: ["DEBUG"])
         debugSettings[.GCC_PREPROCESSOR_DEFINITIONS, default: ["$(inherited)"]].append(contentsOf: ["DEBUG=1"])
+        debugSettings[.SWIFT_INDEX_STORE_ENABLE] = "YES"
         builder.project.addBuildConfig { id in BuildConfig(id: id, name: "Debug", settings: debugSettings) }
 
         // Add the build settings that are specific to release builds, and set those as the "Release" configuration.

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -87,7 +87,7 @@ public func mockBuildParameters(
     shouldDisableLocalRpath: Bool = false,
     canRenameEntrypointFunctionName: Bool = false,
     triple: Basics.Triple = hostTriple,
-    indexStoreMode: BuildParameters.IndexStoreMode = .off,
+    indexStoreMode: BuildParameters.IndexStoreMode = .auto,
     linkerDeadStrip: Bool = true,
     linkTimeOptimizationMode: BuildParameters.LinkTimeOptimizationMode? = nil,
     omitFramePointers: Bool? = nil,

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -14,6 +14,7 @@ extension Tag {
     public enum TestSize {}
     public enum Feature {}
     public enum Platform {}
+    public enum FunctionalArea {}
     @Tag public static var UserWorkflow: Tag
 }
 
@@ -190,4 +191,9 @@ extension Tag.Feature.PackageType {
 extension Tag.Feature.Product {
     @Tag public static var Execute: Tag
     @Tag public static var Link: Tag
+}
+
+extension Tag.FunctionalArea {
+    @Tag public static var PIF: Tag
+    @Tag public static var IndexMode: Tag
 }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -43,13 +43,24 @@ extension PIFBuilderParameters {
     }
 }
 
-fileprivate func withGeneratedPIF(fromFixture fixtureName: String, addLocalRpaths: Bool = true, do doIt: (SwiftBuildSupport.PIF.TopLevelObject, TestingObservability) async throws -> ()) async throws {
+fileprivate func withGeneratedPIF(
+    fromFixture fixtureName: String,
+    addLocalRpaths: Bool = true,
+    buildParameters: BuildParameters? = nil,
+    do doIt: (SwiftBuildSupport.PIF.TopLevelObject, TestingObservability) async throws -> (),
+) async throws {
+    let buildParameters = if let buildParameters {
+        buildParameters
+    } else {
+       mockBuildParameters(destination: .host)
+    }
     try await fixture(name: fixtureName) { fixturePath in
-        let observabilitySystem = ObservabilitySystem.makeForTesting()
+        let observabilitySystem: TestingObservability = ObservabilitySystem.makeForTesting()
+        let toolchain = try UserToolchain.default
         let workspace = try Workspace(
             fileSystem: localFileSystem,
             forRootPackage: fixturePath,
-            customManifestLoader: ManifestLoader(toolchain: UserToolchain.default),
+            customManifestLoader: ManifestLoader(toolchain: toolchain),
             delegate: MockWorkspaceDelegate()
         )
         let rootInput = PackageGraphRootInput(packages: [fixturePath], dependencies: [])
@@ -64,7 +75,7 @@ fileprivate func withGeneratedPIF(fromFixture fixtureName: String, addLocalRpath
             observabilityScope: observabilitySystem.topScope
         )
         let pif = try await builder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host)
+            buildParameters: buildParameters,
         )
         try await doIt(pif, observabilitySystem)
     }
@@ -119,9 +130,9 @@ extension SwiftBuildSupport.PIF.Project {
         }
     }
 
-    fileprivate func buildConfig(named name: String) throws -> SwiftBuild.ProjectModel.BuildConfig {
+    fileprivate func buildConfig(named name: BuildConfiguration) throws -> SwiftBuild.ProjectModel.BuildConfig {
         let matchingConfigs = underlying.buildConfigs.filter {
-            $0.name == name
+            $0.name == name.rawValue.capitalized
         }
         if matchingConfigs.isEmpty {
             throw StringError("No config named \(name) in PIF project")
@@ -134,9 +145,9 @@ extension SwiftBuildSupport.PIF.Project {
 }
 
 extension SwiftBuild.ProjectModel.BaseTarget {
-    fileprivate func buildConfig(named name: String) throws -> SwiftBuild.ProjectModel.BuildConfig {
+    fileprivate func buildConfig(named name: BuildConfiguration) throws -> SwiftBuild.ProjectModel.BuildConfig {
         let matchingConfigs = common.buildConfigs.filter {
-            $0.name == name
+            $0.name == name.pifConfiguration
         }
         if matchingConfigs.isEmpty {
             throw StringError("No config named \(name) in PIF target")
@@ -148,7 +159,20 @@ extension SwiftBuild.ProjectModel.BaseTarget {
     }
 }
 
-@Suite
+extension BuildConfiguration {
+    var pifConfiguration: String {
+        switch self {
+            case .debug, .release: self.rawValue.capitalized
+        }
+    }
+}
+
+@Suite(
+    .tags(
+        .TestSize.medium,
+        .FunctionalArea.PIF,
+    ),
+)
 struct PIFBuilderTests {
     @Test func platformConditionBasics() async throws {
         try await withGeneratedPIF(fromFixture: "PIFBuilder/UnknownPlatforms") { pif, observabilitySystem in
@@ -160,7 +184,7 @@ struct PIFBuilderTests {
             let releaseConfig = try pif.workspace
                 .project(named: "UnknownPlatforms")
                 .target(named: "UnknownPlatforms")
-                .buildConfig(named: "Release")
+                .buildConfig(named: .release)
 
             // The platforms with conditional settings should have those propagated to the PIF.
             #expect(releaseConfig.settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS, .linux] == ["$(inherited)", "BAR"])
@@ -174,7 +198,7 @@ struct PIFBuilderTests {
             let releaseConfig = try pif.workspace
                 .project(named: "CCPackage")
                 .target(id: "PACKAGE-TARGET:CCTarget")
-                .buildConfig(named: "Release")
+                .buildConfig(named: .release)
 
             for platform in ProjectModel.BuildSettings.Platform.allCases {
                 let ld_flags = releaseConfig.impartedBuildProperties.settings[.OTHER_LDFLAGS, platform]
@@ -182,7 +206,7 @@ struct PIFBuilderTests {
                     case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
                          #expect(ld_flags == ["-lc++", "$(inherited)"], "for platform \(platform)")
                     case .android, .linux, .wasi, .openbsd:
-                        #expect(ld_flags == ["-lstdc++", "$(inherited)"], "for platform \(platform)")                    
+                        #expect(ld_flags == ["-lstdc++", "$(inherited)"], "for platform \(platform)")
                     case .windows, ._iOSDevice:
                         #expect(ld_flags == nil, "for platform \(platform)")
                 }
@@ -197,7 +221,7 @@ struct PIFBuilderTests {
 
             let releaseConfig = try pif.workspace
                 .project(named: "PackageWithSDKSpecialization")
-                .buildConfig(named: "Release")
+                .buildConfig(named: .release)
 
             #expect(releaseConfig.settings[.SPECIALIZATION_SDK_OPTIONS, .macOS] == ["foo"])
         }
@@ -241,7 +265,7 @@ struct PIFBuilderTests {
                 let releaseConfig = try pif.workspace
                     .project(named: "ModuleMapGenerationCases")
                     .target(named: "UmbrellaHeader")
-                    .buildConfig(named: "Release")
+                    .buildConfig(named: .release)
 
                 #expect(releaseConfig.impartedBuildProperties.settings[.OTHER_CFLAGS] == ["-fmodule-map-file=\(RelativePath("$(GENERATED_MODULEMAP_DIR)").appending(component: "UmbrellaHeader.modulemap").pathString)", "$(inherited)"])
             }
@@ -250,7 +274,7 @@ struct PIFBuilderTests {
                 let releaseConfig = try pif.workspace
                     .project(named: "ModuleMapGenerationCases")
                     .target(named: "UmbrellaDirectoryInclude")
-                    .buildConfig(named: "Release")
+                    .buildConfig(named: .release)
 
                 #expect(releaseConfig.impartedBuildProperties.settings[.OTHER_CFLAGS] == ["-fmodule-map-file=\(RelativePath("$(GENERATED_MODULEMAP_DIR)").appending(component: "UmbrellaDirectoryInclude.modulemap").pathString)", "$(inherited)"])
             }
@@ -259,7 +283,7 @@ struct PIFBuilderTests {
                 let releaseConfig = try pif.workspace
                     .project(named: "ModuleMapGenerationCases")
                     .target(named: "CustomModuleMap")
-                    .buildConfig(named: "Release")
+                    .buildConfig(named: .release)
                 let arg = try #require(releaseConfig.impartedBuildProperties.settings[.OTHER_CFLAGS]?.first)
                 #expect(arg.hasPrefix("-fmodule-map-file") && arg.hasSuffix(RelativePath("CustomModuleMap").appending(components: ["include", "module.modulemap"]).pathString))
             }
@@ -276,7 +300,7 @@ struct PIFBuilderTests {
                 let releaseConfig = try pif.workspace
                     .project(named: "Foo")
                     .target(named: "Foo")
-                    .buildConfig(named: "Release")
+                    .buildConfig(named: .release)
 
                 #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == ["$(RPATH_ORIGIN)", "$(inherited)"])
             }
@@ -291,9 +315,62 @@ struct PIFBuilderTests {
                 let releaseConfig = try pif.workspace
                     .project(named: "Foo")
                     .target(named: "Foo")
-                    .buildConfig(named: "Release")
+                    .buildConfig(named: .release)
 
                 #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
+            }
+        }
+    }
+
+    @Suite(
+        .tags(
+            .FunctionalArea.IndexMode,
+        ),
+    )
+    struct IndexModeSettingTests {
+
+        @Test(
+            arguments: [BuildParameters.IndexStoreMode.auto], [BuildConfiguration.debug],
+            // arguments: BuildParameters.IndexStoreMode.allCases, BuildConfiguration.allCases,
+        )
+         func indexModeSettingSetTo(
+            indexStoreSettingUT: BuildParameters.IndexStoreMode,
+            configuration: BuildConfiguration,
+         ) async throws {
+            try await withGeneratedPIF(
+                fromFixture: "PIFBuilder/Simple",
+                buildParameters: mockBuildParameters(destination: .host, indexStoreMode: indexStoreSettingUT),
+            ) { pif, observabilitySystem in
+                // #expect(false, "fail purposefully...")
+                #expect(observabilitySystem.diagnostics.filter {
+                    $0.severity == .error
+                }.isEmpty)
+
+                let targetConfig = try pif.workspace
+                    .project(named: "Simple")
+                    // .target(named: "Simple")
+                    .buildConfig(named: configuration)
+                switch indexStoreSettingUT {
+                    case .on, .off:
+                        #expect(targetConfig.settings[.SWIFT_INDEX_STORE_ENABLE] == nil)
+                    case .auto:
+                        let expectedSwiftIndexStoreEnableValue: String? = switch configuration {
+                            case .debug: "YES"
+                            case .release: nil
+                        }
+                        #expect(targetConfig.settings[.SWIFT_INDEX_STORE_ENABLE] == expectedSwiftIndexStoreEnableValue)
+                }
+
+                let testTargetConfig = try pif.workspace
+                    .project(named: "Simple")
+                    .target(named: "SimplePackageTests-product")
+                    .buildConfig(named: configuration)
+                switch indexStoreSettingUT {
+                    case .on, .off:
+                        #expect(testTargetConfig.settings[.SWIFT_INDEX_STORE_ENABLE] == nil)
+                    case .auto:
+                        #expect(testTargetConfig.settings[.SWIFT_INDEX_STORE_ENABLE] == "YES")
+                }
             }
         }
     }

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -1,0 +1,161 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import SwiftBuildSupport
+import SPMBuildCore
+
+
+import var TSCBasic.stderrStream
+import Basics
+import Workspace
+import PackageModel
+import PackageGraph
+import PackageLoading
+
+@testable import SwiftBuild
+import SWBBuildService
+
+import _InternalTestSupport
+
+func withInstantiatedSwiftBuildSystem(
+    fromFixture fixtureName: String,
+    buildParameters: BuildParameters? = nil,
+    logLevel: Basics.Diagnostic.Severity = .warning,
+    do doIt: @escaping (SwiftBuildSupport.SwiftBuildSystem, SWBBuildServiceSession, TestingObservability, BuildParameters,) async throws -> (),
+) async throws {
+    let fileSystem = Basics.localFileSystem
+
+    try await fixture(name: fixtureName) { fixturePath  in
+        try await withTemporaryDirectory  { tmpDir in
+            let buildParameters = if let buildParameters {
+                buildParameters
+            } else {
+                mockBuildParameters(destination: .host)
+            }
+            let observabilitySystem: TestingObservability = ObservabilitySystem.makeForTesting()
+            let toolchain = try UserToolchain.default
+            let workspace = try Workspace(
+                fileSystem: localFileSystem,
+                forRootPackage: fixturePath,
+                customManifestLoader: ManifestLoader(toolchain: toolchain),
+            )
+            let rootInput = PackageGraphRootInput(packages: [fixturePath], dependencies: [])
+            let graphLoader = {
+                try await workspace.loadPackageGraph(
+                    rootInput: rootInput,
+                    observabilityScope: observabilitySystem.topScope
+                )
+            }
+
+            let pluginScriptRunner = try DefaultPluginScriptRunner(
+                fileSystem: fileSystem,
+                cacheDir: tmpDir.appending("plugin-script-cache"),
+                toolchain: UserToolchain.default,
+            )
+
+            let swBuild = try SwiftBuildSystem(
+                buildParameters: buildParameters,
+                packageGraphLoader: graphLoader,
+                packageManagerResourcesDirectory: nil,
+                additionalFileRules: [],
+                outputStream: TSCBasic.stderrStream,
+                logLevel: logLevel,
+                fileSystem: fileSystem,
+                observabilityScope: observabilitySystem.topScope,
+                pluginConfiguration: PluginConfiguration(
+                    scriptRunner: pluginScriptRunner,
+                    workDirectory: AbsolutePath("/tmp/plugin-script-working-dir"),
+                    disableSandbox: true,
+                ),
+                delegate: nil,
+            )
+
+            try await SwiftBuildSupport.withService(
+                connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint),
+            ) { service in
+
+                let result = await service.createSession(
+                    name: "session",
+                    cachePath: nil,
+                    inferiorProductsPath: nil,
+                    environment: nil,
+                )
+
+                let buildSession: SWBBuildServiceSession
+                switch result {
+                case (.success(let session), _):
+                    buildSession = session
+                case (.failure(let error), _):
+                    throw StringError("\(error)")
+                    // throw SessionFailedError(error: error, diagnostics: diagnostics)
+                }
+
+                do {
+                    try await doIt(swBuild, buildSession, observabilitySystem, buildParameters)
+                    try await buildSession.close()
+                } catch {
+                    try await buildSession.close()
+                    throw error
+                }
+            }
+        }
+    }
+}
+
+@Suite(
+    .tags(
+        .TestSize.medium,
+    ),
+)
+struct SwiftBuildSystemTests {
+
+    @Test(
+        arguments: BuildParameters.IndexStoreMode.allCases,
+        // arguments: [BuildParameters.IndexStoreMode.on],
+    )
+    func indexModeSettingSetCorrectBuildRequest(
+        indexStoreSettingUT: BuildParameters.IndexStoreMode
+    ) async throws {
+        try await withInstantiatedSwiftBuildSystem(
+            fromFixture: "PIFBuilder/Simple",
+            buildParameters: mockBuildParameters(
+                destination: .host,
+                indexStoreMode: indexStoreSettingUT,
+            ),
+        ) { swiftBuild, session, observabilityScope, buildParameters in
+            let buildSettings = try await swiftBuild.makeBuildParameters(
+                session: session,
+                symbolGraphOptions: nil,
+                setToolchainSetting: false, // Set this to false as SwiftBuild checks the toolchain path
+            )
+
+            let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+            let expectedSettingValue: String? = switch indexStoreSettingUT {
+                case .on: "YES"
+                case .off: "NO"
+                case .auto: nil
+            }
+            let expectedPathValue: String? = switch indexStoreSettingUT {
+                case .on: buildParameters.indexStore.pathString
+                case .off: nil
+                case .auto: nil
+            }
+
+            #expect(synthesizedArgs.table["SWIFT_INDEX_STORE_ENABLE"] == expectedSettingValue)
+            #expect(synthesizedArgs.table["CLANG_INDEX_STORE_ENABLE"] == expectedSettingValue)
+            #expect(synthesizedArgs.table["SWIFT_INDEX_STORE_PATH"] == expectedPathValue)
+            #expect(synthesizedArgs.table["CLANG_INDEX_STORE_PATH"] == expectedPathValue)
+        }
+    }
+}


### PR DESCRIPTION
Update the PIF builder to take into account of the `--[auto|disable|enable]-index-store` command line option.

When set to `auto`, the PIF builder behaviour does the same as the Native build system.

Fixes: #9325
Issue: rdar://163961900