### PR TITLE
Fix potential hang in SwiftBuildServer where it sends message (and waits indefinitely for response) prior to completing initialization

### DIFF
--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -157,6 +157,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         case is OnBuildInitializedNotification:
             connectionToUnderlyingBuildServer.send(notification)
             state = .running
+            scheduleRegeneratingBuildDescription()
         case let notification as OnWatchedFilesDidChangeNotification:
             // The underlying build server only receives updates via new PIF, so don't forward this notification.
             for change in notification.changes {
@@ -249,7 +250,6 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
             logToClient(.warning, "Underlying build server reported unexpected file watchers")
         }
         state = .waitingForInitializedNotification
-        scheduleRegeneratingBuildDescription()
         return InitializeBuildResponse(
             displayName: "SwiftPM Build Server",
             version: SwiftVersion.current.displayString,


### PR DESCRIPTION
Fix potential hang in SwiftBuildServer where it sends message (and waits indefinitely for response) prior to completing initialization

### Motivation:

scheduleRegeneratingBuildDescription() is called during the InitializeBuildRequest handler, which causes it to send notifications to the underlying server before that server has received OnBuildInitializedNotification. 

The notifications sent in scheduleRegeneratingBuildDescription may be dropped as the server has not completed initialization.  The client is stuck waiting for a response to the notification that will never arrive

### Modifications:

Move scheduleRegeneratingBuildDescription to when it receives the OnBuildInitializedNotification
