### PR TITLE
Pin GitHub actions workflows to a version

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge main into release branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.1
     with:
       head_branch: main
       base_branch: release/6.3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.1
     with:
       linux_os_versions: '["amazonlinux2", "bookworm", "noble", "jammy", "rhel-ubi9"]'
       linux_swift_versions: '["nightly-main"]'
@@ -30,7 +30,7 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.1
     with:
       license_header_check_project_name: "Swift"
       license_header_check_enabled: false


### PR DESCRIPTION
Pinning has a few benefits:
- Workflows are more repeatable for a given a commit ID. We know exactly what steps were performed.
- Updating the workflows version goes though the PR validation process, so we know whether we want to apply a change to the entire repository.
- We avoid potential issues with breaking changes in the upstream workflows.
