### PR TITLE
Bump swift-syntax in template to 603.0.0-latest

### DIFF
--- a/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
+++ b/Sources/PackageModel/InstalledSwiftPMConfiguration.swift
@@ -37,7 +37,7 @@ public struct InstalledSwiftPMConfiguration {
         return .init(
             version: 0,
             swiftSyntaxVersionForMacroTemplate: .init(
-                major: 602,
+                major: 603,
                 minor: 0,
                 patch: 0,
                 prereleaseIdentifier: "latest"

--- a/Utilities/config.json
+++ b/Utilities/config.json
@@ -1,3 +1,3 @@
 {"version":1,
-  "swiftSyntaxVersionForMacroTemplate":{"major":602,"minor":0,"patch":0, "prereleaseIdentifier":"latest"},
+  "swiftSyntaxVersionForMacroTemplate":{"major":603,"minor":0,"patch":0, "prereleaseIdentifier":"latest"},
   "swiftTestingVersionForTestTemplate":{"major":0,"minor":8,"patch":0}}


### PR DESCRIPTION
swift package init --type macro generates a manifest that still points to swift-syntax version 6.0.2 although main has moved on to 6.0.3.

Motivation:

swift package init --type macro is outdated

Modifications:

Modified config.json that is shipped as part of the SDK and version provided by InstalledSwiftPMConfiguration