### PR TITLE
Only include the platform PrivateFrameworks directory as a runtime, not build-time, search path

### DIFF
--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -242,10 +242,10 @@ enum TestingSupport {
         // Since XCTestHelper targets macOS, we need the macOS platform paths here.
         if let sdkPlatformPaths = try? SwiftSDK.sdkPlatformPaths(for: .macOS) {
             // appending since we prefer the user setting (if set) to the one we inject
-            for frameworkPath in sdkPlatformPaths.frameworks {
+            for frameworkPath in sdkPlatformPaths.runtimeFrameworkSearchPaths {
                 env.appendPath(key: "DYLD_FRAMEWORK_PATH", value: frameworkPath.pathString)
             }
-            for libraryPath in sdkPlatformPaths.libraries {
+            for libraryPath in sdkPlatformPaths.runtimeLibrarySearchPaths {
                 env.appendPath(key: "DYLD_LIBRARY_PATH", value: libraryPath.pathString)
             }
         }


### PR DESCRIPTION
This constrains a behavior I landed in #8199 so that it only includes the `PrivateFrameworks` directory from Xcode's platform directory (when present) as a **runtime** framework search path (via `DYLD_FRAMEWORK_PATH`) and no longer includes it as a _build-time_ framework search path (via `-F <path>`).

### Motivation:

This is a follow-up to a change I made in #8199. Those changes had an undesirable side effect of including private frameworks in all builds, and means that when those frameworks are present at build time, they're included in client builds and can be `import`'ed or linked. Exposing those frameworks to clients at _build-time_ was not intended, and can cause unexpected results or failures if (for example) those private frameworks themselves contain unresolvable module imports.

However, platform private frameworks directories _should_ continue to be included in runtime framework search paths, so they can be located and loaded when referenced by public frameworks/libraries.

### Modifications:

- Introduce separate properties for build-time vs. runtime framework and library search paths, so the two categories can be differentiated by callers.
- Omit the private frameworks search path from the new build-time frameworks property.
- Adopt the relevant new properties at both build and runtime usage sites.

### Result:

After this change, I validated that:

- a local package build no longer contains the private frameworks search path entry at build time, using `swift build --build-tests --verbose`, and
- a local package test operation still includes the search path, using `env DYLD_PRINT_ENV=1 swift test`.