### PR TITLE
Forward target change notifications to clients

### DIFF
--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -165,6 +165,9 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         case is OnBuildLogMessageNotification:
             // If we receive a build log message notification, forward it on to the client
             connectionToClient.send(notification)
+        case is OnBuildTargetDidChangeNotification:
+            // If the underlying server notifies us of target updates, forward the notification to the client
+            connectionToClient.send(notification)
         default:
             logToClient(.warning, "SwiftPM build server received unknown notification type: \(notification)")
         }


### PR DESCRIPTION
This ensures that targets know to re-request the list of targets when the underlyinf Swift Build server regenerates the build description