### PR TITLE
Plugin dependencies should not be be linked into executable targets that use those plugins

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -903,7 +903,10 @@ extension Collection<PackageGraph.ResolvedModule> {
                 let (unseenModule, _) = moduleIDsSeen.insert(moduleDependency.id)
                 guard unseenModule else { return }
 
-                if moduleDependency.underlying.type != .macro {
+                // Do not traverse into *macro* or *plugin* dependencies.
+                // Macros run at compile time and their dependencies should not be linked into the client.
+                // Plugins run at build time and their dependencies should not be linked into the client neither.
+                if ![.macro, .plugin].contains(moduleDependency.underlying.type) {
                     for dependency in moduleDependency.dependencies {
                         visitDependency(dependency)
                     }


### PR DESCRIPTION
In the new PIF builder (ie, `--build-system swiftbuild`) plugin dependencies are being linked into executable targets that use those plugins. 

### Motivation:

The following package demonstrates this bug where plugin *dependencies* were incorrectly being linked into executable targets that use those plugins.

#### Package Structure

```
PluginLinkingBugDemo/
├── Package.swift
├── Sources/
│   ├── MyApp/
│   │   └── main.swift           # Simple executable that uses the plugin
│   ├── PluginExecutable/
│   │   └── main.swift           # CLI tool used by the plugin
│   └── PluginHelper/
│       └── PluginHelper.swift   # Library used by PluginExecutable
└── Plugins/
    └── MyBuildPlugin/
        └── MyBuildPlugin.swift  # Build tool plugin that uses PluginExecutable
```

#### Dependency Graph

```
MyApp (executable)
 │
 └── uses plugin ──▶ MyBuildPlugin (plugin)
                       │
                       └── depends on ─▶ PluginExecutable (executable)
                                          │
                                          └── depends on ─▶ PluginHelper (library)
                                                              │
                                                              └─ depends on ─▶ ArgumentParser (external)
```

#### The Bug

The bug is in how `recursivelyTraverseDependencies` works in `PackagePIFBuilder+Helpers.swift`. When traversing dependencies for an executable target:

1. It visits plugin dependencies and all their transitive dependencies.
2. While plugins themselves are marked as `isLinkable: false`, their dependencies still get passed through and processed.
3. Those plugin dependencies end up being linked into the executable target.

The PIF graph below clearly shows the issue (i.e., look at the unexpected dependencies of the `PACKAGE-PRODUCT:MyApp` PIF target):

<img width="11996" height="4089" alt="plugin-linking-bug-demo" src="https://github.com/user-attachments/assets/9918a8ea-5ca1-4f0f-ba18-b7f3e2afe77e" />

#### Expected Behaviour

- `MyApp` should have a build-time dependency on `MyBuildPlugin`.
- `MyApp` should NOT link against `PluginHelper` nor `ArgumentParser`.
- The plugin's dependencies are only needed when the plugin runs at build time.

### Modifications:

In `PackagePIFBuilder+Helpers.swift`, the `recursivelyTraverseDependencies` function now excludes `.plugin` modules from recursive traversal (similar to how `.macro` modules were already excluded).

This fix only applies to the *new* PIF builder (but the bug is also present in the old PIF builder at `XCBuildSupport`).

### Result: 

Resolves these potential issues:

- Unnecessary code linked into executables (larger binaries).
- Confusion about actual dependencies of the executable, messing up *pre-builts* for instance (e.g., #9645).
- Build errors if plugin dependencies don't support the target platform

The updated PIF graph below clearly shows the issue is now resolved (i.e., `MyApp` only depends on `MyBuildPlugin` after this patch):

<img width="10499" height="4056" alt="fixed-pif-deps" src="https://github.com/user-attachments/assets/62c1e426-01db-4229-a3cd-5c92e82a032b" />

This likely means we can revisit this fix #9645.

This fixes rdar://168935735.
