### PR TITLE
Handle invalid source control URLs in registry identity lookup

### DIFF
--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -19,6 +19,7 @@ import class Basics.ObservabilityScope
 import struct Basics.SourceControlURL
 import class Basics.ThreadSafeKeyValueStore
 import class PackageGraph.ResolvedPackagesStore
+import enum PackageRegistry.RegistryError
 import protocol PackageLoading.ManifestLoaderProtocol
 import protocol PackageModel.DependencyMapper
 import protocol PackageModel.IdentityResolver
@@ -332,6 +333,11 @@ extension Workspace {
             url: SourceControlURL,
             observabilityScope: ObservabilityScope
         ) async throws -> PackageIdentity? {
+            // Validate URL before attempting registry lookup
+            guard url.isValid else {
+                throw RegistryError.invalidSourceControlURL(url)
+            }
+
             if let cached = self.identityLookupCache[url], cached.expirationTime > .now() {
                 switch cached.result {
                 case .success(let identity):

--- a/Tests/BasicsTests/SourceControlURLTests.swift
+++ b/Tests/BasicsTests/SourceControlURLTests.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Testing
+
+@Suite("SourceControlURL")
+struct SourceControlURLTests {
+    @Test func validURLs() {
+        #expect(SourceControlURL("https://github.com/owner/repo").isValid)
+        #expect(SourceControlURL("https://github.com/owner/repo.git").isValid)
+        #expect(SourceControlURL("git@github.com:owner/repo.git").isValid)
+        #expect(SourceControlURL("ssh://git@github.com/owner/repo.git").isValid)
+        #expect(SourceControlURL("http://example.com/path/to/repo").isValid)
+    }
+
+    @Test func invalidURLs_withWhitespace() {
+        // URLs containing whitespace are invalid (typically indicates concatenated error messages)
+        #expect(!SourceControlURL("https://github.com/owner/repo.git': failed looking up identity").isValid)
+        #expect(!SourceControlURL("https://github.com/owner/repo error message").isValid)
+        #expect(!SourceControlURL("https://github.com/owner/repo\there").isValid)
+        #expect(!SourceControlURL("https://github.com/owner/repo\nhere").isValid)
+    }
+
+    @Test func invalidURLs_unparseable() {
+        // URLs that can't be parsed
+        #expect(!SourceControlURL("not a url").isValid)
+        #expect(!SourceControlURL("").isValid)
+    }
+
+    @Test func invalidURLs_noHost() {
+        // URLs without a host
+        #expect(!SourceControlURL("file:///path/to/repo").isValid)
+    }
+}


### PR DESCRIPTION
## Summary

Add validation for source control URLs at multiple levels to handle malformed URLs gracefully.

## Problem

When macOS `git-credential-osxkeychain` fails to find credentials, it outputs error messages that can get concatenated with the original URL:

```
https://github.com/owner/repo.git': failed looking up identity for https://github.com/owner/repo.git
```

These malformed URLs were being sent to the registry server, causing errors. This was observed in the [Tuist registry](https://tuist.dev) where we added server-side validation to return HTTP 400 for invalid URLs (see [tuist/tuist#8829](https://github.com/tuist/tuist/pull/8829)).

## Solution

### 1. Add `isValid` property to `SourceControlURL`

```swift
public var isValid: Bool {
    // URLs with whitespace are invalid
    guard !self.urlString.contains(where: \.isWhitespace) else {
        return false
    }
    // Check for standard URL format or SSH-style git URLs
    ...
}
```

Valid source control URLs:
- Don't contain whitespace (error messages contain spaces)
- Are parseable as standard URLs with a host, OR
- Match SSH-style git format (`user@host:path`)

### 2. Early validation in `mapRegistryIdentity`

```swift
guard url.isValid else {
    throw RegistryError.invalidSourceControlURL(url)
}
```

This validates URLs before making any HTTP requests to the registry.

### 3. Handle HTTP 400 from registry servers

```swift
case 400:
    throw RegistryError.invalidSourceControlURL(scmURL)
```

If a URL passes client validation but the server still rejects it with 400 Bad Request, we throw the same specific error.

## Changes

- `Sources/Basics/SourceControlURL.swift`: Added `isValid` computed property
- `Sources/Workspace/Workspace+Registry.swift`: Added early URL validation
- `Sources/PackageRegistry/RegistryClient.swift`: 
  - Added `invalidSourceControlURL` error case
  - Handle 400 response in `lookupIdentities`
- `Tests/BasicsTests/SourceControlURLTests.swift`: Added tests for URL validation
- `Tests/PackageRegistryTests/RegistryClientTests.swift`: Added test for 400 handling

## Test Plan

- [x] `SourceControlURLTests` - Tests for `isValid` property (4 tests)
- [x] `LookupIdentities` - Tests for registry client including 400 handling (6 tests)
- [x] All tests pass (10 tests total)
- [x] Build succeeds

## Related

- Server-side fix in Tuist registry: [tuist/tuist#8829](https://github.com/tuist/tuist/pull/8829)

🤖 Generated with [Claude Code](https://claude.com/claude-code)