### PR TITLE
Ensure that the minimum deployment target for a test target is at least that of _both_ XCTest and Swift Testing.

### DIFF
--- a/Sources/PackageModel/MinimumDeploymentTarget.swift
+++ b/Sources/PackageModel/MinimumDeploymentTarget.swift
@@ -60,20 +60,10 @@ public struct MinimumDeploymentTarget {
 
     /// Temporary hard-coded minimum deployment targets for test targets.
     static func absoluteXCTestMinimumDeploymentTarget(platform: PackageModel.Platform) -> PlatformVersion? {
-        switch platform {
-        case .macOS:
-            PlatformVersion("14.0")
-        case .iOS:
-            PlatformVersion("17.0")
-        case .watchOS:
-            PlatformVersion("10.0")
-        case .tvOS:
-            PlatformVersion("17.0")
-        case .visionOS:
-            PlatformVersion("1.0")
-        default:
-            nil
+        if platform == .macOS {
+            return PlatformVersion("14.0")
         }
+        return nil
     }
 
     static func computeXCTestMinimumDeploymentTarget(with runResult: AsyncProcessResult, platform: PackageModel.Platform) throws -> PlatformVersion? {


### PR DESCRIPTION
This PR changes the logic SwiftPM uses when bumping the minimum deployment target of a package so that it takes into account both XCTest and Swift Testing, not just XCTest.

I have no new unit test for this because the only practical unit test is just tautological. Existing test coverage should ensure this doesn't break builds outright. Will be doing a full toolchain build to verify this change alongside https://github.com/swiftlang/swift/pull/87042 and https://github.com/swiftlang/swift-testing/pull/1533.