### PR TITLE
GHA: Add PR dependency check

### DIFF
--- a/.github/workflows/pull_request_dependency_check.yaml
+++ b/.github/workflows/pull_request_dependency_check.yaml
@@ -1,0 +1,11 @@
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  check_dependencies:
+    uses: bkhouri/github-workflows/.github/workflows/github_actions_dependencies.yml@t/main/pr_dependency-check

--- a/.github/workflows/pull_request_dependency_check.yaml
+++ b/.github/workflows/pull_request_dependency_check.yaml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   check_dependencies:
-    uses: bkhouri/github-workflows/.github/workflows/github_actions_dependencies.yml@t/main/pr_dependency-check
+    uses: swiftlang/github-workflows/.github/workflows/github_actions_dependencies.yml@main


### PR DESCRIPTION
Add a workflow that will check if dependent PR are merged.  If not, fail the build.

Depends on: swiftlang/github-workflows/pull/233