### PR TITLE
SwiftBuild Integration: Enable some sanitizers

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -891,6 +891,20 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             }
         }
 
+        for sanitizer in buildParameters.sanitizers.sanitizers {
+            self.observabilityScope.emit(debug:"Enabling \(sanitizer) sanitizer")
+            switch sanitizer {
+                case .address:
+                    settings["ENABLE_ADDRESS_SANITIZER"] = "YES"
+                case .thread:
+                    settings["ENABLE_THREAD_SANITIZER"] = "YES"
+                case .undefined:
+                    settings["ENABLE_UNDEFINED_BEHAVIOR_SANITIZER"] = "YES"
+                case .fuzzer, .scudo:
+                    throw StringError("\(sanitizer) is not currently supported with this build system.")
+            }
+        }
+
         // FIXME: workaround for old Xcode installations such as what is in CI
         settings["LM_SKIP_METADATA_EXTRACTION"] = "YES"
         if let symbolGraphOptions {

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -92,7 +92,8 @@ public func mockBuildParameters(
     linkTimeOptimizationMode: BuildParameters.LinkTimeOptimizationMode? = nil,
     omitFramePointers: Bool? = nil,
     enableXCFrameworksOnLinux: Bool = false,
-    prepareForIndexing: BuildParameters.PrepareForIndexingMode = .off
+    prepareForIndexing: BuildParameters.PrepareForIndexingMode = .off,
+    sanitizers: [Sanitizer] = [],
 ) -> BuildParameters {
     try! BuildParameters(
         destination: destination,
@@ -104,6 +105,7 @@ public func mockBuildParameters(
         buildSystemKind: buildSystemKind,
         pkgConfigDirectories: [],
         workers: 3,
+        sanitizers: EnabledSanitizers(Set(sanitizers)),
         indexStoreMode: indexStoreMode,
         prepareForIndexing: prepareForIndexing,
         enableXCFrameworksOnLinux: enableXCFrameworksOnLinux,
@@ -120,7 +122,7 @@ public func mockBuildParameters(
             linkTimeOptimizationMode: linkTimeOptimizationMode,
             shouldDisableLocalRpath: shouldDisableLocalRpath,
             shouldLinkStaticSwiftStdlib: shouldLinkStaticSwiftStdlib
-        )
+        ),
     )
 }
 

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -28,6 +28,12 @@ extension Tag.Platform {
     @Tag public static var FileSystem: Tag
 }
 
+extension Tag.FunctionalArea {
+    @Tag public static var PIF: Tag
+    @Tag public static var IndexMode: Tag
+    @Tag public static var Sanitizer: Tag
+}
+
 extension Tag.Feature {
     public enum Command {}
     public enum CommandLineArguments {}
@@ -191,9 +197,4 @@ extension Tag.Feature.PackageType {
 extension Tag.Feature.Product {
     @Tag public static var Execute: Tag
     @Tag public static var Link: Tag
-}
-
-extension Tag.FunctionalArea {
-    @Tag public static var PIF: Tag
-    @Tag public static var IndexMode: Tag
 }

--- a/Tests/CommandsTests/Sanitizer+ExtensionsTests.swift
+++ b/Tests/CommandsTests/Sanitizer+ExtensionsTests.swift
@@ -15,7 +15,8 @@ import enum PackageModel.Sanitizer
 
 @Suite(
     .tags(
-        Tag.TestSize.small,
+        .TestSize.small,
+        .FunctionalArea.Sanitizer,
     ),
 )
 struct SanitizerExtensionTests {

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -180,7 +180,7 @@ struct PIFBuilderTests {
             let releaseConfig = try pif.workspace
                 .project(named: "BasicExecutable")
                 .target(named: "Executable")
-                .buildConfig(named: "Release")
+                .buildConfig(named: .release)
 
             for platform in ProjectModel.BuildSettings.Platform.allCases {
                 let search_paths = releaseConfig.impartedBuildProperties.settings[.LIBRARY_SEARCH_PATHS, platform]


### PR DESCRIPTION
Update the SwiftPM's SwiftBuild integration to support enabling `address`, `thread` and `undefined` sanitizers while erroring out on the `scudo` and `fuzzer`.

Fixes: #9322 
Fixes: #8869 
Depends on: https://github.com/swiftlang/swift-build/pull/926
Depends on #9388 
