### PR TITLE
GHA: Update windows build timeout

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,6 +33,7 @@ jobs:
       linux_pre_build_command: ./.github/scripts/prebuild.sh
       linux_build_command: 'swift run --build-system ${{ matrix.executableTargetBuildSystem }} swift-build --build-tests --build-system ${{ matrix.buildSystem}}'
       # linux_build_command: 'swift run --build-system ${{ matrix.executableTargetBuildSystem }} swift-build --build-tests --build-system ${{ matrix.buildSystem}} && swift run --build-system ${{ matrix.executableTargetBuildSystem }} swift-test --parallel --build-system ${{ matrix.buildSystem}}'
+      windows_build_timeout: 180
       windows_swift_versions: '["nightly-main"]'
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1'
       windows_build_command: 'Invoke-Program swift run -Xlinker /ignore:4217 --configuration release --build-system ${{ matrix.executableTargetBuildSystem }} swift-build --build-tests -Xlinker /ignore:4217 --build-system ${{ matrix.buildSystem}}'
@@ -61,6 +62,7 @@ jobs:
       linux_pre_build_command: ./.github/scripts/prebuild.sh
       linux_build_command: 'swift run --build-system ${{ matrix.executableTargetBuildSystem }} swift-build --build-tests --build-system ${{ matrix.buildSystem }}'
       enable_windows_checks: false
+      windows_build_timeout: 180
       windows_swift_versions: '["nightly-main"]'
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1'
       windows_build_command: 'Invoke-Program swift run --build-system ${{ matrix.executableTargetBuildSystem }} swift-build --build-tests --build-system ${{ matrix.buildSystem }}'


### PR DESCRIPTION
The windows GitHub actions workflows has a timeout defaut of 1 hours. Update the Windows build timeout to 180 minutes - 3 hours.