### PR TITLE
Partially revert #9480 (Use the correct module name for executable targets combined with an executable product with a different name)

### DIFF
--- a/Fixtures/PIFBuilder/ComplexPackage/Package.swift
+++ b/Fixtures/PIFBuilder/ComplexPackage/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "ComplexPackage",
+products: [
+    .executable(name: "exec-1", targets: ["exec"]),
+    .executable(name: "exec-2", targets: ["exec"])
+],
+targets: [
+    .target(
+        name: "corecpp",
+        dependencies: []
+    ),
+    .target(
+        name: "exec",
+        dependencies: ["corecpp"]
+    ),
+        .testTarget(
+            name: "ComplexPackageTests",
+            dependencies: ["exec"]
+        ),
+        .testTarget(
+            name: "ComplexPackageTests2",
+            dependencies: ["exec"]
+        )
+    ]
+)

--- a/Fixtures/PIFBuilder/ComplexPackage/README.md
+++ b/Fixtures/PIFBuilder/ComplexPackage/README.md
@@ -1,0 +1,3 @@
+# ComplexPackage
+
+A description of this package.

--- a/Fixtures/PIFBuilder/ComplexPackage/Sources/corecpp/corecpp.cpp
+++ b/Fixtures/PIFBuilder/ComplexPackage/Sources/corecpp/corecpp.cpp
@@ -1,0 +1,5 @@
+#include<corecpp.h>
+
+int foo() {
+    return 5;
+}

--- a/Fixtures/PIFBuilder/ComplexPackage/Sources/corecpp/include/corecpp.h
+++ b/Fixtures/PIFBuilder/ComplexPackage/Sources/corecpp/include/corecpp.h
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int foo();
+
+#ifdef __cplusplus
+}
+#endif

--- a/Fixtures/PIFBuilder/ComplexPackage/Sources/exec/main.swift
+++ b/Fixtures/PIFBuilder/ComplexPackage/Sources/exec/main.swift
@@ -1,0 +1,3 @@
+import corecpp
+
+print(foo())

--- a/Fixtures/PIFBuilder/ComplexPackage/Tests/ComplexPackageTests/ComplexPackageTests.swift
+++ b/Fixtures/PIFBuilder/ComplexPackage/Tests/ComplexPackageTests/ComplexPackageTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import class Foundation.Bundle
+
+final class ComplexPackageTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        let fooBinary = productsDirectory.appendingPathComponent("ComplexPackage")
+
+        let process = Process()
+        process.executableURL = fooBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(output, "Hello, world!\n")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Fixtures/PIFBuilder/ComplexPackage/Tests/ComplexPackageTests/XCTestManifests.swift
+++ b/Fixtures/PIFBuilder/ComplexPackage/Tests/ComplexPackageTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(ComplexPackageTests.allTests),
+    ]
+}
+#endif

--- a/Fixtures/PIFBuilder/ComplexPackage/Tests/ComplexPackageTests2/ComplexPackageTests.swift
+++ b/Fixtures/PIFBuilder/ComplexPackage/Tests/ComplexPackageTests2/ComplexPackageTests.swift
@@ -1,0 +1,6 @@
+import XCTest
+
+final class ComplexPackageTests2: XCTestCase {
+    func testExample() throws {
+    }
+}

--- a/Fixtures/PIFBuilder/ComplexPackage/Tests/LinuxMain.swift
+++ b/Fixtures/PIFBuilder/ComplexPackage/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import ComplexPackageTests
+
+var tests = [XCTestCaseEntry]()
+tests += ComplexPackageTests.allTests()
+XCTMain(tests)

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -112,8 +112,7 @@ extension PackagePIFProjectBuilder {
         settings[.TARGET_NAME] = product.name
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "regular"
         settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
-        // We must use the main module name here instead of the product name, because they're not guranteed to be the same, and the users may have authored e.g. tests which rely on an executable's module name.
-        settings[.PRODUCT_MODULE_NAME] = mainModule.c99name
+        settings[.PRODUCT_MODULE_NAME] = product.c99name
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(product.name)"
             .spm_mangledToBundleIdentifier()
         settings[.SWIFT_PACKAGE_NAME] = mainModule.packageName

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -394,6 +394,33 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test func multipleProductsSharingModuleHaveDistinctModuleNames() async throws {
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/ComplexPackage") { pif, observabilitySystem in
+            let errors: [Diagnostic] = observabilitySystem.diagnostics.filter { $0.severity == .error }
+            #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+            let project = try pif.workspace.project(named: "ComplexPackage")
+
+            let exec1Config = try project
+                .target(named: "exec-1-product")
+                .buildConfig(named: .release)
+            let exec2Config = try project
+                .target(named: "exec-2-product")
+                .buildConfig(named: .release)
+
+            let exec1ModuleName = exec1Config.settings[.PRODUCT_MODULE_NAME]
+            let exec2ModuleName = exec2Config.settings[.PRODUCT_MODULE_NAME]
+
+            #expect(exec1ModuleName != nil, "exec-1-product should have PRODUCT_MODULE_NAME set")
+            #expect(exec2ModuleName != nil, "exec-2-product should have PRODUCT_MODULE_NAME set")
+            #expect(exec1ModuleName != exec2ModuleName,
+                """
+                Products sharing a module must have distinct PRODUCT_MODULE_NAME values.
+                Got exec-1: \(exec1ModuleName ?? "nil"), exec-2: \(exec2ModuleName ?? "nil")
+                """)
+        }
+    }
+
     @Suite(
         .tags(
             .FunctionalArea.IndexMode,


### PR DESCRIPTION
If a package has two products that depend on the same main module target, the PIF builder will use the same name for both executable product artifacts and cause multiple products with the same name to be emitted.

Add a test to verify this regression, and go back to using the product name instead of mainModule name.
