### PR TITLE
Update various plugin tests so they work on Windows

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/BinaryToolProductPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -2,25 +2,24 @@ import PackagePlugin
 
 @main
 struct MyPlugin: BuildToolPlugin {
-    
+
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         print("Hello from the Build Tool Plugin!")
         guard let target = target as? SourceModuleTarget else { return [] }
-        let inputFiles = target.sourceFiles.filter({ $0.path.extension == "dat" })
+        let inputFiles = target.sourceFiles.filter({ $0.url.pathExtension == "dat" })
         return try inputFiles.map {
-            let inputFile = $0
-            let inputPath = inputFile.path
-            let outputName = inputPath.stem + ".swift"
-            let outputPath = context.pluginWorkDirectory.appending(outputName)
+            let inputPath = $0.url
+            let outputName = inputPath.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
             return .buildCommand(
                 displayName:
-                    "Generating \(outputName) from \(inputPath.lastComponent)",
+                    "Generating \(outputName) from \(inputPath.lastPathComponent)",
                 executable:
-                    try context.tool(named: "mytool").path,
+                    try context.tool(named: "mytool").url,
                 arguments: [
                     "--verbose",
-                    "\(inputPath)",
-                    "\(outputPath)"
+                    inputPath.path,
+                    outputPath.path,
                 ],
                 inputFiles: [
                     inputPath,

--- a/Fixtures/Miscellaneous/Plugins/ClientOfPluginWithInternalExecutable/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/ClientOfPluginWithInternalExecutable/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -41,5 +41,6 @@ let package = Package(
                 .apt(["libpcre-dev"])
             ]
         )
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Plugins/MyAmbiguouslyNamedCommandPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Plugins/MyAmbiguouslyNamedCommandPlugin/plugin.swift
@@ -1,23 +1,23 @@
 import PackagePlugin
- 
+
 @main
 struct MyPlugin: BuildToolPlugin {
-    
+
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         guard let target = target as? SourceModuleTarget else { return [] }
         var commands: [Command] = []
-        for inputFile in target.sourceFiles.filter({ $0.path.extension == "dat" }) {
-            let inputPath = inputFile.path
-            let outputName = "Ambiguous_" + inputPath.stem + ".swift"
-            let outputPath = context.pluginWorkDirectory.appending(outputName)
+        for inputFile in target.sourceFiles.filter({ $0.url.pathExtension == "dat" }) {
+            let inputPath = inputFile.url
+            let outputName = "Ambiguous_" + inputPath.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
             commands.append(.buildCommand(
                 displayName:
                     "This is a constant name",
                 executable:
-                    try context.tool(named: "MySourceGenBuildTool").path,
+                    try context.tool(named: "MySourceGenBuildTool").url,
                 arguments: [
-                    "\(inputPath)",
-                    "\(outputPath)"
+                    inputPath.path,
+                    outputPath.path,
                 ],
                 environment: [
                     "VARIABLE_NAME_PREFIX": "SECOND_PREFIX_"

--- a/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/ContrivedTestPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -1,24 +1,23 @@
 import PackagePlugin
- 
+
 @main
 struct MyPlugin: BuildToolPlugin {
-    
+
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         guard let target = target as? SourceModuleTarget else { return [] }
-        let inputFiles = target.sourceFiles.filter({ $0.path.extension == "dat" })
+        let inputFiles = target.sourceFiles.filter({ $0.url.pathExtension == "dat" })
         return try inputFiles.map {
-            let inputFile = $0
-            let inputPath = inputFile.path
-            let outputName = inputPath.stem + ".swift"
-            let outputPath = context.pluginWorkDirectory.appending(outputName)
+            let inputPath = $0.url
+            let outputName = inputPath.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
             return .buildCommand(
                 displayName:
-                    "Generating \(outputName) from \(inputPath.lastComponent)",
+                    "Generating \(outputName) from \(inputPath.lastPathComponent)",
                 executable:
-                    try context.tool(named: "MySourceGenBuildTool").path,
+                    try context.tool(named: "MySourceGenBuildTool").url,
                 arguments: [
-                    "\(inputPath)",
-                    "\(outputPath)"
+                    inputPath.path,
+                    outputPath.path,
                 ],
                 environment: [
                     "VARIABLE_NAME_PREFIX": "PREFIX_"

--- a/Fixtures/Miscellaneous/Plugins/DependentPlugins/Plugins/MyPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/DependentPlugins/Plugins/MyPlugin/plugin.swift
@@ -3,12 +3,12 @@ import PackagePlugin
 @main
 struct MyPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
-        let outputFilePath = context.pluginWorkDirectory.appending("MyGeneratedFile.swift")        
+        let outputFilePath = context.pluginWorkDirectoryURL.appendingPathComponent("MyGeneratedFile.swift")
         return [
             .buildCommand(
                 displayName: "Running MyExecutable",
-                executable: try context.tool(named: "MyExecutable").path,
-                arguments: ["--output-file-path", outputFilePath.string],
+                executable: try context.tool(named: "MyExecutable").url,
+                arguments: ["--output-file-path", outputFilePath.path],
                 outputFiles: [outputFilePath]
             )
         ]

--- a/Fixtures/Miscellaneous/Plugins/DependentPlugins/Plugins/MyPlugin2/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/DependentPlugins/Plugins/MyPlugin2/plugin.swift
@@ -7,15 +7,15 @@ struct MyPlugin: BuildToolPlugin {
         guard let sourceTarget = target as? SourceModuleTarget else {
             throw "Target is not a source target, cannot get a file list"
         }
-        guard let inputFilePath = sourceTarget.pluginGeneratedSources.first(where: { $0.lastPathComponent == "MyGeneratedFile.swift" })?.path else {
+        guard let inputFilePath = sourceTarget.pluginGeneratedSources.first(where: { $0.lastPathComponent == "MyGeneratedFile.swift" }) else {
             throw "Cannot find MyGeneratedFile.swift, files: \(sourceTarget.pluginGeneratedSources), target: \(target)"
         }
         return [
             .buildCommand(
                 displayName: "Running MyExecutable2",
-                executable: try context.tool(named: "MyExecutable2").path,
-                arguments: ["--input-file-path", inputFilePath],
-                inputFiles: [Path(inputFilePath)]
+                executable: try context.tool(named: "MyExecutable2").url,
+                arguments: ["--input-file-path", inputFilePath.path],
+                inputFiles: [inputFilePath],
             )
         ]
     }

--- a/Fixtures/Miscellaneous/Plugins/IncorrectDependencies/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/IncorrectDependencies/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/IncorrectDependencies/Plugins/MyPlugin/MyPlugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/IncorrectDependencies/Plugins/MyPlugin/MyPlugin.swift
@@ -5,7 +5,7 @@ struct MyPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
         return [.buildCommand(
             displayName: "Running MyPluginExecutable",
-            executable: try context.tool(named: "MyPluginExecutable").path,
+            executable: try context.tool(named: "MyPluginExecutable").url,
             arguments: [],
             environment: [:],
             inputFiles: [],

--- a/Fixtures/Miscellaneous/Plugins/LibraryWithLocalBuildToolPluginUsingRemoteTool/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/LibraryWithLocalBuildToolPluginUsingRemoteTool/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/LibraryWithLocalBuildToolPluginUsingRemoteTool/Plugins/MyLocalSourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/LibraryWithLocalBuildToolPluginUsingRemoteTool/Plugins/MyLocalSourceGenBuildToolPlugin/plugin.swift
@@ -1,26 +1,27 @@
 import PackagePlugin
+import Foundation
 
 @main
 struct MyPlugin: BuildToolPlugin {
-    
+
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         print("Hello from the Build Tool Plugin!")
         guard let target = target as? SourceModuleTarget else { return [] }
-        return try target.sourceFiles.map{ $0.path }.compactMap {
-            guard $0.extension == "dat" else { return .none }
-            let outputName = $0.stem + ".swift"
-            let outputPath = context.pluginWorkDirectory.appending(outputName)
+        return try target.sourceFiles.map{ $0.url }.compactMap { (url: URL) -> Command? in
+            guard url.pathExtension == "dat" else { return nil }
+            let outputName = url.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
             return .buildCommand(
                 displayName:
-                    "Generating \(outputName) from \($0.lastComponent)",
+                    "Generating \(outputName) from \(url.lastPathComponent)",
                 executable:
-                    try context.tool(named: "MySourceGenBuildTool").path,
+                    try context.tool(named: "MySourceGenBuildTool").url,
                 arguments: [
-                    "\($0)",
-                    "\(outputPath)"
+                    url.path,
+                    outputPath.path,
                 ],
                 inputFiles: [
-                    $0,
+                    url,
                 ],
                 outputFiles: [
                     outputPath

--- a/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -2,30 +2,31 @@ import PackagePlugin
 
 @main
 struct MyPlugin: BuildToolPlugin {
-    
+
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         print("Hello from the Build Tool Plugin!")
         guard let target = target as? SourceModuleTarget else { return [] }
-        let inputFiles = target.sourceFiles.filter({ $0.path.extension == "dat" })
+        let inputFiles = target.sourceFiles.filter({ $0.url.pathExtension == "dat" })
         let workDir = context.pluginWorkDirectoryURL
 
         return try inputFiles.map {
             let inputFile = $0
-            let inputPath = inputFile.path
-            let outputName = inputPath.stem + ".swift"
-            let outputPath = context.pluginWorkDirectory.appending(outputName)
+            let inputPath = $0.url
+            let outputName = inputPath.deletingPathExtension().appendingPathExtension("swift")
+                .lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
             return .buildCommand(
                 displayName:
-                    "Generating \(outputName) from \(inputPath.lastComponent)",
+                    "Generating \(outputName) from \(inputPath.lastPathComponent)",
                 executable:
-                    try context.tool(named: "mytool").path,
+                    try context.tool(named: "mytool").url,
                 arguments: [
                     "--verbose",
-                    "\(inputPath)",
-                    "\(outputPath)"
+                    inputPath.path,
+                    outputPath.path,
                 ],
                 inputFiles: [
-                    inputPath,
+                    inputPath
                 ],
                 outputFiles: [
                     outputPath
@@ -37,8 +38,11 @@ struct MyPlugin: BuildToolPlugin {
                     "Generating files in \(workDir.path)",
                 executable:
                     try context.tool(named: "mytool").url,
-                arguments:
-                    ["--verbose", "\(target.directoryURL.appendingPathComponent("bar.in").path)", "\(workDir.appendingPathComponent("bar.swift").path)"],
+                arguments: [
+                    "--verbose",
+                    target.directoryURL.appendingPathComponent("bar.in").path,
+                    workDir.appendingPathComponent("bar.swift").path,
+                ],
                 outputFilesDirectory: workDir
             )
         ]

--- a/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MyBuildToolPluginDependencies/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -74,5 +74,6 @@ let package = Package(
                 "MySourceGenPrebuildPlugin",
             ]
         )
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -1,4 +1,5 @@
 import PackagePlugin
+import Foundation
 
 @main
 struct MyPlugin: BuildToolPlugin {
@@ -11,21 +12,20 @@ struct MyPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         print("Hello from the Build Tool Plugin!")
         guard let target = target as? SourceModuleTarget else { return [] }
-        return try target.sourceFiles.map{ $0.path }.compactMap {
-            guard $0.extension == "dat" else { return .none }
-            let outputName = $0.stem + ".swift"
-            let outputPath = context.pluginWorkDirectory.appending(outputName)
+        return try target.sourceFiles.map { $0.url }.compactMap { (url: URL) -> Command? in
+            guard url.pathExtension == "dat" else { return nil }
+            let outputName = url.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
             return .buildCommand(
-                displayName:
-                    "\(verb) \(outputName) from \($0.lastComponent)",
+                displayName: "\(verb) \(outputName) from \(url.lastPathComponent)",
                 executable:
-                    try context.tool(named: "MySourceGenBuildTool").path,
+                    try context.tool(named: "MySourceGenBuildTool").url,
                 arguments: [
-                    "\($0)",
-                    "\(outputPath)"
+                    url.path,
+                    outputPath.path
                 ],
                 inputFiles: [
-                    $0,
+                    url,
                 ],
                 outputFiles: [
                     outputPath

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Plugins/MySourceGenPrebuildPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPlugin/Plugins/MySourceGenPrebuildPlugin/plugin.swift
@@ -1,31 +1,43 @@
 import PackagePlugin
+import Foundation
 
 #if os(Android)
 let touchExe = "/system/bin/touch"
+let touchArgs: [String]  = []
+#elseif os(Windows)
+let touchExe = "C:/Windows/System32/cmd.exe"
+let touchArgs = ["/c", "copy", "NUL"]
 #else
 let touchExe = "/usr/bin/touch"
+let touchArgs: [String]  = []
 #endif
 
 @main
 struct MyPlugin: BuildToolPlugin {
-    
+
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         print("Hello from the Prebuild Plugin!")
         guard let target = target as? SourceModuleTarget else { return [] }
-        let outputPaths: [Path] = target.sourceFiles.filter{ $0.path.extension == "dat" }.map { file in
-            context.pluginWorkDirectory.appending(file.path.stem + ".swift")
+        let outputPaths: [URL] = target.sourceFiles.filter{ $0.url.pathExtension == "dat" }.map { file in
+            context.pluginWorkDirectoryURL.appendingPathComponent(file.url.deletingPathExtension().appendingPathExtension("swift").lastPathComponent)
         }
         var commands: [Command] = []
+        let paths = outputPaths.map{ $0.path }
+#if os(Windows)
+        let args = ["/c", "FOR %F IN (" + paths.joined(separator: " ") + ") DO TYPE NUL > %F"]
+#else
+        let args = paths
+#endif
         if !outputPaths.isEmpty {
             commands.append(.prebuildCommand(
                 displayName:
                     "Running prebuild command for target \(target.name)",
                 executable:
-                    Path(touchExe),
-                arguments: 
-                    outputPaths.map{ $0.string },
+                    .init(fileURLWithPath: touchExe),
+                arguments:
+                    args,
                 outputFilesDirectory:
-                    context.pluginWorkDirectory
+                    context.pluginWorkDirectoryURL
             ))
         }
         return commands

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPluginNoPreBuildCommands/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPluginNoPreBuildCommands/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -63,5 +63,6 @@ let package = Package(
                 "MySourceGenBuildToolPlugin",
             ]
         )
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPluginNoPreBuildCommands/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPluginNoPreBuildCommands/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -1,4 +1,5 @@
 import PackagePlugin
+import Foundation
 
 @main
 struct MyPlugin: BuildToolPlugin {
@@ -11,21 +12,21 @@ struct MyPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         print("Hello from the Build Tool Plugin!")
         guard let target = target as? SourceModuleTarget else { return [] }
-        return try target.sourceFiles.map{ $0.path }.compactMap {
-            guard $0.extension == "dat" else { return .none }
-            let outputName = $0.stem + ".swift"
-            let outputPath = context.pluginWorkDirectory.appending(outputName)
+        return try target.sourceFiles.map{ $0.url }.compactMap { (url: URL) -> Command? in
+            guard url.pathExtension == "dat" else { return nil }
+            let outputName = url.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
             return .buildCommand(
                 displayName:
-                    "\(verb) \(outputName) from \($0.lastComponent)",
+                    "\(verb) \(outputName) from \(url.lastPathComponent)",
                 executable:
-                    try context.tool(named: "MySourceGenBuildTool").path,
+                    try context.tool(named: "MySourceGenBuildTool").url,
                 arguments: [
-                    "\($0)",
-                    "\(outputPath)"
+                    url.path,
+                    outputPath.path,
                 ],
                 inputFiles: [
-                    $0,
+                    url,
                 ],
                 outputFiles: [
                     outputPath

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI/Plugins/MySourceGenBuildToolPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI/Plugins/MySourceGenBuildToolPlugin/plugin.swift
@@ -1,4 +1,5 @@
 import PackagePlugin
+import Foundation
 
 @main
 struct MyPlugin: BuildToolPlugin {
@@ -11,21 +12,21 @@ struct MyPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         print("Hello from the Build Tool Plugin!")
         guard let target = target as? SourceModuleTarget else { return [] }
-        return try target.sourceFiles.map{ $0.url }.compactMap {
-            guard $0.pathExtension == "dat" else { return .none }
-            let outputName = $0.deletingPathExtension().lastPathComponent + ".swift"
+        return try target.sourceFiles.map{ $0.url }.compactMap { (url: URL) -> Command? in
+            guard url.pathExtension == "dat" else { return nil }
+            let outputName = url.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
             let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
             return .buildCommand(
                 displayName:
-                    "\(verb) \(outputName) from \($0.lastPathComponent)",
+                    "\(verb) \(outputName) from \(url.lastPathComponent)",
                 executable:
                     try context.tool(named: "MySourceGenBuildTool").url,
                 arguments: [
-                    "\($0)",
-                    "\(outputPath.path)"
+                    url.path,
+                    outputPath.path
                 ],
                 inputFiles: [
-                    $0,
+                    url,
                 ],
                 outputFiles: [
                     outputPath

--- a/Fixtures/Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI/Plugins/MySourceGenPrebuildPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI/Plugins/MySourceGenPrebuildPlugin/plugin.swift
@@ -3,28 +3,36 @@ import PackagePlugin
 
 #if os(Android)
 let touchExe = "/system/bin/touch"
+#elseif os(Windows)
+let touchExe = "C:/Windows/System32/cmd.exe"
 #else
 let touchExe = "/usr/bin/touch"
 #endif
 
 @main
 struct MyPlugin: BuildToolPlugin {
-    
+
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         print("Hello from the Prebuild Plugin!")
         guard let target = target as? SourceModuleTarget else { return [] }
         let outputPaths: [URL] = target.sourceFiles.filter{ $0.url.pathExtension == "dat" }.map { file in
             context.pluginWorkDirectoryURL.appendingPathComponent(file.url.lastPathComponent + ".swift")
         }
+        let paths = outputPaths.map{ $0.path }
+#if os(Windows)
+        let args = ["/c", "FOR %F IN (" + paths.joined(separator: " ") + ") DO TYPE NUL > %F"]
+#else
+        let args = paths
+#endif
         var commands: [Command] = []
         if !outputPaths.isEmpty {
             commands.append(.prebuildCommand(
                 displayName:
                     "Running prebuild command for target \(target.name)",
                 executable:
-                    URL(fileURLWithPath: touchExe),
-                arguments: 
-                    outputPaths.map{ $0.path },
+                    .init(fileURLWithPath: touchExe),
+                arguments:
+                    args,
                 outputFilesDirectory:
                     context.pluginWorkDirectoryURL
             ))

--- a/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.0
 
 import PackageDescription
 

--- a/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Plugins/MyPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginCanBeReferencedByProductName/Plugins/MyPlugin/plugin.swift
@@ -3,11 +3,11 @@ import PackagePlugin
 @main
 struct MyPlugin: BuildToolPlugin {
     func createBuildCommands(context: PackagePlugin.PluginContext, target: PackagePlugin.Target) async throws -> [PackagePlugin.Command] {
-        let output = context.pluginWorkDirectory.appending("gen.swift")
+        let output = context.pluginWorkDirectoryURL.appendingPathComponent("gen.swift")
         return [
             .buildCommand(displayName: "Generating code",
-                          executable: try context.tool(named: "Exec").path,
-                          arguments: [output.string],
+                          executable: try context.tool(named: "Exec").url,
+                          arguments: [output.path],
                           outputFiles: [output])
         ]
     }

--- a/Fixtures/Miscellaneous/Plugins/PluginWithInternalExecutable/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/PluginWithInternalExecutable/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -827,7 +827,7 @@ final class PluginInvocationTests: XCTestCase {
             let packageDir = tmpPath.appending(components: "mypkg")
             try localFileSystem.createDirectory(packageDir, recursive: true)
             try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
-                // swift-tools-version:5.7
+                // swift-tools-version:6.0
 
                 import PackageDescription
 
@@ -888,9 +888,9 @@ final class PluginInvocationTests: XCTestCase {
                           [
                               Command.prebuildCommand(
                                   displayName: "X: Running Y before the build...",
-                                  executable: try context.tool(named: "Y").path,
+                                  executable: try context.tool(named: "Y").url,
                                   arguments: [ "ARGUMENT_ONE", "ARGUMENT_TWO" ],
-                                  outputFilesDirectory: context.pluginWorkDirectory.appending("OUTPUT_FILES_DIRECTORY")
+                                  outputFilesDirectory: context.pluginWorkDirectoryURL.appendingPathComponent("OUTPUT_FILES_DIRECTORY")
                               )
                           ]
                       }
@@ -998,7 +998,7 @@ final class PluginInvocationTests: XCTestCase {
             let packageDir = tmpPath.appending(components: "mypkg")
             try localFileSystem.createDirectory(packageDir, recursive: true)
             try localFileSystem.writeFileContents(packageDir.appending("Package.swift"), string: """
-                // swift-tools-version:5.7
+                // swift-tools-version:6.0
 
                 import PackageDescription
 
@@ -1058,9 +1058,9 @@ final class PluginInvocationTests: XCTestCase {
                           [
                               Command.prebuildCommand(
                                   displayName: "X: Running Y before the build...",
-                                  executable: try context.tool(named: "Y").path,
+                                  executable: try context.tool(named: "Y").url,
                                   arguments: [ "ARGUMENT_ONE", "ARGUMENT_TWO" ],
-                                  outputFilesDirectory: context.pluginWorkDirectory.appending("OUTPUT_FILES_DIRECTORY")
+                                  outputFilesDirectory: context.pluginWorkDirectoryURL.appendingPathComponent("OUTPUT_FILES_DIRECTORY")
                               )
                           ]
                       }

--- a/Tests/BuildTests/PluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/PluginsBuildPlanTests.swift
@@ -30,13 +30,11 @@ struct PluginsBuildPlanTests {
             .Feature.Plugin,
             .Feature.SourceGeneration,
         ),
-        .IssueWindowsPathTestsFailures,  // Fails to build the project to due to incorrect Path handling
         arguments: BuildConfiguration.allCases,
     )
     func buildToolsDatabasePath(
         config: BuildConfiguration,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(
                 fixturePath,
@@ -47,9 +45,6 @@ struct PluginsBuildPlanTests {
             // FIXME: This is temporary until build of plugin tools is extracted into its own command.
             #expect(localFileSystem.exists(fixturePath.appending(RelativePath(".build/plugin-tools.db"))))
             #expect(localFileSystem.exists(fixturePath.appending(RelativePath(".build/build.db"))))
-        }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4249,7 +4249,6 @@ struct PackageCommandTests {
             let config = BuildConfiguration.debug
             let featureName = testData.featureName
             let expectedSummary = testData.expectedSummary
-            try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "SwiftMigrate/\(featureName)Migration") { fixturePath in
                 let sourcePaths: [AbsolutePath]
                 let fixedSourcePaths: [AbsolutePath]
@@ -4288,9 +4287,6 @@ struct PackageCommandTests {
 
                 let regexMatch = try Regex("> \(expectedSummary)" + #" \([0-9]\.[0-9]{1,3}s\)"#)
                 #expect(stdout.contains(regexMatch))
-            }
-            } when: {
-                ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
             }
         }
 
@@ -4656,12 +4652,8 @@ struct PackageCommandTests {
                         buildSystem: buildSystem,
                     )
                 ) { error in
-                    withKnownIssue(isIntermittent: true) {
-                        #expect(error.stderr.contains("This is text from the plugin"))
-                        #expect(error.stderr.contains("error: This is an error from the plugin"))
-                    } when: {
-                        ProcessInfo.hostOperatingSystem == .windows
-                    }
+                    #expect(error.stderr.contains("This is text from the plugin"))
+                    #expect(error.stderr.contains("error: This is an error from the plugin"))
                     switch buildSystem {
                         case .native:
                             #expect(
@@ -5665,26 +5657,22 @@ struct PackageCommandTests {
         ) async throws {
             let debugTarget = try buildData.buildSystem.binPath(for: .debug) + [executableName("placeholder")]
             let releaseTarget = try buildData.buildSystem.binPath(for: .release) + [executableName("placeholder")]
-            try await withKnownIssue(isIntermittent: true) {
-                // If the plugin requests a release binary, that is what will be built, regardless of overall configuration
-                try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-                    let _ = try await execute(
-                        ["build-target", "build-release"],
-                        packagePath: fixturePath,
-                        configuration: buildData.config,
-                        buildSystem: buildData.buildSystem,
-                    )
-                    expectFileDoesNotExists(
-                        at: fixturePath.appending(components: debugTarget),
-                        "build-target build-inherit"
-                    )
-                    expectFileIsExecutable(
-                        at: fixturePath.appending(components: releaseTarget),
-                        "build-target build-release"
-                    )
-                }
-            } when: {
-                ProcessInfo.hostOperatingSystem == .windows
+            // If the plugin requests a release binary, that is what will be built, regardless of overall configuration
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+                let _ = try await execute(
+                    ["build-target", "build-release"],
+                    packagePath: fixturePath,
+                    configuration: buildData.config,
+                    buildSystem: buildData.buildSystem,
+                )
+                expectFileDoesNotExists(
+                    at: fixturePath.appending(components: debugTarget),
+                    "build-target build-inherit"
+                )
+                expectFileIsExecutable(
+                    at: fixturePath.appending(components: releaseTarget),
+                    "build-target build-release"
+                )
             }
         }
 
@@ -5703,30 +5691,26 @@ struct PackageCommandTests {
         ) async throws {
             let debugTarget = try buildData.buildSystem.binPath(for: .debug) + [executableName("placeholder")]
             let releaseTarget = try buildData.buildSystem.binPath(for: .release) + [executableName("placeholder")]
-            try await withKnownIssue(isIntermittent: true) {
-                // If the plugin inherits the overall build configuration, that is what will be built
-                try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-                    let _ = try await execute(
-                        ["build-target", "build-inherit"],
-                        packagePath: fixturePath,
-                        configuration: buildData.config,
-                        buildSystem: buildData.buildSystem,
-                    )
-                    let fileShouldNotExist: AbsolutePath
-                    let fileShouldExist: AbsolutePath
-                    switch buildData.config {
-                    case .debug:
-                        fileShouldExist = fixturePath.appending(components: debugTarget)
-                        fileShouldNotExist = fixturePath.appending(components: releaseTarget)
-                    case .release:
-                        fileShouldNotExist = fixturePath.appending(components: debugTarget)
-                        fileShouldExist = fixturePath.appending(components: releaseTarget)
-                    }
-                    expectFileDoesNotExists(at: fileShouldNotExist, "build-target build-inherit")
-                    expectFileIsExecutable(at: fileShouldExist, "build-target build-inherit")
+            // If the plugin inherits the overall build configuration, that is what will be built
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+                let _ = try await execute(
+                    ["build-target", "build-inherit"],
+                    packagePath: fixturePath,
+                    configuration: buildData.config,
+                    buildSystem: buildData.buildSystem,
+                )
+                let fileShouldNotExist: AbsolutePath
+                let fileShouldExist: AbsolutePath
+                switch buildData.config {
+                case .debug:
+                    fileShouldExist = fixturePath.appending(components: debugTarget)
+                    fileShouldNotExist = fixturePath.appending(components: releaseTarget)
+                case .release:
+                    fileShouldNotExist = fixturePath.appending(components: debugTarget)
+                    fileShouldExist = fixturePath.appending(components: releaseTarget)
                 }
-            } when: {
-                ProcessInfo.hostOperatingSystem == .windows
+                expectFileDoesNotExists(at: fileShouldNotExist, "build-target build-inherit")
+                expectFileIsExecutable(at: fileShouldExist, "build-target build-inherit")
             }
         }
 
@@ -5743,20 +5727,16 @@ struct PackageCommandTests {
         ) async throws {
             let config = BuildConfiguration.debug
             // Plugin arguments: check-testability <targetName> <config> <shouldTestable>
-            try await withKnownIssue(isIntermittent: true) {
-                // Overall configuration: debug, plugin build request: debug -> without testability
-                try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-                    let _ = await #expect(throws: Never.self) {
-                        try await execute(
-                            ["check-testability", "InternalModule", "debug", "true"],
-                            packagePath: fixturePath,
-                            configuration: config,
-                            buildSystem: buildSystem,
-                        )
-                    }
+            // Overall configuration: debug, plugin build request: debug -> without testability
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+                let _ = await #expect(throws: Never.self) {
+                    try await execute(
+                        ["check-testability", "InternalModule", "debug", "true"],
+                        packagePath: fixturePath,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
                 }
-            } when: {
-                ProcessInfo.hostOperatingSystem == .windows
             }
         }
 
@@ -5772,20 +5752,16 @@ struct PackageCommandTests {
             buildSystem: BuildSystemProvider.Kind,
         ) async throws {
             let config = BuildConfiguration.debug
-            try await withKnownIssue(isIntermittent: true) {
-                // Overall configuration: debug, plugin build request: release -> without testability
-                try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-                    let _ = await #expect(throws: Never.self) {
-                        try await execute(
-                            ["check-testability", "InternalModule", "release", "false"],
-                            packagePath: fixturePath,
-                            configuration: config,
-                            buildSystem: buildSystem,
-                        )
-                    }
+            // Overall configuration: debug, plugin build request: release -> without testability
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+                let _ = await #expect(throws: Never.self) {
+                    try await execute(
+                        ["check-testability", "InternalModule", "release", "false"],
+                        packagePath: fixturePath,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
                 }
-            } when: {
-                ProcessInfo.hostOperatingSystem == .windows
             }
         }
 
@@ -5853,73 +5829,68 @@ struct PackageCommandTests {
             // otherwise the logs may be different in subsequent tests.
 
             // Check than nothing is echoed when echoLogs is false
-            try await withKnownIssue(isIntermittent: true) {
-                try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-                    let (stdout, stderr) = try await execute(  //got here
-                        ["print-diagnostics", "build"],
-                        packagePath: fixturePath,
-                        env: ["SWIFT_DRIVER_SWIFTSCAN_LIB": "/this/is/a/bad/path"],
-                        configuration: config,
-                        buildSystem: buildSystem,
-                    )
-                    #expect(stdout == isEmpty)
-                    // Filter some unrelated output that could show up on stderr.
-                    let filteredStderr = stderr.components(separatedBy: "\n")
-                        .filter { !$0.contains("Unable to locate libSwiftScan") }
-                        .filter { !($0.contains("warning: ") && $0.contains("unable to find libclang")) }
-                        .filter { !$0.contains("Build description")}
-                        .joined(separator: "\n")
-                    #expect(filteredStderr == isEmpty)
-                }
-
-                // Check that logs are returned to the plugin when echoLogs is false
-                try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-                    let (stdout, stderr) = try await execute(  // got here
-                        ["print-diagnostics", "build", "printlogs"],
-                        packagePath: fixturePath,
-                        env: ["SWIFT_DRIVER_SWIFTSCAN_LIB": "/this/is/a/bad/path"],
-                        configuration: config,
-                        buildSystem: buildSystem,
-                    )
-                    #expect(stdout.contains(containsLogtext))
-                    // Filter some unrelated output that could show up on stderr.
-                    let filteredStderr = stderr.components(separatedBy: "\n")
-                        .filter { !$0.contains("Unable to locate libSwiftScan") }
-                        .filter { !($0.contains("warning: ") && $0.contains("unable to find libclang")) }
-                        .filter { !$0.contains("Build description")}
-                        .joined(separator: "\n")
-                    #expect(filteredStderr == isEmpty)
-                }
-
-                // Check that logs echoed to the console (on stderr) when echoLogs is true
-                try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-                    let (stdout, stderr) = try await execute(
-                        ["print-diagnostics", "build", "echologs"],
-                        packagePath: fixturePath,
-                        env: ["SWIFT_DRIVER_SWIFTSCAN_LIB": "/this/is/a/bad/path"],
-                        configuration: config,
-                        buildSystem: buildSystem,
-                    )
-                    #expect(stdout == isEmpty)
-                    #expect(stderr.contains(containsLogecho))
-                }
-
-                // Check that logs are returned to the plugin and echoed to the console (on stderr) when echoLogs is true
-                try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
-                    let (stdout, stderr) = try await execute(
-                        ["print-diagnostics", "build", "printlogs", "echologs"],
-                        packagePath: fixturePath,
-                        env: ["SWIFT_DRIVER_SWIFTSCAN_LIB": "/this/is/a/bad/path"],
-                        configuration: config,
-                        buildSystem: buildSystem,
-                    )
-                    #expect(stdout.contains(containsLogtext))
-                    #expect(stderr.contains(containsLogecho))
-                }
-            } when: {
-                ProcessInfo.hostOperatingSystem == .windows
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+                let (stdout, stderr) = try await execute(  //got here
+                    ["print-diagnostics", "build"],
+                    packagePath: fixturePath,
+                    env: ["SWIFT_DRIVER_SWIFTSCAN_LIB": "/this/is/a/bad/path"],
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout == isEmpty)
+                // Filter some unrelated output that could show up on stderr.
+                let filteredStderr = stderr.components(separatedBy: "\n")
+                    .filter { !$0.contains("Unable to locate libSwiftScan") }
+                    .filter { !($0.contains("warning: ") && $0.contains("unable to find libclang")) }
+                    .filter { !$0.contains("Build description")}
+                    .joined(separator: "\n")
+                #expect(filteredStderr == isEmpty)
             }
 
+            // Check that logs are returned to the plugin when echoLogs is false
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+                let (stdout, stderr) = try await execute(  // got here
+                    ["print-diagnostics", "build", "printlogs"],
+                    packagePath: fixturePath,
+                    env: ["SWIFT_DRIVER_SWIFTSCAN_LIB": "/this/is/a/bad/path"],
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout.contains(containsLogtext))
+                // Filter some unrelated output that could show up on stderr.
+                let filteredStderr = stderr.components(separatedBy: "\n")
+                    .filter { !$0.contains("Unable to locate libSwiftScan") }
+                    .filter { !($0.contains("warning: ") && $0.contains("unable to find libclang")) }
+                    .filter { !$0.contains("Build description")}
+                    .joined(separator: "\n")
+                #expect(filteredStderr == isEmpty)
+            }
+
+            // Check that logs echoed to the console (on stderr) when echoLogs is true
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+                let (stdout, stderr) = try await execute(
+                    ["print-diagnostics", "build", "echologs"],
+                    packagePath: fixturePath,
+                    env: ["SWIFT_DRIVER_SWIFTSCAN_LIB": "/this/is/a/bad/path"],
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout == isEmpty)
+                #expect(stderr.contains(containsLogecho))
+            }
+
+            // Check that logs are returned to the plugin and echoed to the console (on stderr) when echoLogs is true
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+                let (stdout, stderr) = try await execute(
+                    ["print-diagnostics", "build", "printlogs", "echologs"],
+                    packagePath: fixturePath,
+                    env: ["SWIFT_DRIVER_SWIFTSCAN_LIB": "/this/is/a/bad/path"],
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout.contains(containsLogtext))
+                #expect(stderr.contains(containsLogecho))
+            }
         }
 
         private static let allNetworkConnectionPermissionError = "all network connections on ports: 1, 2, 3"
@@ -6086,61 +6057,57 @@ struct PackageCommandTests {
             testData: CommandPluginNetworkingPermissionsTestData,
         ) async throws {
             let config = BuildConfiguration.debug
-            try await withKnownIssue(isIntermittent: true) {
-                try await testWithTemporaryDirectory { tmpPath in
-                    // Create a sample package with a library target and a plugin.
-                    let packageDir = tmpPath.appending(components: "MyPackage")
-                    try localFileSystem.writeFileContents(
-                        packageDir.appending(components: "Package.swift"),
-                        string:
-                            """
-                            // swift-tools-version: 5.9
-                            import PackageDescription
-                            let package = Package(
-                                name: "MyPackage",
-                                targets: [
-                                    .target(name: "MyLibrary"),
-                                    .plugin(name: "MyPlugin", capability: .command(intent: .custom(verb: "Network", description: "Help description"), permissions: \(testData.permissionsManifestFragment))),
-                                ]
-                            )
-                            """
-                    )
-                    try localFileSystem.writeFileContents(
-                        packageDir.appending(components: "Sources", "MyLibrary", "library.swift"),
-                        string: "public func Foo() { }"
-                    )
-                    try localFileSystem.writeFileContents(
-                        packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift"),
-                        string:
-                            """
-                            import PackagePlugin
-
-                            @main
-                            struct MyCommandPlugin: CommandPlugin {
-                                func performCommand(context: PluginContext, arguments: [String]) throws {
-                                    print("hello world")
-                                }
-                            }
-                            """
-                    )
-
-                    // Check that we don't get an error (and also are allowed to write to the package directory) if we pass `--allow-writing-to-package-directory`.
-                    do {
-                        let (stdout, _) = try await execute(
-                            ["plugin"] + testData.remedy + ["Network"],
-                            packagePath: packageDir,
-                            configuration: config,
-                            buildSystem: buildSystem,
+            try await testWithTemporaryDirectory { tmpPath in
+                // Create a sample package with a library target and a plugin.
+                let packageDir = tmpPath.appending(components: "MyPackage")
+                try localFileSystem.writeFileContents(
+                    packageDir.appending(components: "Package.swift"),
+                    string:
+                        """
+                        // swift-tools-version: 5.9
+                        import PackageDescription
+                        let package = Package(
+                            name: "MyPackage",
+                            targets: [
+                                .target(name: "MyLibrary"),
+                                .plugin(name: "MyPlugin", capability: .command(intent: .custom(verb: "Network", description: "Help description"), permissions: \(testData.permissionsManifestFragment))),
+                            ]
                         )
-                        withKnownIssue(isIntermittent: true) {
-                            #expect(stdout.contains("hello world"))
-                        } when: {
-                            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild && config == .debug && testData.permissionError == Self.allNetworkConnectionPermissionError
+                        """
+                )
+                try localFileSystem.writeFileContents(
+                    packageDir.appending(components: "Sources", "MyLibrary", "library.swift"),
+                    string: "public func Foo() { }"
+                )
+                try localFileSystem.writeFileContents(
+                    packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift"),
+                    string:
+                        """
+                        import PackagePlugin
+
+                        @main
+                        struct MyCommandPlugin: CommandPlugin {
+                            func performCommand(context: PluginContext, arguments: [String]) throws {
+                                print("hello world")
+                            }
                         }
+                        """
+                )
+
+                // Check that we don't get an error (and also are allowed to write to the package directory) if we pass `--allow-writing-to-package-directory`.
+                do {
+                    let (stdout, _) = try await execute(
+                        ["plugin"] + testData.remedy + ["Network"],
+                        packagePath: packageDir,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
+                    withKnownIssue(isIntermittent: true) {
+                        #expect(stdout.contains("hello world"))
+                    } when: {
+                        ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild && config == .debug && testData.permissionError == Self.allNetworkConnectionPermissionError
                     }
                 }
-            } when: {
-                ProcessInfo.hostOperatingSystem == .windows
             }
         }
 
@@ -6326,11 +6293,7 @@ struct PackageCommandTests {
                             configuration: config,
                             buildSystem: buildSystem,
                         )
-                        withKnownIssue(isIntermittent: true) {
-                            #expect(stdout.contains("successfully created it"))
-                        } when: {
-                            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .native && config == .release
-                        }
+                        #expect(stdout.contains("successfully created it"))
                         #expect(!stderr.contains("error: Couldn’t create file at path"))
                     }
 
@@ -6665,138 +6628,137 @@ struct PackageCommandTests {
             buildSystem: BuildSystemProvider.Kind,
         ) async throws {
             let config = BuildConfiguration.debug
-            try await withKnownIssue(isIntermittent: true) {
-                try await testWithTemporaryDirectory { tmpPath in
-                    let buildSystemProvider = buildSystem
-                    // Create a sample package with a library, an executable, and a command plugin.
-                    let packageDir = tmpPath.appending(components: "MyPackage")
-                    try localFileSystem.createDirectory(packageDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        packageDir.appending(components: "Package.swift"),
-                        string: """
-                            // swift-tools-version: 5.6
-                            import PackageDescription
-                            let package = Package(
-                                name: "MyPackage",
-                                products: [
-                                    .library(
-                                        name: "MyAutomaticLibrary",
-                                        targets: ["MyLibrary"]
-                                    ),
-                                    .library(
-                                        name: "MyStaticLibrary",
-                                        type: .static,
-                                        targets: ["MyLibrary"]
-                                    ),
-                                    .library(
-                                        name: "MyDynamicLibrary",
-                                        type: .dynamic,
-                                        targets: ["MyLibrary"]
-                                    ),
-                                    .executable(
-                                        name: "MyExecutable",
-                                        targets: ["MyExecutable"]
-                                    ),
-                                ],
-                                targets: [
-                                    .target(
-                                        name: "MyLibrary"
-                                    ),
-                                    .executableTarget(
-                                        name: "MyExecutable",
-                                        dependencies: ["MyLibrary"]
-                                    ),
-                                    .plugin(
-                                        name: "MyPlugin",
-                                        capability: .command(
-                                            intent: .custom(verb: "my-build-tester", description: "Help description")
-                                        )
-                                    ),
-                                ]
-                            )
-                            """
-                    )
-                    let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
-                    try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        myPluginTargetDir.appending("plugin.swift"),
-                        string: """
-                            import PackagePlugin
-                            @main
-                            struct MyCommandPlugin: CommandPlugin {
-                                func performCommand(
-                                    context: PluginContext,
-                                    arguments: [String]
-                                ) throws {
-                                    // Extract the plugin arguments.
-                                    var argExtractor = ArgumentExtractor(arguments)
-                                    let productNames = argExtractor.extractOption(named: "product")
-                                    if productNames.count != 1 {
-                                        throw "Expected exactly one product name, but had: \\(productNames.joined(separator: ", "))"
+            try await testWithTemporaryDirectory { tmpPath in
+                let buildSystemProvider = buildSystem
+                // Create a sample package with a library, an executable, and a command plugin.
+                let packageDir = tmpPath.appending(components: "MyPackage")
+                try localFileSystem.createDirectory(packageDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    packageDir.appending(components: "Package.swift"),
+                    string: """
+                        // swift-tools-version: 5.6
+                        import PackageDescription
+                        let package = Package(
+                            name: "MyPackage",
+                            products: [
+                                .library(
+                                    name: "MyAutomaticLibrary",
+                                    targets: ["MyLibrary"]
+                                ),
+                                .library(
+                                    name: "MyStaticLibrary",
+                                    type: .static,
+                                    targets: ["MyLibrary"]
+                                ),
+                                .library(
+                                    name: "MyDynamicLibrary",
+                                    type: .dynamic,
+                                    targets: ["MyLibrary"]
+                                ),
+                                .executable(
+                                    name: "MyExecutable",
+                                    targets: ["MyExecutable"]
+                                ),
+                            ],
+                            targets: [
+                                .target(
+                                    name: "MyLibrary"
+                                ),
+                                .executableTarget(
+                                    name: "MyExecutable",
+                                    dependencies: ["MyLibrary"]
+                                ),
+                                .plugin(
+                                    name: "MyPlugin",
+                                    capability: .command(
+                                        intent: .custom(verb: "my-build-tester", description: "Help description")
+                                    )
+                                ),
+                            ]
+                        )
+                        """
+                )
+                let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
+                try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    myPluginTargetDir.appending("plugin.swift"),
+                    string: """
+                        import PackagePlugin
+                        @main
+                        struct MyCommandPlugin: CommandPlugin {
+                            func performCommand(
+                                context: PluginContext,
+                                arguments: [String]
+                            ) throws {
+                                // Extract the plugin arguments.
+                                var argExtractor = ArgumentExtractor(arguments)
+                                let productNames = argExtractor.extractOption(named: "product")
+                                if productNames.count != 1 {
+                                    throw "Expected exactly one product name, but had: \\(productNames.joined(separator: ", "))"
+                                }
+                                let products = try context.package.products(named: productNames)
+                                let printCommands = (argExtractor.extractFlag(named: "print-commands") > 0)
+                                let release = (argExtractor.extractFlag(named: "release") > 0)
+                                if let unextractedArgs = argExtractor.unextractedOptionsOrFlags.first {
+                                    throw "Unknown option: \\(unextractedArgs)"
+                                }
+                                let positionalArgs = argExtractor.remainingArguments
+                                if !positionalArgs.isEmpty {
+                                    throw "Unexpected extra arguments: \\(positionalArgs)"
+                                }
+                                do {
+                                    var parameters = PackageManager.BuildParameters()
+                                    parameters.configuration = release ? .release : .debug
+                                    parameters.logging = printCommands ? .verbose : .concise
+                                    parameters.otherSwiftcFlags = ["-DEXTRA_SWIFT_FLAG"]
+                                    let result = try packageManager.build(.product(products[0].name), parameters: parameters)
+                                    print("succeeded: \\(result.succeeded)")
+                                    for artifact in result.builtArtifacts {
+                                        print("artifact-path: \\(artifact.path.string)")
+                                        print("artifact-kind: \\(artifact.kind)")
                                     }
-                                    let products = try context.package.products(named: productNames)
-                                    let printCommands = (argExtractor.extractFlag(named: "print-commands") > 0)
-                                    let release = (argExtractor.extractFlag(named: "release") > 0)
-                                    if let unextractedArgs = argExtractor.unextractedOptionsOrFlags.first {
-                                        throw "Unknown option: \\(unextractedArgs)"
-                                    }
-                                    let positionalArgs = argExtractor.remainingArguments
-                                    if !positionalArgs.isEmpty {
-                                        throw "Unexpected extra arguments: \\(positionalArgs)"
-                                    }
-                                    do {
-                                        var parameters = PackageManager.BuildParameters()
-                                        parameters.configuration = release ? .release : .debug
-                                        parameters.logging = printCommands ? .verbose : .concise
-                                        parameters.otherSwiftcFlags = ["-DEXTRA_SWIFT_FLAG"]
-                                        let result = try packageManager.build(.product(products[0].name), parameters: parameters)
-                                        print("succeeded: \\(result.succeeded)")
-                                        for artifact in result.builtArtifacts {
-                                            print("artifact-path: \\(artifact.path.string)")
-                                            print("artifact-kind: \\(artifact.kind)")
-                                        }
-                                        print("log:\\n\\(result.logText)")
-                                    }
-                                    catch {
-                                        print("error from the plugin host: \\(error)")
-                                    }
+                                    print("log:\\n\\(result.logText)")
+                                }
+                                catch {
+                                    print("error from the plugin host: \\(error)")
                                 }
                             }
-                            extension String: Error {}
-                            """
-                    )
-                    let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
-                    try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        myLibraryTargetDir.appending("library.swift"),
-                        string: """
-                            public func GetGreeting() -> String { return "Hello" }
-                            """
-                    )
-                    let myExecutableTargetDir = packageDir.appending(components: "Sources", "MyExecutable")
-                    try localFileSystem.createDirectory(myExecutableTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        myExecutableTargetDir.appending("main.swift"),
-                        string: """
-                            import MyLibrary
-                            print("\\(GetGreeting()), World!")
-                            """
-                    )
-
-                    // Invoke the plugin with parameters choosing a verbose build of MyExecutable for debugging.
-                    do {
-                        let (stdout, _) = try await execute(
-                            ["my-build-tester", "--product", "MyExecutable", "--print-commands"],
-                            packagePath: packageDir,
-                            configuration: config,
-                            buildSystem: buildSystem,
-                        )
-                        #expect(stdout.contains("Building for debugging..."))
-                        if buildSystemProvider == .native {
-                            #expect(stdout.contains("-module-name MyExecutable"))
-                            #expect(stdout.contains("-DEXTRA_SWIFT_FLAG"))
-                            #expect(stdout.contains("Build of product 'MyExecutable' complete!"))
                         }
+                        extension String: Error {}
+                        """
+                )
+                let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
+                try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    myLibraryTargetDir.appending("library.swift"),
+                    string: """
+                        public func GetGreeting() -> String { return "Hello" }
+                        """
+                )
+                let myExecutableTargetDir = packageDir.appending(components: "Sources", "MyExecutable")
+                try localFileSystem.createDirectory(myExecutableTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    myExecutableTargetDir.appending("main.swift"),
+                    string: """
+                        import MyLibrary
+                        print("\\(GetGreeting()), World!")
+                        """
+                )
+
+                // Invoke the plugin with parameters choosing a verbose build of MyExecutable for debugging.
+                do {
+                    let (stdout, _) = try await execute(
+                        ["my-build-tester", "--product", "MyExecutable", "--print-commands"],
+                        packagePath: packageDir,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
+                    #expect(stdout.contains("Building for debugging..."))
+                    if buildSystemProvider == .native {
+                        #expect(stdout.contains("-module-name MyExecutable"))
+                        #expect(stdout.contains("-DEXTRA_SWIFT_FLAG"))
+                        #expect(stdout.contains("Build of product 'MyExecutable' complete!"))
+                    }
                         #expect(stdout.contains("succeeded: true"))
                         switch buildSystemProvider {
                         case .native:
@@ -6812,144 +6774,134 @@ struct PackageCommandTests {
                         #expect(stdout.contains("executable"))
                     }
 
-                    // Invoke the plugin with parameters choosing a concise build of MyExecutable for release.
-                    do {
-                        let (stdout, _) = try await execute(
-                            ["my-build-tester", "--product", "MyExecutable", "--release"],
-                            packagePath: packageDir,
-                            configuration: config,
-                            buildSystem: buildSystem,
-                        )
-                        #expect(stdout.contains("Building for production..."))
-                        #expect(!stdout.contains("-module-name MyExecutable"))
-                        if buildSystemProvider == .native {
-                            #expect(stdout.contains("Build of product 'MyExecutable' complete!"))
-                        }
-                        #expect(stdout.contains("succeeded: true"))
-                        switch buildSystemProvider {
-                        case .native:
-                            #expect(stdout.contains("artifact-path:"))
-                            #expect(stdout.contains(RelativePath("release/MyExecutable").pathString))
-                        case .swiftbuild:
-                            #expect(stdout.contains("artifact-path:"))
-                            #expect(stdout.contains(RelativePath("MyExecutable").pathString))
-                        case .xcode:
-                            Issue.record("unimplemented assertion for --build-system xcode")
-                        }
-                        #expect(stdout.contains("artifact-kind:"))
-                        #expect(stdout.contains("executable"))
+                // Invoke the plugin with parameters choosing a concise build of MyExecutable for release.
+                do {
+                    let (stdout, _) = try await execute(
+                        ["my-build-tester", "--product", "MyExecutable", "--release"],
+                        packagePath: packageDir,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
+                    #expect(stdout.contains("Building for production..."))
+                    #expect(!stdout.contains("-module-name MyExecutable"))
+                    if buildSystemProvider == .native {
+                        #expect(stdout.contains("Build of product 'MyExecutable' complete!"))
                     }
-
-                    // SwiftBuild is currently not producing a static archive for static products unless they are linked into some other binary.
-                    try await withKnownIssue(isIntermittent: true) {
-                        // Invoke the plugin with parameters choosing a verbose build of MyStaticLibrary for release.
-                        do {
-                            let (stdout, _) = try await execute(
-                                ["my-build-tester", "--product", "MyStaticLibrary", "--print-commands", "--release"],
-                                packagePath: packageDir,
-                                configuration: config,
-                                buildSystem: buildSystem,
-                            )
-                            #expect(stdout.contains("Building for production..."))
-                            #expect(!stdout.contains("Building for debug..."))
-                            #expect(!stdout.contains("-module-name MyLibrary"))
-                            if buildSystemProvider == .native {
-                                #expect(stdout.contains("Build of product 'MyStaticLibrary' complete!"))
-                            }
-                            #expect(stdout.contains("succeeded: true"))
-                            switch buildSystemProvider {
-                            case .native:
-                                #expect(stdout.contains("artifact-path:"))
-                                #expect(stdout.contains(RelativePath("release/libMyStaticLibrary").pathString))
-                            case .swiftbuild:
-                                #expect(stdout.contains("artifact-path:"))
-                                #expect(stdout.contains(RelativePath("MyStaticLibrary").pathString))
-                            case .xcode:
-                                Issue.record("unimplemented assertion for --build-system xcode")
-                            }
-                            #expect(stdout.contains("artifact-kind:"))
-                            #expect(stdout.contains("staticLibrary"))
-                        }
-                    } when: {
-                        buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
+                    #expect(stdout.contains("succeeded: true"))
+                    switch buildSystemProvider {
+                    case .native:
+                        #expect(stdout.contains("artifact-path:"))
+                        #expect(stdout.contains(RelativePath("release/MyExecutable").pathString))
+                    case .swiftbuild:
+                        #expect(stdout.contains("artifact-path:"))
+                        #expect(stdout.contains(RelativePath("MyExecutable").pathString))
+                    case .xcode:
+                        Issue.record("unimplemented assertion for --build-system xcode")
                     }
-
-                    // Invoke the plugin with parameters choosing a verbose build of MyDynamicLibrary for release.
-                    do {
-                        let (stdout, _) = try await execute(
-                            [
-                                "my-build-tester", "--product", "MyDynamicLibrary", "--print-commands", "--release",
-                            ],
-                            packagePath: packageDir,
-                            configuration: config,
-                            buildSystem: buildSystem,
-                        )
-                        #expect(stdout.contains("Building for production..."))
-                        #expect(!stdout.contains("Building for debug..."))
-                        #expect(!stdout.contains("-module-name MyLibrary"))
-                        if buildSystemProvider == .native {
-                            #expect(stdout.contains("Build of product 'MyDynamicLibrary' complete!"))
-                        }
-                        #expect(stdout.contains("succeeded: true"))
-                        switch buildSystemProvider {
-                        case .native:
-                            #if os(Windows)
-                                #expect(stdout.contains("artifact-path:"))
-                                #expect(stdout.contains(RelativePath("release/MyDynamicLibrary.dll").pathString))
-                            #else
-                                #expect(stdout.contains("artifact-path:"))
-                                #expect(stdout.contains(RelativePath("release/libMyDynamicLibrary").pathString))
-                            #endif
-                        case .swiftbuild:
-                            #expect(stdout.contains("artifact-path:"))
-                            #expect(stdout.contains(RelativePath("MyDynamicLibrary").pathString))
-                        case .xcode:
-                            Issue.record("unimplemented assertion for --build-system xcode")
-                        }
-                        #expect(stdout.contains("artifact-kind:"))
-                        #expect(stdout.contains("dynamicLibrary"))
-                    }
+                    #expect(stdout.contains("artifact-kind:"))
+                    #expect(stdout.contains("executable"))
                 }
-            } when: {
-                ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
+
+                // Invoke the plugin with parameters choosing a verbose build of MyStaticLibrary for release.
+                do {
+                    let (stdout, _) = try await execute(
+                        ["my-build-tester", "--product", "MyStaticLibrary", "--print-commands", "--release"],
+                        packagePath: packageDir,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
+                    #expect(stdout.contains("Building for production..."))
+                    #expect(!stdout.contains("Building for debug..."))
+                    #expect(!stdout.contains("-module-name MyLibrary"))
+                    if buildSystemProvider == .native {
+                        #expect(stdout.contains("Build of product 'MyStaticLibrary' complete!"))
+                    }
+                    #expect(stdout.contains("succeeded: true"))
+                    switch buildSystemProvider {
+                    case .native:
+                        #expect(stdout.contains("artifact-path:"))
+                        #expect(stdout.contains(RelativePath("release/libMyStaticLibrary").pathString))
+                    case .swiftbuild:
+                        #expect(stdout.contains("artifact-path:"))
+                        #expect(stdout.contains(RelativePath("MyStaticLibrary").pathString))
+                    case .xcode:
+                        Issue.record("unimplemented assertion for --build-system xcode")
+                    }
+                    #expect(stdout.contains("artifact-kind:"))
+                    #expect(stdout.contains("staticLibrary"))
+                }
+
+                // Invoke the plugin with parameters choosing a verbose build of MyDynamicLibrary for release.
+                do {
+                    let (stdout, _) = try await execute(
+                        [
+                            "my-build-tester", "--product", "MyDynamicLibrary", "--print-commands", "--release",
+                        ],
+                        packagePath: packageDir,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
+                    #expect(stdout.contains("Building for production..."))
+                    #expect(!stdout.contains("Building for debug..."))
+                    #expect(!stdout.contains("-module-name MyLibrary"))
+                    if buildSystemProvider == .native {
+                        #expect(stdout.contains("Build of product 'MyDynamicLibrary' complete!"))
+                    }
+                    #expect(stdout.contains("succeeded: true"))
+                    switch buildSystemProvider {
+                    case .native:
+                        #if os(Windows)
+                            #expect(stdout.contains("artifact-path:"))
+                            #expect(stdout.contains(RelativePath("release/MyDynamicLibrary.dll").pathString))
+                        #else
+                            #expect(stdout.contains("artifact-path:"))
+                            #expect(stdout.contains(RelativePath("release/libMyDynamicLibrary").pathString))
+                        #endif
+                    case .swiftbuild:
+                        #expect(stdout.contains("artifact-path:"))
+                        #expect(stdout.contains(RelativePath("MyDynamicLibrary").pathString))
+                    case .xcode:
+                        Issue.record("unimplemented assertion for --build-system xcode")
+                    }
+                    #expect(stdout.contains("artifact-kind:"))
+                    #expect(stdout.contains("dynamicLibrary"))
+                }
             }
         }
 
         @Test(
-            .IssueWindowsRelativePathAssert,
             arguments: [BuildSystemProvider.Kind.native, .swiftbuild],
         )
         func commandPluginBuildingCallbacksExcludeUnbuiltArtifacts(buildSystem: BuildSystemProvider.Kind) async throws {
             try await withKnownIssue(isIntermittent: true) {
-                try await fixture(name: "PartiallyUnusedDependency") { fixturePath in
-                    let (stdout, _) = try await execute(
-                        ["dump-artifacts-plugin"],
-                        packagePath: fixturePath,
-                        configuration: .debug,
-                        buildSystem: buildSystem
-                    )
-                    // The build should succeed
-                    #expect(stdout.contains("succeeded: true"))
-                    // The artifacts corresponding to the executable and dylib we built should be reported
-                    #expect(stdout.contains(#/artifact-path: [^\n]+MyExecutable(.*)?\nartifact-kind: executable/#))
-                    #expect(stdout.contains(#/artifact-path: [^\n]+MyDynamicLibrary(.*)?\nartifact-kind: dynamicLibrary/#))
-                    // The not-built executable in the dependency should not be reported. The native build system fails to exclude it.
-                    switch buildSystem {
-                        case .native:
-                            #expect(stdout.contains("MySupportExecutable"))
-                        case .swiftbuild:
-                            #expect(!stdout.contains("MySupportExecutable"))
-                        case .xcode:
-                            Issue.record("unimplemented assertion for --build-system xcode")
-                    }
+            try await fixture(name: "PartiallyUnusedDependency") { fixturePath in
+                let (stdout, _) = try await execute(
+                    ["dump-artifacts-plugin"],
+                    packagePath: fixturePath,
+                    configuration: .debug,
+                    buildSystem: buildSystem
+                )
+                // The build should succeed
+                #expect(stdout.contains("succeeded: true"))
+                // The artifacts corresponding to the executable and dylib we built should be reported
+                #expect(stdout.contains(#/artifact-path: [^\n]+MyExecutable(.*)?\nartifact-kind: executable/#))
+                #expect(stdout.contains(#/artifact-path: [^\n]+MyDynamicLibrary(.*)?\nartifact-kind: dynamicLibrary/#))
+                // The not-built executable in the dependency should not be reported. The native build system fails to exclude it.
+                switch buildSystem {
+                    case .native:
+                        #expect(stdout.contains("MySupportExecutable"))
+                    case .swiftbuild:
+                        #expect(!stdout.contains("MySupportExecutable"))
+                    case .xcode:
+                        Issue.record("unimplemented assertion for --build-system xcode")
                 }
+            }
             } when: {
                 buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
             }
         }
 
         @Test(
-            .IssueWindowsRelativePathAssert,
             .requiresSwiftConcurrencySupport,
             // Depending on how the test is running, the `llvm-profdata` and `llvm-cov` tool might be unavailable.
             .requiresLLVMProfData,
@@ -6963,139 +6915,139 @@ struct PackageCommandTests {
             data: BuildData,
         ) async throws {
             try await withKnownIssue(isIntermittent: true) {
-                try await testWithTemporaryDirectory { tmpPath in
-                    // Create a sample package with a library, a command plugin, and a couple of tests.
-                    let packageDir = tmpPath.appending(components: "MyPackage")
-                    try localFileSystem.createDirectory(packageDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        packageDir.appending(components: "Package.swift"),
-                        string: """
-                            // swift-tools-version: 5.6
-                            import PackageDescription
-                            let package = Package(
-                                name: "MyPackage",
-                                targets: [
-                                    .target(
-                                        name: "MyLibrary"
-                                    ),
-                                    .plugin(
-                                        name: "MyPlugin",
-                                        capability: .command(
-                                            intent: .custom(verb: "my-test-tester", description: "Help description")
-                                        )
-                                    ),
-                                    .testTarget(
-                                        name: "MyBasicTests"
-                                    ),
-                                    .testTarget(
-                                        name: "MyExtendedTests"
-                                    ),
-                                ]
-                            )
-                            """
-                    )
-                    let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
-                    try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        myPluginTargetDir.appending("plugin.swift"),
-                        string: """
-                            import PackagePlugin
-                            @main
-                            struct MyCommandPlugin: CommandPlugin {
-                                func performCommand(
-                                    context: PluginContext,
-                                    arguments: [String]
-                                ) throws {
-                                    do {
-                                        let result = try packageManager.test(.filtered(["MyBasicTests"]), parameters: .init(enableCodeCoverage: true))
-                                        assert(result.succeeded == true)
-                                        assert(result.testTargets.count == 1)
-                                        assert(result.testTargets[0].name == "MyBasicTests")
-                                        assert(result.testTargets[0].testCases.count == 2)
-                                        assert(result.testTargets[0].testCases[0].name == "MyBasicTests.TestSuite1")
-                                        assert(result.testTargets[0].testCases[0].tests.count == 2)
-                                        assert(result.testTargets[0].testCases[0].tests[0].name == "testBooleanInvariants")
-                                        assert(result.testTargets[0].testCases[0].tests[1].result == .succeeded)
-                                        assert(result.testTargets[0].testCases[0].tests[1].name == "testNumericalInvariants")
-                                        assert(result.testTargets[0].testCases[0].tests[1].result == .succeeded)
-                                        assert(result.testTargets[0].testCases[1].name == "MyBasicTests.TestSuite2")
-                                        assert(result.testTargets[0].testCases[1].tests.count == 1)
-                                        assert(result.testTargets[0].testCases[1].tests[0].name == "testStringInvariants")
-                                        assert(result.testTargets[0].testCases[1].tests[0].result == .succeeded)
-                                        assert(result.codeCoverageDataFile?.extension == "json")
-                                    }
-                                    catch {
-                                        print("error from the plugin host: \\(error)")
-                                    }
+            try await testWithTemporaryDirectory { tmpPath in
+                // Create a sample package with a library, a command plugin, and a couple of tests.
+                let packageDir = tmpPath.appending(components: "MyPackage")
+                try localFileSystem.createDirectory(packageDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    packageDir.appending(components: "Package.swift"),
+                    string: """
+                        // swift-tools-version: 5.6
+                        import PackageDescription
+                        let package = Package(
+                            name: "MyPackage",
+                            targets: [
+                                .target(
+                                    name: "MyLibrary"
+                                ),
+                                .plugin(
+                                    name: "MyPlugin",
+                                    capability: .command(
+                                        intent: .custom(verb: "my-test-tester", description: "Help description")
+                                    )
+                                ),
+                                .testTarget(
+                                    name: "MyBasicTests"
+                                ),
+                                .testTarget(
+                                    name: "MyExtendedTests"
+                                ),
+                            ]
+                        )
+                        """
+                )
+                let myPluginTargetDir = packageDir.appending(components: "Plugins", "MyPlugin")
+                try localFileSystem.createDirectory(myPluginTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    myPluginTargetDir.appending("plugin.swift"),
+                    string: """
+                        import PackagePlugin
+                        @main
+                        struct MyCommandPlugin: CommandPlugin {
+                            func performCommand(
+                                context: PluginContext,
+                                arguments: [String]
+                            ) throws {
+                                do {
+                                    let result = try packageManager.test(.filtered(["MyBasicTests"]), parameters: .init(enableCodeCoverage: true))
+                                    assert(result.succeeded == true)
+                                    assert(result.testTargets.count == 1)
+                                    assert(result.testTargets[0].name == "MyBasicTests")
+                                    assert(result.testTargets[0].testCases.count == 2)
+                                    assert(result.testTargets[0].testCases[0].name == "MyBasicTests.TestSuite1")
+                                    assert(result.testTargets[0].testCases[0].tests.count == 2)
+                                    assert(result.testTargets[0].testCases[0].tests[0].name == "testBooleanInvariants")
+                                    assert(result.testTargets[0].testCases[0].tests[1].result == .succeeded)
+                                    assert(result.testTargets[0].testCases[0].tests[1].name == "testNumericalInvariants")
+                                    assert(result.testTargets[0].testCases[0].tests[1].result == .succeeded)
+                                    assert(result.testTargets[0].testCases[1].name == "MyBasicTests.TestSuite2")
+                                    assert(result.testTargets[0].testCases[1].tests.count == 1)
+                                    assert(result.testTargets[0].testCases[1].tests[0].name == "testStringInvariants")
+                                    assert(result.testTargets[0].testCases[1].tests[0].result == .succeeded)
+                                    assert(result.codeCoverageDataFile?.extension == "json")
+                                }
+                                catch {
+                                    print("error from the plugin host: \\(error)")
                                 }
                             }
-                            """
-                    )
-                    let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
-                    try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        myLibraryTargetDir.appending("library.swift"),
-                        string: """
-                            public func Foo() { }
-                            """
-                    )
-                    let myBasicTestsTargetDir = packageDir.appending(components: "Tests", "MyBasicTests")
-                    try localFileSystem.createDirectory(myBasicTestsTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        myBasicTestsTargetDir.appending("Test1.swift"),
-                        string: """
-                            import XCTest
-                            class TestSuite1: XCTestCase {
-                                func testBooleanInvariants() throws {
-                                    XCTAssertEqual(true || true, true)
-                                }
-                                func testNumericalInvariants() throws {
-                                    XCTAssertEqual(1 + 1, 2)
-                                }
+                        }
+                        """
+                )
+                let myLibraryTargetDir = packageDir.appending(components: "Sources", "MyLibrary")
+                try localFileSystem.createDirectory(myLibraryTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    myLibraryTargetDir.appending("library.swift"),
+                    string: """
+                        public func Foo() { }
+                        """
+                )
+                let myBasicTestsTargetDir = packageDir.appending(components: "Tests", "MyBasicTests")
+                try localFileSystem.createDirectory(myBasicTestsTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    myBasicTestsTargetDir.appending("Test1.swift"),
+                    string: """
+                        import XCTest
+                        class TestSuite1: XCTestCase {
+                            func testBooleanInvariants() throws {
+                                XCTAssertEqual(true || true, true)
                             }
-                            """
-                    )
-                    try localFileSystem.writeFileContents(
-                        myBasicTestsTargetDir.appending("Test2.swift"),
-                        string: """
-                            import XCTest
-                            class TestSuite2: XCTestCase {
-                                func testStringInvariants() throws {
-                                    XCTAssertEqual("" + "", "")
-                                }
+                            func testNumericalInvariants() throws {
+                                XCTAssertEqual(1 + 1, 2)
                             }
-                            """
-                    )
-                    let myExtendedTestsTargetDir = packageDir.appending(
-                        components: "Tests",
-                        "MyExtendedTests"
-                    )
-                    try localFileSystem.createDirectory(myExtendedTestsTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        myExtendedTestsTargetDir.appending("Test3.swift"),
-                        string: """
-                            import XCTest
-                            class TestSuite3: XCTestCase {
-                                func testArrayInvariants() throws {
-                                    XCTAssertEqual([] + [], [])
-                                }
-                                func testImpossibilities() throws {
-                                    XCTFail("no can do")
-                                }
+                        }
+                        """
+                )
+                try localFileSystem.writeFileContents(
+                    myBasicTestsTargetDir.appending("Test2.swift"),
+                    string: """
+                        import XCTest
+                        class TestSuite2: XCTestCase {
+                            func testStringInvariants() throws {
+                                XCTAssertEqual("" + "", "")
                             }
-                            """
-                    )
+                        }
+                        """
+                )
+                let myExtendedTestsTargetDir = packageDir.appending(
+                    components: "Tests",
+                    "MyExtendedTests"
+                )
+                try localFileSystem.createDirectory(myExtendedTestsTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    myExtendedTestsTargetDir.appending("Test3.swift"),
+                    string: """
+                        import XCTest
+                        class TestSuite3: XCTestCase {
+                            func testArrayInvariants() throws {
+                                XCTAssertEqual([] + [], [])
+                            }
+                            func testImpossibilities() throws {
+                                XCTFail("no can do")
+                            }
+                        }
+                        """
+                )
 
-                    // Check basic usage with filtering and code coverage. The plugin itself asserts a bunch of values.
-                    try await execute(
-                        ["my-test-tester"],
-                        packagePath: packageDir,
-                        configuration: data.config,
-                        buildSystem: data.buildSystem,
-                    )
+                // Check basic usage with filtering and code coverage. The plugin itself asserts a bunch of values.
+                try await execute(
+                    ["my-test-tester"],
+                    packagePath: packageDir,
+                    configuration: data.config,
+                    buildSystem: data.buildSystem,
+                )
 
-                    // We'll add checks for various error conditions here in a future commit.
-                }
+                // We'll add checks for various error conditions here in a future commit.
+            }
             } when: {
                 ProcessInfo.hostOperatingSystem == .windows && data.buildSystem == .swiftbuild
             }
@@ -7170,219 +7122,219 @@ struct PackageCommandTests {
             testData: PluginAPIsData
         ) async throws {
             try await withKnownIssue(isIntermittent: true) {
-                try await testWithTemporaryDirectory { tmpPath in
-                    // Create a sample package with a plugin to test various parts of the API.
-                    let packageDir = tmpPath.appending(components: "MyPackage")
-                    try localFileSystem.createDirectory(packageDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        packageDir.appending("Package.swift"),
-                        string: """
-                                // swift-tools-version: 5.9
-                                import PackageDescription
-                                let package = Package(
-                                    name: "MyPackage",
-                                    dependencies: [
-                                        .package(name: "HelperPackage", path: "VendoredDependencies/HelperPackage")
-                                    ],
-                                    targets: [
-                                        .target(
-                                            name: "FirstTarget",
-                                            dependencies: [
-                                            ]
-                                        ),
-                                        .target(
-                                            name: "SecondTarget",
-                                            dependencies: [
-                                                "FirstTarget",
-                                            ]
-                                        ),
-                                        .target(
-                                            name: "ThirdTarget",
-                                            dependencies: [
-                                                "FirstTarget",
-                                            ]
-                                        ),
-                                        .target(
-                                            name: "FourthTarget",
-                                            dependencies: [
-                                                "SecondTarget",
-                                                "ThirdTarget",
-                                                .product(name: "HelperLibrary", package: "HelperPackage"),
-                                            ]
-                                        ),
-                                        .executableTarget(
-                                            name: "FifthTarget",
-                                            dependencies: [
-                                                "FirstTarget",
-                                                "ThirdTarget",
-                                            ]
-                                        ),
-                                        .testTarget(
-                                            name: "TestTarget",
-                                            dependencies: [
-                                                "SecondTarget",
-                                            ]
-                                        ),
-                                        .plugin(
-                                            name: "PrintTargetDependencies",
-                                            capability: .command(
-                                                intent: .custom(verb: "print-target-dependencies", description: "Plugin that prints target dependencies; argument is name of target")
-                                            )
-                                        ),
-                                    ]
-                                )
-                            """
-                    )
-
-                    let firstTargetDir = packageDir.appending(components: "Sources", "FirstTarget")
-                    try localFileSystem.createDirectory(firstTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        firstTargetDir.appending("library.swift"),
-                        string: """
-                            public func FirstFunc() { }
-                            """
-                    )
-
-                    let secondTargetDir = packageDir.appending(components: "Sources", "SecondTarget")
-                    try localFileSystem.createDirectory(secondTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        secondTargetDir.appending("library.swift"),
-                        string: """
-                            public func SecondFunc() { }
-                            """
-                    )
-
-                    let thirdTargetDir = packageDir.appending(components: "Sources", "ThirdTarget")
-                    try localFileSystem.createDirectory(thirdTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        thirdTargetDir.appending("library.swift"),
-                        string: """
-                            public func ThirdFunc() { }
-                            """
-                    )
-
-                    let fourthTargetDir = packageDir.appending(components: "Sources", "FourthTarget")
-                    try localFileSystem.createDirectory(fourthTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        fourthTargetDir.appending("library.swift"),
-                        string: """
-                            public func FourthFunc() { }
-                            """
-                    )
-
-                    let fifthTargetDir = packageDir.appending(components: "Sources", "FifthTarget")
-                    try localFileSystem.createDirectory(fifthTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        fifthTargetDir.appending("main.swift"),
-                        string: """
-                            @main struct MyExec {
-                                func run() throws {}
-                            }
-                            """
-                    )
-
-                    let testTargetDir = packageDir.appending(components: "Tests", "TestTarget")
-                    try localFileSystem.createDirectory(testTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        testTargetDir.appending("tests.swift"),
-                        string: """
-                            import XCTest
-                            class MyTestCase: XCTestCase {
-                            }
-                            """
-                    )
-
-                    let pluginTargetTargetDir = packageDir.appending(
-                        components: "Plugins",
-                        "PrintTargetDependencies"
-                    )
-                    try localFileSystem.createDirectory(pluginTargetTargetDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        pluginTargetTargetDir.appending("plugin.swift"),
-                        string: """
-                            import PackagePlugin
-                            @main struct PrintTargetDependencies: CommandPlugin {
-                                func performCommand(
-                                    context: PluginContext,
-                                    arguments: [String]
-                                ) throws {
-                                    // Print names of the recursive dependencies of the given target.
-                                    var argExtractor = ArgumentExtractor(arguments)
-                                    guard let targetName = argExtractor.extractOption(named: "target").first else {
-                                        throw "No target argument provided"
-                                    }
-                                    guard let target = try? context.package.targets(named: [targetName]).first else {
-                                        throw "No target found with the name '\\(targetName)'"
-                                    }
-                                    print("Recursive dependencies of '\\(target.name)': \\(target.recursiveTargetDependencies.map(\\.name))")
-
-                                    let execProducts = context.package.products(ofType: ExecutableProduct.self)
-                                    print("execProducts: \\(execProducts.map{ $0.name })")
-                                    let swiftTargets = context.package.targets(ofType: SwiftSourceModuleTarget.self)
-                                    print("swiftTargets: \\(swiftTargets.map{ $0.name }.sorted())")
-                                    let swiftSources = swiftTargets.flatMap{ $0.sourceFiles(withSuffix: ".swift") }
-                                    print("swiftSources: \\(swiftSources.map{ $0.path.lastComponent }.sorted())")
-
-                                    if let target = target.sourceModule {
-                                        print("Module kind of '\\(target.name)': \\(target.kind)")
-                                    }
-
-                                    var sourceModules = context.package.sourceModules
-                                    print("sourceModules in package: \\(sourceModules.map { $0.name })")
-                                    sourceModules = context.package.products.first?.sourceModules ?? []
-                                    print("sourceModules in first product: \\(sourceModules.map { $0.name })")
-                                }
-                            }
-                            extension String: Error {}
-                            """
-                    )
-
-                    // Create a separate vendored package so that we can test dependencies across products in other packages.
-                    let helperPackageDir = packageDir.appending(
-                        components: "VendoredDependencies",
-                        "HelperPackage"
-                    )
-                    try localFileSystem.createDirectory(helperPackageDir, recursive: true)
-                    try localFileSystem.writeFileContents(
-                        helperPackageDir.appending("Package.swift"),
-                        string: """
-                            // swift-tools-version: 5.6
+            try await testWithTemporaryDirectory { tmpPath in
+                // Create a sample package with a plugin to test various parts of the API.
+                let packageDir = tmpPath.appending(components: "MyPackage")
+                try localFileSystem.createDirectory(packageDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    packageDir.appending("Package.swift"),
+                    string: """
+                            // swift-tools-version: 5.9
                             import PackageDescription
                             let package = Package(
-                                name: "HelperPackage",
-                                products: [
-                                    .library(
-                                        name: "HelperLibrary",
-                                        targets: ["HelperLibrary"])
+                                name: "MyPackage",
+                                dependencies: [
+                                    .package(name: "HelperPackage", path: "VendoredDependencies/HelperPackage")
                                 ],
                                 targets: [
                                     .target(
-                                        name: "HelperLibrary",
-                                        path: ".")
+                                        name: "FirstTarget",
+                                        dependencies: [
+                                        ]
+                                    ),
+                                    .target(
+                                        name: "SecondTarget",
+                                        dependencies: [
+                                            "FirstTarget",
+                                        ]
+                                    ),
+                                    .target(
+                                        name: "ThirdTarget",
+                                        dependencies: [
+                                            "FirstTarget",
+                                        ]
+                                    ),
+                                    .target(
+                                        name: "FourthTarget",
+                                        dependencies: [
+                                            "SecondTarget",
+                                            "ThirdTarget",
+                                            .product(name: "HelperLibrary", package: "HelperPackage"),
+                                        ]
+                                    ),
+                                    .executableTarget(
+                                        name: "FifthTarget",
+                                        dependencies: [
+                                            "FirstTarget",
+                                            "ThirdTarget",
+                                        ]
+                                    ),
+                                    .testTarget(
+                                        name: "TestTarget",
+                                        dependencies: [
+                                            "SecondTarget",
+                                        ]
+                                    ),
+                                    .plugin(
+                                        name: "PrintTargetDependencies",
+                                        capability: .command(
+                                            intent: .custom(verb: "print-target-dependencies", description: "Plugin that prints target dependencies; argument is name of target")
+                                        )
+                                    ),
                                 ]
                             )
-                            """
-                    )
-                    try localFileSystem.writeFileContents(
-                        helperPackageDir.appending("library.swift"),
-                        string: """
-                            public func Foo() { }
-                            """
-                    )
+                        """
+                )
 
-                    let (stdout, stderr) = try await execute(
-                        testData.commandArgs,
-                        packagePath: packageDir,
-                        configuration: buildData.config,
-                        buildSystem: buildData.buildSystem,
-                    )
-                    for expected in testData.expectedStdout {
-                        #expect(stdout.contains(expected))
-                    }
-                    for expected in testData.expectedStderr {
-                        #expect(stderr.contains(expected))
-                    }
+                let firstTargetDir = packageDir.appending(components: "Sources", "FirstTarget")
+                try localFileSystem.createDirectory(firstTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    firstTargetDir.appending("library.swift"),
+                    string: """
+                        public func FirstFunc() { }
+                        """
+                )
+
+                let secondTargetDir = packageDir.appending(components: "Sources", "SecondTarget")
+                try localFileSystem.createDirectory(secondTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    secondTargetDir.appending("library.swift"),
+                    string: """
+                        public func SecondFunc() { }
+                        """
+                )
+
+                let thirdTargetDir = packageDir.appending(components: "Sources", "ThirdTarget")
+                try localFileSystem.createDirectory(thirdTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    thirdTargetDir.appending("library.swift"),
+                    string: """
+                        public func ThirdFunc() { }
+                        """
+                )
+
+                let fourthTargetDir = packageDir.appending(components: "Sources", "FourthTarget")
+                try localFileSystem.createDirectory(fourthTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    fourthTargetDir.appending("library.swift"),
+                    string: """
+                        public func FourthFunc() { }
+                        """
+                )
+
+                let fifthTargetDir = packageDir.appending(components: "Sources", "FifthTarget")
+                try localFileSystem.createDirectory(fifthTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    fifthTargetDir.appending("main.swift"),
+                    string: """
+                        @main struct MyExec {
+                            func run() throws {}
+                        }
+                        """
+                )
+
+                let testTargetDir = packageDir.appending(components: "Tests", "TestTarget")
+                try localFileSystem.createDirectory(testTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    testTargetDir.appending("tests.swift"),
+                    string: """
+                        import XCTest
+                        class MyTestCase: XCTestCase {
+                        }
+                        """
+                )
+
+                let pluginTargetTargetDir = packageDir.appending(
+                    components: "Plugins",
+                    "PrintTargetDependencies"
+                )
+                try localFileSystem.createDirectory(pluginTargetTargetDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    pluginTargetTargetDir.appending("plugin.swift"),
+                    string: """
+                        import PackagePlugin
+                        @main struct PrintTargetDependencies: CommandPlugin {
+                            func performCommand(
+                                context: PluginContext,
+                                arguments: [String]
+                            ) throws {
+                                // Print names of the recursive dependencies of the given target.
+                                var argExtractor = ArgumentExtractor(arguments)
+                                guard let targetName = argExtractor.extractOption(named: "target").first else {
+                                    throw "No target argument provided"
+                                }
+                                guard let target = try? context.package.targets(named: [targetName]).first else {
+                                    throw "No target found with the name '\\(targetName)'"
+                                }
+                                print("Recursive dependencies of '\\(target.name)': \\(target.recursiveTargetDependencies.map(\\.name))")
+
+                                let execProducts = context.package.products(ofType: ExecutableProduct.self)
+                                print("execProducts: \\(execProducts.map{ $0.name })")
+                                let swiftTargets = context.package.targets(ofType: SwiftSourceModuleTarget.self)
+                                print("swiftTargets: \\(swiftTargets.map{ $0.name }.sorted())")
+                                let swiftSources = swiftTargets.flatMap{ $0.sourceFiles(withSuffix: ".swift") }
+                                print("swiftSources: \\(swiftSources.map{ $0.path.lastComponent }.sorted())")
+
+                                if let target = target.sourceModule {
+                                    print("Module kind of '\\(target.name)': \\(target.kind)")
+                                }
+
+                                var sourceModules = context.package.sourceModules
+                                print("sourceModules in package: \\(sourceModules.map { $0.name })")
+                                sourceModules = context.package.products.first?.sourceModules ?? []
+                                print("sourceModules in first product: \\(sourceModules.map { $0.name })")
+                            }
+                        }
+                        extension String: Error {}
+                        """
+                )
+
+                // Create a separate vendored package so that we can test dependencies across products in other packages.
+                let helperPackageDir = packageDir.appending(
+                    components: "VendoredDependencies",
+                    "HelperPackage"
+                )
+                try localFileSystem.createDirectory(helperPackageDir, recursive: true)
+                try localFileSystem.writeFileContents(
+                    helperPackageDir.appending("Package.swift"),
+                    string: """
+                        // swift-tools-version: 5.6
+                        import PackageDescription
+                        let package = Package(
+                            name: "HelperPackage",
+                            products: [
+                                .library(
+                                    name: "HelperLibrary",
+                                    targets: ["HelperLibrary"])
+                            ],
+                            targets: [
+                                .target(
+                                    name: "HelperLibrary",
+                                    path: ".")
+                            ]
+                        )
+                        """
+                )
+                try localFileSystem.writeFileContents(
+                    helperPackageDir.appending("library.swift"),
+                    string: """
+                        public func Foo() { }
+                        """
+                )
+
+                let (stdout, stderr) = try await execute(
+                    testData.commandArgs,
+                    packagePath: packageDir,
+                    configuration: buildData.config,
+                    buildSystem: buildData.buildSystem,
+                )
+                for expected in testData.expectedStdout {
+                    #expect(stdout.contains(expected))
                 }
+                for expected in testData.expectedStderr {
+                    #expect(stderr.contains(expected))
+                }
+            }
             } when: {
                 ProcessInfo.hostOperatingSystem == .windows
             }
@@ -7390,7 +7342,6 @@ struct PackageCommandTests {
 
         @Test(
             .requiresSwiftConcurrencySupport,
-            .IssueWindowsLongPath,
             .tags(
                 .Feature.Command.Package.Plugin,
             ),
@@ -7498,21 +7449,17 @@ struct PackageCommandTests {
                 )
 
                 // Check that building without options compiles both plugins and that the build proceeds.
-                try await withKnownIssue(isIntermittent: true) {
-                    do {
-                        let (stdout, _) = try await executeSwiftBuild(
-                            packageDir,
-                            configuration: data.config,
-                            buildSystem: data.buildSystem,
-                        )
-                        if data.buildSystem == .native {
-                            #expect(stdout.contains("Compiling plugin MyBuildToolPlugin"))
-                            #expect(stdout.contains("Compiling plugin MyCommandPlugin"))
-                        }
-                        #expect(stdout.contains("Building for \(data.config.buildFor)..."))
+                do {
+                    let (stdout, _) = try await executeSwiftBuild(
+                        packageDir,
+                        configuration: data.config,
+                        buildSystem: data.buildSystem,
+                    )
+                    if data.buildSystem == .native {
+                        #expect(stdout.contains("Compiling plugin MyBuildToolPlugin"))
+                        #expect(stdout.contains("Compiling plugin MyCommandPlugin"))
                     }
-                } when: {
-                    ProcessInfo.hostOperatingSystem == .windows && data.buildSystem == .swiftbuild
+                    #expect(stdout.contains("Building for \(data.config.buildFor)..."))
                 }
 
                 // Check that building just one of them just compiles that plugin and doesn't build anything else.
@@ -7851,14 +7798,14 @@ struct PackageCommandTests {
             try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
                 let config = BuildConfiguration.debug
                 let customSBOMDir = fixturePath.appending("custom-sboms")
-                
+
                 let (stdout, _) = try await execute(
                     ["generate-sbom", "--sbom-output-dir", customSBOMDir.pathString],
                     packagePath: fixturePath,
                     configuration: config,
                     buildSystem: buildSystem,
                 )
-                
+
                 #expect(stdout.contains("SBOMs created"))
                 #expect(localFileSystem.isDirectory(customSBOMDir))
                 let files = try localFileSystem.getDirectoryContents(customSBOMDir)
@@ -7908,7 +7855,7 @@ struct PackageCommandTests {
                 let endRange = try #require(stdout[range.upperBound...].range(of: ".json"), "Could not find '.json' in output")
                 let pathString = String(stdout[range.upperBound..<endRange.upperBound])
                 let sbomPath = try AbsolutePath(validating: pathString)
-                
+
                 #expect(localFileSystem.exists(sbomPath))
                 let filesInDirectory = try localFileSystem.getDirectoryContents(sbomPath.parentDirectory)
                 #expect(filesInDirectory.count == 1, "should only produce 1 CycloneDX SBOM")
@@ -7937,13 +7884,13 @@ struct PackageCommandTests {
                 let endRange = try #require(stdout[range.upperBound...].range(of: ".json"), "Could not find '.json' in output")
                 let pathString = String(stdout[range.upperBound..<endRange.upperBound])
                 let sbomPath = try AbsolutePath(validating: pathString)
-                
+
                 #expect(localFileSystem.exists(sbomPath))
                 let filesInDirectory = try localFileSystem.getDirectoryContents(sbomPath.parentDirectory)
                 #expect(filesInDirectory.count == 1, "should only produce 1 SPDX SBOM")
             }
         }
-    
+
         @Test(
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
@@ -7953,7 +7900,7 @@ struct PackageCommandTests {
             try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
                 let config = BuildConfiguration.debug
                 let customSBOMDir = fixturePath.appending("custom-sboms")
-                
+
                 let (stdout, stderr) = try await execute(
                     ["generate-sbom", "--sbom-spec", "cyclonedx", "--sbom-output-dir", customSBOMDir.pathString],
                     packagePath: fixturePath,
@@ -7961,13 +7908,13 @@ struct PackageCommandTests {
                     buildSystem: buildSystem,
                 )
                 #expect(stdout.contains("SBOMs created"))
-                
+
                 #expect(localFileSystem.isDirectory(customSBOMDir))
                 let files = try localFileSystem.getDirectoryContents(customSBOMDir)
                     #expect(files.count == 1)
             }
         }
-    
+
         @Test(
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
@@ -7989,7 +7936,7 @@ struct PackageCommandTests {
                 let endRange = try #require(stdout[range.upperBound...].range(of: ".json"), "Could not find '.json' in output")
                 let pathString = String(stdout[range.upperBound..<endRange.upperBound])
                 let sbomPath = try AbsolutePath(validating: pathString)
-                
+
                 #expect(localFileSystem.exists(sbomPath))
                 let filesInDirectory = try localFileSystem.getDirectoryContents(sbomPath.parentDirectory)
                 #expect(filesInDirectory.count == 1, "should only produce 1 CycloneDX SBOM")
@@ -8038,7 +7985,7 @@ struct PackageCommandTests {
                 let endRange = try #require(stdout[range.upperBound...].range(of: ".json"), "Could not find '.json' in output")
                 let pathString = String(stdout[range.upperBound..<endRange.upperBound])
                 let sbomPath = try AbsolutePath(validating: pathString)
-                
+
                 #expect(localFileSystem.exists(sbomPath))
                 let filesInDirectory = try localFileSystem.getDirectoryContents(sbomPath.parentDirectory)
                 #expect(filesInDirectory.count == 1, "should only produce 1 SPDX SBOM")
@@ -8075,7 +8022,7 @@ struct PackageCommandTests {
             try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
                 let config = BuildConfiguration.debug
                 let customSBOMDir = fixturePath.appending("custom-sboms")
-                
+
                 let (stdout, stderr) = try await execute(
                     ["generate-sbom", "--sbom-spec", "cyclonedx", "--sbom-spec", "spdx", "--sbom-output-dir", customSBOMDir.pathString],
                     packagePath: fixturePath,
@@ -8104,7 +8051,7 @@ struct PackageCommandTests {
                     configuration: config,
                     buildSystem: buildSystem,
                 )
-                
+
                 #expect(stderr.contains("warning: `generate-sbom` subcommand may be inaccurate as it does not contain build-time conditionals."))
             }
         }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -224,10 +224,7 @@ struct TestCommandTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue(
-            "fails to build the package",
-            isIntermittent: true,
-        ) {
+        try await withKnownIssue("fails to build the package", isIntermittent: true) {
             // default should run with testability
             try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
                 let result = try await execute(
@@ -1033,7 +1030,7 @@ struct TestCommandTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue("Fails to find test executable") {
+        try await withKnownIssue("Fails to find test executable", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 let (stdout, stderr) = try await execute(
                     ["list"],
@@ -1126,9 +1123,7 @@ struct TestCommandTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue(
-            isIntermittent: true
-        ) {
+        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 // build first
                     // This might be intermittently failing on windows
@@ -1193,7 +1188,7 @@ struct TestCommandTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue("Fails to find the test executable") {
+        try await withKnownIssue("Fails to find the test executable", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
                 let (stdout, stderr) = try await execute(
                     ["--enable-swift-testing", "--disable-xctest"],

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -33,8 +33,6 @@ import Foundation
 )
 struct PluginTests {
     @Test(
-        .IssueWindowsRelativePathAssert,
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8791"),
         .requiresSwiftConcurrencySupport,
         .tags(
             .Feature.Command.Build,
@@ -46,61 +44,55 @@ struct PluginTests {
     func testUseOfBuildToolPluginTargetByExecutableInSamePackage(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("MySourceGenPlugin"),
-                    configuration: .debug,
-                    extraArgs: ["--product", "MyLocalTool"],
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .xcode:
-                    Issue.record("Test expectations must be defined.")
-                }
+        try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                extraArgs: ["--product", "MyLocalTool"],
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .xcode:
+                Issue.record("Test expectations must be defined.")
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
         .bug("https://github.com/swiftlang/swift-package-manager/issues/8786"),
         .requiresSwiftConcurrencySupport,
+        .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),
         .tags(
             .Feature.Command.Test,
             .Feature.CommandLineArguments.BuildSystem,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
+
     func testUseOfBuildToolPluginTargetNoPreBuildCommands(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
+            try await fixture(name: "Miscellaneous/Plugins/MySourceGenPluginNoPreBuildCommands", createGitRepo: false) { fixturePath in
                 let (_, stderr) = try await executeSwiftTest(
-                    fixturePath.appending("MySourceGenPluginNoPreBuildCommands"),
+                    fixturePath,
                     buildSystem: buildSystem,
                 )
                 #expect(stderr.contains("file(s) which are unhandled; explicitly declare them as resources or exclude from the target"), "expected warning not emitted")
             }
         } when: {
-            (ProcessInfo.hostOperatingSystem == .windows && CiEnvironment.runningInSelfHostedPipeline && buildSystem == .native)
-            || (buildSystem == .swiftbuild)
+            buildSystem == .swiftbuild
         }
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .requiresSwiftConcurrencySupport,
         .tags(
             .Feature.Command.Build,
@@ -112,34 +104,28 @@ struct PluginTests {
     func testUseOfBuildToolPluginProductByExecutableAcrossPackages(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("MySourceGenClient"),
-                    configuration: .debug,
-                    extraArgs: ["--product", "MyTool"],
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Linking MyTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build of product 'MyTool' complete!"), "stdout:\n\(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                 case .xcode:
-                    Issue.record("Test expectations must be defined.")
-               }
+        try await fixture(name: "Miscellaneous/Plugins", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath.appending("MySourceGenClient"),
+                configuration: .debug,
+                extraArgs: ["--product", "MyTool"],
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Linking MyTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build of product 'MyTool' complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+                case .xcode:
+                Issue.record("Test expectations must be defined.")
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .requiresSwiftConcurrencySupport,
         .tags(
             .Feature.Command.Build,
@@ -151,62 +137,53 @@ struct PluginTests {
     func testUseOfPrebuildPluginTargetByExecutableAcrossPackages(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("MySourceGenPlugin"),
-                    configuration: .debug,
-                    extraArgs: ["--product", "MyOtherLocalTool"],
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Compiling MyOtherLocalTool bar.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Compiling MyOtherLocalTool baz.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Linking MyOtherLocalTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build of product 'MyOtherLocalTool' complete!"), "stdout:\n\(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .xcode:
-                    Issue.record("Test expectations must be defined.")
-                }
+        try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                extraArgs: ["--product", "MyOtherLocalTool"],
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Compiling MyOtherLocalTool bar.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Compiling MyOtherLocalTool baz.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Linking MyOtherLocalTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build of product 'MyOtherLocalTool' complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .xcode:
+                Issue.record("Test expectations must be defined.")
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .requiresSwiftConcurrencySupport,
+        .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),
         arguments: SupportedBuildSystemOnAllPlatforms
     )
     func testUseOfPluginWithInternalExecutable(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("ClientOfPluginWithInternalExecutable"),
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Compiling PluginExecutable main.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Linking PluginExecutable"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Compiling RootTarget foo.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Linking RootTarget"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .xcode:
-                    Issue.record("Test expectations must be defined.")
-                }
+        try await fixture(name: "Miscellaneous/Plugins", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath.appending("ClientOfPluginWithInternalExecutable"),
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Compiling PluginExecutable main.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Linking PluginExecutable"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Compiling RootTarget foo.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Linking RootTarget"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .xcode:
+                Issue.record("Test expectations must be defined.")
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 
@@ -221,7 +198,7 @@ struct PluginTests {
     func testInternalExecutableAvailableOnlyToPlugin(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
+        try await fixture(name: "Miscellaneous/Plugins", createGitRepo: false) { fixturePath in
             let error = try await #require(throws: SwiftPMError.self, "Illegally used internal executable") {
                 try await executeSwiftBuild(
                     fixturePath.appending("InvalidUseOfInternalPluginExecutable"),
@@ -241,112 +218,95 @@ struct PluginTests {
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .requiresSwiftConcurrencySupport,
         .tags(
             .Feature.Command.Build,
         ),
+        .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testLocalBuildToolPluginUsingRemoteExecutable(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("LibraryWithLocalBuildToolPluginUsingRemoteTool"),
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Generating generated.swift from generated.dat"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Compiling MyLibrary generated.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .xcode:
-                    Issue.record("Test expectations must be defined.")
-                }
+        try await fixture(name: "Miscellaneous/Plugins", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath.appending("LibraryWithLocalBuildToolPluginUsingRemoteTool"),
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Generating generated.swift from generated.dat"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Compiling MyLibrary generated.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .xcode:
+                Issue.record("Test expectations must be defined.")
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8791"),
         .requiresSwiftConcurrencySupport,
+        .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testBuildToolPluginDependencies(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("MyBuildToolPluginDependencies"),
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Compiling MyLocalTool foo.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .xcode:
-                    Issue.record("Test expectations must be defined.")
-                }
+        try await fixture(name: "Miscellaneous/Plugins/MyBuildToolPluginDependencies", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Compiling MySourceGenBuildTool main.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Compiling MyLocalTool foo.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .xcode:
+                Issue.record("Test expectations must be defined.")
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
         }
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .requiresSwiftConcurrencySupport,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testContrivedTestCases(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let buildSpecificArgs: [String] = switch buildSystem {
-                    case .native, .xcode:
-                        []
-                    case .swiftbuild:
-                        ["--disable-sandbox"]
-                }
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("ContrivedTestPlugin"),
-                    configuration: .debug,
-                    extraArgs: ["--product", "MyLocalTool"] + buildSpecificArgs,
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
+        try await fixture(name: "Miscellaneous/Plugins/ContrivedTestPlugin", createGitRepo: false) { fixturePath in
+            let buildSpecificArgs: [String] = switch buildSystem {
+                case .native, .xcode:
+                    []
                 case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .xcode:
-                    Issue.record("Test expectations must be defined.")
-                }
+                    ["--disable-sandbox"]
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                extraArgs: ["--product", "MyLocalTool"] + buildSpecificArgs,
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Generating foo.swift from foo.dat"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .xcode:
+                Issue.record("Test expectations must be defined.")
+            }
         }
     }
 
@@ -358,9 +318,9 @@ struct PluginTests {
     func testPluginScriptSandbox(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
+        try await fixture(name: "Miscellaneous/Plugins/SandboxTesterPlugin", createGitRepo: false) { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(
-                fixturePath.appending("SandboxTesterPlugin"),
+                fixturePath,
                 configuration: .debug,
                 extraArgs: ["--product", "MyLocalTool"],
                 buildSystem: buildSystem,
@@ -383,24 +343,22 @@ struct PluginTests {
         arguments: [BuildSystemProvider.Kind.native, .swiftbuild]
     )
     func testUseOfVendedBinaryTool(buildSystem: BuildSystemProvider.Kind) async throws {
-        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-            try await withKnownIssue(isIntermittent: true) {
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("MyBinaryToolPlugin"),
-                    configuration: .debug,
-                    extraArgs: ["--product", "MyLocalTool"],
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case  .native:
-                    #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .xcode:
-                    Issue.record("Test has no expectation for \(buildSystem)")
-                }
-            } when: { ProcessInfo.hostOperatingSystem == .windows }
+        try await fixture(name: "Miscellaneous/Plugins/MyBinaryToolPlugin", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                extraArgs: ["--product", "MyLocalTool"],
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case  .native:
+                #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .xcode:
+                Issue.record("Test has no expectation for \(buildSystem)")
+            }
         }
     }
 
@@ -412,9 +370,9 @@ struct PluginTests {
     func testUseOfBinaryToolVendedAsProduct(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
+        try await fixture(name: "Miscellaneous/Plugins/BinaryToolProductPlugin", createGitRepo: false) { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(
-                fixturePath.appending("BinaryToolProductPlugin"),
+                fixturePath,
                 configuration: .debug,
                 extraArgs: ["--product", "MyLocalTool"],
                 buildSystem: buildSystem,
@@ -432,9 +390,8 @@ struct PluginTests {
     }
 
     @Test(
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8794"),
-        .IssueWindowsRelativePathAssert,
         .requiresSwiftConcurrencySupport,
+        .disabled(if: (ProcessInfo.hostOperatingSystem == .windows), "test plugin does not support windows"),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testBuildToolWithoutOutputs(
@@ -486,35 +443,33 @@ struct PluginTests {
             """)
         }
 
-        try await withKnownIssue(isIntermittent: true) {
-            try await testWithTemporaryDirectory { tmpPath in
-                let packageDir = tmpPath.appending(components: "MyPackage")
-                let pathOfGeneratedFile = packageDir.appending(components: [".build", "plugins", "outputs", "mypackage", "SomeTarget", "destination", "Plugin", "best.txt"])
+        try await testWithTemporaryDirectory { tmpPath in
+            let packageDir = tmpPath.appending(components: "MyPackage")
+            let pathOfGeneratedFile = packageDir.appending(components: [".build", "plugins", "outputs", "mypackage", "SomeTarget", "destination", "Plugin", "best.txt"])
 
-                try await withKnownIssue {
-                    try createPackageUnderTest(packageDir: packageDir, toolsVersion: .v5_9)
-                    let (_, stderr) = try await executeSwiftBuild(
-                        packageDir,
-                        env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"],
-                        buildSystem: buildSystem,
-                    )
-                    #expect(stderr.contains("warning: Build tool command 'empty' (applied to target 'SomeTarget') does not declare any output files"), "expected warning not emitted")
-                    #expect(!localFileSystem.exists(pathOfGeneratedFile), "plugin generated file unexpectedly exists at \(pathOfGeneratedFile.pathString)")
-                } when: {
-                    buildSystem == .swiftbuild
-                }
-
-                try createPackageUnderTest(packageDir: packageDir, toolsVersion: .v6_0)
-                let (stdout, stderr2) = try await executeSwiftBuild(
+            try await withKnownIssue {
+                try createPackageUnderTest(packageDir: packageDir, toolsVersion: .v5_9)
+                let (_, stderr) = try await executeSwiftBuild(
                     packageDir,
                     env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"],
                     buildSystem: buildSystem,
                 )
-                #expect(stdout.contains("Build complete!"))
-                #expect(!stderr2.contains("error:"))
-                #expect(localFileSystem.exists(pathOfGeneratedFile), "plugin did not run, generated file does not exist at \(pathOfGeneratedFile.pathString)")
+                #expect(stderr.contains("warning: Build tool command 'empty' (applied to target 'SomeTarget') does not declare any output files"), "expected warning not emitted")
+                #expect(!localFileSystem.exists(pathOfGeneratedFile), "plugin generated file unexpectedly exists at \(pathOfGeneratedFile.pathString)")
+            } when: {
+                buildSystem == .swiftbuild
             }
-        } when: { ProcessInfo.hostOperatingSystem == .windows }
+
+            try createPackageUnderTest(packageDir: packageDir, toolsVersion: .v6_0)
+            let (stdout, stderr2) = try await executeSwiftBuild(
+                packageDir,
+                env: ["SWIFT_DRIVER_SWIFTSCAN_LIB" : "/this/is/a/bad/path"],
+                buildSystem: buildSystem,
+            )
+            #expect(stdout.contains("Build complete!"))
+            #expect(!stderr2.contains("error:"))
+            #expect(localFileSystem.exists(pathOfGeneratedFile), "plugin did not run, generated file does not exist at \(pathOfGeneratedFile.pathString)")
+        }
     }
 
     @Test(
@@ -872,36 +827,31 @@ struct PluginTests {
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
         .requiresSwiftConcurrencySupport,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testLocalAndRemoteToolDependencies(buildSystem: BuildSystemProvider.Kind) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool") { path in
-                let (stdout, stderr) = try await executeSwiftPackage(
-                    path.appending("MyLibrary"),
-                    configuration: .debug,
-                    extraArgs: ["plugin", "my-plugin"],
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    // Native build system is more explicit about what it's doing in stderr
-                    #expect(stderr.contains("Linking RemoteTool"), "stdout:\n\(stderr)\n\(stdout)")
-                    #expect(stderr.contains("Linking LocalTool"), "stdout:\n\(stderr)\n\(stdout)")
-                    #expect(stderr.contains("Linking ImpliedLocalTool"), "stdout:\n\(stderr)\n\(stdout)")
-                    #expect(stderr.contains("Build of product 'ImpliedLocalTool' complete!"), "stdout:\n\(stderr)\n\(stdout)")
-                case .swiftbuild, .xcode:
-                    // There are nothing specific to expect
-                    break
-                }
-                #expect(stdout.contains("A message from the remote tool."), "stdout:\n\(stderr)\n\(stdout)")
-                #expect(stdout.contains("A message from the local tool."), "stdout:\n\(stderr)\n\(stdout)")
-                #expect(stdout.contains("A message from the implied local tool."), "stdout:\n\(stderr)\n\(stdout)")
+        try await fixture(name: "Miscellaneous/Plugins/PluginUsingLocalAndRemoteTool") { path in
+            let (stdout, stderr) = try await executeSwiftPackage(
+                path.appending("MyLibrary"),
+                configuration: .debug,
+                extraArgs: ["plugin", "my-plugin"],
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                // Native build system is more explicit about what it's doing in stderr
+                #expect(stderr.contains("Linking RemoteTool"), "stdout:\n\(stderr)\n\(stdout)")
+                #expect(stderr.contains("Linking LocalTool"), "stdout:\n\(stderr)\n\(stdout)")
+                #expect(stderr.contains("Linking ImpliedLocalTool"), "stdout:\n\(stderr)\n\(stdout)")
+                #expect(stderr.contains("Build of product 'ImpliedLocalTool' complete!"), "stdout:\n\(stderr)\n\(stdout)")
+            case .swiftbuild, .xcode:
+                // There are nothing specific to expect
+                break
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows // Intermittent depending on the file path length
+            #expect(stdout.contains("A message from the remote tool."), "stdout:\n\(stderr)\n\(stdout)")
+            #expect(stdout.contains("A message from the local tool."), "stdout:\n\(stderr)\n\(stdout)")
+            #expect(stdout.contains("A message from the implied local tool."), "stdout:\n\(stderr)\n\(stdout)")
         }
     }
 
@@ -1181,8 +1131,6 @@ struct PluginTests {
             } catch {
                 // Also acceptable - plugin may have been terminated
             }
-
-
         }
     }
 
@@ -1371,8 +1319,6 @@ struct PluginTests {
     )
     struct SnippetTests {
         @Test(
-            .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-            .IssueWindowsRelativePathAssert,
             .requiresSwiftConcurrencySupport,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
@@ -1380,7 +1326,7 @@ struct PluginTests {
             buildSystem: BuildSystemProvider.Kind,
         ) async throws {
             let config = BuildConfiguration.debug
-            try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets") { fixturePath in
+            try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets", createGitRepo: false) { fixturePath in
                 let (stdout, stderr) = try await executeSwiftPackage(
                     fixturePath,
                     configuration: config,
@@ -1403,7 +1349,7 @@ struct PluginTests {
             buildSystem: BuildSystemProvider.Kind,
         ) async throws {
             let config = BuildConfiguration.debug
-            try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets") { fixturePath in
+            try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets", createGitRepo: false) { fixturePath in
                 await #expect(throws: Never.self) {
                     let _ = try await executeSwiftBuild(
                         fixturePath,
@@ -1429,7 +1375,6 @@ struct PluginTests {
 
         @Test(
             .issue("https://github.com/swiftlang/swift-package-manager/issues/9040", relationship: .verifies),
-            .IssueWindowsCannotSaveAttachment,
             .requiresSwiftConcurrencySupport,
             arguments: SupportedBuildSystemOnAllPlatforms, try getFiles(in: RelativePath(validating: "Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Snippets"), matchingExtension: "swift",),
         )
@@ -1438,8 +1383,7 @@ struct PluginTests {
             targetPath: RelativePath,
         ) async throws {
             let config = BuildConfiguration.debug
-            try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets") { fixturePath in
+            try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets", createGitRepo: false) { fixturePath in
                 let targetName = targetPath.basenameWithoutExt
                 await #expect(throws: Never.self) {
                     let _ = try await executeSwiftBuild(
@@ -1450,14 +1394,10 @@ struct PluginTests {
                     )
                 }
             }
-            } when: {
-                ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
-            }
         }
 
         @Test(
             .issue("https://github.com/swiftlang/swift-package-manager/issues/9040", relationship: .verifies),
-            .IssueWindowsCannotSaveAttachment,
             .requiresSwiftConcurrencySupport,
             arguments: SupportedBuildSystemOnAllPlatforms, try getFiles(in: RelativePath(validating: "Fixtures/Miscellaneous/Plugins/PluginsAndSnippets/Snippets"), matchingExtension: "swift",),
         )
@@ -1467,8 +1407,7 @@ struct PluginTests {
         ) async throws {
             let config = BuildConfiguration.debug
             let targetName = targetPath.basenameWithoutExt
-            try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets") { fixturePath in
+            try await fixture(name: "Miscellaneous/Plugins/PluginsAndSnippets", createGitRepo: false) { fixturePath in
                 let (stdout, stderr) = try await executeSwiftRun(
                     fixturePath,
                     targetName,
@@ -1477,9 +1416,6 @@ struct PluginTests {
                 )
 
                 #expect(stdout.contains("hello, snippets"), "stderr: \(stderr)")
-            }
-            } when: {
-                [.windows].contains(ProcessInfo.hostOperatingSystem) && buildSystem == .swiftbuild
             }
         }
     }
@@ -1491,24 +1427,20 @@ struct PluginTests {
             .Feature.Command.Build,
             .Feature.CommandLineArguments.BuildTests,
         ),
+        .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testIncorrectDependencies(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { path in
-                let (stdout, stderr) = try await executeSwiftBuild(
-                    path.appending("IncorrectDependencies"),
-                    extraArgs: ["--build-tests"],
-                    buildSystem: buildSystem,
-                )
+        try await fixture(name: "Miscellaneous/Plugins/IncorrectDependencies") { path in
+            let (stdout, stderr) = try await executeSwiftBuild(
+                path,
+                extraArgs: ["--build-tests"],
+                buildSystem: buildSystem,
+            )
 
-                #expect(stdout.contains("Build complete!"), "output:\n\(stderr)\n\(stdout)")
-            }
-        } when: {
-            (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild)
-            || (ProcessInfo.hostOperatingSystem == .linux && buildSystem == .swiftbuild && CiEnvironment.runningInSmokeTestPipeline)
+            #expect(stdout.contains("Build complete!"), "output:\n\(stderr)\n\(stdout)")
         }
     }
 
@@ -1520,10 +1452,10 @@ struct PluginTests {
         // Build tool plugins aren't permitted to depend on executable targets and use them in the prebuild commands
         // that they return. This is because these commands run immediately and the executable doesn't exist yet or
         // it isn't up-to-date.
-        try await fixture(name: "Miscellaneous/Plugins") { path in
+        try await fixture(name: "Miscellaneous/Plugins/PrebuildDependsExecutableTarget") { path in
             let error = try await #require(throws: Error.self) {
                 try await executeSwiftBuild(
-                    path.appending("PrebuildDependsExecutableTarget"),
+                    path,
                     extraArgs: ["--vv"],
                     buildSystem: buildSystem,
                 )
@@ -1580,9 +1512,9 @@ struct PluginTests {
     func testBuildToolPluginSwiftFileExecutable(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
+        try await fixture(name: "Miscellaneous/Plugins/SwiftFilePlugin", createGitRepo: false) { fixturePath in
             let (stdout, stderr) = try await executeSwiftBuild(
-                fixturePath.appending("SwiftFilePlugin"),
+                fixturePath,
                 configuration: .debug,
                 extraArgs: [ "--verbose"],
                 buildSystem: buildSystem,
@@ -1609,41 +1541,36 @@ struct PluginTests {
     func testTransitivePluginOnlyDependency(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("TransitivePluginOnlyDependency"),
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Compiling Library Library.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .xcode:
-                    Issue.record("Test expected have not been considered")
-                }
+        try await fixture(name: "Miscellaneous/Plugins/TransitivePluginOnlyDependency", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Compiling Library Library.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .xcode:
+                Issue.record("Test expected have not been considered")
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
 
     @Test(
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
-        .IssueWindowsRelativePathAssert,
         .requiresSwiftConcurrencySupport,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testMissingPlugin(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
+        try await fixture(name: "Miscellaneous/Plugins/MissingPlugin", createGitRepo: false) { fixturePath in
+            print(fixturePath)
             do {
                 try await executeSwiftBuild(
-                    fixturePath.appending("MissingPlugin"),
+                    fixturePath,
                     buildSystem: buildSystem,
                 )
             } catch SwiftPMError.executionFailure(_, _, let stderr) {
@@ -1653,42 +1580,35 @@ struct PluginTests {
     }
 
     @Test(
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .requiresSwiftConcurrencySupport,
         .tags(
             .Feature.Command.Build,
         ),
+        .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testPluginCanBeReferencedByProductName(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath.appending("PluginCanBeReferencedByProductName"),
-                    buildSystem: buildSystem,
-                )
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Compiling PluginCanBeReferencedByProductName gen.swift"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-                case .xcode:
-                    Issue.record("Test expected have not been considered")
-                }
+        try await fixture(name: "Miscellaneous/Plugins/PluginCanBeReferencedByProductName", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Compiling plugin MyPlugin"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Compiling PluginCanBeReferencedByProductName gen.swift"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+            case .xcode:
+                Issue.record("Test expected have not been considered")
             }
-
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8791"),
         .requiresSwiftConcurrencySupport,
         .tags(
             .Feature.Command.Build,
@@ -1701,79 +1621,65 @@ struct PluginTests {
     func testPluginCanBeAffectedByXBuildToolsParameters(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins") { fixturePath in
-                let buildArgs: [String] = switch buildSystem {
-                    case .native, .xcode: []
-                    case .swiftbuild: ["-v"]
-                }
-                let (stdout, stderr) = try await executeSwiftBuild(
-                    fixturePath.appending(component: "MySourceGenPlugin"),
-                    configuration: .debug,
-                    extraArgs: ["--product", "MyLocalTool", "-Xbuild-tools-swiftc", "-DUSE_CREATE"] + buildArgs,
-                    buildSystem: buildSystem,
-                )
-
-                switch buildSystem {
-                case .native:
-                    #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Creating foo.swift from foo.dat"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
-                    #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
-                case .swiftbuild:
-                    #expect(stdout.contains("MySourceGenBuildTool-product"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
-                    #expect(stderr.contains("Creating foo.swift from foo.dat"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
-                    #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
-                case .xcode:
-                    Issue.record("Test expected have not been considered")
-                }
+        try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin", createGitRepo: false) { fixturePath in
+            let buildArgs: [String] = switch buildSystem {
+                case .native, .xcode: []
+                case .swiftbuild: ["-v"]
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
+            let (stdout, stderr) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                extraArgs: ["--product", "MyLocalTool", "-Xbuild-tools-swiftc", "-DUSE_CREATE"] + buildArgs,
+                buildSystem: buildSystem,
+            )
+
+            switch buildSystem {
+            case .native:
+                #expect(stdout.contains("Linking MySourceGenBuildTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Creating foo.swift from foo.dat"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Linking MyLocalTool"), "stdout:\n\(stdout)")
+                #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
+            case .swiftbuild:
+                #expect(stdout.contains("MySourceGenBuildTool-product"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
+                #expect(stderr.contains("Creating foo.swift from foo.dat"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
+                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
+            case .xcode:
+                Issue.record("Test expected have not been considered")
+            }
         }
     }
 
     @Test(
-        .IssueWindowsRelativePathAssert,
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8791"),
         .requiresSwiftConcurrencySupport,
+        .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testURLBasedPluginAPI(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath,
-                    configuration: .debug,
-                    buildSystem: buildSystem,
-                )
-                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-            }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
+        try await fixture(name: "Miscellaneous/Plugins/MySourceGenPluginUsingURLBasedAPI", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                buildSystem: buildSystem,
+            )
+            #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
 
     @Test(
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8774"),
         .requiresSwiftConcurrencySupport,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testDependentPlugins(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins/DependentPlugins") { fixturePath in
-                let (stdout, _) = try await executeSwiftBuild(
-                    fixturePath,
-                    buildSystem: buildSystem,
-                )
-                #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
-            }
-        } when: {
-            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
+        try await fixture(name: "Miscellaneous/Plugins/DependentPlugins", createGitRepo: false) { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                buildSystem: buildSystem,
+            )
+            #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
 }


### PR DESCRIPTION
Many test plugins use the Path API that does not work on windows (and is deprecated), this moves many plugin test to use the URL APIs so that we can enable these test on windows.
