### PR TITLE
Add functional test for swift test --sanitize --filter failure

### DIFF
--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -325,7 +325,7 @@ func testWithSanitizeAndFilterFailsWithPlatformPolicyViolation(
 ) async throws {
 #if os(macOS)
 try await withKnownIssue(
-    "Fails due to swiftpm-xctest-helper (Xcode tool) violating platform sanitizer policy"
+    "Fails due to swiftpm-xctest-helper (Xcode tool) violating platform sanitizer policy (#9546, rdar://168234231)"
 ) {
     try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
         let (_, stderr) = try await executeSwiftTest(


### PR DESCRIPTION
Add functional test covering swift test --sanitize --filter failure

Motivation:

When running swift test on macOS with both --sanitize address and --filter enabled, test execution fails with the error:

Sanitizer load violates platform policy.

Running either flag independently works as expected, but the combination consistently fails. This behavior is currently undocumented and untested. Adding coverage ensures the issue is reproducible and prevents accidental regressions while the underlying cause is investigated.

Modifications:

Added a new functional test in TestDiscoveryTests

Used SwiftPM’s functional test harness to invoke swift test

Passed --sanitize address and --filter together

Asserted on the observed platform policy violation message

Guarded the test to macOS

Result:

The sanitizer + filter failure is now captured by SwiftPM’s test suite, making the behavior explicit and providing a stable foundation for future fixes or refactors.
Fixes #9546 