### PR TITLE
Set explicit file types in PIF for binary artifacts

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -227,6 +227,19 @@ extension PackagePIFProjectBuilder {
         case macro
     }
 
+    static func createBinaryModuleFileReference(_ binaryModule: BinaryModule, id: ProjectModel.GUID) -> FileReference {
+        let fileTypeIdentifier: String?
+        switch binaryModule.kind {
+        case .artifactsArchive:
+            fileTypeIdentifier = "wrapper.artifactbundle"
+        case .xcframework:
+            fileTypeIdentifier = "wrapper.xcframework"
+        case .unknown:
+            fileTypeIdentifier = nil
+        }
+        return FileReference(id: id, path: binaryModule.artifactPath.pathString, fileType: fileTypeIdentifier)
+    }
+
     /// Constructs a *PIF target* for building a *module* as a particular type.
     /// An optional target identifier suffix is passed when building variants of a target.
     @discardableResult
@@ -651,7 +664,7 @@ extension PackagePIFProjectBuilder {
                         break
                     }
                     let binaryReference = self.binaryGroup.addFileReference { id in
-                        FileReference(id: id, path: (binaryModule.artifactPath.pathString))
+                        return Self.createBinaryModuleFileReference(binaryModule, id: id)
                     }
                     if shouldLinkProduct {
                         self.project[keyPath: sourceModuleTargetKeyPath].addLibrary { id in

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -346,7 +346,7 @@ extension PackagePIFProjectBuilder {
                         break
                     }
                     let binaryFileRef = self.binaryGroup.addFileReference { id in
-                        FileReference(id: id, path: binaryModule.artifactPath.pathString)
+                        Self.createBinaryModuleFileReference(binaryModule, id: id)
                     }
                     let toolsVersion = self.package.manifest.toolsVersion
                     self.project[keyPath: mainModuleTargetKeyPath].addLibrary { id in


### PR DESCRIPTION
This ensures that even if an artifact bundle is downloaded and unpacked without a file extension, the underlying build system can identify it correctly. 

Closes https://github.com/swiftlang/swift-package-manager/issues/9471
Depends on https://github.com/swiftlang/swift-build/pull/962

I wasn't able to add a test for this because I can only reproduce it with remote packages