### PR TITLE
Expose PackageDependency creation methods

### DIFF
--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -249,7 +249,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         )
     }
 
-    package static func fileSystem(
+    public static func fileSystem(
         identity: PackageIdentity,
         nameForTargetDependencyResolutionOnly: String?,
         path: AbsolutePath,
@@ -284,7 +284,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         )
     }
 
-    package static func localSourceControl(
+    public static func localSourceControl(
         identity: PackageIdentity,
         nameForTargetDependencyResolutionOnly: String?,
         path: AbsolutePath,
@@ -319,7 +319,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         )
     }
 
-    package static func remoteSourceControl(
+    public static func remoteSourceControl(
         identity: PackageIdentity,
         nameForTargetDependencyResolutionOnly: String?,
         url: SourceControlURL,
@@ -354,7 +354,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         )
     }
 
-    package static func sourceControl(
+    public static func sourceControl(
         identity: PackageIdentity,
         nameForTargetDependencyResolutionOnly: String?,
         location: SourceControl.Location,
@@ -387,7 +387,7 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         )
     }
 
-    package static func registry(
+    public static func registry(
         identity: PackageIdentity,
         requirement: Registry.Requirement,
         productFilter: ProductFilter,


### PR DESCRIPTION
The versions without the `traits` parameter were public for clients to use, but the version with the `traits` parameter were marked as `package`. Expose them as `public` just like the versions without traits.
