### PR TITLE
Hide unused legacy `--sdk` and `--toolchain` options from CLI help

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -459,11 +459,11 @@ public struct BuildOptions: ParsableArguments {
     public var customCompileTriple: Triple?
 
     /// Path to the compilation destination’s SDK.
-    @Option(name: .customLong("sdk"))
+    @Option(name: .customLong("sdk"), help: .hidden)
     public var customCompileSDK: AbsolutePath?
 
     /// Path to the compilation destination’s toolchain.
-    @Option(name: .customLong("toolchain"))
+    @Option(name: .customLong("toolchain"), help: .hidden)
     public var customCompileToolchain: AbsolutePath?
 
     /// The architectures to compile for.


### PR DESCRIPTION
These options are not recommended for general use and are confusing for end users that don't clearly distinguish between SDKs and Swift SDKs. These options also predate Swift SDK introduction, that's why historically they were kept in help output still. Now that Swift SDKs are no longer experimental, we should hide legacy options to reduce the chance for confusion.
