### PR TITLE
[6.3] Set isDevelopment flag to false in order to drop the trailing -dev from the version output

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -59,7 +59,7 @@ extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
         version: (6, 3, 0),
-        isDevelopment: true,
+        isDevelopment: false,
         buildIdentifier: getBuildIdentifier()
     )
 }


### PR DESCRIPTION
[6.3] Set isDevelopment flag to false in order to drop the trailing -dev from the version output