### PR TITLE
Disable SwiftPMBuildServerTests on Windows has it hangs intermittently

### DIFF
--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -65,7 +65,9 @@ fileprivate func withSwiftPMBSP(fixtureName: String, body: (Connection, Notifica
     }
 }
 
-@Suite
+@Suite(
+    .disabled(if: ProcessInfo.hostOperatingSystem == .windows, "This hangs intermittently on Windows in CI using the native build system")
+)
 struct SwiftPMBuildServerTests {
     @Test
     func lifecycleBasics() async throws {


### PR DESCRIPTION
Disable SwiftPMBuildServerTests on Windows has it hangs intermittently