### PR TITLE
Add conceptual documentation for SwiftPM plugins

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/Package/Plugins.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/Plugins.md
@@ -1,0 +1,24 @@
+# Plugins
+
+Swift Package Manager supports plugins that can extend package functionality.
+
+## Overview
+
+There are two kinds of plugins in SwiftPM:
+
+- **Command plugins**, which are invoked explicitly by users.
+- **Build tool plugins**, which are applied to targets during the build.
+
+## Build Tool Plugins
+
+Build tool plugins are executed by the build system and may generate files
+that are used as inputs to compilation.
+
+## Plugin Outputs and Visibility
+
+Plugins may generate files that are tracked by the build system for incremental
+builds. Generated files are associated with the target the plugin is applied to.
+
+Plugins do not form a pipeline, and outputs produced by one plugin are not
+guaranteed to be visible to other plugins.
+


### PR DESCRIPTION
This PR adds a conceptual overview of Swift Package Manager plugins.

It explains:
- The two kinds of plugins supported by SwiftPM (command plugins and build tool plugins)
- When and how each type is invoked
- How plugin outputs are handled by the build system
- Visibility and limitations of generated outputs between plugins

This documentation clarifies common points of confusion around plugin execution and output visibility, and addresses the questions raised in #8469.