### PR TITLE
Update PIF to use new common static archive type

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -392,8 +392,10 @@ public final class PackagePIFBuilder {
         init(from pifProductType: ProjectModel.Target.ProductType) {
             self = switch pifProductType {
             case .application: .application
+            case .commonStaticArchive: .staticArchive
             case .staticArchive: .staticArchive
             case .commonObject: .commonObject
+            case .objectFile: .commonObject
             case .dynamicLibrary: .dynamicLibrary
             case .framework: .framework
             case .executable: .executable

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -263,7 +263,10 @@ extension PackagePIFProjectBuilder {
                 productType = .framework
             }
 
-        case .staticLibrary, .executable:
+        case .staticLibrary:
+            productType = .commonStaticArchive
+
+        case .executable:
             productType = .commonObject
 
         case .macro:


### PR DESCRIPTION
Uses new product type for static archives so the source modules for executable and static archive can be different on windows