### PR TITLE
Add Linux aarch64 as a supported platform for the test fixture plugins

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Dependency/MyBinaryTargetExeArtifactBundle.artifactbundle/info.json
+++ b/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Dependency/MyBinaryTargetExeArtifactBundle.artifactbundle/info.json
@@ -11,7 +11,7 @@
                 },
                 {
                     "path": "mytool-linux/mytool",
-                    "supportedTriples": ["x86_64-unknown-linux-gnu"]
+                    "supportedTriples": ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
                 }
             ]
         }

--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Binaries/MyVendedSourceGenBuildTool.artifactbundle/info.json
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Dependency/Binaries/MyVendedSourceGenBuildTool.artifactbundle/info.json
@@ -11,7 +11,7 @@
                 },
                 {
                     "path": "mytool-linux/mytool",
-                    "supportedTriples": ["x86_64-unknown-linux-gnu"]
+                    "supportedTriples": ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
                 }
             ]
         }

--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Binaries/MyVendedSourceGenBuildTool.artifactbundle/info.json
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Binaries/MyVendedSourceGenBuildTool.artifactbundle/info.json
@@ -11,7 +11,7 @@
                 },
                 {
                     "path": "mytool-linux/mytool",
-                    "supportedTriples": ["x86_64-unknown-linux-gnu"]
+                    "supportedTriples": ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
                 },
                 {
                     "path": "mytool-windows/mytool.bat",

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -380,7 +380,6 @@ struct PluginTests {
     @Test(
         .issue("https://github.com/swiftlang/swift-package-manager/issues/9215", relationship: .verifies),
         .requiresSwiftConcurrencySupport,
-        .disabled("rdar://162053979"),
         arguments: [BuildSystemProvider.Kind.native, .swiftbuild]
     )
     func testUseOfVendedBinaryTool(buildSystem: BuildSystemProvider.Kind) async throws {


### PR DESCRIPTION
The test fixtures are using shell scripts that would work in any
processor architecture of Linux. Since Swift is being used
regularly on aarch64 Linux add that architecture to the info.json
files of the test fixture plugin bundles.