### PR TITLE
Pass build-tools flags for macro compilation

### DIFF
--- a/Fixtures/Macros/MinimalMacroPackage/Sources/MacroImpl/StringifyMacro.swift
+++ b/Fixtures/Macros/MinimalMacroPackage/Sources/MacroImpl/StringifyMacro.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+#if SHOULD_NOT_BE_SET
+#error("SHOULD_NOT_BE_SET was passed to macro compilation, but should only affect the target build.")
+#endif
+
 @main
 struct MacroPlugin {
     static func main() throws {
@@ -38,9 +42,14 @@ struct MacroPlugin {
                     try writeMessage(responseData, to: FileHandle.standardOutput)
                 }
             } else if json.keys.contains("expandFreestandingMacro") {
+                #if USE_CUSTOM_EXPANSION
+                let expandedSource = "\"custom_expanded\""
+                #else
+                let expandedSource = "\"expanded\""
+                #endif
                 let response: [String: Any] = [
                     "expandMacroResult": [
-                        "expandedSource": "\"expanded\"",
+                        "expandedSource": expandedSource,
                         "diagnostics": []
                     ]
                 ]

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -444,6 +444,10 @@ public struct BuildOptions: ParsableArguments {
         self._buildToolsSwiftCFlags
     }
 
+    var hostSwiftCFlags: [String] {
+        self._buildToolsSwiftCFlags
+    }
+
     public var buildFlags: BuildFlags {
         BuildFlags(
             cCompilerFlags: self.cCompilerFlags,
@@ -451,6 +455,16 @@ public struct BuildOptions: ParsableArguments {
             swiftCompilerFlags: self.swiftCompilerFlags,
             linkerFlags: self.linkerFlags,
             xcbuildFlags: self.xcbuildFlags
+        )
+    }
+
+    public var hostBuildFlags: BuildFlags {
+        BuildFlags(
+            cCompilerFlags: [],
+            cxxCompilerFlags: [],
+            swiftCompilerFlags: self.hostSwiftCFlags,
+            linkerFlags: [],
+            xcbuildFlags: []
         )
     }
 

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -926,13 +926,20 @@ public final class SwiftCommandState {
             case (true, true): .noLazy
             }
 
+        let flags = switch destination {
+        case .host:
+            options.build.hostBuildFlags
+        case .target:
+            options.build.buildFlags
+        }
+
         return try BuildParameters(
             destination: destination,
             dataPath: dataPath,
             configuration: self.options.build.configuration ?? self.preferredBuildConfiguration,
             toolchain: toolchain,
             triple: triple,
-            flags: options.build.buildFlags,
+            flags: flags,
             buildSystemKind: options.build.buildSystem,
             pkgConfigDirectories: options.locations.pkgConfigDirectories,
             architectures: options.build.architectures,

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -66,4 +66,45 @@ struct MacroTests {
             #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
+
+    @Test(
+        .tags(
+            Tag.Feature.Command.Build,
+            Tag.Feature.CommandLineArguments.XbuildToolsSwiftc,
+        ),
+        arguments: [BuildSystemProvider.Kind.native],
+    )
+    func macroCanBeAffectedByXBuildToolsSwiftcParameters(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Macros/MinimalMacroPackage") { fixturePath in
+            let (stdout, _) = try await executeSwiftRun(
+                fixturePath,
+                "MacroClient",
+                extraArgs: ["-Xbuild-tools-swiftc", "-DUSE_CUSTOM_EXPANSION"],
+                buildSystem: buildSystem,
+            )
+            #expect(stdout.contains("Macro result: custom_expanded"), "stdout:\n\(stdout)")
+        }
+    }
+
+    @Test(
+        .tags(
+            Tag.Feature.Command.Build,
+            Tag.Feature.CommandLineArguments.XbuildToolsSwiftc,
+        ),
+        arguments: [BuildSystemProvider.Kind.native],
+    )
+    func macroIsNotAffectedByXswiftcParameters(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Macros/MinimalMacroPackage") { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                Xswiftc: ["-DSHOULD_NOT_BE_SET"],
+                buildSystem: buildSystem,
+            )
+            #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+        }
+    }
 }


### PR DESCRIPTION
Similar in spirit to #5966, but where that one was about plugins, this one is about Swift macros.

We reuse the existing `-Xbuild-tools-swiftc` because that was what was designed to be used for (any usage of `swiftc` used for the build tools, which in the case of macros, need to build for the building machine, to not the target machine).

Motivation:
----------

For most cases, compiling against the host toolchain does not need extra arguments, but mixing the arguments for the target with those for the host toolchain can create problems if the target is different enough to the host. In the case of Swift macros, any argument passed to `-Xswiftc` and others was being forwarded to the Swift macro compilation, which is not correct, since the macros need to compile and execute in the host machine, not the target machine.

The original intention of #5966 was that all host compilation used the "host" flags, and the original spelling proposed in #5966 (`-Xhost`) was chosen because of this, but the PR review settled in `-Xbuild-tools-swiftc`, and I think macro compilation did not end up using those flags because it did not convey the actual intention of those flags.

Modifications:
--------------

This creates a parallel variable to the existing `pluginSwiftCFlags` named `hostSwiftCFlags` which picks up the `buildToolsSwiftCFlags` that come from the command line `-Xbuild-tools-swiftc` flags.

With those, it builds a `hostBuildFlags` with mostly empty flags, except for the `swiftCompilerFlags` taking its value from `hostSwiftCFlags`. The rest of the flags are empty because there is not equivalent `-Xbuild-tools-cc`, `-Xbuild-tools-cxx`, to take their values from, and they have never been needed.

When building the `SwiftCommandState`, depending on the `destination`, one set of flags or the other will be chosen, allowing macros to avoid the `-Xswiftc` flags intended for the target.

Result:
-------

With these modifications the `-Xswiftc` flags of the target in complicated setups are not propagated to the macro compilation, while the ones from `-Xbuild-tools-swiftc` are, allowing issuing `swift build` that just works when host and target are very different.
