### PR TITLE
[Commands] Set `ApproachableConcurrency` in new package templates

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -315,7 +315,10 @@ public final class InitPackage {
                         testTarget = """
                                 .testTarget(
                                     name: "\(moduleName)Tests",
-                                    dependencies: ["\(moduleName)"]
+                                    dependencies: ["\(moduleName)"],
+                                    swiftSettings: [
+                                        .enableUpcomingFeature("ApproachableConcurrency"),
+                                    ],
                                 ),
                         """
                     } else {
@@ -323,7 +326,10 @@ public final class InitPackage {
                     }
                     param += """
                             .executableTarget(
-                                name: "\(moduleName)"
+                                name: "\(moduleName)",
+                                swiftSettings: [
+                                    .enableUpcomingFeature("ApproachableConcurrency"),
+                                ],
                             ),
                     \(testTarget)
                         ]
@@ -334,7 +340,10 @@ public final class InitPackage {
                         testTarget = """
                                 .testTarget(
                                     name: "\(moduleName)Tests",
-                                    dependencies: ["\(moduleName)"]
+                                    dependencies: ["\(moduleName)"],
+                                    swiftSettings: [
+                                        .enableUpcomingFeature("ApproachableConcurrency"),
+                                    ],
                                 ),
                         """
                     } else {
@@ -345,7 +354,10 @@ public final class InitPackage {
                                 name: "\(moduleName)",
                                 dependencies: [
                                     .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                                ]
+                                ],
+                                swiftSettings: [
+                                    .enableUpcomingFeature("ApproachableConcurrency"),
+                                ],
                             ),
                     \(testTarget)
                         ]
@@ -393,7 +405,10 @@ public final class InitPackage {
                                     dependencies: [
                                         "\(moduleName)Macros",
                                         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-                                    ]
+                                    ],
+                                    swiftSettings: [
+                                        .enableUpcomingFeature("ApproachableConcurrency"),
+                                    ],
                                 ),
                         """
                     } else {
@@ -410,10 +425,22 @@ public final class InitPackage {
                             ),
 
                             // Library that exposes a macro as part of its API, which is used in client programs.
-                            .target(name: "\(moduleName)", dependencies: ["\(moduleName)Macros"]),
+                            .target(
+                                name: "\(moduleName)", 
+                                dependencies: ["\(moduleName)Macros"],
+                                swiftSettings: [
+                                    .enableUpcomingFeature("ApproachableConcurrency"),
+                                ],
+                            ),
 
                             // A client of the library, which is able to use the macro in its own code.
-                            .executableTarget(name: "\(moduleName)Client", dependencies: ["\(moduleName)"]),
+                            .executableTarget(
+                                name: "\(moduleName)Client", 
+                                dependencies: ["\(moduleName)"],
+                                swiftSettings: [
+                                    .enableUpcomingFeature("ApproachableConcurrency"),
+                                ],
+                            ),
                     \(testTarget)
                         ]
                     """
@@ -423,7 +450,10 @@ public final class InitPackage {
                         testTarget = """
                                 .testTarget(
                                     name: "\(moduleName)Tests",
-                                    dependencies: ["\(moduleName)"]
+                                    dependencies: ["\(moduleName)"],
+                                    swiftSettings: [
+                                        .enableUpcomingFeature("ApproachableConcurrency"),
+                                    ],
                                 ),
                         """
                     } else {
@@ -432,7 +462,10 @@ public final class InitPackage {
 
                     param += """
                             .target(
-                                name: "\(moduleName)"
+                                name: "\(moduleName)",
+                                swiftSettings: [
+                                    .enableUpcomingFeature("ApproachableConcurrency"),
+                                ],
                             ),
                     \(testTarget)
                         ]

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -2040,6 +2040,8 @@ struct PackageCommandTests {
                 )
 
                 let manifest = path.appending("Package.swift")
+                expectFileExists(at: manifest)
+
                 let contents: String = try localFileSystem.readFileContents(manifest)
                 let version = InitPackage.newPackageToolsVersion
                 let versionSpecifier = "\(version.major).\(version.minor)"
@@ -2048,6 +2050,7 @@ struct PackageCommandTests {
                         "// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"
                     )
                 )
+                #expect(contents.contains(#".enableUpcomingFeature("ApproachableConcurrency")"#))
 
                 expectFileExists(at: manifest)
                 #expect(
@@ -2077,7 +2080,12 @@ struct PackageCommandTests {
                     buildSystem: buildSystem,
                 )
 
-                expectFileExists(at: path.appending("Package.swift"))
+                let manifest = path.appending("Package.swift")
+                expectFileExists(at: manifest)
+
+                let contents: String = try localFileSystem.readFileContents(manifest)
+                #expect(contents.contains(#".enableUpcomingFeature("ApproachableConcurrency")"#))
+
                 #expect(
                     try fs.getDirectoryContents(path.appending("Sources").appending("Foo")) == ["Foo.swift"]
                 )
@@ -2108,6 +2116,8 @@ struct PackageCommandTests {
                 )
 
                 let manifest = path.appending("Package.swift")
+                expectFileExists(at: manifest)
+
                 let contents: String = try localFileSystem.readFileContents(manifest)
                 let version = InitPackage.newPackageToolsVersion
                 let versionSpecifier = "\(version.major).\(version.minor)"
@@ -2116,8 +2126,8 @@ struct PackageCommandTests {
                         "// swift-tools-version:\(version < .v5_4 ? "" : " ")\(versionSpecifier)\n"
                     )
                 )
+                #expect(contents.contains(#".enableUpcomingFeature("ApproachableConcurrency")"#))
 
-                expectFileExists(at: manifest)
                 #expect(
                     try fs.getDirectoryContents(path.appending("Sources").appending("CustomName")) == [
                         "CustomName.swift"


### PR DESCRIPTION
### Motivation:

This used to be five distinct Swift flags that are now combined into a single upcoming feature. The feature aims to improve Swift Concurrency experience for the new packages.

### Modifications:

Adds `.enableUpcomingFeature("ApproachableConcurrency")` swift setting to all targets generated by new package templates excluding macros and plugins.

### Result:

Provides a better Swift Concurrency experience in new packages.

Issue: rdar://170192252