### PR TITLE
Filter out testable target variants when building macros with swiftbuild

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -578,8 +578,13 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         let workspaceInfo = try await session.workspaceInfo()
 
                         configuredTargets = try [pifTargetName].map { targetName in
-                            // TODO we filter dynamic targets until Swift Build doesn't give them to us anymore
-                            let infos = workspaceInfo.targetInfos.filter { $0.targetName == targetName && !TargetSuffix.dynamic.hasSuffix(id: GUID($0.guid)) }
+                            // TODO: we filter target variants until Swift Build doesn't give them to us anymore
+                            let infos = workspaceInfo.targetInfos.filter {
+                                let guid = GUID($0.guid)
+                                return $0.targetName == targetName &&
+                                    !guid.hasSuffix(.dynamic) &&
+                                    !guid.hasSuffix(.testable)
+                            }
                             switch infos.count {
                             case 0:
                                 self.observabilityScope.emit(error: "Could not find target named '\(targetName)'")


### PR DESCRIPTION
This PR fixes building macros with `--target` in swiftbuild.

### Motivation:

`swift build --target <macro_name> --build-system swiftbuild` fails with `Found multiple targets named` error. 
The PIF builder creates both a macro target and its `.testable` variant, and both match by name.
The existing code only filtered out `.dynamic` variants (#8845), but not `.testable` variants.

### Modifications:

Extend the target filter to exclude both `.dynamic` and `.testable` variants.

### Result:

`swift build --target <macro_name> --build-system swiftbuild` works correctly.