### PR TITLE
Allow `QueueBasedMessageHandler.handle` to return `any Error` instead of `ResponseError`

### DIFF
--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -185,7 +185,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
     public func handle<Request: RequestType>(
         request: Request,
         id: RequestID,
-        reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
+        reply: @Sendable @escaping (Result<Request.Response, any Error>) -> Void
     ) async {
         let request = RequestAndReply(request, reply: reply)
         switch request {


### PR DESCRIPTION
Linked PR: swiftlang/swift-tools-protocols#33

Update for the API changed in https://github.com/swiftlang/swift-tools-protocols/pull/33.
