### PR TITLE
Do not set a fixture prefix

### DIFF
--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -125,7 +125,7 @@ public func testWithTemporaryDirectory<Result>(
         let copyName = fixtureSubpath.components.joined(separator: "_")
 
         // Create a temporary directory for the duration of the block.
-        return try withTemporaryDirectory(prefix: copyName) { tmpDirPath in
+        return try withTemporaryDirectory(prefix: "") { tmpDirPath in
 
             defer {
                 // Unblock and remove the tmp dir on deinit.
@@ -167,7 +167,7 @@ public enum TestError: Error {
         let copyName = fixtureSubpath.components.joined(separator: "_")
 
         // Create a temporary directory for the duration of the block.
-        return try await withTemporaryDirectory(prefix: copyName) { tmpDirPath in
+        return try await withTemporaryDirectory(prefix: "") { tmpDirPath in
 
             defer {
                 // Unblock and remove the tmp dir on deinit.
@@ -217,7 +217,7 @@ fileprivate func setup(
         #else
         try systemQuietly("cp", "-R", "-H", srcDir.pathString, dstDir.pathString)
         #endif
-        
+
         // Ensure we get a clean test fixture.
         try localFileSystem.removeFileTree(dstDir.appending(component: ".build"))
         try localFileSystem.removeFileTree(dstDir.appending(component: ".swiftpm"))
@@ -436,7 +436,7 @@ private func swiftArgs(
     return args
 }
 
-@available(*, 
+@available(*,
     deprecated,
     renamed: "loadModulesGraph",
     message: "Rename for consistency: the type of this functions return value is named `ModulesGraph`."
@@ -580,7 +580,7 @@ public func getNumberOfMatches(of match: String, in value: String) -> Int {
 }
 
 public extension String {
-    var withSwiftLineEnding: String {   
+    var withSwiftLineEnding: String {
         return replacingOccurrences(of: "\r\n", with: "\n")
     }
 }

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -53,7 +53,7 @@ struct RunCommandTests {
         buildSystem: BuildSystemProvider.Kind
     ) async throws {
         let stdout = try await execute(["-help"], buildSystem: buildSystem).stdout
-        
+
         #expect(stdout.contains("USAGE: swift run <options>") || stdout.contains("USAGE: swift run [<options>]"), "got stdout:\n \(stdout)")
     }
 
@@ -99,7 +99,6 @@ struct RunCommandTests {
     func toolsetDebugger(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue {
         try await fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
             #if os(Windows)
                 let win32 = ".win32"
@@ -127,9 +126,6 @@ struct RunCommandTests {
             } when: {
                 buildSystem == .swiftbuild
             }
-        }
-        } when: {
-            .swiftbuild == buildSystem && ProcessInfo.hostOperatingSystem == .windows
         }
     }
 
@@ -167,8 +163,7 @@ struct RunCommandTests {
                 }
             }
         } when: {
-            (.windows == ProcessInfo.hostOperatingSystem && buildSystem == .swiftbuild)
-            || (.linux == ProcessInfo.hostOperatingSystem && buildSystem == .swiftbuild && CiEnvironment.runningInSelfHostedPipeline)
+            (.linux == ProcessInfo.hostOperatingSystem && buildSystem == .swiftbuild && CiEnvironment.runningInSelfHostedPipeline)
         }
     }
 
@@ -229,7 +224,7 @@ struct RunCommandTests {
             #expect(runOutput.contains("2"))
         }
         } when: {
-            [.windows, .linux].contains(ProcessInfo.hostOperatingSystem) && buildSystem == .swiftbuild && CiEnvironment.runningInSelfHostedPipeline
+            [.linux].contains(ProcessInfo.hostOperatingSystem) && buildSystem == .swiftbuild && CiEnvironment.runningInSelfHostedPipeline
         }
     }
 

--- a/Tests/PackageLoadingTests/PD_6_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_6_2_LoadingTests.swift
@@ -68,25 +68,21 @@ struct PackageDescription6_2LoadingTests {
             """
 
         let observability = ObservabilitySystem.makeForTesting()
-        try await withKnownIssue("https://github.com/swiftlang/swift-package-manager/issues/8543: there are compilation errors on Windows") {
-            let (_, validationDiagnostics) = try await PackageDescriptionLoadingTests
-                .loadAndValidateManifest(
-                    content,
-                    toolsVersion: .v6_2,
-                    packageKind: .fileSystem(.root),
-                    manifestLoader: ManifestLoader(
-                        toolchain: try! UserToolchain.default
-                    ),
-                    observabilityScope: observability.topScope
-                )
-            try expectDiagnostics(validationDiagnostics) { results in
-                results.checkIsEmpty()
-            }
-            try expectDiagnostics(observability.diagnostics) { results in
-                results.checkIsEmpty()
-            }
-        } when: {
-            isWindows
+        let (_, validationDiagnostics) = try await PackageDescriptionLoadingTests
+            .loadAndValidateManifest(
+                content,
+                toolsVersion: .v6_2,
+                packageKind: .fileSystem(.root),
+                manifestLoader: ManifestLoader(
+                    toolchain: try! UserToolchain.default
+                ),
+                observabilityScope: observability.topScope
+            )
+        try expectDiagnostics(validationDiagnostics) { results in
+            results.checkIsEmpty()
+        }
+        try expectDiagnostics(observability.diagnostics) { results in
+            results.checkIsEmpty()
         }
     }
 }


### PR DESCRIPTION
Ensure `fixture` prefix is an empty string, and update the tests to reflect the new behaviour.