### PR TITLE
Remove withKnownIssue with some coverage Tests

### DIFF
--- a/Sources/_InternalTestSupport/BuildSystemProvider+Supported.swift
+++ b/Sources/_InternalTestSupport/BuildSystemProvider+Supported.swift
@@ -26,6 +26,14 @@ public var SupportedBuildSystemOnPlatform: [BuildSystemProvider.Kind] {
 public struct BuildData {
     public let buildSystem: BuildSystemProvider.Kind
     public let config: BuildConfiguration
+
+    public init(
+        buildSystem: BuildSystemProvider.Kind,
+        config: BuildConfiguration,
+    ) {
+        self.buildSystem = buildSystem
+        self.config = config
+    }
 }
 
 public func getBuildData(for buildSystems: [BuildSystemProvider.Kind]) -> [BuildData] {

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -709,3 +709,18 @@ public func executableName(_ name: String) -> String {
   return name
 #endif
 }
+
+package func getCoveragePath(
+    _ path: AbsolutePath,
+    with buildData: BuildData,
+) async throws -> String {
+    return try await executeSwiftTest(
+            path,
+            configuration: buildData.config,
+            extraArgs: [
+                "--show-coverage-path",
+            ],
+            buildSystem: buildData.buildSystem,
+            throwIfCommandFails: true,
+        ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+}

--- a/Tests/CommandsTests/CoverageTests.swift
+++ b/Tests/CommandsTests/CoverageTests.swift
@@ -29,12 +29,13 @@ import Testing
 )
 struct CoverageTests {
     @Test(
-        .SWBINTTODO("Test failed because of missing plugin support in the PIF builder. This can be reinvestigated after the support is there."),
         .tags(
             .Feature.Command.Build,
             .Feature.Command.Test,
             .Feature.CommandLineArguments.BuildTests,
         ),
+        .IssueWindowsPathNoEntry,
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9600", relationship: .defect),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func executingTestsWithCoverageWithoutCodeBuiltWithCoverageGeneratesAFailure(
@@ -49,6 +50,7 @@ struct CoverageTests {
                     extraArgs: ["--build-tests"],
                     buildSystem: buildSystem,
                 )
+                await withKnownIssue(isIntermittent: true) {
                 await #expect(throws: (any Error).self ) {
                     try await executeSwiftTest(
                         path,
@@ -61,15 +63,18 @@ struct CoverageTests {
                         throwIfCommandFails: true,
                     )
                 }
+                } when: {
+                    ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
+                }
             }
         } when: {
-            buildSystem == .swiftbuild && [.linux, .windows].contains(ProcessInfo.hostOperatingSystem)
+            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
 
     @Test(
-        .SWBINTTODO("Test failed because of missing plugin support in the PIF builder. This can be reinvestigated after the support is there."),
-        .IssueWindowsCannotSaveAttachment,
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9588", relationship: .defect),
+        .IssueWindowsPathNoEntry,
         .tags(
             .Feature.Command.Test,
             .Feature.CommandLineArguments.BuildTests,
@@ -83,20 +88,14 @@ struct CoverageTests {
         // Test that enabling code coverage during building produces the expected folder.
         try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
-            let codeCovPathString = try await executeSwiftTest(
+            let codeCovPathString = try await getCoveragePath(
                 path,
-                configuration: config,
-                extraArgs: [
-                    "--show-coverage-path",
-                ],
-                buildSystem: buildSystem,
-                throwIfCommandFails: true,
-            ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                with: BuildData(buildSystem: buildSystem, config: config),
+            )
 
             let codeCovPath = try AbsolutePath(validating: codeCovPathString)
 
             // WHEN we build with coverage enabled
-            try await withKnownIssue(isIntermittent: true) {
                 try await executeSwiftBuild(
                     path,
                     configuration: config,
@@ -121,12 +120,9 @@ struct CoverageTests {
                 // AND the parent directory is non empty
                 let codeCovFiles = try localFileSystem.getDirectoryContents(codeCovPath.parentDirectory)
                 #expect(codeCovFiles.count > 0)
-            } when: {
-                ProcessInfo.hostOperatingSystem == .linux && buildSystem == .swiftbuild
-            }
         }
         } when: {
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
+            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild // This was no longer an issue when I tested at-desk
         }
     }
 
@@ -134,6 +130,8 @@ struct CoverageTests {
         .tags(
             .Feature.Command.Test,
         ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9588", relationship: .defect),
+        .IssueWindowsPathNoEntry,
         arguments: SupportedBuildSystemOnAllPlatforms, [
             "Coverage/Simple",
             "Miscellaneous/TestDiscovery/Simple",
@@ -145,15 +143,10 @@ struct CoverageTests {
     ) async throws {
         let config = BuildConfiguration.debug
         try await fixture(name: fixtureName) { path in
-            let coveragePathString = try await executeSwiftTest(
+            let coveragePathString = try await getCoveragePath(
                 path,
-                configuration: config,
-                extraArgs: [
-                    "--show-coverage-path",
-                ],
-                buildSystem: buildSystem,
-                throwIfCommandFails: true,
-            ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                with: BuildData(buildSystem: buildSystem, config: config),
+            )
             let coveragePath = try AbsolutePath(validating: coveragePathString)
             try #require(!localFileSystem.exists(coveragePath))
 
@@ -172,8 +165,9 @@ struct CoverageTests {
                 // THEN we expect the file to exists
                 #expect(localFileSystem.exists(coveragePath))
             } when: {
-                (buildSystem == .swiftbuild && [.windows, .linux].contains(ProcessInfo.hostOperatingSystem))
+                (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild)
             }
         }
     }
+
 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1233,7 +1233,6 @@ struct PackageCommandTests {
         withPrettyPrinting: Bool,
     ) async throws {
         let config = BuildConfiguration.debug
-        // try await withKnownIssue(isIntermittent: true) {
             try await fixture(
                 name: "DependencyResolution/Internal/Simple",
                 removeFixturePathOnDeinit: true
@@ -1284,10 +1283,6 @@ struct PackageCommandTests {
                     #expect(JSONText.components(separatedBy: .newlines).count == 1)
                 }
             }
-        // } when: {
-        //     (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild && !withPrettyPrinting)
-        //         || (buildSystem == .swiftbuild && withPrettyPrinting)
-        // }
     }
 
     @Suite(

--- a/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/Tests/IntegrationTests/SwiftPMTests.swift
@@ -233,6 +233,7 @@ private struct SwiftPMTests {
 
     @Test(
         .requireSwift6_2,
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9588", relationship: .defect),
         .tags(
             .UserWorkflow,
             .Feature.CodeCoverage,
@@ -248,6 +249,7 @@ private struct SwiftPMTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let config = BuildConfiguration.debug
+        try await withKnownIssue(isIntermittent: true) {
         try await withTemporaryDirectory(removeTreeOnDeinit: false) { tmpDir in
             let packagePath = tmpDir.appending(component: "test-package-coverage")
             try localFileSystem.createDirectory(packagePath)
@@ -287,48 +289,49 @@ private struct SwiftPMTests {
                 }
                 """
             )
-            let expectedCoveragePath = try await executeSwiftTest(
+            let expectedCoveragePath = try await getCoveragePath(
                 packagePath,
-                configuration: config,
-                extraArgs: ["--show-coverage-path"],
-                buildSystem: buildSystem,
-            ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                with: BuildData(buildSystem: buildSystem, config: config),
+            )
+
             try await executeSwiftTest(
                 packagePath,
                 configuration: config,
                 extraArgs: ["--enable-code-coverage", "--disable-xctest"],
                 buildSystem: buildSystem,
+                throwIfCommandFails: true,
             )
             let coveragePath = try AbsolutePath(validating: expectedCoveragePath)
 
             // Check the coverage path exists.
-            try withKnownIssue(isIntermittent: true) {
-                // the CoveragePath file does not exists in Linux platform build
-                expectFileExists(at: coveragePath)
+            // the CoveragePath file does not exists in Linux platform build
+            expectFileExists(at: coveragePath)
 
-                // This resulting coverage file should be merged JSON, with a schema that valiades against this subset.
-                struct Coverage: Codable {
-                    var data: [Entry]
-                    struct Entry: Codable {
-                        var files: [File]
-                        struct File: Codable {
-                            var filename: String
-                            var summary: Summary
-                            struct Summary: Codable {
-                                var functions: Functions
-                                struct Functions: Codable {
-                                    var count, covered: Int
-                                    var percent: Double
-                                }
+            // This resulting coverage file should be merged JSON, with a schema that valiades against this subset.
+            struct Coverage: Codable {
+                var data: [Entry]
+                struct Entry: Codable {
+                    var files: [File]
+                    struct File: Codable {
+                        var filename: String
+                        var summary: Summary
+                        struct Summary: Codable {
+                            var functions: Functions
+                            struct Functions: Codable {
+                                var count, covered: Int
+                                var percent: Double
                             }
                         }
                     }
                 }
-                let coverageJSON = try localFileSystem.readFileContents(coveragePath)
-                let coverage = try JSONDecoder().decode(Coverage.self, from: Data(coverageJSON.contents))
+            }
+            let coverageJSON = try localFileSystem.readFileContents(coveragePath)
+            let coverage = try JSONDecoder().decode(Coverage.self, from: Data(coverageJSON.contents))
 
-                // Check for 100% coverage for Subject.swift, which should happen because the per-PID files got merged.
-                let subjectCoverage = try #require(coverage.data.first?.files.first(where: { $0.filename.hasSuffix("Subject.swift") }))
+            // Check for 100% coverage for Subject.swift, which should happen because the per-PID files got merged.
+            try withKnownIssue(isIntermittent: true) {
+                let data = try #require(coverage.data.first, "covege JSON = \(coverage)")
+                let subjectCoverage = try #require(data.files.first(where: { $0.filename.hasSuffix("Subject.swift") }), "covege JSON = \(data.files)")
                 #expect(subjectCoverage.summary.functions.count == 2)
                 #expect(subjectCoverage.summary.functions.covered == 2)
                 #expect(subjectCoverage.summary.functions.percent == 100)
@@ -357,6 +360,9 @@ private struct SwiftPMTests {
             } when: {
                 [.linux, .windows].contains(ProcessInfo.hostOperatingSystem) && buildSystem == .swiftbuild
             }
+        }
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
 }


### PR DESCRIPTION
Remove the withKnownIssue on some coverage tests as the underlying issues have been fixed.