### PR TITLE
Revert "Change AsyncProcess stdout/err reads to 4096 instead of Int.max (#9408)"

### DIFF
--- a/Sources/Basics/Concurrency/AsyncProcess.swift
+++ b/Sources/Basics/Concurrency/AsyncProcess.swift
@@ -509,8 +509,7 @@ package final class AsyncProcess {
 
             group.enter()
             stdoutPipe.fileHandleForReading.readabilityHandler = { (fh: FileHandle) in
-                // 4096 is default pipe buffer size so reading in that size seems most efficient and still get output as it available
-                let data = (try? fh.read(upToCount: 4096)) ?? Data()
+                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
                 if data.count == 0 {
                     stdoutPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()
@@ -525,8 +524,7 @@ package final class AsyncProcess {
 
             group.enter()
             stderrPipe.fileHandleForReading.readabilityHandler = { (fh: FileHandle) in
-                // 4096 is default pipe buffer size so reading in that size seems most efficient and still get output as it available
-                let data = (try? fh.read(upToCount: 4096)) ?? Data()
+                let data = (try? fh.read(upToCount: Int.max)) ?? Data()
                 if data.count == 0 {
                     stderrPipe.fileHandleForReading.readabilityHandler = nil
                     group.leave()

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -283,7 +283,6 @@ def main() -> None:
                     "build",
                     *global_args,
                     *BUILD_OVERRIDES,
-                    "--build-tests",
                     *ignore_args,
                     *args.additional_build_args.split(" ")
                 ]
@@ -301,7 +300,6 @@ def main() -> None:
                     *args.additional_run_args.split(" "),
                     "swift-test",
                     *global_args,
-                    "--vv",
                     "--force-resolved-versions",
                     "--parallel",
                     "--scratch-path",


### PR DESCRIPTION
I am reverting this since it seems like a probable cause for timeouts on sourcekit-lsp tests on windows. Example:  https://ci-external.swift.org/job/swift-PR-windows/49259/console