### PR TITLE
Disable SwiftPMBuildServerTests on Windows while we investigate intermittent hangs

### DIFF
--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -65,7 +65,9 @@ fileprivate func withSwiftPMBSP(fixtureName: String, body: (Connection, Notifica
     }
 }
 
-@Suite
+@Suite(
+    .disabled(if: ProcessInfo.hostOperatingSystem == .windows, "Intermittent hangs on Windows")
+)
 struct SwiftPMBuildServerTests {
     @Test
     func lifecycleBasics() async throws {


### PR DESCRIPTION
Disable testableExecutableWithEmbeddedResources on Windows has it hangs intermittently
