### PR TITLE
Update build-using-self

### DIFF
--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -132,13 +132,25 @@ def log_environment() -> None:
         logging.info("  --> %s=%r", key, value)
 
 
+BUILD_OVERRIDES: t.List[str] = [
+    "--build-system",
+    "native",
+]
+
+
 def get_swiftpm_bin_dir(
         *,
         global_args: t.List[str],
 ) -> pathlib.Path:
     logging.info("Retrieving Swift PM binary directory.")
     swiftpm_bin_dir = pathlib.Path(
-        call_output(["swift", "build", *global_args, "--show-bin-path"])
+        call_output([
+            "swift",
+            "build",
+            *global_args,
+            *BUILD_OVERRIDES,
+            "--show-bin-path",
+        ])
     )
     logging.info("SwiftPM BIN DIR: %s", swiftpm_bin_dir)
     return swiftpm_bin_dir
@@ -245,6 +257,7 @@ def main() -> None:
                         "swift",
                         "package",
                         *global_args,
+                        *BUILD_OVERRIDES,
                         "clean",
                     ]
                 )
@@ -257,6 +270,7 @@ def main() -> None:
                         "swift",
                         "package",
                         *global_args,
+                        *BUILD_OVERRIDES,
                         "update",
                     ]
                 )
@@ -268,6 +282,7 @@ def main() -> None:
                     "swift",
                     "build",
                     *global_args,
+                    *BUILD_OVERRIDES,
                     "--build-tests",
                     *ignore_args,
                     *args.additional_build_args.split(" ")
@@ -281,6 +296,7 @@ def main() -> None:
                     "swift",
                     "run",
                     *global_args,
+                    *BUILD_OVERRIDES,
                     *ignore_args,
                     *args.additional_run_args.split(" "),
                     "swift-test",


### PR DESCRIPTION
Update the build-using-self to the `swift-build` and `swift-test` executable targets are built using the native build system.

Fixes: #9070