### PR TITLE
Unset DEVELOPER_DIR in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,9 @@
         "--security-opt",
         "seccomp=unconfined"
     ],
+    "remoteEnv": {
+        "DEVELOPER_DIR": null
+    },
     "customizations": {
         "vscode": {
             "settings": {


### PR DESCRIPTION
When launching the Linux devcontainer on macOS its possible to have a DEVELOPER_DIR env var set, which doesn't apply to the Linux devcontainer. However it will confuse the VS Code Swift extension, so simply unset it.
