### PR TITLE
[6.3] Docs: Add SwiftBuild behavioural difference

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftBuildPreview.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftBuildPreview.md
@@ -56,7 +56,7 @@ swift run --build-system swiftbuild
 #### Other
 
 - When targeting Apple platforms, `--build-system swiftbuild` supports building universal binaries. Example invocation: `swift build --build-system swiftbuild --arch arm64 --arch x86_64`
-- Swift Build build system outputs build artifacta to a different location.  Use the `swift build --show-bin-path <other build arguments>` to determine the build output location.
+- The Swift Build build system outputs build artifacts to a different location.  Use the `swift build --show-bin-path <other build arguments>` to determine the build output location.
 
 ## Known issues
 


### PR DESCRIPTION
The SwiftBuild build system has a different build artifacts output directory compared to the native build system.  Update the "Previewing Swift Build" documentation to provide a command to get the build output location.

cherry-pick from #9666 