### PR TITLE
Add mirroring support for remote binary targets

### DIFF
--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1227,7 +1227,12 @@ extension Workspace {
                             } else {
                                 throw StringError("\(artifactPath) does not contain binary artifact")
                             }
-                        } else if let url = target.url.flatMap(URL.init(string:)) {
+                        } else if let urlString = target.url {
+                            // Apply mirroring to the URL
+                            let mappedURLString = self.identityResolver.mappedLocation(for: urlString)
+                            guard let url = URL(string: mappedURLString) else {
+                                throw StringError("Invalid URL after mirroring: \(mappedURLString)")
+                            }
                             let fakePath = try manifest.path.parentDirectory.appending(components: "remote", "archive")
                                 .appending(RelativePath(validating: url.lastPathComponent))
                             partial[target.name] = BinaryArtifact(


### PR DESCRIPTION
Add mirroring support for remote binary targets

### Motivation:

Currently, Swift Package Manager supports mirroring for package dependencies (source control URLs and registry identifiers), but remote binary targets (XCFrameworks, artifact archives) downloaded via URLs do not respect mirror configuration. This creates a gap where organizations using internal artifact mirrors or CDNs cannot redirect binary artifact downloads through their preferred endpoints. This is particularly important for:
- Corporate environments requiring all downloads through internal mirrors
- Caching/CDN setups for binary artifacts
- Security policies mandating downloads through specific endpoints

### Modifications:

1. **Updated `BinaryArtifactsManager.parseArtifacts()`** (`Sources/Workspace/Workspace+BinaryArtifacts.swift`):
   - Added `IdentityResolver` parameter to enable mirroring lookups
   - Applied mirroring to remote binary target URLs using `identityResolver.mappedLocation(for:)` before creating `RemoteArtifact` instances
   - Added error handling for invalid URLs after mirroring

2. **Updated `_updateBinaryArtifacts()`** (`Sources/Workspace/Workspace+BinaryArtifacts.swift`):
   - Modified call site to pass `self.identityResolver` to `parseArtifacts()`

3. **Updated `loadRootPackage()`** (`Sources/Workspace/Workspace.swift`):
   - Applied mirroring when creating `BinaryArtifact` instances for remote binary targets in the package model, ensuring consistency across all code paths

4. **Added comprehensive tests** (`Tests/WorkspaceTests/WorkspaceTests.swift`):
   - `testRemoteBinaryArtifactMirroring`: Verifies mirroring works for direct zip file downloads
   - `testRemoteBinaryArtifactNoMirroring`: Ensures original URLs are used when no mirror is configured
   - `testRemoteBinaryArtifactMirroringWithArtifactBundleIndex`: Tests mirroring for artifactbundleindex files and archive URL construction
   - `testRemoteBinaryArtifactPartialMirroring`: Verifies mixed scenarios where some artifacts are mirrored and others are not

The implementation follows the same pattern used for package dependency mirroring, ensuring consistency across the codebase.

### Result:

After this change, remote binary targets will respect mirror configuration set via `swift package config set-mirror`. When a mirror is configured for a binary artifact URL:
- The mirrored URL will be used for downloading the artifact
- Both direct zip files and artifactbundleindex files are supported

If no mirror is configured, the original URL from the manifest is used (backward compatible). This change maintains full backward compatibility and follows the existing mirroring patterns in SwiftPM.
