### PR TITLE
Use `--swift-sdk` selector as SDK name for Wasm platform

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1014,6 +1014,7 @@ public final class SwiftCommandState {
     private lazy var _targetToolchain: Result<UserToolchain, Swift.Error> = {
         let swiftSDK: SwiftSDK
         let hostSwiftSDK: SwiftSDK
+        let swiftSDKSelector: String?
         do {
             let hostToolchain = try _hostToolchain.get()
             hostSwiftSDK = hostToolchain.swiftSDK
@@ -1032,6 +1033,8 @@ public final class SwiftCommandState {
                 outputHandler: { print($0.description) }
             )
 
+            swiftSDKSelector = self.options.build.swiftSDKSelector ?? self.options.build.deprecatedSwiftSDKSelector
+
             swiftSDK = try SwiftSDK.deriveTargetSwiftSDK(
                 hostSwiftSDK: hostSwiftSDK,
                 hostTriple: hostToolchain.targetTriple,
@@ -1040,7 +1043,7 @@ public final class SwiftCommandState {
                 customCompileTriple: self.options.build.customCompileTriple,
                 customCompileToolchain: self.options.build.customCompileToolchain,
                 customCompileSDK: self.options.build.customCompileSDK,
-                swiftSDKSelector: self.options.build.swiftSDKSelector ?? self.options.build.deprecatedSwiftSDKSelector,
+                swiftSDKSelector: swiftSDKSelector,
                 architectures: self.options.build.architectures,
                 store: store,
                 observabilityScope: self.observabilityScope,
@@ -1057,6 +1060,7 @@ public final class SwiftCommandState {
         return Result(catching: {
             try UserToolchain(
                 swiftSDK: swiftSDK,
+                swiftSDKSelector: swiftSDKSelector,
                 environment: self.environment,
                 customTargetInfo: targetInfo,
                 observabilityScope: self.observabilityScope,

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -82,6 +82,9 @@ public final class UserToolchain: Toolchain {
     /// The Swift SDK used by this toolchain.
     public let swiftSDK: SwiftSDK
 
+    /// The Swift SDK selector used to select this toolchain.
+    public let swiftSDKSelector: String?
+
     /// The target triple that should be used for compilation.
     @available(*, deprecated, renamed: "targetTriple")
     public var triple: Basics.Triple { targetTriple }
@@ -736,6 +739,7 @@ public final class UserToolchain: Toolchain {
 
     public init(
         swiftSDK: SwiftSDK,
+        swiftSDKSelector: String? = nil,
         environment: Environment = .current,
         searchStrategy: SearchStrategy = .default,
         customTargetInfo: JSON? = nil,
@@ -745,6 +749,7 @@ public final class UserToolchain: Toolchain {
         fileSystem: any FileSystem = localFileSystem
     ) throws {
         self.swiftSDK = swiftSDK
+        self.swiftSDKSelector = swiftSDKSelector
         self.environment = environment
 
         switch searchStrategy {

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -710,8 +710,15 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             sdkName = platformName
         } else if self.buildParameters.triple.isWasm {
             // Swift Build uses webassembly instead of wasi as the platform name
+            let swiftSDKSelector = {
+                let defaultSDKSelector = "webassembly"
+                guard let userToolchain = self.buildParameters.toolchain as? UserToolchain else {
+                    return defaultSDKSelector
+                }
+                return userToolchain.swiftSDKSelector ?? defaultSDKSelector
+            }()
             platformName = "webassembly"
-            sdkName = platformName
+            sdkName = swiftSDKSelector
         } else {
             platformName = self.buildParameters.triple.darwinPlatform?.platformName ?? self.buildParameters.triple.osNameUnversioned
             sdkName = platformName


### PR DESCRIPTION
Use `--swift-sdk` selector as SDK name for Wasm platform

### Motivation:

The expected SDK name for Wasm platform support in SwiftBuild is always Swift SDK id, not `"webassembly"`, so passing always passing `"webassembly"` makes SwiftBuild unable to resolve a particular Swift SDK.

Close https://github.com/swiftlang/swift-package-manager/issues/9364

### Modifications:

Propagate `--swift-sdk` value as SDK name to SwiftBuild for Wasm targets.

### Result:

With this change and https://github.com/swiftlang/swift-build/pull/998, we can build a simple hello world package with `--build-system swiftbuild` with Swift SDK for Wasm.

```
$ swift build --swift-sdk DEVELOPMENT-SNAPSHOT-2025-12-19-a-wasm32-unknown-wasip1 --build-system swiftbuild
Building for debugging...
[0/100] Using on-disk description
[100/100]
Build complete! (0.91 secs)
```