### PR TITLE
Fix warnings in Sources/Commands

### DIFF
--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -201,7 +201,7 @@ struct DumpPIF: AsyncSwiftCommand {
 }
 
 fileprivate extension BuildOutput.SymbolGraphAccessLevel {
-    fileprivate static func accessLevel(_ accessLevel: SymbolGraphExtract.AccessLevel) -> BuildOutput.SymbolGraphAccessLevel {
+    static func accessLevel(_ accessLevel: SymbolGraphExtract.AccessLevel) -> BuildOutput.SymbolGraphAccessLevel {
         return BuildOutput.SymbolGraphAccessLevel.init(rawValue: accessLevel.rawValue)!
     }
 }

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -181,11 +181,11 @@ final class PluginDelegate: PluginInvocationDelegate {
         let result = await buildSystem.buildIgnoringError(subset: buildSubset, buildOutputs: [.builtArtifacts])
         let success = result != nil
 
-        let packageGraph = try await buildSystem.getPackageGraph()
+        _ = try await buildSystem.getPackageGraph()
 
-        var builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = (result?.builtArtifacts ?? []).filter { (name, _) in
+        let builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = (result?.builtArtifacts ?? []).filter { (name, _) in
             switch subset {
-            case .all(let includingTests):
+            case .all:
                 return true
             case .product(let productName):
                 return name == productName


### PR DESCRIPTION
### Motivation:

Cleanup some leftover warnings.
