### PR TITLE
[🍒] Include linker generated symbol in default defined set (#9416)

### DIFF
--- a/Sources/BinarySymbols/ReferencedSymbols.swift
+++ b/Sources/BinarySymbols/ReferencedSymbols.swift
@@ -15,7 +15,26 @@ package struct ReferencedSymbols {
     package private(set) var undefined: Set<String>
 
     package init() {
-        self.defined = []
+        // Some symbols are defined by linker directly by convention and need to be assumed defined.
+        // The list below was pulled from
+        // https://github.com/llvm/llvm-project/blob/177e38286cd61a7b5a968636e1f147f128dd25a2/lld/ELF/Config.h#L632
+        self.defined = [
+            "__bss_start",
+            "_etext",
+            "etext",
+            "_edata",
+            "edata",
+            "_end",
+            "end",
+            "_GLOBAL_OFFSET_TABLE_",
+            "_gp",
+            "_gp_disp",
+            "__gnu_local_gp",
+            "__global_pointer$",
+            "__rela_iplt_start",
+            "__rela_iplt_end",
+            "_TLS_MODULE_BASE",
+        ]
         self.undefined = []
     }
 

--- a/Tests/BinarySymbolsTests/LLVMObjdumpSymbolProviderTests.swift
+++ b/Tests/BinarySymbolsTests/LLVMObjdumpSymbolProviderTests.swift
@@ -34,8 +34,7 @@ struct LLVMObjdumpSymbolProviderTests {
             DYNAMIC SYMBOL TABLE:
             """
         )
-
-        #expect(output.defined.isEmpty)
+        #expect(output.defined == ReferencedSymbols().defined)
         #expect(output.undefined.isEmpty)
     }
 
@@ -51,7 +50,7 @@ struct LLVMObjdumpSymbolProviderTests {
     func detectsUndefinedSymbol() throws {
         let output = try getSymbols("0000000000000000         *UND*  0000000000000000 calloc")
 
-        #expect(output.defined.isEmpty)
+        #expect(output.defined == ReferencedSymbols().defined)
         #expect(output.undefined.contains("calloc"))
     }
 


### PR DESCRIPTION
Cherry-pick of #9416