### PR TITLE
Remove placeholder line in WritingCommandPlugin.md

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingCommandPlugin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingCommandPlugin.md
@@ -83,7 +83,6 @@ import Foundation
 
 @main
 struct MyCommandPlugin: CommandPlugin {
-123456789012345678901234567890123456789012345678901234567890
   func performCommand(
     context: PluginContext,
     arguments: [String]


### PR DESCRIPTION
Remove placeholder line in WritingCommandPlugin.md.

### Motivation:
The doc contains a meaningless placeholder line.

### Modifications:
Removed the placeholder line.

### Result:
Syntax errors are removed from demo code snippet.
