### PR TITLE
Compute correct compiler arguments for build plugins

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -148,7 +148,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     let packageGraphLoader: () async throws -> ModulesGraph
 
     /// the plugin configuration for build plugins
-    let pluginConfiguration: PluginConfiguration?
+    package let pluginConfiguration: PluginConfiguration?
 
     /// The llbuild build system reference previously created
     /// via `createBuildSystem` call.
@@ -946,7 +946,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
 public struct PluginConfiguration {
     /// Entity responsible for compiling and running plugin scripts.
-    let scriptRunner: PluginScriptRunner
+    package let scriptRunner: PluginScriptRunner
 
     /// Directory where plugin intermediate files are stored.
     let workDirectory: AbsolutePath

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -60,7 +60,7 @@ public protocol Toolchain {
     // the OSS clang compiler. This API should not used for any other purpose.
     /// Returns true if clang compiler's vendor is Apple and nil if unknown.
     func _isClangCompilerVendorApple() throws -> Bool?
-    
+
     /// Additional flags to be passed to the build tools.
     var extraFlags: BuildFlags { get }
 
@@ -77,6 +77,14 @@ public protocol Toolchain {
     var extraCPPFlags: [String] { get }
 
     var swiftSDK: SwiftSDK { get }
+
+    var targetTriple: Basics.Triple { get }
+
+    var swiftCompilerEnvironment: Environment { get }
+
+    var swiftCompilerFlags: [String] { get }
+
+    var swiftCompilerPathForManifests: AbsolutePath { get }
 }
 
 extension Toolchain {
@@ -145,7 +153,7 @@ extension Toolchain {
     public var extraCPPFlags: [String] {
         extraFlags.cxxCompilerFlags.rawFlags
     }
-    
+
     public var extraSwiftCFlags: [String] {
         extraFlags.swiftCompilerFlags.rawFlags
     }

--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -31,7 +31,7 @@ import Android
 public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
     private let fileSystem: FileSystem
     private let cacheDir: Basics.AbsolutePath
-    private let toolchain: UserToolchain
+    private let toolchain: any Toolchain
     private let extraPluginSwiftCFlags: [String]
     private let enableSandbox: Bool
     private let cancellator: Cancellator
@@ -42,7 +42,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
     public init(
         fileSystem: Basics.FileSystem,
         cacheDir: Basics.AbsolutePath,
-        toolchain: UserToolchain,
+        toolchain: any Toolchain,
         extraPluginSwiftCFlags: [String] = [],
         enableSandbox: Bool = true,
         verboseOutput: Bool = false
@@ -116,17 +116,13 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         return self.toolchain.targetTriple
     }
 
-    /// Starts compiling a plugin script asynchronously and when done, calls the completion handler on the callback queue with the results (including the path of the compiled plugin executable and with any emitted diagnostics, etc).  Existing compilation results that are still valid are reused, if possible.  This function itself returns immediately after starting the compile.  Note that the completion handler only receives a `.failure` result if the compiler couldn't be invoked at all; a non-zero exit code from the compiler still returns `.success` with a full compilation result that notes the error in the diagnostics (in other words, a `.failure` result only means "failure to invoke the compiler").
-    public func compilePluginScript(
+    public func buildCommandLine(
         sourceFiles: [Basics.AbsolutePath],
         pluginName: String,
         toolsVersion: ToolsVersion,
         workers: UInt32,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        delegate: PluginScriptCompilerDelegate,
-        completion: @escaping (Result<PluginCompilationResult, Error>) -> Void
-    ) {
+        observabilityScope: ObservabilityScope?
+    ) -> (commandLine: [String], execName: String, execFilePath: AbsolutePath, diagFilePath: AbsolutePath) {
         // Determine the path of the executable and other produced files.
         let execName = pluginName.spm_mangledToC99ExtendedIdentifier()
         #if os(Windows)
@@ -136,7 +132,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         #endif
         let execFilePath = self.cacheDir.appending(component: execName + execSuffix)
         let diagFilePath = self.cacheDir.appending(component: execName + ".dia")
-        observabilityScope.emit(debug: "Compiling plugin to executable at \(execFilePath)")
+        observabilityScope?.emit(debug: "Compiling plugin to executable at \(execFilePath)")
 
         // Construct the command line for compiling the plugin script(s).
         // FIXME: Much of this is similar to what the ManifestLoader is doing. This should be consolidated.
@@ -144,7 +140,7 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         // We use the toolchain's Swift compiler for compiling the plugin.
         var commandLine = [self.toolchain.swiftCompilerPathForManifests.pathString]
 
-        observabilityScope.emit(debug: "Using compiler \(self.toolchain.swiftCompilerPathForManifests.pathString)")
+        observabilityScope?.emit(debug: "Using compiler \(self.toolchain.swiftCompilerPathForManifests.pathString)")
 
         // Get access to the path containing the PackagePlugin module and library.
         let pluginLibraryPath = self.toolchain.swiftPMLibrariesLocation.pluginLibraryPath
@@ -242,6 +238,28 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         if (verboseOutput) {
             commandLine.append("-v")
         }
+        return (commandLine, execName, execFilePath, diagFilePath)
+    }
+
+    /// Starts compiling a plugin script asynchronously and when done, calls the completion handler on the callback queue with the results (including the path of the compiled plugin executable and with any emitted diagnostics, etc).  Existing compilation results that are still valid are reused, if possible.  This function itself returns immediately after starting the compile.  Note that the completion handler only receives a `.failure` result if the compiler couldn't be invoked at all; a non-zero exit code from the compiler still returns `.success` with a full compilation result that notes the error in the diagnostics (in other words, a `.failure` result only means "failure to invoke the compiler").
+    public func compilePluginScript(
+        sourceFiles: [Basics.AbsolutePath],
+        pluginName: String,
+        toolsVersion: ToolsVersion,
+        workers: UInt32,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        delegate: PluginScriptCompilerDelegate,
+        completion: @escaping (Result<PluginCompilationResult, Error>) -> Void
+    ) {
+        let (commandLine, execName, execFilePath, diagFilePath) = self.buildCommandLine(
+            sourceFiles: sourceFiles,
+            pluginName: pluginName,
+            toolsVersion: toolsVersion,
+            workers: workers,
+            observabilityScope: observabilityScope
+        )
+
         // Pass through the compilation environment.
         let environment = toolchain.swiftCompilerEnvironment
 

--- a/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
@@ -35,6 +35,14 @@ public protocol PluginScriptRunner {
         completion: @escaping (Result<PluginCompilationResult, Error>) -> Void
     )
 
+    func buildCommandLine(
+        sourceFiles: [Basics.AbsolutePath],
+        pluginName: String,
+        toolsVersion: ToolsVersion,
+        workers: UInt32,
+        observabilityScope: ObservabilityScope?
+    ) -> (commandLine: [String], execName: String, execFilePath: Basics.AbsolutePath, diagFilePath: Basics.AbsolutePath)
+
     /// Implements the mechanics of running a plugin script implemented as a set of Swift source files, for use
     /// by the package graph when it is evaluating package plugins.
     ///

--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -203,19 +203,17 @@ private struct WrappedSwiftTargetBuildDescription: BuildTarget {
 public struct BuildDescription {
     private let buildPlan: Build.BuildPlan
 
+    private let pluginConfiguration: PluginConfiguration
+
     /// The inputs of the build plan so we don't need to re-compute them  on every call to
     /// `fileAffectsSwiftOrClangBuildSettings`.
     private let inputs: [Build.BuildPlan.Input]
 
     /// Wrap an already constructed build plan.
-    public init(buildPlan: Build.BuildPlan) {
+    public init(buildPlan: Build.BuildPlan, pluginConfiguration: PluginConfiguration) {
         self.buildPlan = buildPlan
         self.inputs = buildPlan.inputs
-    }
-
-    /// Temporary initializer to stage in https://github.com/swiftlang/swift-package-manager/pull/9583.
-    public init(buildPlan: Build.BuildPlan, pluginConfiguration: PluginConfiguration) {
-        self.init(buildPlan: buildPlan)
+        self.pluginConfiguration = pluginConfiguration
     }
 
     /// Construct a build description, compiling build tool plugins and generating their output when necessary.
@@ -254,7 +252,8 @@ public struct BuildDescription {
         )
 
         let plan = try await operation.generatePlan()
-        return (BuildDescription(buildPlan: plan), bufferedOutput.bytes.description)
+        let buildDescription = BuildDescription(buildPlan: plan, pluginConfiguration: pluginConfiguration)
+        return (buildDescription, bufferedOutput.bytes.description)
     }
 
     func getBuildTarget(
@@ -280,8 +279,9 @@ public struct BuildDescription {
                 let modulesGraph = self.buildPlan.graph
                 return PluginTargetBuildDescription(
                     target: module,
+                    toolsBuildParameters: buildPlan.toolsBuildParameters,
                     toolsVersion: package.manifest.toolsVersion,
-                    toolchain: buildPlan.toolsBuildParameters.toolchain,
+                    pluginConfiguration: pluginConfiguration,
                     isPartOfRootPackage: modulesGraph.rootPackages.map(\.id).contains(package.id)
                 )
             }

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -42,6 +42,10 @@ public struct MockToolchain: PackageModel.Toolchain {
         manifestLibraryPath: AbsolutePath("/fake/manifestLib/path"), pluginLibraryPath: AbsolutePath("/fake/pluginLibrary/path")
     )
     public var swiftSDK: PackageModel.SwiftSDK
+    public let targetTriple = Basics.Triple.macOS
+    public let swiftCompilerEnvironment: Basics.Environment = .mockEnvironment
+    public let swiftCompilerFlags: [String] = []
+    public let swiftCompilerPathForManifests = AbsolutePath("/fake/path/to/manifest/swiftc")
 
     public func getClangCompiler() throws -> AbsolutePath {
         "/fake/path/to/clang"

--- a/Tests/BuildTests/CGenPluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/CGenPluginsBuildPlanTests.swift
@@ -122,6 +122,16 @@ import Build
                 }
             }
 
+            func buildCommandLine(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                toolsVersion: ToolsVersion,
+                workers: UInt32,
+                observabilityScope: ObservabilityScope?
+            ) -> (commandLine: [String], execName: String, execFilePath: Basics.AbsolutePath, diagFilePath: Basics.AbsolutePath) {
+                fatalError("Not implemented")
+            }
+
             func runPluginScript(
                 sourceFiles: [Basics.AbsolutePath],
                 pluginName: String,

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -151,6 +151,16 @@ final class PluginInvocationTests: XCTestCase {
                 }
             }
 
+            func buildCommandLine(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                toolsVersion: ToolsVersion,
+                workers: UInt32,
+                observabilityScope: ObservabilityScope?
+            ) -> (commandLine: [String], execName: String, execFilePath: Basics.AbsolutePath, diagFilePath: Basics.AbsolutePath) {
+                fatalError("Not implemented")
+            }
+
             func runPluginScript(
                 sourceFiles: [AbsolutePath],
                 pluginName: String,

--- a/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
+++ b/Tests/SourceKitLSPAPITests/SourceKitLSPAPITests.swift
@@ -23,6 +23,18 @@ import _InternalTestSupport
 import XCTest
 
 final class SourceKitLSPAPITests: XCTestCase {
+    private func pluginConfiguration(fileSystem: InMemoryFileSystem) throws -> PluginConfiguration {
+        return PluginConfiguration(
+            scriptRunner: DefaultPluginScriptRunner(
+                fileSystem: fileSystem,
+                cacheDir: "/tmp/cache",
+                toolchain: try MockToolchain()
+            ),
+            workDirectory: "/tmp/cache",
+            disableSandbox: false
+        )
+    }
+
     func testBasicSwiftPackage() async throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Pkg/Sources/exe/main.swift",
@@ -78,7 +90,7 @@ final class SourceKitLSPAPITests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let description = BuildDescription(buildPlan: plan)
+        let description = BuildDescription(buildPlan: plan, pluginConfiguration: try pluginConfiguration(fileSystem: fs))
 
         try description.checkArguments(
             for: "exe",
@@ -114,7 +126,7 @@ final class SourceKitLSPAPITests: XCTestCase {
             for: "plugin",
             graph: graph,
             partialArguments: [
-                "-I", AbsolutePath("/fake/manifestLib/path").pathString
+                "-I", AbsolutePath("/fake/pluginLibrary/path").pathString
             ],
             isPartOfRootPackage: true,
             destination: .host
@@ -167,7 +179,7 @@ final class SourceKitLSPAPITests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let description = BuildDescription(buildPlan: plan)
+        let description = BuildDescription(buildPlan: plan, pluginConfiguration: try pluginConfiguration(fileSystem: fs))
 
         struct Result: Equatable {
             let moduleName: String
@@ -240,7 +252,7 @@ final class SourceKitLSPAPITests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let description = BuildDescription(buildPlan: plan)
+        let description = BuildDescription(buildPlan: plan, pluginConfiguration: try pluginConfiguration(fileSystem: fs))
 
         struct Result: Equatable {
             let moduleName: String
@@ -365,7 +377,7 @@ final class SourceKitLSPAPITests: XCTestCase {
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
-        let description = BuildDescription(buildPlan: plan)
+        let description = BuildDescription(buildPlan: plan, pluginConfiguration: try pluginConfiguration(fileSystem: fs))
 
         let target = try XCTUnwrap(description.getBuildTarget(for: XCTUnwrap(graph.module(for: "lib")), destination: .target))
         XCTAssertEqual(target.compiler, .clang)
@@ -383,25 +395,27 @@ extension SourceKitLSPAPI.BuildDescription {
         ignoredFiles: [URL] = [],
         otherFiles: [URL] = [],
         isPartOfRootPackage: Bool,
-        destination: BuildParameters.Destination = .target
+        destination: BuildParameters.Destination = .target,
+        file: StaticString = #file,
+        line: UInt = #line
     ) throws -> Bool {
-        let target = try XCTUnwrap(graph.module(for: targetName))
-        let buildTarget = try XCTUnwrap(self.getBuildTarget(for: target, destination: destination))
+        let target = try XCTUnwrap(graph.module(for: targetName), file: file, line: line)
+        let buildTarget = try XCTUnwrap(self.getBuildTarget(for: target, destination: destination), file: file, line: line)
 
-        XCTAssertEqual(buildTarget.resources, resources, "build target \(targetName) contains unexpected resource files")
-        XCTAssertEqual(buildTarget.ignored, ignoredFiles, "build target \(targetName) contains unexpected ignored files")
-        XCTAssertEqual(buildTarget.others, otherFiles, "build target \(targetName) contains unexpected other files")
+        XCTAssertEqual(buildTarget.resources, resources, "build target \(targetName) contains unexpected resource files", file: file, line: line)
+        XCTAssertEqual(buildTarget.ignored, ignoredFiles, "build target \(targetName) contains unexpected ignored files", file: file, line: line)
+        XCTAssertEqual(buildTarget.others, otherFiles, "build target \(targetName) contains unexpected other files", file: file, line: line)
 
         guard let source = buildTarget.sources.first?.sourceFile else {
-            XCTFail("build target \(targetName) contains no source files")
+            XCTFail("build target \(targetName) contains no source files", file: file, line: line)
             return false
         }
 
         let arguments = try buildTarget.compileArguments(for: source)
         let result = arguments.contains(partialArguments)
 
-        XCTAssertTrue(result, "could not match \(partialArguments) to actual arguments \(arguments)")
-        XCTAssertEqual(buildTarget.isPartOfRootPackage, isPartOfRootPackage)
+        XCTAssertTrue(result, "could not match \(partialArguments) to actual arguments \(arguments)", file: file, line: line)
+        XCTAssertEqual(buildTarget.isPartOfRootPackage, isPartOfRootPackage, file: file, line: line)
         return result
     }
 }

--- a/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
@@ -116,6 +116,16 @@ import SwiftBuild
                 }
             }
 
+            func buildCommandLine(
+                sourceFiles: [Basics.AbsolutePath],
+                pluginName: String,
+                toolsVersion: ToolsVersion,
+                workers: UInt32,
+                observabilityScope: ObservabilityScope?
+            ) -> (commandLine: [String], execName: String, execFilePath: Basics.AbsolutePath, diagFilePath: Basics.AbsolutePath) {
+                fatalError("Not implemented")
+            }
+
             func runPluginScript(
                 sourceFiles: [Basics.AbsolutePath],
                 pluginName: String,


### PR DESCRIPTION
The computation of compiler arguments for package plugins was plain out broken and didn’t even include the search path to `lib/swift/pm/PluginAPI`. Call into the same logic with which we compute the build settings during building from `SourceKitLSPAPI`.

Tested as part of https://github.com/swiftlang/sourcekit-lsp/pull/2446.

Fixes swiftlang/sourcekit-lsp#2115
