### PR TITLE
Revert "Change AsyncProcess stdout/err reads to 4096 instead of Int.m…

### DIFF
--- a/Sources/Basics/Concurrency/AsyncProcess.swift
+++ b/Sources/Basics/Concurrency/AsyncProcess.swift
@@ -508,8 +508,7 @@ package final class AsyncProcess {
 
             group.enter()
             stdoutPipe.fileHandleForReading.readabilityHandler = { (fh: FileHandle) in
-                // 4096 is default pipe buffer size so reading in that size seems most efficient and still get output as it available
-                let data = (try? fh.read(upToCount: 4096)) ?? Data()
+                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
                 if data.count == 0 {
                     stdoutPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()
@@ -524,8 +523,7 @@ package final class AsyncProcess {
 
             group.enter()
             stderrPipe.fileHandleForReading.readabilityHandler = { (fh: FileHandle) in
-                // 4096 is default pipe buffer size so reading in that size seems most efficient and still get output as it available
-                let data = (try? fh.read(upToCount: 4096)) ?? Data()
+                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
                 if data.count == 0 {
                     stderrPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -268,7 +268,8 @@ def main() -> None:
                     "swift",
                     "build",
                     *global_args,
-                    "--build-tests",
+                    "--configuration",
+                    args.config,
                     *ignore_args,
                     *args.additional_build_args.split(" ")
                 ]
@@ -285,8 +286,9 @@ def main() -> None:
                     *args.additional_run_args.split(" "),
                     "swift-test",
                     *global_args,
-                    "--vv",
                     "--force-resolved-versions",
+                    "--configuration",
+                    args.config,
                     "--parallel",
                     "--scratch-path",
                     ".test",


### PR DESCRIPTION
…ax (#9408)"

This reverts commit 41f7eeae05573c378e5cd9cfca3ed07393437262.

Test revert to see if this resolves SourceKit-LSP test hangs