### PR TITLE
Fix: URLSessionHTTPClient only move file if response code is within OK range

### DIFF
--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -307,6 +307,12 @@ private final class DownloadTaskManager: NSObject, URLSessionDownloadDelegate {
         do {
             let path = try AbsolutePath(validating: location.path)
 
+            // Only proceed to move the file if status code is within 200-299 range.
+            if let response = downloadTask.response as? HTTPURLResponse,
+               response.statusCode < 200 || response.statusCode >= 300 {
+                throw HTTPClientError.badResponseStatusCode(response.statusCode)
+            }
+
             // Always using synchronous `localFileSystem` here since `URLSession` requires temporary `location`
             // to be moved from synchronously. Otherwise the file will be immediately cleaned up after returning
             // from this delegate method.


### PR DESCRIPTION
Only move the downloaded file if the HTTP status code is within the OK range

### Motivation:

Our `Package.swift` has package dependencies that are hosted in our internal JFrog instance. We have noticed that when a server error occurs, a JSON payload is still returned. In our particular case the JFrog instance was returning `HTTP 500` as the curl snippet below shows.


```
% curl --verbose -L \
  --netrc \
  --netrc-file bogusnetrc \
  -o "./Artifact.zip" \
  "https://host_redacted/Artifact.zip"
  <redacted logs>
 > GET /Artifact.zip HTTP/2
> Host: redacted_host
> Authorization: Basic <redacted>
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 500 
< date: Mon, 08 Dec 2025 11:01:50 GMT
< content-type: application/json;charset=ISO-8859-1
< content-length: 65
< 
% cat Artifact.zip 
{
  "errors" : [ {
    "status" : 500,
    "message" : ""
  } ]
}
```

Because of that, the error shown in the `swift package PackagePath resolve` is not very clear. 

```
% swift package --package-path ./path/to/package resolve
Downloading binary artifact https://host_redacted/Artifact.zip
error: failed downloading 'https://host_redacted/Artifact.zip' which is required by binary target 'TargetName': $HOME_REDACTED/Library/Caches/org.swift.swiftpm/artifacts/ArtifactPath.zip already exists in file system
error: fatalError
```

This does not tell much about the exact underlying error that happened here. 

### Result:

After the changes in this PR, the error message will become much clearer about the underlying issue with the HTTP call

```
% ./build-folder/swift-package --package-path ./path/to/package resolve
Downloading binary artifact https://host_redacted/Artifact.zip
error: failed downloading 'https://host_redacted/Artifact.zip' which is required by binary target 'TargetName': badResponseStatusCode(500)
error: fatalError
```
