### PR TITLE
Make sure Windows DLLs are copied over with their LIBs. (cherry-pick #9709)

### DIFF
--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -113,6 +113,10 @@ public final class ClangModuleBuildDescription {
     /// Paths to the binary libraries the target depends on.
     var libraryBinaryPaths: Set<AbsolutePath> = []
 
+    /// Path to Windows DLLs that ship with binary libraries that need to be copied
+    /// over to the build output directory so executables that use them can find them.
+    var windowsDLLBinaryPaths: Set<AbsolutePath> = []
+
     /// Any addition flags to be added. These flags are expected to be computed during build planning.
     var additionalFlags: [String] = []
 

--- a/Sources/Build/BuildDescription/ModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ModuleBuildDescription.swift
@@ -95,6 +95,15 @@ public enum ModuleBuildDescription: SPMBuildCore.ModuleBuildDescription {
         }
     }
 
+    var windowsDLLBinaryPaths: Set<AbsolutePath> {
+        switch self {
+        case .swift(let target):
+            return target.windowsDLLBinaryPaths
+        case .clang(let target):
+            return target.windowsDLLBinaryPaths
+        }
+    }
+
     var resourceBundleInfoPlistPath: AbsolutePath? {
         switch self {
         case .swift(let buildDescription):

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -168,6 +168,10 @@ public final class SwiftModuleBuildDescription {
     /// Paths to the binary libraries the target depends on.
     var libraryBinaryPaths: Set<AbsolutePath> = []
 
+    /// Path to Windows DLLs that ship with binary libraries that need to be copied
+    /// over to the build output directory so executables that use them can find them.
+    var windowsDLLBinaryPaths: Set<AbsolutePath> = []
+
     /// Any addition flags to be added. These flags are expected to be computed during build planning.
     var additionalFlags: [String] = []
 

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -305,6 +305,17 @@ extension LLBuildManifestBuilder {
             }
         }
 
+        // Make sure the windows DLLs get copied over
+        for binaryPath in target.windowsDLLBinaryPaths {
+            let path = target.buildParameters.destinationPath(forBinaryAt: binaryPath)
+            if self.fileSystem.isDirectory(binaryPath) {
+                inputs.append(directory: path)
+            } else {
+                inputs.append(file: path)
+            }
+        }
+
+
         let additionalInputs = try self.addBuildToolPlugins(.swift(target))
 
         // Depend on any required macro's output.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -168,6 +168,9 @@ extension LLBuildManifestBuilder {
             for binaryPath in target.libraryBinaryPaths {
                 destinations[target.buildParameters.destinationPath(forBinaryAt: binaryPath)] = binaryPath
             }
+            for binaryPath in target.windowsDLLBinaryPaths {
+                destinations[target.buildParameters.destinationPath(forBinaryAt: binaryPath)] = binaryPath
+            }
         }
         for (destination, source) in destinations {
             self.addCopyCommand(from: source, to: destination)

--- a/Sources/Build/BuildPlan/BuildPlan+Product.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Product.swift
@@ -27,6 +27,7 @@ import class PackageModel.SystemLibraryModule
 import struct SPMBuildCore.BuildParameters
 import struct SPMBuildCore.ExecutableInfo
 import struct SPMBuildCore.LibraryInfo
+import struct SPMBuildCore.WindowsDLLInfo
 import func TSCBasic.topologicalSort
 
 extension BuildPlan {
@@ -351,10 +352,17 @@ extension BuildPlan {
     }
 
     /// Extracts the artifacts  from an artifactsArchive
-    private func parseExecutableArtifactsArchive(for module: BinaryModule, triple: Triple) throws -> [ExecutableInfo] {
+    func parseExecutableArtifactsArchive(for module: BinaryModule, triple: Triple) throws -> [ExecutableInfo] {
         try self.externalExecutablesCache.memoize(key: module) {
             let execInfos = try module.parseExecutableArtifactArchives(for: triple, fileSystem: self.fileSystem)
             return execInfos.filter { !$0.supportedTriples.isEmpty }
+        }
+    }
+
+    func parseWindowsDLLArtifactsArchive(for module: BinaryModule, triple: Triple) throws -> [WindowsDLLInfo] {
+        try self.externalWindowsDLLCache.memoize(key: module) {
+            let dllInfos = try module.parseWindowsDLLArtifactArchives(for: triple, fileSystem: self.fileSystem)
+            return dllInfos.filter { !$0.supportedTriples.isEmpty }
         }
     }
 

--- a/Sources/Build/BuildPlan/BuildPlan+Swift.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Swift.swift
@@ -74,6 +74,11 @@ extension BuildPlan {
 
                         swiftTarget.libraryBinaryPaths.insert(library.libraryPath)
                     }
+
+                    // Record usages of Windows DLLs
+                    for dll in try parseWindowsDLLArtifactsArchive(for: target, triple: swiftTarget.buildParameters.triple) {
+                        swiftTarget.windowsDLLBinaryPaths.insert(dll.dllPath)
+                    }
                 case .xcframework:
                     let libraries = try self.parseXCFramework(
                         for: target,

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -208,6 +208,9 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// Cache for tools information.
     var externalExecutablesCache = [BinaryModule: [ExecutableInfo]]()
 
+    /// Cache for Windows DLL information.
+    var externalWindowsDLLCache = [BinaryModule: [WindowsDLLInfo]]()
+
     /// Whether to disable sandboxing (e.g. for macros).
     private let shouldDisableSandbox: Bool
 

--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -46,6 +46,8 @@ public struct ArtifactsArchiveMetadata: Equatable {
         case executable
         case staticLibrary
         case swiftSDK
+        // Experimental support for Windows DLLs
+        case experimentalWindowsDLL
 
         // Can't be marked as formally deprecated as we still need to use this value for warning users.
         case crossCompilationDestination

--- a/Tests/BuildTests/LLBuildManifestBuilderTests.swift
+++ b/Tests/BuildTests/LLBuildManifestBuilderTests.swift
@@ -206,4 +206,140 @@ struct LLBuildManifestBuilderTests {
         // Ensure that Objects.LinkFileList is -tool suffixed.
         #expect(manifest.commands[AbsolutePath("/path/to/build/aarch64-unknown-linux-gnu/debug/MMIOMacros-tool.product/Objects.LinkFileList").pathString] != nil)
     }
+
+    /// Verifies the DLLs in an artifact bundle are copied to the output directory on Windows only
+    @Test func windowsDLLsInArtifactBundle() async throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles: [
+                "/MyPkg/Sources/MyExe/MyExe.swift"
+            ]
+        )
+
+        try fs.writeFileContents("/MyPkg/my.artifactbundle/info.json", string: """
+            {
+              "schemaVersion": "1.0",
+              "artifacts": {
+                "MyBinaryLib": {
+                  "version": "1",
+                  "type": "staticLibrary",
+                  "variants": [
+                    {
+                      "path": "x86_64-unknown-windows-msvc/MyBinaryLib.lib",
+                      "staticLibraryMetadata": {
+                        "headerPaths": [
+                          "include"
+                        ]
+                      },
+                      "supportedTriples": [
+                        "x86_64-unknown-windows-msvc"
+                      ]
+                    },
+                    {
+                      "path": "arm64-apple-macosx/libMyBinaryLib.a",
+                      "staticLibraryMetadata": {
+                        "headerPaths": [
+                          "include"
+                        ]
+                      },
+                      "supportedTriples": [
+                        "arm64-apple-macosx"
+                      ]
+                    },
+                  ]
+                },
+                "MyBinaryLib.DLL": {
+                  "type": "experimentalWindowsDLL",
+                  "version": "1.0.0",
+                  "variants": [
+                    {
+                      "path": "x86_64-unknown-windows-msvc/MyBinaryLib.dll",
+                      "supportedTriples": [
+                        "x86_64-unknown-windows-msvc"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+            """)
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                .createRootManifest(
+                    displayName: "MyPkg",
+                    path: "/MyPkg",
+                    products: [
+                        .init(name: "MyExe", type: .executable, targets: ["MyExe"])
+                    ],
+                    targets: [
+                        .init(name: "MyBinaryLib", path: "dist", type: .binary),
+                        .init(name: "MyExe", dependencies: ["MyBinaryLib"], type: .executable),
+                    ]
+                )
+            ],
+            binaryArtifacts: [
+                .plain("MyPkg"): [
+                    "MyBinaryLib": .init(
+                        kind: .artifactsArchive(types: [
+                            .staticLibrary,
+                            .executable,
+                        ]),
+                        originURL: nil, path: "/MyPkg/my.artifactbundle")
+                ]
+            ],
+            observabilityScope: observability.topScope
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        let windowsPlan = try await mockBuildPlan(
+            triple: .x86_64Windows,
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        let windowsBuild = LLBuildManifestBuilder(windowsPlan, fileSystem: fs, observabilityScope: observability.topScope)
+        #expect(!observability.hasErrorDiagnostics)
+        let windowsManifest = try windowsBuild.generateManifest(at: "/windows.manifest")
+
+        let windowsLink = try #require(windowsManifest.commands["C.MyExe-x86_64-unknown-windows-msvc-debug.exe"])
+        let windowsLinkTool = try #require(windowsLink.tool as? ShellTool)
+        #expect(windowsLinkTool.arguments.contains("-lMyBinaryLib"))
+
+        let dll: AbsolutePath = "/path/to/build/x86_64-unknown-windows-msvc/debug/MyBinaryLib.dll"
+        let windowsDLLCopy = try #require(windowsManifest.commands[dll.pathString])
+        let windowsDLLCopyTool = try #require(windowsDLLCopy.tool as? CopyTool)
+        let windowsDLLOutput: Node = .file("/path/to/build/x86_64-unknown-windows-msvc/debug/MyBinaryLib.dll")
+        #expect(
+            windowsDLLCopyTool.inputs == [.file("/MyPkg/my.artifactbundle/x86_64-unknown-windows-msvc/MyBinaryLib.dll")]
+            && windowsDLLCopyTool.outputs == [windowsDLLOutput]
+        )
+
+        // Make sure the copy command is consumed in the build graph
+        let consumerCommand = try #require(windowsManifest.commands.filter({ $0.value.tool.inputs.contains(windowsDLLOutput) }).only)
+        #expect(consumerCommand.key == "C.MyExe-x86_64-unknown-windows-msvc-debug.module")
+
+        let macosPlan = try await mockBuildPlan(
+            triple: .arm64MacOS,
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        let macosBuild = LLBuildManifestBuilder(macosPlan, fileSystem: fs, observabilityScope: observability.topScope)
+        #expect(!observability.hasErrorDiagnostics)
+        let macosManifest = try macosBuild.generateManifest(at: "/macos.manifest")
+
+        let macosLink = try #require(macosManifest.commands["C.MyExe-arm64-apple-macosx-debug.exe"])
+        let macosLinkTool = try #require(macosLink.tool as? ShellTool)
+        #expect(macosLinkTool.arguments.contains("-lMyBinaryLib"))
+
+        #expect(!macosManifest.commands.contains(where: {
+            $0.value.tool.inputs.contains(.file("/MyPkg/my.artifactbundle/x86_64-unknown-windows-msvc/MyBinaryLib.dll"))
+        }))
+    }
 }


### PR DESCRIPTION
On Windows, static and dynamic libraries are similar in that you link in the LIB file. If it's for a DLL, it also needs to be copied over to the build output directory so the resulting executable can find it in the same directory without having to mess with PATH. Since artifact bundles don't have that concept, we reuse "executable" type and check if it's a Windows target and a ".dll" file extension.

Note this is Native build system only.
