### PR TITLE
Emit warning for unhandled files in SwiftBuild

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -398,6 +398,12 @@ public final class PIFBuilder {
                     observabilityScope: observabilityScope
                 )
 
+                self.diagnoseUnhandledFiles(
+                    package: package,
+                    module: module,
+                    buildToolPluginInvocationResults: buildToolPluginResults
+                )
+
                 let result = PackagePIFBuilder.BuildToolPluginInvocationResult(
                     prebuildCommandOutputPaths: runResults.flatMap( { $0.derivedFiles }),
                     buildCommands: buildCommands
@@ -569,6 +575,42 @@ public final class PIFBuilder {
             observabilityScope: observabilityScope
         )
         return try await builder.generatePIF(preservePIFModelStructure: preservePIFModelStructure, buildParameters: buildParameters)
+    }
+
+    private func diagnoseUnhandledFiles(
+        package: ResolvedPackage,
+        module: ResolvedModule,
+        buildToolPluginInvocationResults: [BuildToolPluginInvocationResult]
+    ) {
+        guard package.manifest.toolsVersion >= .v5_3 else {
+            return
+        }
+
+        var unhandledFiles = Set(module.underlying.others)
+        if unhandledFiles.isEmpty {
+            return
+        }
+
+        let handledFiles = buildToolPluginInvocationResults.flatMap { $0.buildCommands.flatMap(\.inputFiles) }
+        unhandledFiles.subtract(handledFiles)
+
+        if unhandledFiles.isEmpty {
+            return
+        }
+
+        let diagnosticsEmitter = self.observabilityScope.makeDiagnosticsEmitter {
+            var metadata = ObservabilityMetadata()
+            metadata.packageIdentity = package.identity
+            metadata.packageKind = package.manifest.packageKind
+            metadata.moduleName = module.name
+            return metadata
+        }
+        var warning =
+            "found \(unhandledFiles.count) file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n"
+        for file in unhandledFiles {
+            warning += "    " + file.pathString + "\n"
+        }
+        diagnosticsEmitter.emit(warning: warning)
     }
 }
 

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -66,7 +66,7 @@ struct PluginTests {
     }
 
     @Test(
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8786"),
+        .IssueWindowsRelativePathAssert,
         .requiresSwiftConcurrencySupport,
         .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),
         .tags(
@@ -88,7 +88,7 @@ struct PluginTests {
                 #expect(stderr.contains("file(s) which are unhandled; explicitly declare them as resources or exclude from the target"), "expected warning not emitted")
             }
         } when: {
-            buildSystem == .swiftbuild
+            ProcessInfo.hostOperatingSystem == .windows && CiEnvironment.runningInSelfHostedPipeline && buildSystem == .native
         }
     }
 


### PR DESCRIPTION
When building with the native build system, SwiftPM emits a warning if there are files in a target's source directory that aren't being handled - they're not Swift sources, not declared as resources, and not explicitly excluded. This is helpful for catching forgotten files or misconfigurations. However, when using SwiftBuild, this warning was silently skipped, which could lead to confusion when switching between build systems.

I traced the issue to `PIFBuilder.swift`, which generates the PIF representation for SwiftBuild but was missing the diagnostic check that `BuildOperation.swift` performs for the native build system. The fix adds a `diagnoseUnhandledFiles` method to `PIFBuilder` that mirrors the native implementation - it runs after plugin invocation, checks for files in `module.underlying.others` that weren't handled by any build tool plugins, and emits the same warning with proper metadata.

I also updated the existing test in `PluginTests.swift` that was marked as a known issue for SwiftBuild (referencing this exact issue #8786) to remove that condition since the fix resolves it.

Fixes #8786