### PR TITLE
Ensure static archive products of root packages are always materialized

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -46,6 +46,9 @@ package struct PIFBuilderParameters {
     /// Whether to create dylibs for dynamic library products.
     let shouldCreateDylibForDynamicProducts: Bool
 
+    /// Eagerly materialize static archive products.
+    let materializeStaticArchiveProductsForRootPackages: Bool
+
     /// The path to the library directory of the active toolchain.
     let toolchainLibDir: AbsolutePath
 
@@ -72,10 +75,11 @@ package struct PIFBuilderParameters {
     /// the build products to a different location.
     let addLocalRpaths: Bool
 
-    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRPaths: Bool) {
+    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRPaths: Bool) {
         self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
         self.enableTestability = enableTestability
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
+        self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
         self.toolchainLibDir = toolchainLibDir
         self.pkgConfigDirectories = pkgConfigDirectories
         self.supportedSwiftVersions = supportedSwiftVersions
@@ -405,6 +409,7 @@ public final class PIFBuilder {
                 delegate: packagePIFBuilderDelegate,
                 buildToolPluginResultsByTargetName: buildToolPluginResultsByTargetName,
                 createDylibForDynamicProducts: self.parameters.shouldCreateDylibForDynamicProducts,
+                materializeStaticArchiveProductsForRootPackages: self.parameters.materializeStaticArchiveProductsForRootPackages,
                 addLocalRpaths: self.parameters.addLocalRpaths,
                 packageDisplayVersion: package.manifest.displayName,
                 fileSystem: self.fileSystem,
@@ -525,7 +530,8 @@ public final class PIFBuilder {
         pluginWorkingDirectory: AbsolutePath,
         pkgConfigDirectories: [Basics.AbsolutePath],
         additionalFileRules: [FileRuleDescription],
-        addLocalRpaths: Bool
+        addLocalRpaths: Bool,
+        materializeStaticArchiveProductsForRootPackages: Bool
     ) async throws -> String {
         let parameters = PIFBuilderParameters(
             buildParameters,
@@ -534,7 +540,8 @@ public final class PIFBuilder {
             disableSandbox: disableSandbox,
             pluginWorkingDirectory: pluginWorkingDirectory,
             additionalFileRules: additionalFileRules,
-            addLocalRpaths: addLocalRpaths
+            addLocalRpaths: addLocalRpaths,
+            materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages
         )
         let builder = Self(
             graph: packageGraph,
@@ -797,12 +804,14 @@ extension PIFBuilderParameters {
         disableSandbox: Bool,
         pluginWorkingDirectory: AbsolutePath,
         additionalFileRules: [FileRuleDescription],
-        addLocalRpaths: Bool
+        addLocalRpaths: Bool,
+        materializeStaticArchiveProductsForRootPackages: Bool,
     ) {
         self.init(
             isPackageAccessModifierSupported: buildParameters.driverParameters.isPackageAccessModifierSupported,
             enableTestability: buildParameters.enableTestability,
             shouldCreateDylibForDynamicProducts: buildParameters.shouldCreateDylibForDynamicProducts,
+            materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
             toolchainLibDir: (try? buildParameters.toolchain.toolchainLibDir) ?? .root,
             pkgConfigDirectories: buildParameters.pkgConfigDirectories,
             supportedSwiftVersions: supportedSwiftVersions,

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -1033,7 +1033,7 @@ extension ProjectModel.BuildSettings {
         self[.SWIFT_PACKAGE_NAME] = packageName ?? nil
 
         // This should really be swift-build defaults set in the .xcspec files, but changing that requires
-        // some extensive testing to ensure xcode projects are not effected.
+        // some extensive testing to ensure xcode projects are not affected.
         // So for now lets just force it here.
         self[.EXECUTABLE_PREFIX] = "lib"
         self[.EXECUTABLE_PREFIX, Platform.windows] = ""

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -171,6 +171,11 @@ public final class PackagePIFBuilder {
     /// * <rdar://56889224> Remove IDEPackageSupportCreateDylibsForDynamicProducts.
     let createDylibForDynamicProducts: Bool
 
+    /// When building a static library product for a root package, ensure the final build product is always materialized.
+    /// In other words, don't represent it using the `packageProduct` target type which only allows other targets
+    /// built from source in the same build to consume it without eagerly linking it into a product.
+    let materializeStaticArchiveProductsForRootPackages: Bool
+
     /// Add rpaths which allow loading libraries adjacent to the current image at runtime. This is desirable
     /// when launching build products from the build directory, but should often be disabled when deploying
     /// the build products to a different location.
@@ -203,6 +208,7 @@ public final class PackagePIFBuilder {
         delegate: PackagePIFBuilder.BuildDelegate,
         buildToolPluginResultsByTargetName: [String: [BuildToolPluginInvocationResult]],
         createDylibForDynamicProducts: Bool = false,
+        materializeStaticArchiveProductsForRootPackages: Bool = false,
         addLocalRpaths: Bool = true,
         packageDisplayVersion: String?,
         fileSystem: FileSystem,
@@ -214,6 +220,7 @@ public final class PackagePIFBuilder {
         self.delegate = delegate
         self.buildToolPluginResultsByTargetName = buildToolPluginResultsByTargetName
         self.createDylibForDynamicProducts = createDylibForDynamicProducts
+        self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
         self.packageDisplayVersion = packageDisplayVersion
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
@@ -227,6 +234,7 @@ public final class PackagePIFBuilder {
         delegate: PackagePIFBuilder.BuildDelegate,
         buildToolPluginResultsByTargetName: [String: BuildToolPluginInvocationResult],
         createDylibForDynamicProducts: Bool = false,
+        materializeStaticArchiveProductsForRootPackages: Bool = false,
         addLocalRpaths: Bool = true,
         packageDisplayVersion: String?,
         fileSystem: FileSystem,
@@ -238,6 +246,7 @@ public final class PackagePIFBuilder {
         self.delegate = delegate
         self.buildToolPluginResultsByTargetName = buildToolPluginResultsByTargetName.mapValues { [$0] }
         self.createDylibForDynamicProducts = createDylibForDynamicProducts
+        self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
         self.addLocalRpaths = addLocalRpaths
         self.packageDisplayVersion = packageDisplayVersion
         self.fileSystem = fileSystem

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1134,7 +1134,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     disableSandbox: self.pluginConfiguration.disableSandbox,
                     pluginWorkingDirectory: self.pluginConfiguration.workDirectory,
                     additionalFileRules: additionalFileRules,
-                    addLocalRpaths: !self.buildParameters.linkingParameters.shouldDisableLocalRpath
+                    addLocalRpaths: !self.buildParameters.linkingParameters.shouldDisableLocalRpath,
+                    materializeStaticArchiveProductsForRootPackages: true
                 ),
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -27,6 +27,7 @@ extension PIFBuilderParameters {
             isPackageAccessModifierSupported: true,
             enableTestability: false,
             shouldCreateDylibForDynamicProducts: false,
+            materializeStaticArchiveProductsForRootPackages: true,
             toolchainLibDir: temporaryDirectory.appending(component: "toolchain-lib-dir"),
             pkgConfigDirectories: [],
             supportedSwiftVersions: [.v4, .v4_2, .v5, .v6],
@@ -301,13 +302,13 @@ struct PIFBuilderTests {
                 ),
                 ExpectedValue(
                     targetName: "LibraryStatic-product",
-                    expectedValue: nil,
-                    expectedValueForWindows: nil,
+                    expectedValue: "lib",
+                    expectedValueForWindows: "",
                 ),
                 ExpectedValue(
                     targetName: "LibraryAuto-product",
-                    expectedValue: nil,
-                    expectedValueForWindows: nil,
+                    expectedValue: "lib",
+                    expectedValueForWindows: "",
                 ),
             ]
             for targetUnderTest in targetsUnderTest {

--- a/Tests/SwiftBuildSupportTests/ProductTests.swift
+++ b/Tests/SwiftBuildSupportTests/ProductTests.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Foundation
+import _InternalTestSupport
+
+// Tests which rely on implementation details of the build system's directory layout to verify outputs are correct.
+// These are fairly susceptible to breaking when implementation details change, so should be extended sparingly.
+@Suite
+struct ProductTests {
+    @Test
+    func materializedStaticProducts() async throws {
+        try await fixture(name: "Miscellaneous/Simple") { fixturePath in
+            try await executeSwiftBuild(fixturePath, buildSystem: .swiftbuild)
+            let productsSubDirectory: String
+            let expectedProductName: String
+            switch try ProcessInfo.processInfo.hostOperatingSystem() {
+            case .macOS:
+                productsSubDirectory = "Debug"
+                expectedProductName = "libFoo.a"
+            case .iOS:
+                productsSubDirectory = "Debug-iphoneos"
+                expectedProductName = "libFoo.a"
+            case .tvOS:
+                productsSubDirectory = "Debug-appletvos"
+                expectedProductName = "libFoo.a"
+            case .watchOS:
+                productsSubDirectory = "Debug-watchos"
+                expectedProductName = "libFoo.a"
+            case .visionOS:
+                productsSubDirectory = "Debug-xros"
+                expectedProductName = "libFoo.a"
+            case .windows:
+                productsSubDirectory = "Debug-windows"
+                expectedProductName = "Foo.objlib"
+            case .linux:
+                productsSubDirectory = "Debug-linux"
+                expectedProductName = "libFoo.a"
+            case .freebsd:
+                productsSubDirectory = "Debug-freebsd"
+                expectedProductName = "libFoo.a"
+            case .openbsd:
+                productsSubDirectory = "Debug-openbsd"
+                expectedProductName = "libFoo.a"
+            case .android:
+                productsSubDirectory = "Debug-android"
+                expectedProductName = "libFoo.a"
+            case .unknown:
+                productsSubDirectory = "Debug"
+                expectedProductName = "libFoo.a"
+            }
+            let products = try FileManager.default.contentsOfDirectory(atPath: fixturePath.appending(components: [".build", "out", "Products", productsSubDirectory]).pathString)
+            #expect(products.contains(expectedProductName))
+        }
+    }
+}


### PR DESCRIPTION
Previously, "automatic" and "static" products were always represented by the packageProduct target type in the PIF, which aggregated the constituent targets making up the product but was not guaranteed to materialize the final product. In the context of SwiftPM builds, we should use the staticArchive product type for these products in root packages to ensure we always produce that final product