### PR TITLE
Tests: Add package-path on some PackageCommand tests

### DIFF
--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -104,7 +104,7 @@ struct PackageCommandTests {
         data: BuildData,
     ) async throws {
         let stdout = try await executeSwiftPackage(
-            nil,
+            AbsolutePath.root,
             configuration: data.config,
             buildSystem: data.buildSystem,
         ).stdout
@@ -130,9 +130,18 @@ struct PackageCommandTests {
         }
     }
 
-    @Test
-    func seeAlso() async throws {
-        let stdout = try await SwiftPM.Package.execute(["--help"]).stdout
+    @Test(
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+    )
+    func seeAlso(
+        buildData: BuildData,
+     ) async throws {
+        let stdout = try await executeSwiftPackage(
+            AbsolutePath.root,
+            configuration: buildData.config,
+            extraArgs: ["--help"],
+            buildSystem: buildData.buildSystem,
+        ).stdout
         #expect(stdout.contains("SEE ALSO: swift build, swift run, swift test \n(Run this command without --help to see possible dynamic plugin commands.)"))
     }
 


### PR DESCRIPTION
The `swift package` command with no arguemnts, or the `--help` argument invokes part of the package graph to find the command plugin from dependencies.   This can cause the test execution to hang as the current directory may have a lock on the package database.

Update the tests to use the root directory as the package path.