### PR TITLE
Change AsyncProcess stdout/err reads to 4096 instead of Int.max

### DIFF
--- a/Sources/Basics/Concurrency/AsyncProcess.swift
+++ b/Sources/Basics/Concurrency/AsyncProcess.swift
@@ -517,7 +517,8 @@ package final class AsyncProcess {
 
             group.enter()
             stdoutPipe.fileHandleForReading.readabilityHandler = { (fh: FileHandle) in
-                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
+                // 4096 is default pipe buffer size so reading in that size seems most efficient and still get output as it available
+                let data = (try? fh.read(upToCount: 4096)) ?? Data()
                 if data.count == 0 {
                     stdoutPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()
@@ -532,7 +533,8 @@ package final class AsyncProcess {
 
             group.enter()
             stderrPipe.fileHandleForReading.readabilityHandler = { (fh: FileHandle) in
-                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
+                // 4096 is default pipe buffer size so reading in that size seems most efficient and still get output as it available
+                let data = (try? fh.read(upToCount: 4096)) ?? Data()
                 if data.count == 0 {
                     stderrPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -236,6 +236,7 @@ def main() -> None:
                     *global_args,
                     "--configuration",
                     args.config,
+                    "--build-tests",
                     *ignore_args,
                     *args.additional_build_args.split(" ")
                 ]
@@ -252,6 +253,7 @@ def main() -> None:
                     *global_args,
                     "--configuration",
                     args.config,
+                    "--vv",
                     "--parallel",
                     "--scratch-path",
                     ".test",


### PR DESCRIPTION
- this should allow us to consume available in the Pipe as its filled and flushed but the running process.

rdar://155634107

