### PR TITLE
Fix containsAtMain to handle @main on same line as block comment end

### DIFF
--- a/Tests/SPMBuildCoreTests/MainAttrDetectionTests.swift
+++ b/Tests/SPMBuildCoreTests/MainAttrDetectionTests.swift
@@ -249,7 +249,7 @@ struct MainAttrDetectionTests {
                 fileContent: """
                 /*
                 This is a multi-line comment
-                /* @main
+                */ @main
                 struct MyApp {
                     static func main() {
                         print("Hello, World!")
@@ -257,17 +257,28 @@ struct MainAttrDetectionTests {
                 }
                 """,
                 expected: true,
-                id: "Multi-line comment end on a line containing @main",
-            )
-
+                id: "Multi-line comment end on same line as @main",
+            ),
+            ContainsAtMainReturnsExpectedValueTestData(
+                fileContent: """
+                /*
+                This is a multi-line comment
+                /* @main
+                struct MyApp {
+                    static func main() {
+                        print("Hello, World!")
+                    }
+                }
+                """,
+                expected: false,
+                id: "Nested comment opening with @main (still inside comment)",
+            ),
         ],
     )
-    func containsAtMainReturnsExpectedValueCurrentlyFails(
+    func containsAtMainIssue9685(
         data: ContainsAtMainReturnsExpectedValueTestData,
     ) async throws {
-        await withKnownIssue {
-            try await self._testImplementation_containsAtMainReturnsExpectedValue(data: data)
-        }
+        try await self._testImplementation_containsAtMainReturnsExpectedValue(data: data)
     }
 
     fileprivate func _testImplementation_containsAtMainReturnsExpectedValue(


### PR DESCRIPTION
## Summary

Fixes #9685

The `containsAtMain` function failed to detect `@main` when it appeared on the same line as a block comment end (`*/ @main`).

## Changes

**`Sources/SPMBuildCore/MainAttrDetection.swift`:**
- Replaced line-level `hasPrefix`/`hasSuffix` comment checks with a scanning approach that tracks `/*` and `*/` boundaries within a single line
- After encountering `*/`, the scanner continues processing the remainder of the line, allowing `@main` to be detected

**`Tests/SPMBuildCoreTests/MainAttrDetectionTests.swift`:**
- Corrected the existing regression test data (`/* @main` → `*/ @main`) to match the actual bug scenario
- Removed `withKnownIssue` wrapper since the fix resolves the defect
- Added a new test case for nested comment opening (`/* @main` inside an existing block comment, expected: `false`)

## Testing

All existing tests continue to pass with the new implementation. The previously-failing regression test now passes.