### PR TITLE
Reenable tests after fixing whitespace quoting issues

### DIFF
--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -48,7 +48,6 @@ fileprivate func expectDirectoryContainsFile(
 )
 struct CFamilyTargetTestCase {
     @Test(
-        .issue("https://github.com/swiftlang/swift-build/issues/333", relationship: .defect),
         .tags(
             .Feature.Command.Build,
             .Feature.SpecialCharacters,
@@ -73,7 +72,7 @@ struct CFamilyTargetTestCase {
                 }
             }
         } when: {
-            data.buildSystem == .swiftbuild
+            data.buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
         }
     }
 

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -81,9 +81,6 @@ struct TestDiscoveryTests {
             .Feature.CommandLineArguments.BuildSystem,
         ),
         .IssueWindowsCannotSaveAttachment,
-        .issue("https://github.com/swiftlang/swift-build/issues/333", relationship: .defect),
-        .bug("https://github.com/swiftlang/swift-build/issues/13"),
-        // arguments: [BuildSystemProvider.Kind.native],
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func nonStandardName(_ buildSystem: BuildSystemProvider.Kind) async throws {
@@ -96,7 +93,7 @@ struct TestDiscoveryTests {
                 #expect(stdout.contains("Executed 1 test"))
             }
         } when: {
-            buildSystem == .swiftbuild && [.windows, .macOS].contains(ProcessInfo.hostOperatingSystem)
+            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
         }
     }
 


### PR DESCRIPTION
The underlying quoting issues in the build system have been fixed, so these two tests can be reenabled