### PR TITLE
Fixup licence header in DisableSigpipe.swift

### DIFF
--- a/Sources/SwiftPMBuildServer/DisableSigpipe.swift
+++ b/Sources/SwiftPMBuildServer/DisableSigpipe.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift open source project
 //
-// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
It is causing the licence check CI job to fail.
