### PR TITLE
Use the correct module name for executable targets combined with an executable product with a different name

### DIFF
--- a/Fixtures/Miscellaneous/TestableExeWithDifferentProductName/Package.swift
+++ b/Fixtures/Miscellaneous/TestableExeWithDifferentProductName/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.5
+import PackageDescription
+
+let package = Package(
+    name: "TestableExe",
+    products: [
+        .executable(name: "testable-exe", targets: ["TestableExe"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "TestableExe"
+        ),
+        .testTarget(
+            name: "TestableExeTests",
+            dependencies: [
+                "TestableExe",
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestableExeWithDifferentProductName/Sources/TestableExe/main.swift
+++ b/Fixtures/Miscellaneous/TestableExeWithDifferentProductName/Sources/TestableExe/main.swift
@@ -1,0 +1,5 @@
+public func functionFromTestableExecutable() {
+    print("Hello, world")
+}
+
+functionFromTestableExecutable()

--- a/Fixtures/Miscellaneous/TestableExeWithDifferentProductName/Tests/TestableExeTests/TestableExeTests.swift
+++ b/Fixtures/Miscellaneous/TestableExeWithDifferentProductName/Tests/TestableExeTests/TestableExeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import TestableExe
+
+final class TestableExeTests: XCTestCase {
+    func testExample() throws {
+        functionFromTestableExecutable()
+    }
+}

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -112,7 +112,8 @@ extension PackagePIFProjectBuilder {
         settings[.TARGET_NAME] = product.name
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "regular"
         settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
-        settings[.PRODUCT_MODULE_NAME] = product.c99name
+        // We must use the main module name here instead of the product name, because they're not guranteed to be the same, and the users may have authored e.g. tests which rely on an executable's module name.
+        settings[.PRODUCT_MODULE_NAME] = mainModule.c99name
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(product.name)"
             .spm_mangledToBundleIdentifier()
         settings[.SWIFT_PACKAGE_NAME] = mainModule.packageName
@@ -415,7 +416,7 @@ extension PackagePIFProjectBuilder {
                 case .executable, .snippet:
                     // For executable targets, we depend on the *product* instead
                     // (i.e., we infuse the product's main module target into the one for the product itself).
-                    let productDependency = modulesGraph.allProducts.only { $0.name == moduleDependency.name }
+                    let productDependency = modulesGraph.allProducts.only { $0.mainModule?.name == moduleDependency.name }
                     if let productDependency {
                         let productDependencyGUID = productDependency.pifTargetGUID
                         self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -318,6 +318,31 @@ struct TestCommandTests {
     }
 
     @Test(
+        .IssueWindowsLongPath,
+        .tags(
+            .Feature.TargetType.Executable,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+    )
+    func testableExecutableWithDifferentlyNamedExecutableProduct(
+        buildSystem: BuildSystemProvider.Kind,
+        configuration: BuildConfiguration,
+    ) async throws {
+        try await withKnownIssue(isIntermittent: true) {
+            try await fixture(name: "Miscellaneous/TestableExeWithDifferentProductName") { fixturePath in
+                let result = try await execute(
+                    ["--vv"],
+                    packagePath: fixturePath,
+                    configuration: configuration,
+                    buildSystem: buildSystem,
+                )
+            }
+        } when: {
+            .windows == ProcessInfo.hostOperatingSystem
+        }
+    }
+
+    @Test(
         .tags(
             .Feature.TargetType.Executable,
         ),


### PR DESCRIPTION
If an executable target is combined with an executable product at the PIF layer, it must retain the target's module name, so that tests which consume it can import the right module name.