### PR TITLE
Fix containsAtMain to detect @main after */ on same line

### DIFF
--- a/Sources/SPMBuildCore/MainAttrDetection.swift
+++ b/Sources/SPMBuildCore/MainAttrDetection.swift
@@ -28,8 +28,15 @@ package func containsAtMain(fileSystem: FileSystem, path: AbsolutePath) throws -
         if line.hasPrefix("/*") {
             multilineComment = true
         }
-        if line.hasSuffix("*/") {
+        if line.contains("*/") {
             multilineComment = false
+            // Comment may end mid-line; check remainder for @main (e.g. "*/ @main")
+            if let endIndex = line.range(of: "*/")?.upperBound, endIndex < line.endIndex {
+                let afterComment = line[endIndex...].trimmingCharacters(in: .whitespaces)
+                if afterComment.hasPrefix("@main") {
+                    return true
+                }
+            }
         }
         if multilineComment {
             continue

--- a/Tests/SPMBuildCoreTests/MainAttrDetectionTests.swift
+++ b/Tests/SPMBuildCoreTests/MainAttrDetectionTests.swift
@@ -250,7 +250,7 @@ struct MainAttrDetectionTests {
                 fileContent: """
                 /*
                 This is a multi-line comment
-                /* @main
+                */ @main
                 struct MyApp {
                     static func main() {
                         print("Hello, World!")
@@ -258,7 +258,7 @@ struct MainAttrDetectionTests {
                 }
                 """,
                 expected: true,
-                knownIssue: true,
+                knownIssue: false,
                 id: "Multi-line comment end on a line containing @main",
             )
         ],


### PR DESCRIPTION
Fix containsAtMain handling of @main following block comments

Motivation

containsAtMain fails to detect @main when a block comment ends mid-line and the annotation appears after the closing */. In this case, the remainder of the line is not scanned, causing valid @main declarations to be missed.

This affects otherwise valid Swift sources that place @main after a block comment terminator on the same line.

Modifications

Updated containsAtMain to continue scanning the remainder of a line after a block comment ends.

Added a regression test covering @main appearing on the same line as a block comment terminator.

Result

@main is now correctly detected when it appears after */ on the same line, with no change to existing behavior in other cases.