### PR TITLE
Tests: Update tests

### DIFF
--- a/Sources/Commands/PackageCommands/BuildServer.swift
+++ b/Sources/Commands/PackageCommands/BuildServer.swift
@@ -45,10 +45,10 @@ struct BuildServer: AsyncSwiftCommand {
         let clientConnection = JSONRPCConnection(
             name: "client",
             protocol: MessageRegistry.bspProtocol,
-            inFD: FileHandle.standardInput,
-            outFD: realStdoutHandle,
-            inputMirrorFile: nil,
-            outputMirrorFile: nil
+            receiveFD: FileHandle.standardInput,
+            sendFD: realStdoutHandle,
+            receiveMirrorFile: nil,
+            sendMirrorFile: nil
         )
 
         guard let buildSystem = try await swiftCommandState.createBuildSystem() as? SwiftBuildSystem else {

--- a/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/Tests/IntegrationTests/SwiftPMTests.swift
@@ -111,14 +111,11 @@ private struct SwiftPMTests {
     }
 
     @Test(
-        .bug(id: 0, "SWBINTTODO: Linux: /lib/x86_64-linux-gnu/Scrt1.o:function _start: error:"),
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8380", "lld-link: error: subsystem must be defined"),
-        .bug(id: 0, "SWBINTTODO: MacOS: Could not find or use auto-linked library 'Testing': library 'Testing' not found"),
         .tags(
             Tag.Feature.Command.Package.Init,
             Tag.Feature.PackageType.Library,
         ),
-        arguments: SupportedBuildSystemOnPlatform,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func packageInitLibrary(_ buildSystemProvider: BuildSystemProvider.Kind) async throws {
         try await withTemporaryDirectory { tmpDir in
@@ -129,28 +126,17 @@ private struct SwiftPMTests {
                 extraArgs: ["init", "--type", "library"],
                 buildSystem: buildSystemProvider,
             )
-            try await withKnownIssue(
-                """
-                Linux: /lib/x86_64-linux-gnu/Scrt1.o:function _start: error: undefined reference to 'main'
-                Windows: lld-link: error: subsystem must be defined
-                MacOS: Could not find or use auto-linked library 'Testing': library 'Testing' not found
-                """,
-                isIntermittent: true
-            ) {
-                try await executeSwiftBuild(
-                    packagePath,
-                    buildSystem: buildSystemProvider,
-                )
-                let testOutput = try await executeSwiftTest(
-                    packagePath,
-                    buildSystem: buildSystemProvider,
-                )
-                // #expect(testOutput.returnCode == .terminated(code: 0))
-                #expect(!testOutput.stderr.contains("error:"))
 
-            } when: {
-                (buildSystemProvider == .swiftbuild) || (buildSystemProvider == .xcode && ProcessInfo.hostOperatingSystem == .macOS)
-            }
+            try await executeSwiftBuild(
+                packagePath,
+                buildSystem: buildSystemProvider,
+            )
+            let testOutput = try await executeSwiftTest(
+                packagePath,
+                buildSystem: buildSystemProvider,
+            )
+            // #expect(testOutput.returnCode == .terminated(code: 0))
+            #expect(!testOutput.stderr.contains("error:"))
         }
     }
 


### PR DESCRIPTION
- Augment the IntegrationTests.Basics to run on cross matrix of native/swiftbuild and debug/release
- Remove withKnownIssue in IntegrationTests.SwifTPMtests
- Replace deprecated call top `JSONRPCConnection` initialization with non-deprecated calls