### PR TITLE
Some command-line parity fixes when using swift-build

### DIFF
--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Debugging.swift
@@ -16,7 +16,7 @@ import enum PackageModel.BuildConfiguration
 extension BuildParameters {
     public struct Debugging: Encodable {
         public init(
-            debugInfoFormat: DebugInfoFormat = .dwarf,
+            debugInfoFormat: DebugInfoFormat? = nil,
             triple: Triple,
             shouldEnableDebuggingEntitlement: Bool,
             omitFramePointers: Bool?
@@ -40,8 +40,8 @@ extension BuildParameters {
             }
         }
 
-        public var debugInfoFormat: DebugInfoFormat
-        
+        public var debugInfoFormat: DebugInfoFormat?
+
         /// Whether the produced executable should be codesigned with the debugging entitlement, enabling enhanced
         /// backtraces on macOS.
         public var shouldEnableDebuggingEntitlement: Bool

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -201,7 +201,7 @@ public struct BuildParameters: Encodable {
         self.triple = triple
         self.buildSystemKind = buildSystemKind
         switch self.debuggingParameters.debugInfoFormat {
-        case .dwarf:
+        case .dwarf, nil:
             var flags = flags
             // DWARF requires lld as link.exe expects CodeView debug info.
             self.flags = flags.merging(triple.isWindows() ? BuildFlags(
@@ -221,7 +221,7 @@ public struct BuildParameters: Encodable {
                 swiftCompilerFlags: ["-g", "-debug-info-format=codeview"].constructBuildFlags(source: .debugging),
                 linkerFlags: ["-debug"].constructBuildFlags(source: .debugging)
             ))
-        case .none:
+        case .none?:
             var flags = flags
             self.flags = flags.merging(BuildFlags(
                 cCompilerFlags: ["-g0"].constructBuildFlags(source: .debugging),

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -972,11 +972,6 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             }
         }
 
-        if buildParameters.driverParameters.codesizeProfileEnabled {
-            // dSYM generation is required to attribute code size to source locations
-            settings["DEBUG_INFORMATION_FORMAT"] = "dwarf-with-dsym"
-        }
-
         // Optionally also set the list of architectures to build for.
         if let architectures = buildParameters.architectures, !architectures.isEmpty {
             settings["ARCHS"] = architectures.joined(separator: " ")
@@ -1027,6 +1022,14 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         try settings.merge(self.constructLinkerSettingsOverrides(from: buildParameters.linkingParameters, triple: buildParameters.triple), uniquingKeysWith: reportConflict)
         try settings.merge(Self.constructTestingSettingsOverrides(from: buildParameters.testingParameters), uniquingKeysWith: reportConflict)
         try settings.merge(Self.constructAPIDigesterSettingsOverrides(from: buildParameters.apiDigesterMode), uniquingKeysWith: reportConflict)
+
+        if buildParameters.driverParameters.codesizeProfileEnabled {
+            // dSYM generation is required to attribute code size to source locations
+            if let debugFormat = settings["DEBUG_INFORMATION_FORMAT"] {
+                self.observabilityScope.emit(warning: "--experimental-enable-codesize-profile requires 'dwarf-with-dsym' debug format, overriding the user specified value of '\(debugFormat)''")
+            }
+            settings["DEBUG_INFORMATION_FORMAT"] = "dwarf-with-dsym"
+        }
 
         // Generate the build parameters.
         var params = SwiftBuild.SWBBuildParameters()
@@ -1098,11 +1101,30 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
     private static func constructDebuggingSettingsOverrides(from parameters: BuildParameters.Debugging) -> [String: String] {
         var settings: [String: String] = [:]
-        // TODO: debugInfoFormat: https://github.com/swiftlang/swift-build/issues/560
         if parameters.shouldEnableDebuggingEntitlement {
             settings["DEPLOYMENT_POSTPROCESSING"] = "NO"
         }
-        // TODO: omitFramePointer: https://github.com/swiftlang/swift-build/issues/561
+        // Set DEBUG_INFORMATION_FORMAT based on debugInfoFormat
+        switch parameters.debugInfoFormat {
+        case .dwarf:
+            settings["DEBUG_INFORMATION_FORMAT"] = "dwarf"
+        case .codeview:
+            settings["DEBUG_INFORMATION_FORMAT"] = "codeview"
+        case .none?:
+            settings["GCC_GENERATE_DEBUGGING_SYMBOLS"] = "NO"
+            break
+        case nil:
+            break
+        }
+        if let omitFramePointers = parameters.omitFramePointers {
+            if omitFramePointers {
+                settings["CLANG_OMIT_FRAME_POINTERS"] = "YES"
+                settings["SWIFT_OMIT_FRAME_POINTERS"] = "YES"
+            } else {
+                settings["CLANG_OMIT_FRAME_POINTERS"] = "NO"
+                settings["SWIFT_OMIT_FRAME_POINTERS"] = "NO"
+            }
+        }
         return settings
     }
 
@@ -1357,8 +1379,7 @@ fileprivate extension [BuildFlag] {
                 // FIXME: Not yet handled
                 return true
             case .debugging:
-                // FIXME: Not yet handled
-                return true
+                return false
             case .toolset:
                 // Swift Build loads toolset flags internally as part of loading Swift SDKs, or by passing the custom toolsets
                 // via the SWIFT_SDK_TOOLSETS build setting, and may introspect them to override build settings.

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -97,6 +97,8 @@ public func mockBuildParameters(
     indexStoreMode: BuildParameters.IndexStoreMode = .auto,
     linkerDeadStrip: Bool = true,
     linkTimeOptimizationMode: BuildParameters.LinkTimeOptimizationMode? = nil,
+    debugInfoFormat: BuildParameters.DebugInfoFormat = .dwarf,
+    shouldEnableDebuggingEntitlement: Bool? = nil,
     omitFramePointers: Bool? = nil,
     enableXCFrameworksOnLinux: Bool = false,
     prepareForIndexing: BuildParameters.PrepareForIndexingMode = .off,
@@ -118,8 +120,9 @@ public func mockBuildParameters(
         prepareForIndexing: prepareForIndexing,
         enableXCFrameworksOnLinux: enableXCFrameworksOnLinux,
         debuggingParameters: .init(
+            debugInfoFormat: debugInfoFormat,
             triple: triple,
-            shouldEnableDebuggingEntitlement: config == .debug,
+            shouldEnableDebuggingEntitlement: shouldEnableDebuggingEntitlement ?? (config == .debug),
             omitFramePointers: omitFramePointers
         ),
         driverParameters: .init(

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -383,4 +383,283 @@ struct SwiftBuildSystemTests {
             }
         }
     }
+
+    @Suite
+    struct DebuggingSettingsTests {
+
+        private static let isMacOS: Bool = {
+            #if os(macOS)
+            return true
+            #else
+            return false
+            #endif
+        }()
+
+        @Test(
+            .disabled(if: !Self.isMacOS, "shouldEnableDebuggingEntitlement is only effective on macOS"),
+            arguments: [true, false]
+        )
+        func shouldEnableDebuggingEntitlementSetsDeploymentPostprocessing(
+            shouldEnableDebuggingEntitlement: Bool
+        ) async throws {
+            // Note: shouldEnableDebuggingEntitlement is only effective on macOS
+            // (see BuildParameters.Debugging.init where it checks triple.isMacOSX)
+            try await withInstantiatedSwiftBuildSystem(
+                fromFixture: "PIFBuilder/Simple",
+                buildParameters: mockBuildParameters(
+                    destination: .host,
+                    triple: .x86_64MacOS,
+                    shouldEnableDebuggingEntitlement: shouldEnableDebuggingEntitlement
+                ),
+            ) { swiftBuild, session, observabilityScope, buildParameters in
+                let buildSettings = try await swiftBuild.makeBuildParameters(
+                    session: session,
+                    symbolGraphOptions: nil,
+                    setToolchainSetting: false
+                )
+
+                let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+
+                if shouldEnableDebuggingEntitlement {
+                    #expect(synthesizedArgs.table["DEPLOYMENT_POSTPROCESSING"] == "NO")
+                } else {
+                    #expect(synthesizedArgs.table["DEPLOYMENT_POSTPROCESSING"] == nil)
+                }
+            }
+        }
+
+        @Test(
+            arguments: [
+                (debugInfoFormat: BuildParameters.DebugInfoFormat.dwarf, expectedSetting: "DEBUG_INFORMATION_FORMAT", expectedValue: "dwarf"),
+                (debugInfoFormat: BuildParameters.DebugInfoFormat.none, expectedSetting: "GCC_GENERATE_DEBUGGING_SYMBOLS", expectedValue: "NO"),
+            ]
+        )
+        func debugInfoFormatSetsCorrectBuildSettings(
+            debugInfoFormat: BuildParameters.DebugInfoFormat,
+            expectedSetting: String,
+            expectedValue: String
+        ) async throws {
+            try await withInstantiatedSwiftBuildSystem(
+                fromFixture: "PIFBuilder/Simple",
+                buildParameters: mockBuildParameters(
+                    destination: .host,
+                    debugInfoFormat: debugInfoFormat
+                ),
+            ) { swiftBuild, session, observabilityScope, buildParameters in
+                let buildSettings = try await swiftBuild.makeBuildParameters(
+                    session: session,
+                    symbolGraphOptions: nil,
+                    setToolchainSetting: false
+                )
+
+                let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+                #expect(synthesizedArgs.table[expectedSetting] == expectedValue)
+            }
+        }
+
+        #if os(Windows)
+        @Test
+        func debugInfoFormatCodeViewOnWindows() async throws {
+            // Test CodeView format separately as it's only supported on Windows
+            try await withInstantiatedSwiftBuildSystem(
+                fromFixture: "PIFBuilder/Simple",
+                buildParameters: mockBuildParameters(
+                    destination: .host,
+                    triple: .windows,
+                    debugInfoFormat: .codeview
+                ),
+            ) { swiftBuild, session, observabilityScope, buildParameters in
+                let buildSettings = try await swiftBuild.makeBuildParameters(
+                    session: session,
+                    symbolGraphOptions: nil,
+                    setToolchainSetting: false
+                )
+
+                let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+                #expect(synthesizedArgs.table["DEBUG_INFORMATION_FORMAT"] == "codeview")
+            }
+        }
+        #endif
+
+        @Test(
+            arguments: [
+                (omitFramePointers: true, expectedValue: "YES"),
+                (omitFramePointers: false, expectedValue: "NO"),
+            ]
+        )
+        func omitFramePointersSetsCorrectBuildSettings(
+            omitFramePointers: Bool,
+            expectedValue: String
+        ) async throws {
+            try await withInstantiatedSwiftBuildSystem(
+                fromFixture: "PIFBuilder/Simple",
+                buildParameters: mockBuildParameters(
+                    destination: .host,
+                    omitFramePointers: omitFramePointers
+                ),
+            ) { swiftBuild, session, observabilityScope, buildParameters in
+                let buildSettings = try await swiftBuild.makeBuildParameters(
+                    session: session,
+                    symbolGraphOptions: nil,
+                    setToolchainSetting: false
+                )
+
+                let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+                #expect(synthesizedArgs.table["CLANG_OMIT_FRAME_POINTERS"] == expectedValue)
+                #expect(synthesizedArgs.table["SWIFT_OMIT_FRAME_POINTERS"] == expectedValue)
+            }
+        }
+
+        @Test
+        func omitFramePointersNilDoesNotSetBuildSettings() async throws {
+            try await withInstantiatedSwiftBuildSystem(
+                fromFixture: "PIFBuilder/Simple",
+                buildParameters: mockBuildParameters(
+                    destination: .host,
+                    omitFramePointers: nil
+                ),
+            ) { swiftBuild, session, observabilityScope, buildParameters in
+                let buildSettings = try await swiftBuild.makeBuildParameters(
+                    session: session,
+                    symbolGraphOptions: nil,
+                    setToolchainSetting: false
+                )
+
+                let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+
+                // Note: On Linux, omitFramePointers=nil is converted to false by BuildParameters.Debugging.init
+                // to preserve frame pointers for better backtraces (see BuildParameters+Debugging.swift:34-36)
+                #if os(Linux)
+                #expect(synthesizedArgs.table["CLANG_OMIT_FRAME_POINTERS"] == "NO")
+                #expect(synthesizedArgs.table["SWIFT_OMIT_FRAME_POINTERS"] == "NO")
+                #else
+                #expect(synthesizedArgs.table["CLANG_OMIT_FRAME_POINTERS"] == nil)
+                #expect(synthesizedArgs.table["SWIFT_OMIT_FRAME_POINTERS"] == nil)
+                #endif
+            }
+        }
+
+        @Test
+        func allDebuggingSettingsCombinedWork() async throws {
+            // Test that all debugging settings work together correctly
+            try await withInstantiatedSwiftBuildSystem(
+                fromFixture: "PIFBuilder/Simple",
+                buildParameters: mockBuildParameters(
+                    destination: .host,
+                    debugInfoFormat: .dwarf,
+                    shouldEnableDebuggingEntitlement: true,
+                    omitFramePointers: false
+                ),
+            ) { swiftBuild, session, observabilityScope, buildParameters in
+                let buildSettings = try await swiftBuild.makeBuildParameters(
+                    session: session,
+                    symbolGraphOptions: nil,
+                    setToolchainSetting: false
+                )
+
+                let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+
+                // Check all settings are present
+                #if os(macOS)
+                #expect(synthesizedArgs.table["DEPLOYMENT_POSTPROCESSING"] == "NO")
+                #endif
+                #expect(synthesizedArgs.table["DEBUG_INFORMATION_FORMAT"] == "dwarf")
+                #expect(synthesizedArgs.table["CLANG_OMIT_FRAME_POINTERS"] == "NO")
+                #expect(synthesizedArgs.table["SWIFT_OMIT_FRAME_POINTERS"] == "NO")
+            }
+        }
+
+        @Test
+        func debuggingFlagsAreFilteredFromCompilerFlags() async throws {
+            // Verify that flags with source: .debugging are properly filtered out by rawFlagsForSwiftBuild
+            // and don't appear in OTHER_CFLAGS, OTHER_CPLUSPLUSFLAGS, OTHER_SWIFT_FLAGS, or OTHER_LDFLAGS
+
+            let debuggingCFlags = [
+                BuildFlag(value: "-g", source: .debugging),
+                BuildFlag(value: "-fomit-frame-pointer", source: .debugging)
+            ]
+            let debuggingSwiftFlags = [
+                BuildFlag(value: "-g", source: .debugging),
+                BuildFlag(value: "-Xcc", source: .debugging),
+                BuildFlag(value: "-fno-omit-frame-pointer", source: .debugging)
+            ]
+            let userCFlags = [
+                BuildFlag(value: "-DUSER_DEFINE", source: .commandLineOptions)
+            ]
+            let userSwiftFlags = [
+                BuildFlag(value: "-DSWIFT_USER", source: .commandLineOptions)
+            ]
+
+            let flags = BuildFlags(
+                cCompilerFlags: debuggingCFlags + userCFlags,
+                cxxCompilerFlags: debuggingCFlags,
+                swiftCompilerFlags: debuggingSwiftFlags + userSwiftFlags,
+                linkerFlags: []
+            )
+
+            try await withInstantiatedSwiftBuildSystem(
+                fromFixture: "PIFBuilder/Simple",
+                buildParameters: mockBuildParameters(
+                    destination: .host,
+                    flags: flags,
+                    debugInfoFormat: .dwarf,
+                    omitFramePointers: false
+                ),
+            ) { swiftBuild, session, observabilityScope, buildParameters in
+                let buildSettings = try await swiftBuild.makeBuildParameters(
+                    session: session,
+                    symbolGraphOptions: nil,
+                    setToolchainSetting: false
+                )
+
+                let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+
+                // Check OTHER_CFLAGS
+                let otherCFlags = synthesizedArgs.table["OTHER_CFLAGS"] ?? ""
+                #expect(
+                    !otherCFlags.contains("-g"),
+                    "OTHER_CFLAGS should not contain debug flags with source: .debugging"
+                )
+                #expect(
+                    !otherCFlags.contains("-fomit-frame-pointer"),
+                    "OTHER_CFLAGS should not contain frame pointer flags with source: .debugging"
+                )
+                #expect(
+                    otherCFlags.contains("-DUSER_DEFINE"),
+                    "OTHER_CFLAGS should contain user flags with source: .commandLineOptions"
+                )
+
+                // Check OTHER_CPLUSPLUSFLAGS
+                let otherCPlusPlusFlags = synthesizedArgs.table["OTHER_CPLUSPLUSFLAGS"] ?? ""
+                #expect(
+                    !otherCPlusPlusFlags.contains("-g"),
+                    "OTHER_CPLUSPLUSFLAGS should not contain debug flags with source: .debugging"
+                )
+                #expect(
+                    !otherCPlusPlusFlags.contains("-fomit-frame-pointer"),
+                    "OTHER_CPLUSPLUSFLAGS should not contain frame pointer flags with source: .debugging"
+                )
+
+                // Check OTHER_SWIFT_FLAGS
+                let otherSwiftFlags = synthesizedArgs.table["OTHER_SWIFT_FLAGS"] ?? ""
+                #expect(
+                    !otherSwiftFlags.contains("-g"),
+                    "OTHER_SWIFT_FLAGS should not contain debug flags with source: .debugging"
+                )
+                #expect(
+                    !otherSwiftFlags.contains("-fno-omit-frame-pointer"),
+                    "OTHER_SWIFT_FLAGS should not contain frame pointer flags with source: .debugging"
+                )
+                #expect(
+                    otherSwiftFlags.contains("-DSWIFT_USER"),
+                    "OTHER_SWIFT_FLAGS should contain user flags with source: .commandLineOptions"
+                )
+
+                // Verify that dedicated build settings are still set correctly
+                #expect(synthesizedArgs.table["DEBUG_INFORMATION_FORMAT"] == "dwarf")
+                #expect(synthesizedArgs.table["CLANG_OMIT_FRAME_POINTERS"] == "NO")
+                #expect(synthesizedArgs.table["SWIFT_OMIT_FRAME_POINTERS"] == "NO")
+            }
+        }
+    }
 }


### PR DESCRIPTION
- support -debug-info-format option
- support --omit-frame-pointers option
