### PR TITLE
Avoid producing duplicate modules in the products dir when 2 executable products incorporate the same executable target

### DIFF
--- a/Fixtures/Miscellaneous/ExecutableTargetWithTwoProducts/Foo.swift
+++ b/Fixtures/Miscellaneous/ExecutableTargetWithTwoProducts/Foo.swift
@@ -1,0 +1,9 @@
+@main struct Entry {
+    static func main() {
+        // Ensure that Bar can be referenced as a member of the module named Foo,
+        // even though the executable target Foo may have been merged into the Exe1 or Exe2 products.
+        let x = Foo.Bar()
+    }
+}
+
+struct Bar {}

--- a/Fixtures/Miscellaneous/ExecutableTargetWithTwoProducts/Package.swift
+++ b/Fixtures/Miscellaneous/ExecutableTargetWithTwoProducts/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+let package = Package(
+    name: "Foo",
+    products: [
+        .executable(name: "Exe1", targets: ["Foo"]),
+        .executable(name: "Exe2", targets: ["Foo"]),
+    ],
+    targets: [
+        .executableTarget(name: "Foo", path: "./"),
+    ]
+)

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -451,6 +451,8 @@ extension PackagePIFProjectBuilder {
 
             settings[.SWIFT_PACKAGE_NAME] = sourceModule.packageName
 
+            // This entrypoint is only used for the testable variant of executable targets. The primary PIF generation
+            // for executables is in makeMainModuleProduct.
             if desiredModuleType == .executable {
                 // Tell the Swift compiler to produce an alternate entry point rather than the standard `_main` entry
                 // point`,
@@ -470,14 +472,6 @@ extension PackagePIFProjectBuilder {
 
                 // on windows modules are libraries, so we need to add a search path so the linker finds them
                 impartedSettings[.LIBRARY_SEARCH_PATHS, .windows] = ["$(inherited)", "$(TARGET_BUILD_DIR)/ExecutableModules"]
-
-                // Don't install the Swift module of the testable side-built artifact, lest it conflict with the regular
-                // one.
-                // The modules should have compatible contents in any case — only the entry point function name is
-                // different in the Swift module
-                // (the actual runtime artifact is of course very different, and that's why we're building a separate
-                // testable artifact).
-                settings[.SWIFT_INSTALL_MODULE] = "NO"
             }
 
             if let aliases = sourceModule.moduleAliases {

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -115,6 +115,14 @@ extension PackagePIFProjectBuilder {
         settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
         // We must use the main module name here instead of the product name, because they're not guranteed to be the same, and the users may have authored e.g. tests which rely on an executable's module name.
         settings[.PRODUCT_MODULE_NAME] = mainModule.c99name
+        if product.type == .executable {
+            // Don't install the Swift module of the executable product, lest it conflict with the testable variant.
+            // The contents of the testable variant's module will exactly match the binary linked by dependencies (test targets).
+            // Also, multiple executable products may incorporate sources from the same executable target, while the testable
+            // variant of an execuytable target's module will always be unique, so we avoid producing conflicting copies.
+            settings[.SWIFT_INSTALL_MODULE] = "NO"
+        }
+
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(product.name)"
             .spm_mangledToBundleIdentifier()
         settings[.SWIFT_PACKAGE_NAME] = mainModule.packageName


### PR DESCRIPTION
Only install the testable swiftmodule in the products directory. The comments explain some of the rationale behind this decision.