### PR TITLE
Tests: Update test to use temp directory

### DIFF
--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -155,11 +155,13 @@ struct PackageCommandTests {
     func commandDoesNotEmitDuplicateSymbols(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
+        let config = BuildConfiguration.debug
         let duplicateSymbolRegex = try #require(duplicateSymbolRegex)
 
-        try await withTemporaryDirectory { tmpDir in
+        try await withTemporaryDirectory { tempDir in
             let (stdout, stderr) = try await executeSwiftPackage(
-                tmpDir,
+                tempDir,
+                configuration: config,
                 extraArgs: ["--help"],
                 buildSystem: buildSystem,
             )


### PR DESCRIPTION
The `swift package --help` command required a lock on the Package so it can include all the command plugin in the help output. A test which invokes this command was not completing as another process (the parent "swift test") had a lock acquire.

Update the impacted test to execute using a temporary directory for a package path.