### PR TITLE
Promote to public operation to compute PIF GUID for products

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -61,7 +61,7 @@ import enum SwiftBuild.ProjectModel
 
 // MARK: - PIF GUID Helpers
 
-enum TargetSuffix: String {
+public enum TargetSuffix: String {
     case testable, dynamic
     
     func hasSuffix(id: GUID) -> Bool {
@@ -136,7 +136,7 @@ extension PackagePIFBuilder {
     ///
     /// This format helps make sure that there is no collision with any other PIF targets,
     /// and in particular that a PIF target and a PIF product can have the same name (as they often do).
-    static func targetGUID(forProductName name: String, withId id: String, suffix: TargetSuffix? = nil) -> GUID {
+    public static func targetGUID(forProductName name: String, withId id: String, suffix: TargetSuffix? = nil) -> GUID {
         let suffixDescription: String = suffix.uniqueDescription(forName: name)
         return "PACKAGE-PRODUCT:\(id).\(name)\(suffixDescription)"
     }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -34,7 +34,7 @@ import struct PackageGraph.ResolvedPackage
 
 import enum SwiftBuild.ProjectModel
 
-typealias GUID = SwiftBuild.ProjectModel.GUID
+public typealias GUID = SwiftBuild.ProjectModel.GUID
 typealias BuildFile = SwiftBuild.ProjectModel.BuildFile
 typealias BuildConfig = SwiftBuild.ProjectModel.BuildConfig
 typealias BuildSettings = SwiftBuild.ProjectModel.BuildSettings


### PR DESCRIPTION
### Motivation:

Ensures external clients (e.g., Xcode) can reuse some PIF GUID operations implemented internally by SwiftPM.

Without this patch, clients were instead duplicating the exact same code externally.

### Modifications:

For now, this is a quick fix to ensure that we reuse this single function from `SwiftBuildSupport/PackagePIFBuilder+Helpers.swift` 

```swift
static func targetGUID(
    forProductName name: String, 
    withId id: String, 
    suffix: TargetSuffix? = nil
) -> GUID
```

Related to rdar://165063807.
