### PR TITLE
Remove function computing legacy pif package product name

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -198,10 +198,6 @@ public final class PackagePIFBuilder {
         UserDefaults.standard.bool(forKey: "SkipStaticAnalyzerForPackageDependencies", defaultValue: true)
     }
 
-    public static func computePackageProductFrameworkName(productName: String) -> String {
-        "\(productName)_\(String(productName.hash, radix: 16, uppercase: true))_PackageProduct"
-    }
-
     public init(
         modulesGraph: ModulesGraph,
         resolvedPackage: ResolvedPackage,


### PR DESCRIPTION
This PR removes the unused `computePackageProductFrameworkName` function.

### Motivation:
This function was introduced in #8405 but the only call site was removed in #9130.

### Modifications:
Remove the unused `computePackageProductFrameworkName` function.