### PR TITLE
Treat package root top dependencies as exporting for prebuilts (#9665)

### DIFF
--- a/Sources/PackageGraph/PackageGraphRoot.swift
+++ b/Sources/PackageGraph/PackageGraphRoot.swift
@@ -78,6 +78,11 @@ public struct PackageGraphRoot {
         }
     }
 
+    /// Whether a package is exporting out the root, i.e. a root package or a root dependency
+    public func isExporting(_ identity: PackageIdentity) -> Bool{
+        return packages[identity] != nil || dependencies.contains(where: { $0.identity == identity })
+    }
+
     private let dependencyMapper: DependencyMapper?
     private let observabilityScope: ObservabilityScope
 


### PR DESCRIPTION
The package dependencies in the PackageGraphRoot are also exporting to the outside world. That means they can be built for destination (non-host). Factor that into the leaky product algorithm for prebuilts to ensure we don't force libraries exported out that way to build for host only.
