### PR TITLE
Add 6.3 to Swift Build preview release notes

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftBuildPreview.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftBuildPreview.md
@@ -1,6 +1,10 @@
-# Preview the Swift Build System Integration
+# [6.3] Preview the Swift Build System Integration
 
 Understand, use, and preview the next-generation build system for Package Manager.
+
+@Metadata {
+    @Available("Swift", introduced: "6.3")
+}
 
 ## Overview
 


### PR DESCRIPTION
Update the documentation to clarify the preview of Swift Build to 6.3+.