### PR TITLE
Added clarity to `swift package update --dry-run`

### DIFF
--- a/Sources/Commands/PackageCommands/Update.swift
+++ b/Sources/Commands/PackageCommands/Update.swift
@@ -61,7 +61,7 @@ extension SwiftPackageCommand {
         private func logPackageChanges(changes: [(PackageReference, Workspace.PackageStateChange)], store: ResolvedPackagesStore) {
             let changes = changes.filter { $0.1 != .unchanged }
             
-            var report = "\(changes.count) dependenc\(changes.count == 1 ? "y has" : "ies have") changed\(changes.count > 0 ? ":" : ".")"
+            var report = "[Dry-run] \(changes.count) dependenc\(changes.count == 1 ? "y would" : "ies would") change\(changes.count > 0 ? ":" : ".")"
             for (package, change) in changes {
                 let currentVersion = store.resolvedPackages[package.identity]?.state.description ?? ""
                 switch change {


### PR DESCRIPTION
Changed wording to signal to users that the --dry-run has not changed the package but rather would change the package
### Motivation:
[Motivation](https://github.com/swiftlang/swift-package-manager/issues/9339)
### Modifications:
One-line change to edit grammar and meaning of printed output
### Result:
Nothing, just the output of dry-run