### PR TITLE
Don't set OBJC_ARC build setting

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -582,7 +582,6 @@ public final class PackagePIFBuilder {
         settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS]
             .lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) { $0.append("SWIFT_PACKAGE") }
         settings[.GCC_PREPROCESSOR_DEFINITIONS] = ["$(inherited)", "SWIFT_PACKAGE"]
-        settings[.CLANG_ENABLE_OBJC_ARC] = "YES"
         settings[.KEEP_PRIVATE_EXTERNS] = "NO"
 
         // We currently deliberately do not support Swift ObjC interface headers.


### PR DESCRIPTION
- build system already knows correct defaults for each supported
  platform

closes: https://github.com/swiftlang/swift-package-manager/issues/9750

