### PR TITLE
Docs: Update Windows docker image

### DIFF
--- a/Utilities/README.md
+++ b/Utilities/README.md
@@ -6,7 +6,7 @@ Here are some steps the worked running on Windows.
 2. Launch a `Powershell.exe` session
 3. Run the following in power shell to start a container running the nightly toolchain
     ```
-    docker run --pull always --rm --interactive --tty swiftlang/swift:nightly-6.1-windowsservercore-1809 powershell.exe
+    docker run --pull always --rm --interactive --tty swiftlang/swift:nightly-6.2-windowsservercore-1809 powershell.exe
     ```
 4. When the container start, clone the "merged" PR to `C:\source`
     ```


### PR DESCRIPTION
Update the instructions to run, at-desk, a simulation of the Jenkins CI Windows self hosted pipeline build.  Update the docker image to use Swift 6.2 instead of 6.1.
