### PR TITLE
Ensure only one module is installed when building testable variants of macros

### DIFF
--- a/Fixtures/Macros/MinimalMacroPackage/Package.swift
+++ b/Fixtures/Macros/MinimalMacroPackage/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+import PackageDescription
+import CompilerPluginSupport
+
+let package = Package(
+    name: "MinimalMacroPackage",
+    platforms: [
+        .macOS(.v13),
+    ],
+    targets: [
+        .macro(name: "MacroImpl"),
+        .target(name: "MacroDef", dependencies: ["MacroImpl"]),
+        .executableTarget(name: "MacroClient", dependencies: ["MacroDef"]),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/Fixtures/Macros/MinimalMacroPackage/Sources/MacroClient/main.swift
+++ b/Fixtures/Macros/MinimalMacroPackage/Sources/MacroClient/main.swift
@@ -1,0 +1,4 @@
+import MacroDef
+
+let result = #stringify(42)
+print("Macro result: \(result)")

--- a/Fixtures/Macros/MinimalMacroPackage/Sources/MacroDef/MacroDef.swift
+++ b/Fixtures/Macros/MinimalMacroPackage/Sources/MacroDef/MacroDef.swift
@@ -1,0 +1,2 @@
+@freestanding(expression)
+public macro stringify<T>(_ value: T) -> String = #externalMacro(module: "MacroImpl", type: "StringifyMacro")

--- a/Fixtures/Macros/MinimalMacroPackage/Sources/MacroImpl/StringifyMacro.swift
+++ b/Fixtures/Macros/MinimalMacroPackage/Sources/MacroImpl/StringifyMacro.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+@main
+struct MacroPlugin {
+    static func main() throws {
+        while true {
+            guard let headerData = try read(count: 8),
+                  headerData.count == 8 else {
+                break
+            }
+            let length = headerData.withUnsafeBytes { buffer in
+                buffer.load(as: UInt64.self)
+            }
+            let payloadLength = UInt64(littleEndian: length)
+
+            if payloadLength == 0 {
+                break
+            }
+
+            guard let payloadData = try read(count: Int(payloadLength)),
+                  payloadData.count == Int(payloadLength) else {
+                break
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any] else {
+                continue
+            }
+
+            if json.keys.contains("getCapability") {
+                let response: [String: Any] = [
+                    "getCapabilityResult": [
+                        "capability": [
+                            "protocolVersion": 2
+                        ]
+                    ]
+                ]
+                if let responseData = try? JSONSerialization.data(withJSONObject: response) {
+                    try writeMessage(responseData, to: FileHandle.standardOutput)
+                }
+            } else if json.keys.contains("expandFreestandingMacro") {
+                let response: [String: Any] = [
+                    "expandMacroResult": [
+                        "expandedSource": "\"expanded\"",
+                        "diagnostics": []
+                    ]
+                ]
+                if let responseData = try? JSONSerialization.data(withJSONObject: response) {
+                    try writeMessage(responseData, to: FileHandle.standardOutput)
+                }
+            }
+        }
+    }
+}
+
+private func read(count: Int) throws -> Data? {
+    var accumulated = Data()
+    while accumulated.count < count {
+        let remaining = count - accumulated.count
+        guard let chunk = try FileHandle.standardInput.read(upToCount: remaining), !chunk.isEmpty else {
+            return accumulated.isEmpty ? nil : accumulated
+        }
+        accumulated.append(chunk)
+    }
+    return accumulated
+}
+
+private func writeMessage(_ data: Data, to handle: FileHandle) throws {
+    var length = UInt64(data.count).littleEndian
+    let headerData = withUnsafeBytes(of: &length) { buffer in
+        Data(buffer)
+    }
+    try handle.write(contentsOf: headerData)
+    try handle.write(contentsOf: data)
+}

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -451,7 +451,7 @@ extension PackagePIFProjectBuilder {
 
             settings[.SWIFT_PACKAGE_NAME] = sourceModule.packageName
 
-            // This entrypoint is only used for the testable variant of executable targets. The primary PIF generation
+            // This entrypoint is only used for the testable variant of executable and macro targets. The primary PIF generation
             // for executables is in makeMainModuleProduct.
             if desiredModuleType == .executable {
                 // Tell the Swift compiler to produce an alternate entry point rather than the standard `_main` entry
@@ -626,6 +626,10 @@ extension PackagePIFProjectBuilder {
 
         if desiredModuleType == .macro {
             settings[.SWIFT_IMPLEMENTS_MACROS_FOR_MODULE_NAMES] = [sourceModule.c99name]
+
+            // Don't install the Swift module when building the macro executable, lest it conflict with the testable variant.
+            // The contents of the testable variant's module will exactly match the binary linked by dependencies (test targets).
+            settings[.SWIFT_INSTALL_MODULE] = "NO"
         }
         if sourceModule.type == .macro {
             settings[.SKIP_BUILDING_DOCUMENTATION] = "YES"

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -119,7 +119,7 @@ extension PackagePIFProjectBuilder {
             // Don't install the Swift module of the executable product, lest it conflict with the testable variant.
             // The contents of the testable variant's module will exactly match the binary linked by dependencies (test targets).
             // Also, multiple executable products may incorporate sources from the same executable target, while the testable
-            // variant of an execuytable target's module will always be unique, so we avoid producing conflicting copies.
+            // variant of an executable target's module will always be unique, so we avoid producing conflicting copies.
             settings[.SWIFT_INSTALL_MODULE] = "NO"
         }
 

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -48,4 +48,22 @@ struct MacroTests {
             #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
+
+    @Test(
+        .tags(
+            Tag.Feature.Command.Build
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func minimalExecutableMacro(
+        buildSystem: BuildSystemProvider.Kind
+    ) async throws {
+        try await fixture(name: "Macros/MinimalMacroPackage") { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                buildSystem: buildSystem,
+            )
+            #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+        }
+    }
 }


### PR DESCRIPTION
Update the fix from https://github.com/swiftlang/swift-package-manager/pull/9650 to account for macros as well, by ensuring we don't install two variants of the module.

Also, add a basic test fixture which implements a minimal macro without a swift-syntax dependency, to allow us to test macro builds end to end. The implementation of the compiler plugin is pretty janky, but it's relatively small and closes an important testing gap.