### PR TITLE
Tests: Remove withKnownIssues on some test suites for macOS

### DIFF
--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -45,9 +45,17 @@ struct DumpSymbolGraph: AsyncSwiftCommand {
 
     @Flag(help: "Add symbols with SPI information to the symbol graph.")
     var includeSPISymbols = false
-    
+
     @Flag(help: "Emit extension block symbols for extensions to external types or directly associate members and conformances with the extended nominal.")
     var extensionBlockSymbolBehavior: ExtensionBlockSymbolBehavior = .omitExtensionBlockSymbols
+
+    @Option(
+        help: .init(
+            "Specify symbol graph output directory",
+            visibility: .hidden,
+        ),
+    )
+    var outputDir: Basics.AbsolutePath? = nil
 
     func run(_ swiftCommandState: SwiftCommandState) async throws {
         // Build the current package.
@@ -69,7 +77,7 @@ struct DumpSymbolGraph: AsyncSwiftCommand {
             )
         ), .buildPlan])
 
-        let symbolGraphDirectory = try swiftCommandState.productsBuildParameters.dataPath.appending("symbolgraph")
+        let symbolGraphDirectory = try self.outputDir ?? swiftCommandState.productsBuildParameters.dataPath.appending("symbolgraph")
 
         let fs = swiftCommandState.fileSystem
 

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -206,4 +206,15 @@ extension Trait where Self == Testing.ConditionTrait {
             #endif
         }
     }
+    /// Skip test if compiler is older than 6.2.
+    public static var requireSwift6_3: Self {
+        enabled("This test requires Swift 6.2, or newer.") {
+            #if compiler(>=6.3)
+                true
+            #else
+                false
+            #endif
+        }
+    }
+
 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1202,9 +1202,7 @@ struct PackageCommandTests {
     }
 
     @Test(
-        .disabled(
-            "disabling this suite.. first one to fail. due to \"couldn't determine the current working directory\""
-        ),
+        .requireSwift6_3,
         .tags(
             .Feature.Command.Package.DumpSymbolGraph,
         ),
@@ -1222,22 +1220,19 @@ struct PackageCommandTests {
         withPrettyPrinting: Bool,
     ) async throws {
         let config = BuildConfiguration.debug
-        // try XCTSkipIf(buildSystemProvider == .native && (try? UserToolchain.default.getSymbolGraphExtract()) == nil, "skipping test because the `swift-symbolgraph-extract` tools isn't available")
-        try await withKnownIssue(isIntermittent: true) {
+        // try await withKnownIssue(isIntermittent: true) {
             try await fixture(
                 name: "DependencyResolution/Internal/Simple",
                 removeFixturePathOnDeinit: true
             ) { fixturePath in
-                let tool = try SwiftCommandState.makeMockState(
-                    options: GlobalOptions.parse(["--package-path", fixturePath.pathString])
-                )
-                let symbolGraphExtractorPath = try tool.getTargetToolchain().getSymbolGraphExtract()
+                let symbolGraphExtractorPath = try UserToolchain.default.getSymbolGraphExtract()
 
-                let arguments =
-                    withPrettyPrinting ? ["dump-symbol-graph", "--pretty-print"] : ["dump-symbol-graph"]
+                let symbolGraphOutputDir = fixturePath.appending("symbolgraph")
+
+                let arguments = withPrettyPrinting ? ["--pretty-print"] : []
 
                 let result = try await execute(
-                    arguments,
+                    ["dump-symbol-graph", "--output-dir", symbolGraphOutputDir.pathString] + arguments,
                     packagePath: fixturePath,
                     env: ["SWIFT_SYMBOLGRAPH_EXTRACT": symbolGraphExtractorPath.pathString],
                     configuration: config,
@@ -1276,10 +1271,10 @@ struct PackageCommandTests {
                     #expect(JSONText.components(separatedBy: .newlines).count == 1)
                 }
             }
-        } when: {
-            (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild && !withPrettyPrinting)
-                || (buildSystem == .swiftbuild && withPrettyPrinting)
-        }
+        // } when: {
+        //     (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild && !withPrettyPrinting)
+        //         || (buildSystem == .swiftbuild && withPrettyPrinting)
+        // }
     }
 
     @Suite(
@@ -6803,7 +6798,7 @@ struct PackageCommandTests {
                             #expect(stdout.contains("staticLibrary"))
                         }
                     } when: {
-                        buildSystem == .swiftbuild
+                        buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem != .macOS
                     }
 
                     // Invoke the plugin with parameters choosing a verbose build of MyDynamicLibrary for release.
@@ -6866,10 +6861,13 @@ struct PackageCommandTests {
                     #expect(stdout.contains(#/artifact-path: [^\n]+MyExecutable(.*)?\nartifact-kind: executable/#))
                     #expect(stdout.contains(#/artifact-path: [^\n]+MyDynamicLibrary(.*)?\nartifact-kind: dynamicLibrary/#))
                     // The not-built executable in the dependency should not be reported. The native build system fails to exclude it.
-                    withKnownIssue {
-                        #expect(!stdout.contains("MySupportExecutable"))
-                    } when: {
-                        buildSystem == .native
+                    switch buildSystem {
+                        case .native:
+                            #expect(stdout.contains("MySupportExecutable"))
+                        case .swiftbuild:
+                            #expect(!stdout.contains("MySupportExecutable"))
+                        case .xcode:
+                            Issue.record("unimplemented assertion for --build-system xcode")
                     }
                 }
             } when: {
@@ -7757,7 +7755,7 @@ struct PackageCommandTests {
                     #expect(stdout.contains("Works fine!"))
                 }
             } when: {
-                (ProcessInfo.hostOperatingSystem == .windows && buildData.buildSystem == .swiftbuild) || (ProcessInfo.hostOperatingSystem == .linux && buildData.buildSystem == .swiftbuild)
+                [.linux, .windows].contains(ProcessInfo.hostOperatingSystem) && buildData.buildSystem == .swiftbuild
             }
         }
     }


### PR DESCRIPTION
Remove `withKnownIssue` calls in tests that are no longer applicable on macOS.

Issue: rdar://169992919