### PR TITLE
Tests: Remove withKnownIssue in a few test suites

### DIFF
--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -123,15 +123,12 @@ struct RunCommandTests {
             #expect(stdout.contains("sentinel"))
 
             // swift-build-tool output should go to stderr.
-            withKnownIssue {
-                #expect(stderr.contains("Compiling"))
-            } when: {
-                buildSystem == .swiftbuild
-            }
-            withKnownIssue {
-                #expect(stderr.contains("Linking"))
-            } when: {
-                buildSystem == .swiftbuild
+            switch buildSystem {
+                case .native:
+                    #expect(stderr.contains("Compiling"))
+                    #expect(stderr.contains("Linking"))
+                case .swiftbuild, .xcode:
+                    break
             }
         }
     }
@@ -140,8 +137,6 @@ struct RunCommandTests {
          .tags(
             .Feature.TargetType.Executable,
         ),
-        .IssueWindowsPathTestsFailures,
-        .IssueWindowsRelativePathAssert,
         arguments: SupportedBuildSystemOnPlatform,
     )
     func productArgumentPassing(
@@ -160,21 +155,17 @@ struct RunCommandTests {
                 """))
 
             // swift-build-tool output should go to stderr.
-            withKnownIssue {
-                #expect(stderr.contains("Compiling"))
-            } when: {
-                buildSystem == .swiftbuild
-            }
-            withKnownIssue {
-                #expect(stderr.contains("Linking"))
-            } when: {
-                buildSystem == .swiftbuild
+            switch buildSystem {
+                case .native:
+                    #expect(stderr.contains("Compiling"))
+                    #expect(stderr.contains("Linking"))
+                case .swiftbuild, .xcode:
+                    break
             }
         }
     }
 
     @Test(
-        .SWBINTTODO("Swift run using Swift Build does not output executable content to the terminal"),
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8279"),
         arguments: SupportedBuildSystemOnPlatform,
     )

--- a/Tests/IntegrationTests/BasicTests.swift
+++ b/Tests/IntegrationTests/BasicTests.swift
@@ -190,11 +190,10 @@ private struct BasicTests {
             // Create a new package with an executable target.
             let packagePath = tempDir.appending(component: "Project")
             try localFileSystem.createDirectory(packagePath)
-            await withKnownIssue("error: no tests found; create a target in the 'Tests' directory") {
                 try await executeSwiftPackage(
                     packagePath,
                     configuration: config,
-                    extraArgs: ["init", "--type", "library"],
+                    extraArgs: ["init", "--type", "library", "--enable-xctest", "--enable-swift-testing"],
                     buildSystem: buildSystem,
                 )
                 let packageOutput = try await executeSwiftTest(
@@ -205,22 +204,12 @@ private struct BasicTests {
                 )
 
                 // Check the test log.
-                switch buildSystem {
-                    case .native:
-                        let compilingRegex = try Regex("Compiling .*ProjectTests.*")
-                        #expect(packageOutput.stderr.contains(compilingRegex), "stdout: '\(packageOutput.stdout)'\n stderr:'\(packageOutput.stderr)'")
-                    case .swiftbuild:
-                        break
-                    case .xcode:
-                        Issue.record("Test configuration error.  Test backend is not meant to be tested.")
-
-                }
-                #expect(packageOutput.stdout.contains("Executed 1 test"), "stdout: '\(packageOutput.stdout)'\n stderr:'\(packageOutput.stderr)'")
+                #expect(packageOutput.stdout.contains("Executed 1 test"), "stdout: '\(packageOutput.stdout)'\n\n\n stderr:'\(packageOutput.stderr)'")
+                #expect(packageOutput.stdout.contains("Test run with 1 test"), "stdout: '\(packageOutput.stdout)'\n\n\n stderr:'\(packageOutput.stderr)'")
 
                 // Check there were no compile errors or warnings.
                 #expect(!packageOutput.stdout.contains("error"))
                 #expect(!packageOutput.stdout.contains("warning"))
-            }
         }
     }
 


### PR DESCRIPTION
Remove `withKnownIssue` code blocks there were added in test found wthin multiple test suites (`BuildCommandTests`, `PackageCommandTests`, `RunCommandTests`, `BasicTests`).

Issue: rdar://159459559
Depends on #9702