### PR TITLE
Serialize PackageCommandTests to avoid concurrent tests deleting current working directory

### DIFF
--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -90,7 +90,7 @@ private func executeAddURLDependencyAndAssert(
 }
 
 @Suite(
-    .serializedIfOnWindows,
+    .serialized,
     .tags(
         .TestSize.large,
         .Feature.Command.Package.General,


### PR DESCRIPTION
Serialize PackageCommandTests to avoid concurrent tests deleting current working directory