### PR TITLE
Do not pass temporary to CStringArray in attempt to avoid underlying runtime issue on AL2

### DIFF
--- a/Sources/Basics/Concurrency/AsyncProcess.swift
+++ b/Sources/Basics/Concurrency/AsyncProcess.swift
@@ -678,7 +678,8 @@ package final class AsyncProcess {
             resolvedArgs[0] = executablePath.pathString
         }
         let argv = CStringArray(resolvedArgs)
-        let env = CStringArray(environment.map { "\($0.0)=\($0.1)" })
+        let envValues = environment.map { "\($0.0)=\($0.1)" }
+        let env = CStringArray(envValues)
         let rv = posix_spawnp(&self.processID, argv.cArray[0]!, &fileActions, &attributes, argv.cArray, env.cArray)
 
         guard rv == 0 else {


### PR DESCRIPTION
Do not pass temporary to CStringArray in attempt to avoid underlying runtime issue on AL2

### Motivation:

There is nothing obviously wrong with the usage here, but the way we are working with temporaries may be triggering a lower level runtime issue on AL2.  Making this change to attempt to work around the underlying issue while it is investigated by runtime team.