### PR TITLE
Fix Swift SDK triple handling

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -773,13 +773,13 @@ public struct SwiftSDK: Equatable {
             } else {
                 throw SwiftSDKError.noSwiftSDKDecoded(customDestination)
             }
-        } else if let targetTriple = customCompileTriple,
-                  let targetSwiftSDK = SwiftSDK.defaultSwiftSDK(for: targetTriple, hostSDK: hostSwiftSDK)
-        {
-            swiftSDK = targetSwiftSDK
         } else if let swiftSDKSelector {
             do {
-                swiftSDK = try store.selectBundle(matching: swiftSDKSelector, hostTriple: hostTriple)
+                swiftSDK = try store.selectBundle(
+                    matching: swiftSDKSelector,
+                    hostTriple: hostTriple,
+                    targetTriple: customCompileTriple
+                )
             } catch {
                 // If a user-installed bundle for the selector doesn't exist, check if the
                 // selector is recognized as a default SDK.
@@ -790,6 +790,10 @@ public struct SwiftSDK: Equatable {
                     throw error
                 }
             }
+        } else if let targetTriple = customCompileTriple,
+                  let targetSwiftSDK = SwiftSDK.defaultSwiftSDK(for: targetTriple, hostSDK: hostSwiftSDK)
+        {
+            swiftSDK = targetSwiftSDK
         } else {
             // Otherwise use the host toolchain.
             swiftSDK = hostSwiftSDK

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
@@ -123,10 +123,12 @@ public final class SwiftSDKBundleStore {
     /// - Parameters:
     ///   - query: either an artifact ID or target triple to filter with.
     ///   - hostTriple: triple of the host building with these Swift SDKs.
+    ///   - targetTriple: target triple for compilation.
     /// - Returns: ``SwiftSDK`` value matching `query` either by artifact ID or target triple, `nil` if none found.
     public func selectBundle(
         matching selector: String,
-        hostTriple: Triple
+        hostTriple: Triple,
+        targetTriple: Triple? = nil
     ) throws -> SwiftSDK {
         let validBundles = try self.allValidBundles
 
@@ -139,6 +141,7 @@ public final class SwiftSDKBundleStore {
         guard var selectedSwiftSDKs = validBundles.selectSwiftSDK(
             matching: selector,
             hostTriple: hostTriple,
+            targetTriple: targetTriple,
             observabilityScope: self.observabilityScope
         ) else {
             throw Error.noMatchingSwiftSDK(selector: selector, hostTriple: hostTriple)


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift-package-manager/issues/9220, https://github.com/swiftlang/swift-package-manager/issues/7973, and others.

### Motivation:

When a user has two SDK bundles installed that have at least two supported target triples in common, then it's impossible to disambiguate the SDKs via the command line. That issue is tracked by https://github.com/swiftlang/swift-package-manager/issues/7973.

### Modifications:

I've solved the issue by updating the SDK resolution logic to respect `--triple` when present (which fixes #9220). I've simply extended the search logic to require the candidate SDKs' target triples to match the provided triple to be considered.

### Result:

These changes should only affect SwiftPM behaviour when both `--triple` and `--swift-sdk` are present. Currently, SwiftPM ignores `--triple` when `--swift-sdk` is present. After the changes, it respects `--triple` in a way that I find intuitive, and others in the linked issues seem to find intuitive as well.

---

The PR currently targets `release/6.3` because it's late at night and `main` wasn't compiling on my machine. Before undrafting I will rebase onto whichever branch is considered suitable. Please let me know which branch I should target with this PR.