### PR TITLE
[6.3] Fix pkg-config path lookup on non-macOS platforms when using Swift Build

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -414,6 +414,7 @@ public final class PIFBuilder {
                 materializeStaticArchiveProductsForRootPackages: self.parameters.materializeStaticArchiveProductsForRootPackages,
                 addLocalRpaths: self.parameters.addLocalRpaths,
                 packageDisplayVersion: package.manifest.displayName,
+                pkgConfigDirectories: self.parameters.pkgConfigDirectories,
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope
             )

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -185,6 +185,8 @@ public final class PackagePIFBuilder {
     /// Package display version, if any (i.e., it can be a version, branch or a git ref).
     let packageDisplayVersion: String?
 
+    let pkgConfigDirectories: [AbsolutePath]
+
     /// The file system to read from.
     let fileSystem: FileSystem
 
@@ -212,6 +214,7 @@ public final class PackagePIFBuilder {
         materializeStaticArchiveProductsForRootPackages: Bool = false,
         addLocalRpaths: Bool = true,
         packageDisplayVersion: String?,
+        pkgConfigDirectories: [AbsolutePath],
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
     ) {
@@ -223,6 +226,7 @@ public final class PackagePIFBuilder {
         self.createDylibForDynamicProducts = createDylibForDynamicProducts
         self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
         self.packageDisplayVersion = packageDisplayVersion
+        self.pkgConfigDirectories = pkgConfigDirectories
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.addLocalRpaths = addLocalRpaths
@@ -238,6 +242,7 @@ public final class PackagePIFBuilder {
         materializeStaticArchiveProductsForRootPackages: Bool = false,
         addLocalRpaths: Bool = true,
         packageDisplayVersion: String?,
+        pkgConfigDirectories: [AbsolutePath],
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
     ) {
@@ -250,6 +255,7 @@ public final class PackagePIFBuilder {
         self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
         self.addLocalRpaths = addLocalRpaths
         self.packageDisplayVersion = packageDisplayVersion
+        self.pkgConfigDirectories = pkgConfigDirectories
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
     }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -867,6 +867,7 @@ extension PackagePIFProjectBuilder {
         let settings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
         let pkgConfig = try systemLibrary.pkgConfig(
             package: self.package,
+            pkgConfigDirectories: self.pifBuilder.pkgConfigDirectories,
             fileSystem: self.pifBuilder.fileSystem,
             observabilityScope: pifBuilder.observabilityScope
         )


### PR DESCRIPTION
Explanation:
Ensure we don't attempt to pass a homebrew prefix on linux, where it will cause us to fail the tool lookup.

Closes https://github.com/swiftlang/swift-package-manager/issues/9630

Scope: Packages with system library targets built on non-Darwin platforms
Original PRs: [#9650](https://github.com/swiftlang/swift-package-manager/pull/9650)](https://github.com/swiftlang/swift-package-manager/pull/9682)
Risk: Low, the change is narrow in scope (png-config path lookup).
Testing: Updated automated tests
Reviewers: [@dschaefer2](https://github.com/dschaefer2)