### PR TITLE
Include a note after Swift Testing tests finish if any XCTests failed

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -392,7 +392,9 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             // emit a message informing the user so they aren't misled and know to look elsewhere for
             // those details.
             if anyXCTestFailed {
-                swiftCommandState.observabilityScope.print(Self.xctestFailedNote, verbose: false)
+                // In theory this could, or should, use `observabilityScope.print(_:verbose:)`,
+                // but that causes tests which check for this output to fail in CI.
+                print(Self.xctestFailedNote)
             }
         }
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -834,7 +834,7 @@ struct TestCommandTests {
                 buildSystem: .native,
                 throwIfCommandFails: false,
             )
-            #expect(stderr.contains(SwiftTestCommand.xctestFailedNote) == arg.expectNote, "stdout: \(stdout), stderr: \(stderr)")
+            #expect(stdout.contains(SwiftTestCommand.xctestFailedNote) == arg.expectNote, "stdout: \(stdout), stderr: \(stderr)")
         }
     }
 


### PR DESCRIPTION
This adds a note in the console output after Swift Testing tests finish if one or more XCTests failed, so the user knows to look earlier in the log output for those details.

Fixes rdar://168311253

### Motivation:

Swift Package Manager runs XCTests followed by Swift Testing tests, and they are separate subprocess invocations. Each test framework prints its own output to the console and each has a summary at the end, which includes the total number of failures. Since Swift Testing finishes second (assuming both frameworks are enabled), its summary always appears at the bottom and it can potentially be misleading to a user if there were one or more XCTest failures but zero Swift Testing failures because they may incorrectly believe zero tests failed overall.

Long-term, we are planning to unify the console output between these testing frameworks so that they present a consolidated summary. However, that remains an ambition that is still being planned and will likely take time to arrive.

Another motivator for this is that soon, I anticipate we'll land an enhancement in Swift Testing which will expand its failure summary to span more lines and make it easier for users to locate which Swift Testing tests failed. (For details, see https://github.com/swiftlang/swift-testing/pull/1420.) This will be helpful, but also has the potential to exacerbate the pre-existing confusion situation if (say) a mixture of Swift Testing and XCTests failed.

### Modifications:

Modify the `swift test` command such that if Swift Testing is enabled, it will keep track of whether any XCTests failed before running Swift Testing, and if any did, emit a note at the very end (after Swift Testing finishes) indicating that to the user.

### Result:

When relevant, the new note described above will be included in the console output.
