### PR TITLE
Tests: Remove withKnownIssues in a few Tests

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -35,6 +35,7 @@ extension Tag.FunctionalArea {
     @Tag public static var PIF: Tag
     @Tag public static var IndexMode: Tag
     @Tag public static var Sanitizer: Tag
+    @Tag public static var LibraryEvoluton: Tag
     @Tag public static var LinkSwiftStaticStdlib: Tag
     @Tag public static var Metal: Tag
     @Tag public static var ModuleMaps: Tag

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -86,7 +86,7 @@ fileprivate func build(
                 moduleContents = (try? localFileSystem.getDirectoryContents(binPath.appending(component: "Modules"))) ?? []
             case .swiftbuild, .xcode:
                 let moduleDirs = (try? localFileSystem.getDirectoryContents(binPath).filter {
-                    $0.hasSuffix(".swiftmodule")
+                    $0.contains(".swiftmodule")
                 }) ?? []
                 for dir: String in moduleDirs {
                     moduleContents +=
@@ -722,8 +722,7 @@ struct BuildCommandTestCases {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let config = BuildConfiguration.debug
-        try await withKnownIssue("SWBINTTODO: Test failed. This needs to be investigated") {
-            try await fixture(name: "Miscellaneous/UnreachableTargets") { fixturePath in
+            try await fixture(name: "Miscellaneous/UnreachableTargets", removeFixturePathOnDeinit: false) { fixturePath in
                 let aPath = fixturePath.appending("A")
 
                 // Dependency contains a dependent product
@@ -734,19 +733,30 @@ struct BuildCommandTestCases {
                     configuration: config,
                     buildSystem: buildSystem,
                 )
-                #expect(result.binContents.contains("BTarget2.build"))
+                switch buildSystem {
+                    case .native:
+                    #expect(result.binContents.contains("BTarget2.build"))
+                    case .swiftbuild, .xcode:
+                    break
+                }
                 #expect(result.binContents.contains(executableName("bexec")))
                 #expect(!result.binContents.contains(executableName("aexec")))
                 #expect(!result.binContents.contains("ATarget.build"))
                 #expect(!result.binContents.contains("BLibrary.a"))
 
-                // FIXME: We create the modulemap during build planning, hence this ugliness.
-                let bTargetBuildDir =
-                ((try? localFileSystem.getDirectoryContents(result.binPath.appending("BTarget1.build"))) ?? [])
-                    .filter { $0 != moduleMapFilename }
-                #expect(bTargetBuildDir.isEmpty, "bTargetBuildDir should be empty")
 
                 #expect(!result.binContents.contains("cexec"))
+                switch buildSystem {
+                    case .native:
+                    // FIXME: We create the modulemap during build planning, hence this ugliness.
+                    let bTargetBuildDir =
+                    ((try? localFileSystem.getDirectoryContents(result.binPath.appending("BTarget1.build"))) ?? [])
+                        .filter { $0 != moduleMapFilename }
+                    #expect(bTargetBuildDir.isEmpty, "bTargetBuildDir should be empty")
+                    #expect(result.binContents.contains("BTarget2.build"))
+                    case .swiftbuild, .xcode:
+                    break
+                }
                 #expect(!result.binContents.contains("CTarget.build"))
 
                 // Also make sure we didn't emit parseable module interfaces
@@ -756,9 +766,6 @@ struct BuildCommandTestCases {
                 #expect(!result.moduleContents.contains("BTarget.swiftinterface"))
                 #expect(!result.moduleContents.contains("CTarget.swiftinterface"))
             }
-        } when: {
-            buildSystem == .swiftbuild
-        }
     }
 
     @Test(
@@ -799,10 +806,11 @@ struct BuildCommandTestCases {
 
     @Test(
         .tags(
+            .FunctionalArea.LibraryEvoluton,
             .Feature.CommandLineArguments.Product,
             .Feature.CommandLineArguments.BuildTests,
         ),
-        arguments: SupportedBuildSystemOnPlatform,
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func automaticParseableInterfacesWithLibraryEvolution(
         buildSystem: BuildSystemProvider.Kind,
@@ -820,15 +828,13 @@ struct BuildCommandTestCases {
                     case .native:
                         #expect(result.moduleContents.contains("A.swiftinterface"))
                         #expect(result.moduleContents.contains("B.swiftinterface"))
-                    case .swiftbuild, .xcode:
-                        let moduleARegex = try Regex(#"A[.]swiftmodule[/].*[.]swiftinterface"#)
+                    case .swiftbuild:
+                        let moduleARegex = try Regex(#"A[.]swiftmodule[/].*[.]swiftmodule"#)
                         let moduleBRegex = try Regex(#"B[.]swiftmodule[/].*[.]swiftmodule"#)
-                        withKnownIssue("SWBINTTODO: Test failed because of missing 'A.swiftmodule/*.swiftinterface' files") {
-                            #expect(result.moduleContents.contains { $0.contains(moduleARegex) })
-                        } when: {
-                            buildSystem == .swiftbuild
-                        }
+                        #expect(result.moduleContents.contains { $0.contains(moduleARegex) })
                         #expect(result.moduleContents.contains { $0.contains(moduleBRegex) })
+                    case .xcode:
+                        Issue.record("Test configuration error. Build backend is not intended to be tested.")
                 }
             }
         } when: {
@@ -1028,13 +1034,10 @@ struct BuildCommandTestCases {
             .Feature.EnvironmentVariables.SWIFT_EXEC,
             .Feature.EnvironmentVariables.SWIFT_EXEC_MANIFEST,
         ),
-        arguments: [BuildSystemProvider.Kind.swiftbuild, .xcode],
     )
-    func buildSystemOverrides(
-        buildSystem: BuildSystemProvider.Kind,
-    ) async throws {
+    func buildSystemOverrides() async throws {
         let config = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
+        let buildSystem = BuildSystemProvider.Kind.swiftbuild
         try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             let swiftCompilerPath = try UserToolchain.default.swiftCompilerPath
             // try await building without specifying overrides.  This should succeed, and should use the default
@@ -1068,9 +1071,6 @@ struct BuildCommandTestCases {
                 return
             }
             #expect(stderr.contains("/usr/bin/false"))
-        }
-        } when: {
-            buildSystem == .swiftbuild
         }
     }
 
@@ -1279,6 +1279,7 @@ struct BuildCommandTestCases {
         // Windows builds of ExecutableNew using swiftbuild can fail because of problem with handling long paths which
         // is root cause of linked issue
         .issue("https://github.com/swiftlang/swift-package-manager/issues/9420", relationship: .defect),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9745", relationship: .defect),
         .tags(
             .Feature.CommandLineArguments.DisableGetTaskAllowEntitlement,
             .Feature.CommandLineArguments.EnableGetTaskAllowEntitlement,
@@ -1721,7 +1722,6 @@ struct BuildCommandTestCases {
         }
     }
 
-
     @Test(
         .requireHostOS(.macOS),
         .tags(
@@ -1845,7 +1845,7 @@ extension Triple {
     ),
 )
 struct BuildSBOMCommandTests {
-    
+
     /// Helper function to verify SBOM creation from stderr
     private func verifySBOMCreated(
         in stderr: String,
@@ -1854,7 +1854,7 @@ struct BuildSBOMCommandTests {
     ) throws {
         let lines = stderr.split(separator: "\n")
         var sbomPaths: [String] = []
-        
+
         for line in lines {
             // Match the new format: "- created {spec} v{version} SBOM at {path}"
             if line.contains(" SBOM at "),
@@ -1864,22 +1864,22 @@ struct BuildSBOMCommandTests {
                 sbomPaths.append(pathString)
             }
         }
-        
+
         guard !sbomPaths.isEmpty else {
             Issue.record("No SBOM paths found in stderr")
             return
         }
-        
+
         for pathString in sbomPaths {
             let absolutePath = try AbsolutePath(validating: pathString)
             #expect(localFileSystem.exists(absolutePath), "Reported SBOM should exist at \(absolutePath)")
-            
+
             if let expectedDir = expectedDirectory {
                 #expect(absolutePath.parentDirectory == expectedDir, "SBOM should be created in the expected directory: \(expectedDir)")
             }
         }
     }
-    
+
     @Test(
         arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
@@ -2009,7 +2009,7 @@ struct BuildSBOMCommandTests {
                 env: ["SWIFTPM_BUILD_SBOM_SPEC": "cyclonedx,spdx"],
                 buildSystem: data.buildSystem,
             )
-            
+
             #expect(stdout.contains("Build complete!"))
             #expect(stderr.contains("SBOMs created"))
             try verifySBOMCreated(in: stderr, message: "should produce at least 2 SBOMs from environment variable")
@@ -2024,7 +2024,7 @@ struct BuildSBOMCommandTests {
     ) async throws {
         try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             let customSBOMDir = fixturePath.appending("env-sboms")
-            
+
             let (stdout, stderr) = try await executeSwiftBuild(
                 fixturePath,
                 configuration: data.config,
@@ -2035,7 +2035,7 @@ struct BuildSBOMCommandTests {
                 ],
                 buildSystem: data.buildSystem,
             )
-            
+
             #expect(stderr.contains("SBOMs created"))
             try verifySBOMCreated(
                 in: stderr,
@@ -2062,7 +2062,7 @@ struct BuildSBOMCommandTests {
                 ],
                 buildSystem: data.buildSystem,
             )
-            
+
             #expect(stderr.contains("SBOMs created"))
             try verifySBOMCreated(in: stderr, message: "should produce at least 1 SBOM from environment variable")
         }
@@ -2082,13 +2082,13 @@ struct BuildSBOMCommandTests {
                 env: ["SWIFTPM_BUILD_SBOM_SPEC": "cyclonedx"],
                 buildSystem: data.buildSystem,
             )
-            
+
             #expect(stderr.contains("SBOMs created"))
-            
+
             // Verify that command line flag overrides environment variable by checking SBOM path
             let spdxRegex = try Regex(#"created spdx.* v.* SBOM at .*\.json"#)
             let cyclonedxRegex = try Regex(#"created cyclonedx.* v.* SBOM at .*\.json"#)
-            
+
             #expect(stderr.contains(spdxRegex), "should create SPDX SBOM from command line, not CycloneDX from environment")
             #expect(!stderr.contains(cyclonedxRegex), "should not create CycloneDX SBOM from environment variable")
         }
@@ -2102,7 +2102,7 @@ struct BuildSBOMCommandTests {
     ) async throws {
         try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
             let customSBOMDir = fixturePath.appending("all-env-sboms")
-            
+
             let (stdout, stderr) = try await executeSwiftBuild(
                 fixturePath,
                 configuration: data.config,
@@ -2115,7 +2115,7 @@ struct BuildSBOMCommandTests {
                 ],
                 buildSystem: data.buildSystem,
             )
-            
+
             try verifySBOMCreated(in: stderr, expectedDirectory: customSBOMDir, message: "should produce at least 1 CycloneDX SBOM")
         }
     }
@@ -2133,7 +2133,7 @@ struct BuildSBOMCommandTests {
             let invalidPath = ProcessInfo.hostOperatingSystem == .windows
                 ? "NUL"
                 : "/invalid/readonlypath"
-            
+
             await expectThrowsCommandExecutionError(
                 try await executeSwiftBuild(
                     fixturePath,
@@ -2261,7 +2261,7 @@ struct BuildSBOMCommandTests {
                 ],
                 buildSystem: data.buildSystem,
             )
-            
+
             #expect(stderr.contains("SBOMs created"))
             try verifySBOMCreated(in: stderr, message: "should produce SBOM despite invalid environment variables")
         }
@@ -2280,7 +2280,7 @@ struct BuildSBOMCommandTests {
                 extraArgs: ["--sbom-spec", "cyclonedx"],
                 buildSystem: data.buildSystem,
             )
-            
+
             if data.buildSystem != .swiftbuild {
                 #expect(stderr.contains("warning: generating SBOM(s) without `--build-system swiftbuild` flag creates SBOM(s) without build-time conditionals."))
             } else {

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -5408,7 +5408,6 @@ struct PackageCommandTests {
             let containsWarning = "command plugin: Diagnostics.warning"
             let containsError = "command plugin: Diagnostics.error"
 
-            await withKnownIssue(isIntermittent: true) {
                 try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
                     func runPlugin(
                         flags: [String],
@@ -5575,7 +5574,6 @@ struct PackageCommandTests {
                         #expect(stderr.contains(containsError))
                     }
                 }
-            }
         }
 
         // Test target builds requested by a command plugin
@@ -5820,7 +5818,6 @@ struct PackageCommandTests {
                 }
             } when: {
                 ProcessInfo.hostOperatingSystem == .windows
-                    || (ProcessInfo.hostOperatingSystem == .linux && buildSystem == .swiftbuild)
             }
         }
 
@@ -6874,7 +6871,7 @@ struct PackageCommandTests {
                             #expect(stdout.contains("staticLibrary"))
                         }
                     } when: {
-                        buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem != .macOS
+                        buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
                     }
 
                     // Invoke the plugin with parameters choosing a verbose build of MyDynamicLibrary for release.


### PR DESCRIPTION
A few tests had `withKnownIssue(isIntermittent: true)` in them.  Some of the tests were not failing. Remove withKnownIssue from those tests to ensure we do not regress.

Issue: rdar//159459559