### PR TITLE
Tests: Run release configuration on select tests

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+Data.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Data.swift
@@ -24,11 +24,3 @@ public let buildDataUsingAllBuildSystemWithTags = TestBuildData(
         .Feature.CommandLineArguments.Configuration
     )
 )
-
-public let buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags = TestBuildData(
-    buildData: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
-    tags: .tags(
-        .Feature.CommandLineArguments.BuildSystem,
-        .Feature.CommandLineArguments.Configuration
-    )
-)

--- a/Tests/CommandsTests/CoverageTests.swift
+++ b/Tests/CommandsTests/CoverageTests.swift
@@ -134,24 +134,25 @@ struct CoverageTests {
         .tags(
             .Feature.Command.Test,
         ),
-        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms), [
+        arguments: SupportedBuildSystemOnAllPlatforms, [
             "Coverage/Simple",
             "Miscellaneous/TestDiscovery/Simple",
         ],
     )
     func generateCoverageReport(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
         fixtureName: String
     ) async throws {
+        let config = BuildConfiguration.debug
         try await fixture(name: fixtureName) { path in
             let coveragePathString = try await executeSwiftTest(
                 path,
-                configuration: buildData.config,
+                configuration: config,
                 extraArgs: [
                     "--show-coverage-path",
                 ],
                 throwIfCommandFails: true,
-                buildSystem: buildData.buildSystem,
+                buildSystem: buildSystem,
             ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
             let coveragePath = try AbsolutePath(validating: coveragePathString)
             try #require(!localFileSystem.exists(coveragePath))
@@ -160,18 +161,18 @@ struct CoverageTests {
             try await withKnownIssue(isIntermittent: true) {
                 try await executeSwiftTest(
                     path,
-                    configuration: buildData.config,
+                    configuration: config,
                     extraArgs: [
                         "--enable-code-coverage",
                     ],
                     throwIfCommandFails: true,
-                    buildSystem: buildData.buildSystem,
+                    buildSystem: buildSystem,
                 )
 
                 // THEN we expect the file to exists
                 #expect(localFileSystem.exists(coveragePath))
             } when: {
-                (buildData.buildSystem == .swiftbuild && [.windows, .linux].contains(ProcessInfo.hostOperatingSystem))
+                (buildSystem == .swiftbuild && [.windows, .linux].contains(ProcessInfo.hostOperatingSystem))
             }
         }
     }

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -114,12 +114,12 @@ struct PackageRegistryCommandTests {
             .Feature.Command.PackageRegistry.Set,
             .Feature.Command.PackageRegistry.Unset,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func localConfiguration(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -245,12 +245,12 @@ struct PackageRegistryCommandTests {
             .TestSize.large,
             .Feature.Command.PackageRegistry.Set,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func setMissingURL(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -279,12 +279,12 @@ struct PackageRegistryCommandTests {
             .TestSize.large,
             .Feature.Command.PackageRegistry.Set,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func setInvalidURL(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -313,12 +313,12 @@ struct PackageRegistryCommandTests {
             .TestSize.large,
             .Feature.Command.PackageRegistry.Set,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func setInsecureURL(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -347,12 +347,12 @@ struct PackageRegistryCommandTests {
             .TestSize.large,
             .Feature.Command.PackageRegistry.Set,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func setAllowedInsecureURL(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -379,12 +379,12 @@ struct PackageRegistryCommandTests {
             .TestSize.large,
             .Feature.Command.PackageRegistry.Set,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func setInvalidScope(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -416,12 +416,12 @@ struct PackageRegistryCommandTests {
             .Feature.Command.PackageRegistry.Set,
             .Feature.Command.PackageRegistry.Unset,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func unsetMissingEntry(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
             let packageRoot = fixturePath.appending("Bar")
             let configurationFilePath = AbsolutePath(
@@ -474,12 +474,12 @@ struct PackageRegistryCommandTests {
             .TestSize.large,
         ),
         .requiresWorkingDirectorySupport,
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func archiving(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         let observability = ObservabilitySystem.makeForTesting()
 
         let packageIdentity = PackageIdentity.plain("org.package")
@@ -601,12 +601,12 @@ struct PackageRegistryCommandTests {
             .Feature.Command.PackageRegistry.Publish,
         ),
         .requiresWorkingDirectorySupport,
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func publishingToHTTPRegistry(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) throws {
+        let config = BuildConfiguration.debug
 
 
         let packageIdentity = "test.my-package"
@@ -653,12 +653,12 @@ struct PackageRegistryCommandTests {
             .Feature.Command.PackageRegistry.Publish,
         ),
         .requiresWorkingDirectorySupport,
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func publishingToAllowedHTTPRegistry(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         let packageIdentity = "test.my-package"
         let version = "0.1.0"
         let registryURL = "http://packages.example.com"
@@ -748,12 +748,12 @@ struct PackageRegistryCommandTests {
             .TestSize.large,
             .Feature.Command.PackageRegistry.Publish,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func publishingUnsignedPackage(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) throws {
+        let config = BuildConfiguration.debug
         let packageIdentity = "test.my-package"
         let version = "0.1.0"
         let registryURL = "https://packages.example.com"
@@ -916,13 +916,13 @@ struct PackageRegistryCommandTests {
             .TestSize.large,
             .Feature.Command.PackageRegistry.Publish,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func publishingSignedPackage(
         buildSystem: BuildSystemProvider.Kind,
-        config: BuildConfiguration,
     ) async throws {
+        let config = BuildConfiguration.debug
         let observabilityScope = ObservabilitySystem.makeForTesting().topScope
 
         let packageIdentity = "test.my-package"

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -420,11 +420,11 @@ struct RunCommandTests {
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8844", relationship: .verifies),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8911", relationship: .defect),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8912", relationship: .defect),
-        arguments: SupportedBuildSystemOnPlatform, BuildConfiguration.allCases
+        arguments: SupportedBuildSystemOnPlatform, BuildConfiguration.allCases,
     )
     func swiftRunQuietLogLevel(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration
+        configuration: BuildConfiguration,
     ) async throws {
         try await withKnownIssue(isIntermittent: true) {
             // GIVEN we have a simple test package
@@ -449,12 +449,12 @@ struct RunCommandTests {
 
     @Test(
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8844"),
-        arguments: SupportedBuildSystemOnPlatform, BuildConfiguration.allCases
+        arguments: SupportedBuildSystemOnPlatform,
     )
     func swiftRunQuietLogLevelWithError(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration
     ) async throws {
+        let configuration = BuildConfiguration.debug
         // GIVEN we have a simple test package
         try await fixture(name: "Miscellaneous/SwiftRun") { fixturePath in
             let mainFilePath = fixturePath.appending("main.swift")
@@ -471,7 +471,7 @@ struct RunCommandTests {
                 try await executeSwiftRun(
                     fixturePath,
                     nil,
-                    configuration: .debug,
+                    configuration: configuration,
                     extraArgs: ["--quiet"],
                     buildSystem: buildSystem
                 )

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -47,12 +47,12 @@ struct TestCommandTests {
     }
 
     @Test(
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func usage(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         let stdout = try await execute(
             ["-help"],
             configuration: configuration,
@@ -62,12 +62,12 @@ struct TestCommandTests {
     }
 
     @Test(
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func experimentalXunitMessageFailureArgumentIsHidden(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         let stdout = try await execute(
             ["--help"],
             configuration: configuration,
@@ -84,12 +84,12 @@ struct TestCommandTests {
     }
 
     @Test(
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func seeAlso(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         let stdout = try await execute(
             ["--help"],
             configuration: configuration,
@@ -99,12 +99,12 @@ struct TestCommandTests {
     }
 
     @Test(
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func version(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         let stdout = try await execute(
             ["--version"],
             configuration: configuration,
@@ -119,14 +119,13 @@ struct TestCommandTests {
         .tags(
             .Feature.CommandLineArguments.Toolset,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func toolsetRunner(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let buildSystem = buildData.buildSystem
-        let configuration = buildData.config
+
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(
             "Windows: Driver threw unable to load output file map",
             isIntermittent: true
@@ -171,12 +170,12 @@ struct TestCommandTests {
     }
 
     @Test(
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func numWorkersParallelRequirement(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
             let error = await #expect(throws: SwiftPMError.self) {
                 try await execute(
@@ -199,12 +198,12 @@ struct TestCommandTests {
     }
 
     @Test(
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func numWorkersValueSetToZeroRaisesAnError(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
             let error = await #expect(throws: SwiftPMError.self) {
                 try await execute(
@@ -229,12 +228,12 @@ struct TestCommandTests {
         .tags(
             .Feature.TargetType.Executable,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func enableDisableTestabilityDefaultShouldRunWithTestability(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(
             "fails to build the package",
             isIntermittent: true,
@@ -259,12 +258,12 @@ struct TestCommandTests {
             .Feature.TargetType.Executable,
         ),
         .SWBINTTODO("Test currently fails due to 'error: build failed'"),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func enableDisableTestabilityDisabled(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         // disabled
         try await withKnownIssue("fails to build", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
@@ -295,12 +294,12 @@ struct TestCommandTests {
         .tags(
             .Feature.TargetType.Executable,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func enableDisableTestabilityEnabled(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("failes to build the package", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
                 let result = try await execute(
@@ -321,12 +320,12 @@ struct TestCommandTests {
         .tags(
             .Feature.TargetType.Executable,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testableExecutableWithDifferentlyNamedExecutableProduct(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestableExeWithDifferentProductName") { fixturePath in
                 let result = try await execute(
@@ -347,12 +346,12 @@ struct TestCommandTests {
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8479", relationship: .defect),
         .SWBINTTODO("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms"),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func swiftTestParallel_SerialTesting(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
                 // First try normal serial testing.
@@ -385,12 +384,12 @@ struct TestCommandTests {
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8479", relationship: .defect),
         .SWBINTTODO("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms"),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func swiftTestParallel_NoParallelArgument(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
                 // Try --no-parallel.
@@ -421,12 +420,12 @@ struct TestCommandTests {
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8479", relationship: .defect),
         .SWBINTTODO("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms"),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func swiftTestParallel_ParallelArgument(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
                 // Run tests in parallel.
@@ -460,12 +459,12 @@ struct TestCommandTests {
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8479", relationship: .defect),
         .SWBINTTODO("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms"),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func swiftTestParallel_ParallelArgumentWithXunitOutputGeneration(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/ParallelTestsPkg") { fixturePath in
                 let xUnitOutput = fixturePath.appending("result.xml")
@@ -514,12 +513,12 @@ struct TestCommandTests {
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8479", relationship: .defect),
         .SWBINTTODO("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms"),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func swiftTestXMLOutputWhenEmpty(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/EmptyTestsPkg") { fixturePath in
                 let xUnitOutput = fixturePath.appending("result.xml")
@@ -572,118 +571,116 @@ struct TestCommandTests {
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8479", relationship: .defect),
         .SWBINTTODO("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms"),
-        arguments: SupportedBuildSystemOnAllPlatforms.filter { $0 != .xcode }, BuildConfiguration.allCases.map { config in
-            [
-                (
-                    fixtureName: "Miscellaneous/TestSingleFailureXCTest",
-                    testRunner: TestRunner.XCTest,
-                    enableExperimentalFlag: true,
-                    matchesPattern: ["Purposely failing &amp; validating XML espace &quot;'&lt;&gt;"],
-                    configuration: config,
-                    id: "Single XCTest Test Failure Message With Flag Enabled",
-                ),
-                (
-                    fixtureName: "Miscellaneous/TestSingleFailureSwiftTesting",
-                    testRunner: TestRunner.SwiftTesting,
-                    enableExperimentalFlag: true,
-                    matchesPattern: ["Purposely failing &amp; validating XML espace &quot;'&lt;&gt;"],
-                    configuration: config,
-                    id: "Single Swift Testing Test Failure Message With Flag Enabled",
-                ),
-                (
-                    fixtureName: "Miscellaneous/TestSingleFailureXCTest",
-                    testRunner: TestRunner.XCTest,
-                    enableExperimentalFlag: false,
-                    matchesPattern: ["failure"],
-                    configuration: config,
-                    id: "Single XCTest Test Failure Message With Flag Disabled",
-                ),
-                (
-                    fixtureName: "Miscellaneous/TestSingleFailureSwiftTesting",
-                    testRunner: TestRunner.SwiftTesting,
-                    enableExperimentalFlag: false,
-                    matchesPattern: ["Purposely failing &amp; validating XML espace &quot;'&lt;&gt;"],
-                    configuration: config,
-                    id: "Single Swift Testing Test Failure Message With Flag Disabled",
-                ),
-                (
-                    fixtureName: "Miscellaneous/TestMultipleFailureXCTest",
-                    testRunner: TestRunner.XCTest,
-                    enableExperimentalFlag: true,
-                    matchesPattern: [
-                        "Test failure 1",
-                        "Test failure 2",
-                        "Test failure 3",
-                        "Test failure 4",
-                        "Test failure 5",
-                        "Test failure 6",
-                        "Test failure 7",
-                        "Test failure 8",
-                        "Test failure 9",
-                        "Test failure 10",
-                    ],
-                    configuration: config,
-                    id: "Single Multiple Test Failure Message With Flag Enabled",
-                ),
-                (
-                    fixtureName: "Miscellaneous/TestMultipleFailureSwiftTesting",
-                    testRunner: TestRunner.SwiftTesting,
-                    enableExperimentalFlag: true,
-                    matchesPattern: [
-                        "ST Test failure 1",
-                        "ST Test failure 2",
-                        "ST Test failure 3",
-                        "ST Test failure 4",
-                        "ST Test failure 5",
-                        "ST Test failure 6",
-                        "ST Test failure 7",
-                        "ST Test failure 8",
-                        "ST Test failure 9",
-                        "ST Test failure 10",
-                    ],
-                    configuration: config,
-                    id: "Multiple Swift Testing Test Failure Message With Flag Enabled",
-                ),
-                (
-                    fixtureName: "Miscellaneous/TestMultipleFailureXCTest",
-                    testRunner: TestRunner.XCTest,
-                    enableExperimentalFlag: false,
-                    matchesPattern: [
-                        "failure",
-                        "failure",
-                        "failure",
-                        "failure",
-                        "failure",
-                        "failure",
-                        "failure",
-                        "failure",
-                        "failure",
-                        "failure",
-                    ],
-                    configuration: config,
-                    id: "Multiple XCTest Tests Failure Message With Flag Disabled",
-                ),
-                (
-                    fixtureName: "Miscellaneous/TestMultipleFailureSwiftTesting",
-                    testRunner: TestRunner.SwiftTesting,
-                    enableExperimentalFlag: false,
-                    matchesPattern: [
-                        "ST Test failure 1",
-                        "ST Test failure 2",
-                        "ST Test failure 3",
-                        "ST Test failure 4",
-                        "ST Test failure 5",
-                        "ST Test failure 6",
-                        "ST Test failure 7",
-                        "ST Test failure 8",
-                        "ST Test failure 9",
-                        "ST Test failure 10",
-                    ],
-                    configuration: config,
-                    id: "Multiple Swift Testing Tests Failure Message With Flag Disabled",
-                )
-            ]
-        }.flatMap { $0 }
+        arguments: SupportedBuildSystemOnAllPlatforms.filter { $0 != .xcode }, [
+            (
+                fixtureName: "Miscellaneous/TestSingleFailureXCTest",
+                testRunner: TestRunner.XCTest,
+                enableExperimentalFlag: true,
+                matchesPattern: ["Purposely failing &amp; validating XML espace &quot;'&lt;&gt;"],
+                configuration: BuildConfiguration.debug,
+                id: "Single XCTest Test Failure Message With Flag Enabled",
+            ),
+            (
+                fixtureName: "Miscellaneous/TestSingleFailureSwiftTesting",
+                testRunner: TestRunner.SwiftTesting,
+                enableExperimentalFlag: true,
+                matchesPattern: ["Purposely failing &amp; validating XML espace &quot;'&lt;&gt;"],
+                configuration: BuildConfiguration.debug,
+                id: "Single Swift Testing Test Failure Message With Flag Enabled",
+            ),
+            (
+                fixtureName: "Miscellaneous/TestSingleFailureXCTest",
+                testRunner: TestRunner.XCTest,
+                enableExperimentalFlag: false,
+                matchesPattern: ["failure"],
+                configuration: BuildConfiguration.debug,
+                id: "Single XCTest Test Failure Message With Flag Disabled",
+            ),
+            (
+                fixtureName: "Miscellaneous/TestSingleFailureSwiftTesting",
+                testRunner: TestRunner.SwiftTesting,
+                enableExperimentalFlag: false,
+                matchesPattern: ["Purposely failing &amp; validating XML espace &quot;'&lt;&gt;"],
+                configuration: BuildConfiguration.debug,
+                id: "Single Swift Testing Test Failure Message With Flag Disabled",
+            ),
+            (
+                fixtureName: "Miscellaneous/TestMultipleFailureXCTest",
+                testRunner: TestRunner.XCTest,
+                enableExperimentalFlag: true,
+                matchesPattern: [
+                    "Test failure 1",
+                    "Test failure 2",
+                    "Test failure 3",
+                    "Test failure 4",
+                    "Test failure 5",
+                    "Test failure 6",
+                    "Test failure 7",
+                    "Test failure 8",
+                    "Test failure 9",
+                    "Test failure 10",
+                ],
+                configuration: BuildConfiguration.debug,
+                id: "Single Multiple Test Failure Message With Flag Enabled",
+            ),
+            (
+                fixtureName: "Miscellaneous/TestMultipleFailureSwiftTesting",
+                testRunner: TestRunner.SwiftTesting,
+                enableExperimentalFlag: true,
+                matchesPattern: [
+                    "ST Test failure 1",
+                    "ST Test failure 2",
+                    "ST Test failure 3",
+                    "ST Test failure 4",
+                    "ST Test failure 5",
+                    "ST Test failure 6",
+                    "ST Test failure 7",
+                    "ST Test failure 8",
+                    "ST Test failure 9",
+                    "ST Test failure 10",
+                ],
+                configuration: BuildConfiguration.debug,
+                id: "Multiple Swift Testing Test Failure Message With Flag Enabled",
+            ),
+            (
+                fixtureName: "Miscellaneous/TestMultipleFailureXCTest",
+                testRunner: TestRunner.XCTest,
+                enableExperimentalFlag: false,
+                matchesPattern: [
+                    "failure",
+                    "failure",
+                    "failure",
+                    "failure",
+                    "failure",
+                    "failure",
+                    "failure",
+                    "failure",
+                    "failure",
+                    "failure",
+                ],
+                configuration: BuildConfiguration.debug,
+                id: "Multiple XCTest Tests Failure Message With Flag Disabled",
+            ),
+            (
+                fixtureName: "Miscellaneous/TestMultipleFailureSwiftTesting",
+                testRunner: TestRunner.SwiftTesting,
+                enableExperimentalFlag: false,
+                matchesPattern: [
+                    "ST Test failure 1",
+                    "ST Test failure 2",
+                    "ST Test failure 3",
+                    "ST Test failure 4",
+                    "ST Test failure 5",
+                    "ST Test failure 6",
+                    "ST Test failure 7",
+                    "ST Test failure 8",
+                    "ST Test failure 9",
+                    "ST Test failure 10",
+                ],
+                configuration: BuildConfiguration.debug,
+                id: "Multiple Swift Testing Tests Failure Message With Flag Disabled",
+            )
+        ]
     )
     func swiftTestXMLOutputFailureMessage(
         buildSystem: BuildSystemProvider.Kind,
@@ -845,12 +842,12 @@ struct TestCommandTests {
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8479", relationship: .defect),
         .SWBINTTODO("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms"),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func swiftTestFilter(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/SkipTests") { fixturePath in
                 let (stdout, _) = try await execute(
@@ -891,12 +888,12 @@ struct TestCommandTests {
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8479", relationship: .defect),
         .SWBINTTODO("Result XML could not be found. The build fails because of missing test helper generation logic for non-macOS platforms"),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func swiftTestSkip(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/SkipTests") { fixturePath in
                 let (stdout, _) = try await execute(
@@ -966,12 +963,12 @@ struct TestCommandTests {
         ),
         .SWBINTTODO("Fails to find test executable"),
         .issue("https://github.com/swiftlang/swift-package-manager/pull/8722", relationship: .fixedBy),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func enableTestDiscoveryDeprecation(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("Fails to find test executable") {
             let compilerDiagnosticFlags = ["-Xswiftc", "-Xfrontend", "-Xswiftc", "-Rmodule-interface-rebuild"]
             // should emit when LinuxMain is present
@@ -1016,12 +1013,12 @@ struct TestCommandTests {
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func listWithoutBuildingFirst(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("Fails to find test executable") {
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 let (stdout, stderr) = try await execute(
@@ -1054,12 +1051,12 @@ struct TestCommandTests {
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func listBuildFirstThenList(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             // build first
             try await withKnownIssue("Fails to save attachment", isIntermittent: true) {
@@ -1109,12 +1106,12 @@ struct TestCommandTests {
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func listBuildFirstThenListWhileSkippingBuild(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("Failed to find test executable, or getting error: module 'Simple' was not compiled for testing, onMacOS", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 // build first
@@ -1144,12 +1141,12 @@ struct TestCommandTests {
     }
 
     @Test(
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func listWithSkipBuildAndNoBuildArtifacts(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
             let error = await #expect(throws: SwiftPMError.self) {
                 try await execute(
@@ -1176,12 +1173,12 @@ struct TestCommandTests {
             .Feature.TargetType.Executable,
             .Feature.CommandLineArguments.TestEnableSwiftTesting,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func basicSwiftTestingIntegration(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("Fails to find the test executable") {
             try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
                 let (stdout, stderr) = try await execute(
@@ -1206,12 +1203,12 @@ struct TestCommandTests {
         ),
         .skipHostOS(.macOS),  // because this was guarded with `#if !canImport(Darwin)`
         .SWBINTTODO("This is a PIF builder missing GUID problem. Further investigation is needed."),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func generatedMainIsConcurrencySafe_XCTest(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             let strictConcurrencyFlags = ["-Xswiftc", "-strict-concurrency=complete"]
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
@@ -1233,12 +1230,12 @@ struct TestCommandTests {
         ),
         .skipHostOS(.macOS),  // because this was guarded with `#if !canImport(Darwin)`
         .SWBINTTODO("This is a PIF builder missing GUID problem. Further investigation is needed."),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func generatedMainIsExistentialAnyClean(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             let existentialAnyFlags = ["-Xswiftc", "-enable-upcoming-feature", "-Xswiftc", "ExistentialAny"]
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
@@ -1261,12 +1258,12 @@ struct TestCommandTests {
         ),
         .IssueWindowsPathTestsFailures,
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8602", relationship: .defect),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func libraryEnvironmentVariable(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("produces a filepath that is too long, needs investigation", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/CheckTestLibraryEnvironmentVariable") { fixturePath in
                 var extraEnv = Environment()
@@ -1294,12 +1291,12 @@ struct TestCommandTests {
         ),
         .SWBINTTODO("Fails to find test executable"),
         .issue("https://github.com/swiftlang/swift-package-manager/pull/8722", relationship: .fixedBy),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func XCTestOnlyDoesNotLogAboutNoMatchingTests(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("Fails to find test executable",  isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 let (_, stderr) = try await execute(
@@ -1321,12 +1318,12 @@ struct TestCommandTests {
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/6605", relationship: .verifies),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8602", relationship: .defect),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func fatalErrorDisplayedCorrectNumberOfTimesWhenSingleXCTestHasFatalErrorInBuildCompilation(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("Windows path issue", isIntermittent: true) {
             // GIVEN we have a Swift Package that has a fatalError building the tests
             let expected = 1
@@ -1373,12 +1370,12 @@ struct TestCommandTests {
             .tags(
                 .Feature.TargetType.Executable,
             ),
-            arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func testableExecutableWithEmbeddedResources(
             buildSystem: BuildSystemProvider.Kind,
-            configuration: BuildConfiguration,
         ) async throws {
+            let configuration = BuildConfiguration.debug
             try await withKnownIssue(isIntermittent: true) {
                 try await fixture(name: "Miscellaneous/TestableExeWithResources") { fixturePath in
                     let result = try await execute(

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -53,8 +53,7 @@ struct CFamilyTargetTestCase {
             .Feature.Command.Build,
             .Feature.SpecialCharacters,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func cLibraryWithSpaces(
         data: BuildData,
@@ -85,8 +84,7 @@ struct CFamilyTargetTestCase {
         .tags(
             .Feature.Command.Build,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func cUsingCAndSwiftDep(
         data: BuildData,
@@ -121,8 +119,7 @@ struct CFamilyTargetTestCase {
         .tags(
             .Feature.Command.Build,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func moduleMapGenerationCases(
         data: BuildData,
@@ -151,8 +148,7 @@ struct CFamilyTargetTestCase {
         .tags(
             .Feature.Command.Build,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func noIncludeDirCheck(
         data: BuildData,
@@ -181,8 +177,7 @@ struct CFamilyTargetTestCase {
             .Feature.Command.Build,
             .Feature.CommandLineArguments.Xld,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func canForwardExtraFlagsToClang(
         data: BuildData,
@@ -211,8 +206,7 @@ struct CFamilyTargetTestCase {
             .Feature.Command.Build,
             .Feature.Command.Test,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func objectiveCPackageWithTestTarget(
         data: BuildData,
@@ -251,8 +245,7 @@ struct CFamilyTargetTestCase {
         .tags(
             .Feature.Command.Build,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func canBuildRelativeHeaderSearchPaths(
         data: BuildData,

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -37,12 +37,11 @@ struct DependencyResolutionTests {
             Tag.Feature.Command.Build,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
-        BuildConfiguration.allCases,
     )
     func internalSimple(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
                 try await executeSwiftBuild(
@@ -67,12 +66,11 @@ struct DependencyResolutionTests {
             Tag.Feature.Command.Build,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
-        BuildConfiguration.allCases,
     )
     func internalExecAsDep(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "DependencyResolution/Internal/InternalExecutableAsDependency") { fixturePath in
             await withKnownIssue(isIntermittent: true) {
                 await #expect(throws: (any Error).self) {
@@ -95,12 +93,11 @@ struct DependencyResolutionTests {
             Tag.Feature.Command.Build,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
-        BuildConfiguration.allCases,
     )
     func internalComplex(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "DependencyResolution/Internal/Complex") { fixturePath in
                 try await executeSwiftBuild(
@@ -127,12 +124,11 @@ struct DependencyResolutionTests {
             Tag.Feature.Command.Build,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
-        BuildConfiguration.allCases,
     )
     func externalSimple(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
                 // Add several other tags to check version selection.
@@ -169,12 +165,11 @@ struct DependencyResolutionTests {
             Tag.Feature.Command.Build,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
-        BuildConfiguration.allCases,
     )
     func externalComplex(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(
             isIntermittent: ProcessInfo.hostOperatingSystem == .windows
             // rdar://162339964
@@ -206,12 +201,11 @@ struct DependencyResolutionTests {
             Tag.Feature.Command.Build,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
-        BuildConfiguration.allCases,
     )
     func convenienceBranchInit(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "DependencyResolution/External/Branch") { fixturePath in
                 // Tests the convenience init .package(url: , branch: )
@@ -235,12 +229,11 @@ struct DependencyResolutionTests {
             Tag.Feature.Command.Package.Config,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
-        BuildConfiguration.allCases,
     )
     func mirrors(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("https://github.com/swiftlang/swift-build/issues/609", isIntermittent: true) {
             try await fixture(name: "DependencyResolution/External/Mirror") { fixturePath in
                 let prefix = try resolveSymlinks(fixturePath)
@@ -350,12 +343,11 @@ struct DependencyResolutionTests {
             Tag.Feature.Command.Package.Update,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
-        BuildConfiguration.allCases,
     )
     func packageLookupCaseInsensitive(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "DependencyResolution/External/PackageLookupCaseInsensitive") {
             fixturePath in
             try await executeSwiftPackage(

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -32,12 +32,12 @@ struct MacroTests {
         .tags(
             Tag.Feature.Command.Build
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func macrosBasic(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Macros") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(
                 fixturePath.appending("MacroPackage"),

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -32,13 +32,12 @@ struct ModuleAliasingFixtureTests {
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func moduleDirectDeps1(
-        data: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let buildSystem = data.buildSystem
-        let configuration = data.config
+        let configuration = BuildConfiguration.debug
 
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "ModuleAliasing/DirectDeps1") { fixturePath in
@@ -85,13 +84,12 @@ struct ModuleAliasingFixtureTests {
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func moduleDirectDeps2(
-        data: BuildData
+        buildSystem: BuildSystemProvider.Kind
     ) async throws {
-        let buildSystem = data.buildSystem
-        let configuration = data.config
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "ModuleAliasing/DirectDeps2") { fixturePath in
                 let pkgPath = fixturePath.appending(components: "AppPkg")
@@ -136,13 +134,12 @@ struct ModuleAliasingFixtureTests {
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func moduleNestedDeps1(
-        data: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let buildSystem = data.buildSystem
-        let configuration = data.config
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "ModuleAliasing/NestedDeps1") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")
@@ -192,13 +189,12 @@ struct ModuleAliasingFixtureTests {
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func moduleNestedDeps2(
-        data: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let buildSystem = data.buildSystem
-        let configuration = data.config
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "ModuleAliasing/NestedDeps2") { fixturePath in
             let pkgPath = fixturePath.appending(components: "AppPkg")

--- a/Tests/FunctionalTests/ModuleMapTests.swift
+++ b/Tests/FunctionalTests/ModuleMapTests.swift
@@ -54,13 +54,12 @@ struct ModuleMapsTestCase {
     }
 
     @Test(
-        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func directDependency(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let configuration = buildData.config
-        let buildSystem = buildData.buildSystem
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await localFixture(
                 name: "ModuleMaps/Direct",
@@ -90,13 +89,12 @@ struct ModuleMapsTestCase {
 
     @Test(
         .serialized, // crash occurs when executed in parallel. needs investigation
-        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func transitiveDependency(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let configuration = buildData.config
-        let buildSystem = buildData.buildSystem
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await localFixture(
                 name: "ModuleMaps/Transitive",

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1374,17 +1374,18 @@ struct PluginTests {
             .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
             .IssueWindowsRelativePathAssert,
             .requiresSwiftConcurrencySupport,
-            arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func testSnippetSupport(
-            buildData: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws {
+            let config = BuildConfiguration.debug
             try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets") { fixturePath in
                 let (stdout, stderr) = try await executeSwiftPackage(
                     fixturePath,
-                    configuration: buildData.config,
+                    configuration: config,
                     extraArgs: ["do-something"],
-                    buildSystem: buildData.buildSystem,
+                    buildSystem: buildSystem,
                 )
                 #expect(stdout.contains("type of snippet target: snippet"), "stderr:\n\(stderr)")
             }
@@ -1396,30 +1397,31 @@ struct PluginTests {
             .tags(
                 .Feature.Command.Package.CompletionTool,
             ),
-            arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func testBasicBuildSnippets(
-            data: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws {
+            let config = BuildConfiguration.debug
             try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets") { fixturePath in
                 await #expect(throws: Never.self) {
                     let _ = try await executeSwiftBuild(
                         fixturePath,
-                        configuration: data.config,
-                        buildSystem: data.buildSystem,
+                        configuration: config,
+                        buildSystem: buildSystem,
                     )
                 }
 
                 let snippets = try await executeSwiftPackage(
                     fixturePath,
-                    configuration: data.config,
+                    configuration: config,
                     extraArgs: ["completion-tool", "list-snippet"],
-                    buildSystem: data.buildSystem,
+                    buildSystem: buildSystem,
                 ).stdout.split(whereSeparator: \.isNewline)
 
                 for snippet in snippets {
                     try expectFileExists(
-                        at: fixturePath.appending(components: data.buildSystem.binPath(for: data.config) + ["\(snippet)"])
+                        at: fixturePath.appending(components: buildSystem.binPath(for: config) + ["\(snippet)"])
                     )
                 }
             }
@@ -1429,26 +1431,27 @@ struct PluginTests {
             .issue("https://github.com/swiftlang/swift-package-manager/issues/9040", relationship: .verifies),
             .IssueWindowsCannotSaveAttachment,
             .requiresSwiftConcurrencySupport,
-            arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms), try getFiles(in: RelativePath(validating: "Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Snippets"), matchingExtension: "swift",),
+            arguments: SupportedBuildSystemOnAllPlatforms, try getFiles(in: RelativePath(validating: "Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Snippets"), matchingExtension: "swift",),
         )
         func testBasicBuildIndividualSnippets(
-            data: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
             targetPath: RelativePath,
         ) async throws {
+            let config = BuildConfiguration.debug
             try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets") { fixturePath in
                 let targetName = targetPath.basenameWithoutExt
                 await #expect(throws: Never.self) {
                     let _ = try await executeSwiftBuild(
                         fixturePath,
-                        configuration: data.config,
+                        configuration: config,
                         extraArgs: ["--product", targetName],
-                        buildSystem: data.buildSystem,
+                        buildSystem: buildSystem,
                     )
                 }
             }
             } when: {
-                ProcessInfo.hostOperatingSystem == .windows && data.buildSystem == .swiftbuild
+                ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
             }
         }
 
@@ -1456,26 +1459,27 @@ struct PluginTests {
             .issue("https://github.com/swiftlang/swift-package-manager/issues/9040", relationship: .verifies),
             .IssueWindowsCannotSaveAttachment,
             .requiresSwiftConcurrencySupport,
-            arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms), try getFiles(in: RelativePath(validating: "Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Snippets"), matchingExtension: "swift",),
+            arguments: SupportedBuildSystemOnAllPlatforms, try getFiles(in: RelativePath(validating: "Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Snippets"), matchingExtension: "swift",),
         )
         func testBasicRunSnippets(
-            data: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
             targetPath: RelativePath,
         ) async throws {
+            let config = BuildConfiguration.debug
             let targetName = targetPath.basenameWithoutExt
             try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets") { fixturePath in
                 let (stdout, stderr) = try await executeSwiftRun(
                     fixturePath,
                     targetName,
-                    configuration: data.config,
-                    buildSystem: data.buildSystem,
+                    configuration: config,
+                    buildSystem: buildSystem,
                 )
 
                 #expect(stdout.contains("hello, snippets"), "stderr: \(stderr)")
             }
             } when: {
-                [.windows].contains(ProcessInfo.hostOperatingSystem) && data.buildSystem == .swiftbuild
+                [.windows].contains(ProcessInfo.hostOperatingSystem) && buildSystem == .swiftbuild
             }
         }
     }

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -15,6 +15,7 @@ import Basics
 import PackageModel
 import _InternalTestSupport
 import Testing
+import struct SPMBuildCore.BuildSystemProvider
 
 @Suite(
     .tags(
@@ -29,12 +30,12 @@ struct ResourcesTests{
         .tags(
             .Feature.Command.Run,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func simpleResources(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
+        let config = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Resources/Simple") { fixturePath in
                 var executables = ["SwiftyResource"]
@@ -49,8 +50,8 @@ struct ResourcesTests{
                     let (output, _) = try await executeSwiftRun(
                         fixturePath,
                         execName,
-                        configuration: buildData.config,
-                        buildSystem: buildData.buildSystem,
+                        configuration: config,
+                        buildSystem: buildSystem,
                     )
                     #expect(output.contains("foo"))
                 }
@@ -64,14 +65,12 @@ struct ResourcesTests{
         .tags(
             .Feature.Command.Build,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func localizedResources(
-        buildData: BuildData
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let configuration = buildData.config
-        let buildSystem = buildData.buildSystem
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Resources/Localized") { fixturePath in
             try await executeSwiftBuild(
                 fixturePath,
@@ -98,19 +97,19 @@ struct ResourcesTests{
         .tags(
             .Feature.Command.Build,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func resourcesInMixedClangPackage(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Resources/Simple") { fixturePath in
             try await withKnownIssue(isIntermittent: true) {
                 try await executeSwiftBuild(
                     fixturePath,
-                    configuration: buildData.config,
+                    configuration: configuration,
                     extraArgs: ["--target", "MixedClangResource"],
-                    buildSystem: buildData.buildSystem,
+                    buildSystem: buildSystem,
                 )
             } when: {
                 [.windows, .linux].contains(ProcessInfo.hostOperatingSystem) // Test was originally enabled on macOS only
@@ -122,14 +121,12 @@ struct ResourcesTests{
         .tags(
             .Feature.Command.Build,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func movedBinaryResources(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let configuration = buildData.config
-        let buildSystem = buildData.buildSystem
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Resources/Moved") { fixturePath in
                 var executables = ["SwiftyResource"]
@@ -188,20 +185,19 @@ struct ResourcesTests{
         .tags(
             .Feature.Command.Build,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
-
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func swiftResourceAccessorDoesNotCauseInconsistentImportWarning(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Resources/FoundationlessClient/UtilsWithFoundationPkg") { fixturePath in
             try await withKnownIssue(isIntermittent: true) {
                 try await executeSwiftBuild(
                     fixturePath,
-                    configuration: buildData.config,
+                    configuration: configuration,
                     Xswiftc: ["-warnings-as-errors"],
-                    buildSystem: buildData.buildSystem,
+                    buildSystem: buildSystem,
                 )
             } when: {
                 // fails on native and SwiftBuild
@@ -216,18 +212,18 @@ struct ResourcesTests{
         .tags(
             .Feature.Command.Test,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments:buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func resourceBundleInClangPackageWhenRunningSwiftTest(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Resources/Simple") { fixturePath in
             try await executeSwiftTest(
                 fixturePath,
-                configuration: buildData.config,
+                configuration: configuration,
                 extraArgs: ["--filter", "ClangResourceTests"],
-                buildSystem: buildData.buildSystem,
+                buildSystem: buildSystem,
             )
         }
     }
@@ -238,14 +234,12 @@ struct ResourcesTests{
         .tags(
             .Feature.Command.Build,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func resourcesEmbeddedInCode(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let configuration = buildData.config
-        let buildSystem = buildData.buildSystem
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue {
             try await fixture(name: "Resources/EmbedInCodeSimple") { fixturePath in
                 let execPath = try fixturePath.appending(components: buildSystem.binPath(for: configuration) + [executableName("EmbedInCodeSimple")])
@@ -285,14 +279,12 @@ struct ResourcesTests{
             .Feature.Command.Test,
         ),
         // .issue("", relationship: .defect),  TODO: Create GitHub issue
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func resourcesOutsideOfTargetCanBeIncluded(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let configuration = buildData.config
-        let buildSystem = buildData.buildSystem
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue {
             try await testWithTemporaryDirectory { tmpPath in
                 let packageDir = tmpPath.appending(components: "MyPackage")

--- a/Tests/FunctionalTests/StaticBinaryLibrary.swift
+++ b/Tests/FunctionalTests/StaticBinaryLibrary.swift
@@ -15,6 +15,7 @@ import PackageModel
 import TSCBasic
 import Testing
 import _InternalTestSupport
+import struct SPMBuildCore.BuildSystemProvider
 
 struct StaticBinaryLibraryTests {
     @Test(
@@ -26,19 +27,18 @@ struct StaticBinaryLibraryTests {
             .Feature.TargetType.Library,
             .Feature.TargetType.BinaryTarget.ArtifactBundle,
         ),
-        buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-        arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func staticLibrary(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         try await fixture(name: "BinaryLibraries") { fixturePath in
             let (stdout, _) = try await executeSwiftRun(
                 fixturePath.appending("Static").appending("Package1"),
                 "Example",
-                configuration: buildData.config,
+                configuration: .debug,
                 extraArgs: ["--experimental-prune-unused-dependencies"],
-                buildSystem: buildData.buildSystem,
+                buildSystem: buildSystem,
             )
             #expect(stdout == """
             42

--- a/Tests/FunctionalTests/ToolsVersionTests.swift
+++ b/Tests/FunctionalTests/ToolsVersionTests.swift
@@ -33,13 +33,12 @@ struct ToolsVersionTests {
             .Feature.Command.Package.ToolsVersion,
             .Feature.ProductType.Library,
         ),
-        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func toolsVersion(
-        buildData: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        let buildSystem = buildData.buildSystem
-        let configuration = buildData.config
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("https://github.com/swiftlang/swift-build/issues/609", isIntermittent: true) {
             try await testWithTemporaryDirectory{ path in
                 let fs = localFileSystem

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -34,12 +34,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func traits_whenNoFlagPassed(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, stderr) = try await executeSwiftRun(
@@ -74,12 +74,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func traits_whenTraitUnification(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(
             """
             Windows: "https://github.com/swiftlang/swift-build/issues/609"
@@ -125,12 +125,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func traits_whenTraitUnification_whenSecondTraitNotEnabled(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(
             """
             Windows: https://github.com/swiftlang/swift-build/issues/609
@@ -173,12 +173,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func traits_whenIndividualTraitsEnabled_andDefaultTraits(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(
             """
             Windows: https://github.com/swiftlang/swift-build/issues/609
@@ -225,12 +225,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func traits_whenDefaultTraitsDisabled(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, stderr) = try await executeSwiftRun(
@@ -262,12 +262,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func traits_whenIndividualTraitsEnabled_andDefaultTraitsDisabled(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue("""
             Windows: https://github.com/swiftlang/swift-build/issues/609
             """,
@@ -306,12 +306,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func traits_whenAllTraitsEnabled(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(
             """
             Windows: https://github.com/swiftlang/swift-build/issues/609
@@ -361,12 +361,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func traits_whenAllTraitsEnabled_andDefaultTraitsDisabled(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(
             """
             Windows: https://github.com/swiftlang/swift-build/issues/609
@@ -416,12 +416,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Package.DumpPackage,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func traits_dumpPackage(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Traits") { fixturePath in
             let packageRoot = fixturePath.appending("Example")
             let (dumpOutput, _) = try await executeSwiftPackage(
@@ -443,12 +443,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Test,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func tests_whenNoFlagPassed(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "Traits") { fixturePath in
             let (stdout, _) = try await executeSwiftTest(
@@ -478,12 +478,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Test,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func tests_whenAllTraitsEnabled_andDefaultTraitsDisabled(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(
             """
             Windows: "https://github.com/swiftlang/swift-build/issues/609"
@@ -528,12 +528,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Package.DumpSymbolGraph,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func packageDumpSymbolGraph_enablesAllTraits(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Traits") { fixturePath in
                 let (stdout, _) = try await executeSwiftPackage(
@@ -563,12 +563,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Package.Plugin,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func packagePluginGetSymbolGraph_enablesAllTraits(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
         ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Traits") { fixturePath in
                 // The swiftbuild build system doesn't yet have the ability for command plugins to request symbol graphs
@@ -606,12 +606,12 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func packageDisablingDefaultsTrait_whenNoTraits(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await fixture(name: "Traits") { fixturePath in
             let error = await #expect(throws: SwiftPMError.self) {
                 try await executeSwiftRun(
@@ -640,8 +640,7 @@ struct TraitTests {
         .tags(
             Tag.Feature.Command.Run,
         ),
-        arguments:
-        getBuildData(for: SupportedBuildSystemOnAllPlatforms),
+        arguments: SupportedBuildSystemOnAllPlatforms,
         getTraitCombinations(
             ("ExtraTrait",
             """
@@ -649,7 +648,7 @@ struct TraitTests {
             DEFINE1 disabled
             DEFINE2 disabled
             DEFINE3 disabled
-            
+
             """
             ),
             ("Package10",
@@ -660,7 +659,7 @@ struct TraitTests {
             DEFINE1 disabled
             DEFINE2 disabled
             DEFINE3 disabled
-            
+
             """
             ),
             ("ExtraTrait,Package10",
@@ -672,15 +671,16 @@ struct TraitTests {
             DEFINE1 disabled
             DEFINE2 disabled
             DEFINE3 disabled
-            
+
             """
             )
         )
     )
     func traits_whenManyTraitsEnableTargetDependency(
-        data: BuildData,
+        buildSystem: BuildSystemProvider.Kind,
         traits: TraitArgumentData
     ) async throws {
+        let config = BuildConfiguration.debug
         try await withKnownIssue(
             """
             Windows: https://github.com/swiftlang/swift-build/issues/609
@@ -694,15 +694,15 @@ struct TraitTests {
                 let (stdout, stderr) = try await executeSwiftRun(
                     fixturePath.appending("Example"),
                     "Example",
-                    configuration: data.config,
+                    configuration: config,
                     extraArgs: ["--traits", traits.traitsArgument],
-                    buildSystem: data.buildSystem,
+                    buildSystem: buildSystem,
                 )
                 #expect(!stderr.contains(unusedDependencyRegex))
                 #expect(stdout == traits.expectedOutput)
             }
         } when: {
-            (ProcessInfo.hostOperatingSystem == .windows && (CiEnvironment.runningInSmokeTestPipeline || data.buildSystem == .swiftbuild))
+            (ProcessInfo.hostOperatingSystem == .windows && (CiEnvironment.runningInSmokeTestPipeline || buildSystem == .swiftbuild))
         }
     }
 }

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -33,12 +33,12 @@ struct VersionSpecificTests {
             .Feature.Command.Package.Reset,
             .Feature.Version,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms, BuildConfiguration.allCases,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func endToEndResolution(
         buildSystem: BuildSystemProvider.Kind,
-        configuration: BuildConfiguration,
     ) async throws {
+        let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) { // Test passed on Windows at-desk
         try await testWithTemporaryDirectory{ path in
             let fs = localFileSystem

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -78,14 +78,12 @@ struct InitTests {
             .tags(
                 .Feature.Command.Build,
             ),
-            buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-            arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func initPackageExecutable(
-            buildData: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws  {
-            let buildSystem = buildData.buildSystem
-            let configuration = buildData.config
+            let configuration = BuildConfiguration.debug
             try await testWithTemporaryDirectory { tmpPath in
                 let fs = localFileSystem
                 let path = tmpPath.appending("Foo")
@@ -145,14 +143,12 @@ struct InitTests {
             .tags(
                 .Feature.Command.Build,
             ),
-            buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-            arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func initPackageExecutableCalledMain(
-            buildData: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws {
-            let buildSystem = buildData.buildSystem
-            let configuration = buildData.config
+            let configuration = BuildConfiguration.debug
             try await testWithTemporaryDirectory { tmpPath in
                 let fs = localFileSystem
                 let path = tmpPath.appending("main")
@@ -182,14 +178,12 @@ struct InitTests {
             .tags(
                 .Feature.Command.Build,
             ),
-            buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-            arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func initPackageLibraryWithXCTestOnly(
-            buildData: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws {
-            let buildSystem = buildData.buildSystem
-            let configuration = buildData.config
+            let configuration = BuildConfiguration.debug
             try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpPath in
                 let fs = localFileSystem
                 let path = tmpPath.appending("Foo")
@@ -259,15 +253,12 @@ struct InitTests {
             .tags(
                 .Feature.Command.Build,
             ),
-            buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-            arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func initPackageLibraryWithSwiftTestingOnly(
-            buildData: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws  {
-
-            let buildSystem = buildData.buildSystem
-            let configuration = buildData.config
+            let configuration = BuildConfiguration.debug
             try withTemporaryDirectory { tmpPath in
                 let fs = localFileSystem
                 let path = tmpPath.appending("Foo")
@@ -312,14 +303,12 @@ struct InitTests {
             .tags(
                 .Feature.Command.Build,
             ),
-            buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-            arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func initPackageLibraryWithBothSwiftTestingAndXCTest(
-            buildData: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws  {
-            let buildSystem = buildData.buildSystem
-            let configuration = buildData.config
+            let configuration = BuildConfiguration.debug
             try withTemporaryDirectory { tmpPath in
                 let fs = localFileSystem
                 let path = tmpPath.appending("Foo")
@@ -364,14 +353,12 @@ struct InitTests {
             .tags(
                 .Feature.Command.Build,
             ),
-            buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-            arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func initPackageLibraryWithNoTests(
-            buildData: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws {
-            let buildSystem = buildData.buildSystem
-            let configuration = buildData.config
+            let configuration = BuildConfiguration.debug
             try withTemporaryDirectory { tmpPath in
                 let fs = localFileSystem
                 let path = tmpPath.appending("Foo")
@@ -416,14 +403,12 @@ struct InitTests {
             .tags(
                 .Feature.Command.Build,
             ),
-            buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-            arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func initPackageNonc99Directory(
-            buildData: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws {
-            let buildSystem = buildData.buildSystem
-            let configuration = buildData.config
+            let configuration = BuildConfiguration.debug
             try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
                 expectDirectoryExists(at: tempDirPath)
 
@@ -469,15 +454,12 @@ struct InitTests {
             .tags(
                 .Feature.Command.Build,
             ),
-            buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-            buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.tags,
-            arguments: buildDataUsingBuildSystemAvailableOnAllPlatformsWithTags.buildData,
+            arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func nonC99NameExecutablePackage(
-            buildData: BuildData,
+            buildSystem: BuildSystemProvider.Kind,
         ) async throws {
-            let buildSystem = buildData.buildSystem
-            let configuration = buildData.config
+            let configuration = BuildConfiguration.debug
             try await withTemporaryDirectory(removeTreeOnDeinit: true) { tempDirPath in
                 expectDirectoryExists(at: tempDirPath)
 


### PR DESCRIPTION
The SwiftPM test execution time is long as many large tests run against a cross matrix of build systems and build configuration.  To reduce the test execution time, update the tests to execute against the `release` build configuration only on select tests.
