### PR TITLE
Mark Windows tests as intermittently failing

### DIFF
--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -818,7 +818,7 @@ struct BuildCommandTestCases {
         data: BuildData,
     ) async throws {
         let buildSystem = data.buildSystem
-        try await withKnownIssue {
+        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/LibraryEvolution") { fixturePath in
                 let result = try await build(
                     [],
@@ -1469,7 +1469,7 @@ struct BuildCommandTestCases {
             """
             Windows: Sometimes failed to build due to a possible path issue
             All: --very-verbose causes rebuild on SwiftBuild (https://github.com/swiftlang/swift-package-manager/issues/9299)
-            """, 
+            """,
             isIntermittent: true) {
             try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
                 _ = try await build(
@@ -1571,7 +1571,7 @@ struct BuildCommandTestCases {
      ) async throws {
          let buildSystem = data.buildSystem
          let configuration = data.config
-         try await withKnownIssue {
+         try await withKnownIssue(isIntermittent: true) {
              // GIVEN we have a simple test package
              try await fixture(name: "Miscellaneous/SwiftBuild") { fixturePath in
                 //WHEN we build with the --quiet option

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4136,6 +4136,7 @@ struct PackageCommandTests {
                 "https://github.com/swiftlang/swift-package-manager/issues/9006",
                 relationship: .defect
             ),
+            .IssueWindowsCannotSaveAttachment,
             arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
             [
                 // When updating these, make sure we keep testing both the singular and
@@ -4160,7 +4161,7 @@ struct PackageCommandTests {
         ) async throws {
             let featureName = testData.featureName
             let expectedSummary = testData.expectedSummary
-
+            try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "SwiftMigrate/\(featureName)Migration") { fixturePath in
                 let sourcePaths: [AbsolutePath]
                 let fixedSourcePaths: [AbsolutePath]
@@ -4201,6 +4202,9 @@ struct PackageCommandTests {
                 let regexMatch = try Regex("> \(expectedSummary)" + #" \([0-9]\.[0-9]{1,3}s\)"#)
                 #expect(stdout.contains(regexMatch))
             }
+            } when: {
+                ProcessInfo.hostOperatingSystem == .windows && buildData.buildSystem == .swiftbuild
+            }
         }
 
         @Test(
@@ -4214,6 +4218,7 @@ struct PackageCommandTests {
         func migrateCommandWithBuildToolPlugins(
             data: BuildData,
         ) async throws {
+            try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "SwiftMigrate/ExistentialAnyWithPluginMigration") { fixturePath in
                 let (stdout, _) = try await execute(
                     ["migrate", "--to-feature", "ExistentialAny"],
@@ -4239,6 +4244,9 @@ struct PackageCommandTests {
                 )
                 #expect(stdout.contains(regexMatch))
             }
+            } when: {
+                ProcessInfo.hostOperatingSystem == .windows
+            }
         }
 
         @Test(
@@ -4247,11 +4255,13 @@ struct PackageCommandTests {
                 "https://github.com/swiftlang/swift-package-manager/issues/9006",
                 relationship: .defect
             ),
+            .IssueWindowsCannotSaveAttachment,
             arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
         )
         func migrateCommandWhenDependencyBuildsForHostAndTarget(
             data: BuildData,
         ) async throws {
+            try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "SwiftMigrate/ExistentialAnyWithCommonPluginDependencyMigration") {
                 fixturePath in
                 let (stdout, _) = try await execute(
@@ -4267,6 +4277,9 @@ struct PackageCommandTests {
                     "> \("Applied 1 fix-it in 1 file")" + #" \([0-9]\.[0-9]{1,3}s\)"#
                 )
                 #expect(stdout.contains(regexMatch))
+            }
+            } when: {
+                ProcessInfo.hostOperatingSystem == .windows
             }
         }
 
@@ -4528,7 +4541,7 @@ struct PackageCommandTests {
         @Test(
             .tags(
               .Feature.Command.Build,
-              .Feature.PackageType.BuildToolPlugin  
+              .Feature.PackageType.BuildToolPlugin
             ),
             .requiresSwiftConcurrencySupport,
             arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
@@ -5270,7 +5283,7 @@ struct PackageCommandTests {
         @Test(
             .tags(
               .Feature.Command.Build,
-              .Feature.PackageType.CommandPlugin 
+              .Feature.PackageType.CommandPlugin
             ),
             .requiresSwiftConcurrencySupport,
             .issue(

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1604,7 +1604,7 @@ struct PluginTests {
     func testTransitivePluginOnlyDependency(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue {
+        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
                 let (stdout, _) = try await executeSwiftBuild(
                     fixturePath.appending("TransitivePluginOnlyDependency"),

--- a/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/Tests/IntegrationTests/SwiftPMTests.swift
@@ -34,7 +34,7 @@ private struct SwiftPMTests {
                     runOutput.stdout == """
                             SwiftFramework()
                             Library(framework: SwiftFramework.SwiftFramework())
-                            
+
                             """
                 )
             }
@@ -311,7 +311,7 @@ private struct SwiftPMTests {
             let coveragePath = try AbsolutePath(validating: expectedCoveragePath)
 
             // Check the coverage path exists.
-            try withKnownIssue {
+            try withKnownIssue(isIntermittent: ProcessInfo.hostOperatingSystem == .windows) {
                 // the CoveragePath file does not exists in Linux platform build
                 expectFileExists(at: coveragePath)
 
@@ -364,7 +364,7 @@ private struct SwiftPMTests {
                     #expect(binarySpecificProfrawFiles.count == 3)
                 }
             } when: {
-                ProcessInfo.hostOperatingSystem == .linux && buildSystem == .swiftbuild
+                [.linux, .windows].contains(ProcessInfo.hostOperatingSystem) && buildSystem == .swiftbuild
             }
         }
     }

--- a/Tests/PackageLoadingTests/PD_6_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_6_2_LoadingTests.swift
@@ -72,25 +72,21 @@ struct PackageDescription6_2LoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        try await withKnownIssue("https://github.com/swiftlang/swift-package-manager/issues/8543: there are compilation errors on Windows") {
-            let (_, validationDiagnostics) = try await PackageDescriptionLoadingTests
-                .loadAndValidateManifest(
-                    content,
-                    toolsVersion: .v6_2,
-                    packageKind: .fileSystem(.root),
-                    manifestLoader: ManifestLoader(
-                        toolchain: try! UserToolchain.default
-                    ),
-                    observabilityScope: observability.topScope
-                )
-            try expectDiagnostics(validationDiagnostics) { results in
-                results.checkIsEmpty()
-            }
-            try expectDiagnostics(observability.diagnostics) { results in
-                results.checkIsEmpty()
-            }
-        } when: {
-            isWindows && !CiEnvironment.runningInSmokeTestPipeline
+        let (_, validationDiagnostics) = try await PackageDescriptionLoadingTests
+            .loadAndValidateManifest(
+                content,
+                toolsVersion: .v6_2,
+                packageKind: .fileSystem(.root),
+                manifestLoader: ManifestLoader(
+                    toolchain: try! UserToolchain.default
+                ),
+                observabilityScope: observability.topScope
+            )
+        try expectDiagnostics(validationDiagnostics) { results in
+            results.checkIsEmpty()
+        }
+        try expectDiagnostics(observability.diagnostics) { results in
+            results.checkIsEmpty()
         }
     }
 }


### PR DESCRIPTION
Some tests are now failing on Windows, which may or may not have been related to the new toolchain used in the self hosted pipelines.