### PR TITLE
Fix race condition in PIFBuilderTests when running tests concurrently

### DIFF
--- a/Sources/Basics/Concurrency/ThreadSafeKeyValueStore.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeKeyValueStore.swift
@@ -90,9 +90,7 @@ public actor AsyncThrowingValueMemoizer<Value: Sendable> {
     }
 }
 
-
-
-/// Thread-safe dictionary like structure
+/// Thread-safe dictionary like structure.
 public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
     private var underlying: [Key: Value]
     private let lock = NSLock()

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -669,45 +669,45 @@ public struct SwiftSDK: Equatable {
         for darwinPlatform: DarwinPlatform,
         environment: Environment = .current
     ) throws -> PlatformPaths {
-        if let path = _sdkPlatformFrameworkPath[darwinPlatform] {
-            return path
+        let sdkPlatformFrameworkPath = try _sdkPlatformFrameworkPathCache.memoize(darwinPlatform) {
+            // Compute the platform path.
+            let platformPath = try environment[
+                EnvironmentKey("SWIFTPM_PLATFORM_PATH_\(darwinPlatform.xcrunName)")
+            ] ?? AsyncProcess.checkNonZeroExit(
+                arguments: ["/usr/bin/xcrun", "--sdk", darwinPlatform.xcrunName, "--show-sdk-platform-path"],
+                environment: environment
+            ).spm_chomp()
+
+            guard !platformPath.isEmpty else {
+                throw StringError("could not determine SDK platform path")
+            }
+
+            // For testing frameworks.
+            let frameworksPath = try Basics.AbsolutePath(validating: platformPath).appending(
+                components: "Developer", "Library", "Frameworks"
+            )
+            let privateFrameworksPath = try Basics.AbsolutePath(validating: platformPath).appending(
+                components: "Developer", "Library", "PrivateFrameworks"
+            )
+
+            // For testing libraries.
+            let librariesPath = try Basics.AbsolutePath(validating: platformPath).appending(
+                components: "Developer", "usr", "lib"
+            )
+
+            let sdkPlatformFrameworkPath = PlatformPaths(
+                buildTimeFrameworkSearchPaths: [frameworksPath /* omit privateFrameworksPath */],
+                buildTimeLibrarySearchPaths: [librariesPath],
+                runtimeFrameworkSearchPaths: [frameworksPath, privateFrameworksPath],
+                runtimeLibrarySearchPaths: [librariesPath]
+            )
+            return sdkPlatformFrameworkPath
         }
-        let platformPath = try environment[
-            EnvironmentKey("SWIFTPM_PLATFORM_PATH_\(darwinPlatform.xcrunName)")
-        ] ?? AsyncProcess.checkNonZeroExit(
-            arguments: ["/usr/bin/xcrun", "--sdk", darwinPlatform.xcrunName, "--show-sdk-platform-path"],
-            environment: environment
-        ).spm_chomp()
-
-        guard !platformPath.isEmpty else {
-            throw StringError("could not determine SDK platform path")
-        }
-
-        // For testing frameworks.
-        let frameworksPath = try Basics.AbsolutePath(validating: platformPath).appending(
-            components: "Developer", "Library", "Frameworks"
-        )
-        let privateFrameworksPath = try Basics.AbsolutePath(validating: platformPath).appending(
-            components: "Developer", "Library", "PrivateFrameworks"
-        )
-
-        // For testing libraries.
-        let librariesPath = try Basics.AbsolutePath(validating: platformPath).appending(
-            components: "Developer", "usr", "lib"
-        )
-
-        let sdkPlatformFrameworkPath = PlatformPaths(
-            buildTimeFrameworkSearchPaths: [frameworksPath /* omit privateFrameworksPath */],
-            buildTimeLibrarySearchPaths: [librariesPath],
-            runtimeFrameworkSearchPaths: [frameworksPath, privateFrameworksPath],
-            runtimeLibrarySearchPaths: [librariesPath]
-        )
-        _sdkPlatformFrameworkPath[darwinPlatform] = sdkPlatformFrameworkPath
         return sdkPlatformFrameworkPath
     }
 
     /// Cache storage for sdk platform paths.
-    private static var _sdkPlatformFrameworkPath: [DarwinPlatform: PlatformPaths] = [:]
+    private static let _sdkPlatformFrameworkPathCache = ThreadSafeKeyValueStore<DarwinPlatform, PlatformPaths>()
 
     /// Returns a default Swift SDK for a given target environment
     @available(*, deprecated, renamed: "defaultSwiftSDK")

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -21,6 +21,8 @@ import SwiftBuildSupport
 import _InternalTestSupport
 import Workspace
 
+// MARK: - Helpers
+
 extension PIFBuilderParameters {
     fileprivate static func constructDefaultParametersForTesting(temporaryDirectory: Basics.AbsolutePath, addLocalRpaths: Bool) throws -> Self {
         self.init(
@@ -55,7 +57,7 @@ fileprivate func withGeneratedPIF(
        mockBuildParameters(destination: .host)
     }
     try await fixture(name: fixtureName) { fixturePath in
-        let observabilitySystem: TestingObservability = ObservabilitySystem.makeForTesting()
+        let observabilitySystem: TestingObservability = ObservabilitySystem.makeForTesting(verbose: false)
         let toolchain = try UserToolchain.default
         let workspace = try Workspace(
             fileSystem: localFileSystem,
@@ -167,11 +169,13 @@ extension BuildConfiguration {
     }
 }
 
+// MARK: - Tests
+
 @Suite(
     .tags(
         .TestSize.medium,
-        .FunctionalArea.PIF,
-    ),
+        .FunctionalArea.PIF
+    )
 )
 struct PIFBuilderTests {
 
@@ -393,8 +397,8 @@ struct PIFBuilderTests {
 
     @Suite(
         .tags(
-            .FunctionalArea.IndexMode,
-        ),
+            .FunctionalArea.IndexMode
+        )
     )
     struct IndexModeSettingTests {
 

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemMessageHandlerTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemMessageHandlerTests.swift
@@ -21,14 +21,13 @@ import SwiftBuildSupport
 import TSCBasic
 import _InternalTestSupport
 
-
 @Suite
 struct SwiftBuildSystemMessageHandlerTests {
     private func createMessageHandler(
         _ logLevel: Basics.Diagnostic.Severity = .warning
     ) -> (handler: SwiftBuildSystemMessageHandler, outputStream: BufferedOutputByteStream, observability: TestingObservability) {
         let outputStream = BufferedOutputByteStream()
-        let observability = ObservabilitySystem.makeForTesting(outputStream: outputStream)
+        let observability = ObservabilitySystem.makeForTesting(verbose: true, outputStream: outputStream)
 
         let handler = SwiftBuildSystemMessageHandler(
             observabilityScope: observability.topScope,

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -15,7 +15,6 @@ import Testing
 @testable import SwiftBuildSupport
 import SPMBuildCore
 
-
 import var TSCBasic.stderrStream
 import Basics
 import Workspace


### PR DESCRIPTION
### Motivation:
Fix a race condition when running PIF tests in parallel. The crash was caused by a *concurrent* mutation in a shared, global `Dictionary` in `PackageModel.SwiftSDK`:

```swift
private static var _sdkPlatformFrameworkPath: [DarwinPlatform: PlatformPaths] = [:]
```

### Modifications:

Replace the plain `Dictionary` above with our safer `ThreadSafeKeyValueStore` instead. This seemed as a more sensible alternative than promoting the whole `SwiftSDK` class to a (singleton) `actor`, resulting in clients having to handle an async APIs, etc. 

This PR also reduces the logging noise in `PIFBuilderTests.swift`.

### Result:

Tests can now safely run concurrently providing a nice 5x speed up for execution time. This works fine now:

```
$ swift test --filter SwiftBuildSupport
Test run started.
…
Test run with 21 tests in 6 suites passed after 4.5 seconds.
```

…and works okay in Xcode too ;)

Fixes rdar://168686020.