### PR TITLE
Ensure call to unsafe_await is not called from Swifts concurrency system

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -27,6 +27,12 @@ public enum Concurrency {
 
 @available(*, noasync, message: "This method blocks the current thread indefinitely. Calling it from the concurrency pool can cause deadlocks")
 public func unsafe_await<T: Sendable>(_ body: @Sendable @escaping () async -> T) -> T {
+    withUnsafeCurrentTask { task in
+        if task != nil {
+            fatalError("This function must not be invoked from the Swift Concurrency thread pool.")
+        }
+    }
+    
     let semaphore = DispatchSemaphore(value: 0)
 
     let box = ThreadSafeBox<T>()


### PR DESCRIPTION
Ensure call to unsafe_await is not called from Swifts concurrency system

### Motivation:

Defensive check in response to:
https://github.com/swiftlang/swift-package-manager/issues/9441

### Modifications:

Ensure call to unsafe_await is not called from Swift's concurrency system (an asynchronous context).
