### PR TITLE
Reuse Collections utilities from SWBUtil instead of duplicating the c…

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -11,14 +11,18 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(SwiftPMInternal) import Basics
+import struct Basics.AbsolutePath
+import struct Basics.Environment
+
 import Foundation
 import PackageGraph
 import PackageLoading
 import PackageModel
 import TSCUtility
 
-@_spi(SwiftPMInternal)
-import SPMBuildCore
+import SWBUtil
+
+@_spi(SwiftPMInternal) import SPMBuildCore
 
 import func TSCBasic.topologicalSort
 import var TSCBasic.stdoutStream

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -58,15 +58,12 @@ import func PackageLoading.pkgConfigArgs
 import SPMBuildCore
 
 import enum SwiftBuild.ProjectModel
+import SWBUtil
 
 // MARK: - PIF GUID Helpers
 
 public enum TargetSuffix: String {
     case testable, dynamic
-
-    func hasSuffix(id: GUID) -> Bool {
-        id.value.hasSuffix("-\(self.rawValue)")
-    }
 }
 
 extension TargetSuffix? {
@@ -354,7 +351,7 @@ extension PackageGraph.ResolvedModule {
 
     /// The stable sorted list of resources in the module
     var resources: [PackageModel.Resource] {
-        self.underlying.resources.sorted(on: \.path)
+        self.underlying.resources.sorted(by: \.path)
     }
 
     /// The name of the group this module belongs to; by default, the package identity.
@@ -1199,10 +1196,11 @@ extension Optional {
     }
 }
 
-extension Sequence {
-    /// Evaluates `predicate` on each element in the collection.
-    /// If exactly 1 element returns `true` return that element.
+package extension Sequence {
     /// Returns the *only* element in the sequence satisfying the specified predicate.
+    ///
+    /// Evaluates `predicate` on each element in the collection.
+    /// If exactly 1 element returns `true` return that element, otherwise returns `nil`.
     ///
     /// **Complexity**.  O(n), where n is the length of the sequence.
     func only(where predicate: (Element) throws -> Bool) rethrows -> Element? {
@@ -1226,24 +1224,8 @@ extension Collection {
         !self.isEmpty
     }
 
-    var only: Element? {
-        (count == 1) ? first : nil
-    }
-
     func anySatisfy(_ predicate: (Element) throws -> Bool) rethrows -> Bool {
         try contains(where: predicate)
-    }
-
-    /// For example: `people.sorted(on: \.name)`.
-    func sorted(on projection: (Element) -> some Comparable) -> [Element] {
-        self.sorted(on: projection, by: <)
-    }
-
-    /// For example: `people.sorted(on: \.name, comparator: >)`.
-    func sorted<T>(on projection: (Element) -> T, by comparator: (T, T) -> Bool) -> [Element] {
-        self.sorted { lhs, rhs in
-            comparator(projection(lhs), projection(rhs))
-        }
     }
 }
 
@@ -1253,7 +1235,7 @@ extension Array {
     }
 }
 
-extension UserDefaults {
+extension Foundation.UserDefaults {
     func bool(forKey key: String, defaultValue: Bool) -> Bool {
         if self.object(forKey: key) != nil {
             self.bool(forKey: key)

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -13,6 +13,7 @@
 import Foundation
 import TSCBasic
 import TSCUtility
+import SWBUtil
 
 import struct Basics.AbsolutePath
 import class Basics.ObservabilitySystem

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -579,7 +579,9 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
                         configuredTargets = try [pifTargetName].map { targetName in
                             // TODO we filter dynamic targets until Swift Build doesn't give them to us anymore
-                            let infos = workspaceInfo.targetInfos.filter { $0.targetName == targetName && !TargetSuffix.dynamic.hasSuffix(id: GUID($0.guid)) }
+                            let infos = workspaceInfo.targetInfos.filter {
+                                $0.targetName == targetName && !GUID($0.guid).hasSuffix(.dynamic)
+                            }
                             switch infos.count {
                             case 0:
                                 self.observabilityScope.emit(error: "Could not find target named '\(targetName)'")


### PR DESCRIPTION
### Motivation:

Reduce code duplication in the PIF builder (within the `SwiftBuildSupport` module).

### Modifications:

Some `Collection` *extensions* in `SwiftBuildSupport/PackagePIFBuilder+Helpers.swift` were also available in `SWBUtil` too (from Swift Build) — so let’s use that instead! Some provided even better/faster implementation :)

### Result:

Less code duplication in the `SwiftBuildSupport` module.

Fixes rdar://168274021.
