### PR TITLE
Fix for linking tests with swiftbuild on windows

### DIFF
--- a/Fixtures/PIFBuilder/BasicExecutable/Package.swift
+++ b/Fixtures/PIFBuilder/BasicExecutable/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "BasicExecutable",
+    targets: [
+        .executableTarget(
+            name: "Executable",
+        ),
+    ]
+)

--- a/Fixtures/PIFBuilder/BasicExecutable/Sources/BasicExecutable/BasicExecutable.swift
+++ b/Fixtures/PIFBuilder/BasicExecutable/Sources/BasicExecutable/BasicExecutable.swift
@@ -1,0 +1,9 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+@main
+struct BasicExecutable {
+    static func main() {
+        print("Hello, world!")
+    }
+}

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -440,6 +440,9 @@ extension PackagePIFProjectBuilder {
                 // Redirect the built executable into a separate directory so it won't conflict with the real one.
                 settings[.TARGET_BUILD_DIR] = "$(TARGET_BUILD_DIR)/ExecutableModules"
 
+                // on windows modules are libraries, so we need to add a search path so the linker finds them
+                impartedSettings[.LIBRARY_SEARCH_PATHS, .windows] = ["$(inherited)", "$(TARGET_BUILD_DIR)/ExecutableModules"]
+
                 // Don't install the Swift module of the testable side-built artifact, lest it conflict with the regular
                 // one.
                 // The modules should have compatible contents in any case — only the entry point function name is


### PR DESCRIPTION
- need library search path to ExecutableModules for windows

