### PR TITLE
Add --enable-codesize-profile option to emit SIL, LLVM IR, and optimization records for code size profiling.

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -485,6 +485,11 @@ public final class SwiftModuleBuildDescription {
         args += self.optimizationArguments
         args += self.testingArguments
 
+        if self.buildParameters.driverParameters.emitOptimizationRecord {
+            args += ["-save-optimization-record"]
+            args += ["-g"]
+        }
+
         args += ["-j\(self.buildParameters.workers)"]
         args += self.activeCompilationConditions
         args += self.additionalFlags
@@ -804,6 +809,33 @@ public final class SwiftModuleBuildDescription {
 
                 """#
 
+            if self.buildParameters.driverParameters.emitSILFiles {
+                let silPath = try self.silOutputPath()
+                content +=
+                    #"""
+                        "sil": "\#(silPath._nativePathString(escaped: true))",
+
+                    """#
+            }
+
+            if !self.useParallelWMO {
+                if self.buildParameters.driverParameters.emitIRFiles {
+                    let irPath = try self.irOutputPath()
+                    content +=
+                        #"""
+                            "llvm-ir": "\#(irPath._nativePathString(escaped: true))",
+
+                        """#
+                }
+
+                if self.buildParameters.driverParameters.emitOptimizationRecord {
+                    content +=
+                        #"""
+                            "yaml-opt-record": "\#(try self.optimizationRecordOutputPath()._nativePathString(escaped: true))",
+
+                        """#
+                }
+            }
         }
         content +=
             #"""
@@ -850,6 +882,36 @@ public final class SwiftModuleBuildDescription {
                     "swiftmodule": "\#(partialModulePath._nativePathString(escaped: true))",
                     "swift-dependencies": "\#(swiftDepsPath._nativePathString(escaped: true))",
                     "diagnostics": "\#(diagnosticsPath._nativePathString(escaped: true))"
+                """#
+
+            if self.buildParameters.driverParameters.emitSILFiles && !self.useWholeModuleOptimization {
+                let silPath = try self.silOutputPath(for: source)
+                content +=
+                    #"""
+                    ,
+                        "sil": "\#(silPath._nativePathString(escaped: true))"
+                    """#
+            }
+
+            if self.buildParameters.driverParameters.emitIRFiles {
+                let irPath = try self.irOutputPath(for: source)
+                content +=
+                    #"""
+                    ,
+                        "llvm-ir": "\#(irPath._nativePathString(escaped: true))"
+                    """#
+            }
+
+            if self.buildParameters.driverParameters.emitOptimizationRecord {
+                content +=
+                    #"""
+                    ,
+                        "yaml-opt-record": "\#(try self.optimizationRecordOutputPath(for: source)._nativePathString(escaped: true))"
+                    """#
+            }
+
+            content +=
+                #"""
                   }\#((idx + 1) < sources.count ? "," : "")
 
                 """#
@@ -857,8 +919,84 @@ public final class SwiftModuleBuildDescription {
 
         content += "}\n"
 
+        if let silOutputDir = self.buildParameters.driverParameters.silOutputDirectory {
+            do {
+                try fileSystem.createDirectory(silOutputDir, recursive: true)
+                observabilityScope.emit(info: "Writing SIL files to: \(silOutputDir)")
+            } catch {
+                throw StringError("Failed to create SIL output directory at \(silOutputDir): \(error)")
+            }
+        } else if self.buildParameters.driverParameters.emitSILFiles {
+            observabilityScope.emit(info: "Writing SIL files to: \(self.tempsPath)")
+        }
+
+        if let irOutputDir = self.buildParameters.driverParameters.irOutputDirectory {
+            do {
+                try fileSystem.createDirectory(irOutputDir, recursive: true)
+                observabilityScope.emit(info: "Writing LLVM IR files to: \(irOutputDir)")
+            } catch {
+                throw StringError("Failed to create LLVM IR output directory at \(irOutputDir): \(error)")
+            }
+        } else if self.buildParameters.driverParameters.emitIRFiles {
+            observabilityScope.emit(info: "Writing LLVM IR files to: \(self.tempsPath)")
+        }
+
+        if let optRecordDir = self.buildParameters.driverParameters.optimizationRecordDirectory {
+            do {
+                try fileSystem.createDirectory(optRecordDir, recursive: true)
+                observabilityScope.emit(info: "Writing optimization records to: \(optRecordDir)")
+            } catch {
+                throw StringError("Failed to create optimization record output directory at \(optRecordDir): \(error)")
+            }
+        } else if self.buildParameters.driverParameters.emitOptimizationRecord {
+            observabilityScope.emit(info: "Writing optimization records to: \(self.tempsPath)")
+        }
+
         try fileSystem.createDirectory(path.parentDirectory, recursive: true)
         try self.fileSystem.writeFileContents(path, bytes: .init(encodingAsUTF8: content), atomically: true)
+    }
+
+    /// Returns the path for SIL output file.
+    /// In WMO mode, returns the path for the whole module's SIL output.
+    /// In non-WMO mode, returns the path for the given source file's SIL output.
+    private func silOutputPath(for source: AbsolutePath? = nil) throws -> AbsolutePath {
+        let outputDir = self.buildParameters.driverParameters.silOutputDirectory ?? self.tempsPath
+        let baseName: String
+        if self.useWholeModuleOptimization {
+            baseName = self.target.c99name
+        } else {
+            guard let source = source else {
+                throw InternalError("Source file required for SIL output path in non-WMO mode")
+            }
+            baseName = source.basenameWithoutExt
+        }
+        return outputDir.appending(component: baseName + ".sil")
+    }
+
+    private func irOutputPath(for source: AbsolutePath? = nil) throws -> AbsolutePath {
+        let outputDir = self.buildParameters.driverParameters.irOutputDirectory ?? self.tempsPath
+        let baseName: String
+        if let source {
+            baseName = source.basenameWithoutExt
+        } else if self.useWholeModuleOptimization {
+            baseName = self.target.c99name
+        } else {
+            throw InternalError("Source file required for IR output path in non-WMO mode")
+        }
+        return outputDir.appending(component: baseName + ".ll")
+    }
+
+    private func optimizationRecordOutputPath(for source: AbsolutePath? = nil) throws -> AbsolutePath {
+        let outputDir = self.buildParameters.driverParameters.optimizationRecordDirectory ?? self.tempsPath
+        let baseName: String
+        if let source {
+            baseName = source.basenameWithoutExt
+        } else if self.useWholeModuleOptimization {
+            baseName = self.target.c99name
+        } else {
+            throw InternalError("Source file required for optimization record path in non-WMO mode")
+        }
+        return outputDir.appending(component: baseName + ".opt.yaml")
     }
 
     /// Directory for the the compatibility header and module map generated for this target.
@@ -1049,6 +1187,12 @@ public final class SwiftModuleBuildDescription {
         case .release:
             return true
         }
+    }
+
+    /// Whether the Swift driver will use multi-threaded WMO.
+    /// With only one source file, the driver treats it as single-threaded.
+    var useParallelWMO: Bool {
+        ProcessInfo.processInfo.activeProcessorCount > 1 && self.sources.count > 1
     }
 }
 

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -176,6 +176,22 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
             toolsBuildParameters.printPIFManifestGraphviz = true
         }
 
+        if swiftCommandState.options.build.enableCodesizeProfile {
+            var driverParameters = productsBuildParameters.driverParameters
+            driverParameters.codesizeProfileEnabled = true
+            driverParameters.emitSILFiles = true
+            driverParameters.emitIRFiles = true
+            driverParameters.emitOptimizationRecord = true
+
+            if let outputDir = swiftCommandState.options.build.codesizeProfileOutputDirectory {
+                let outputPath = try AbsolutePath(validating: outputDir, relativeTo: swiftCommandState.originalWorkingDirectory)
+                driverParameters.silOutputDirectory = outputPath
+                driverParameters.irOutputDirectory = outputPath
+                driverParameters.optimizationRecordDirectory = outputPath
+            }
+            productsBuildParameters.driverParameters = driverParameters
+        }
+
         do {
             try await build(
                 swiftCommandState,

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -603,6 +603,14 @@ public struct BuildOptions: ParsableArguments {
     @Flag(name: .customLong("experimental-build-dylibs-as-frameworks"), help: .hidden )
     public var shouldBuildDylibsAsFrameworks: Bool = false
 
+    /// Enable code size profiling by emitting SIL, LLVM IR, and optimization records.
+    @Flag(name: .customLong("experimental-enable-codesize-profile"), help: "Generate SIL, LLVM IR, and optimization record files for code size profiling.")
+    public var enableCodesizeProfile: Bool = false
+
+    /// Directory for code size profiling output files (SIL, IR, optimization records).
+    @Option(name: .customLong("experimental-codesize-profile-output-dir"), help: "Directory to store code size profiling output files.")
+    public var codesizeProfileOutputDirectory: String?
+
     // @Flag works best when there is a default value present
     // if true, false aren't enough and a third state is needed
     // nil should not be the goto. Instead create an enum

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Driver.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Driver.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
+
 extension BuildParameters {
     /// A mode for explicit import checking
     public enum TargetDependencyImportCheckingMode : Codable {
@@ -25,13 +27,27 @@ extension BuildParameters {
             enableParseableModuleInterfaces: Bool = false,
             explicitTargetDependencyImportCheckingMode: TargetDependencyImportCheckingMode = .none,
             useIntegratedSwiftDriver: Bool = false,
-            isPackageAccessModifierSupported: Bool = false
+            isPackageAccessModifierSupported: Bool = false,
+            codesizeProfileEnabled: Bool = false,
+            emitSILFiles: Bool = false,
+            emitIRFiles: Bool = false,
+            emitOptimizationRecord: Bool = false,
+            silOutputDirectory: AbsolutePath? = nil,
+            irOutputDirectory: AbsolutePath? = nil,
+            optimizationRecordDirectory: AbsolutePath? = nil
         ) {
             self.canRenameEntrypointFunctionName = canRenameEntrypointFunctionName
             self.enableParseableModuleInterfaces = enableParseableModuleInterfaces
             self.explicitTargetDependencyImportCheckingMode = explicitTargetDependencyImportCheckingMode
             self.useIntegratedSwiftDriver = useIntegratedSwiftDriver
             self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
+            self.codesizeProfileEnabled = codesizeProfileEnabled
+            self.emitSILFiles = emitSILFiles
+            self.emitIRFiles = emitIRFiles
+            self.emitOptimizationRecord = emitOptimizationRecord
+            self.silOutputDirectory = silOutputDirectory
+            self.irOutputDirectory = irOutputDirectory
+            self.optimizationRecordDirectory = optimizationRecordDirectory
         }
 
         /// Whether to enable the entry-point-function-name feature.
@@ -53,5 +69,26 @@ extension BuildParameters {
         /// supports `-package-name` options.
         @_spi(SwiftPMInternal)
         public var isPackageAccessModifierSupported: Bool
+
+        /// Whether code size profiling mode is enabled
+        public var codesizeProfileEnabled: Bool
+
+        /// Whether to emit SIL files
+        public var emitSILFiles: Bool
+
+        /// Whether to emit LLVM IR files
+        public var emitIRFiles: Bool
+
+        /// Whether to emit optimization records
+        public var emitOptimizationRecord: Bool
+
+        /// Output directory for SIL files.
+        public var silOutputDirectory: AbsolutePath?
+
+        /// Output directory for IR files.
+        public var irOutputDirectory: AbsolutePath?
+
+        /// Output directory for optimization record files.
+        public var optimizationRecordDirectory: AbsolutePath?
     }
 }

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -926,6 +926,32 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 + buildParameters.flags.swiftCompilerFlags.map { $0.shellEscaped() }
         ).joined(separator: " ")
 
+        if buildParameters.driverParameters.emitSILFiles {
+            settings["SWIFT_EMIT_SIL_FILES"] = "YES"
+            if let outputDir = buildParameters.driverParameters.silOutputDirectory {
+                settings["SWIFT_SIL_OUTPUT_DIR"] = outputDir.pathString
+            }
+        }
+
+        if buildParameters.driverParameters.emitIRFiles {
+            settings["SWIFT_EMIT_IR_FILES"] = "YES"
+            if let outputDir = buildParameters.driverParameters.irOutputDirectory {
+                settings["SWIFT_IR_OUTPUT_DIR"] = outputDir.pathString
+            }
+        }
+
+        if buildParameters.driverParameters.emitOptimizationRecord {
+            settings["SWIFT_EMIT_OPT_RECORDS"] = "YES"
+            if let outputDir = buildParameters.driverParameters.optimizationRecordDirectory {
+                settings["SWIFT_OPT_RECORD_OUTPUT_DIR"] = outputDir.pathString
+            }
+        }
+
+        if buildParameters.driverParameters.codesizeProfileEnabled {
+            // dSYM generation is required to attribute code size to source locations
+            settings["DEBUG_INFORMATION_FORMAT"] = "dwarf-with-dsym"
+        }
+
         let inherited = ["$(inherited)"]
 
         let buildParametersLinkFlags =

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -206,10 +206,21 @@ extension Trait where Self == Testing.ConditionTrait {
             #endif
         }
     }
-    /// Skip test if compiler is older than 6.2.
+    /// Skip test if compiler is older than 6.3.
     public static var requireSwift6_3: Self {
-        enabled("This test requires Swift 6.2, or newer.") {
+        enabled("This test requires Swift 6.3, or newer.") {
             #if compiler(>=6.3)
+                true
+            #else
+                false
+            #endif
+        }
+    }
+
+    /// Skip test if compiler is older than 6.4.
+    public static var requireSwift6_4: Self {
+        enabled("This test requires Swift 6.4, or newer.") {
+            #if compiler(>=6.4)
                 true
             #else
                 false

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -7646,6 +7646,90 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             false
         )
     }
+
+    func testSupplementaryOutputsCompileArguments() async throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles: "/Pkg/Sources/exe/main.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    targets: [
+                        TargetDescription(name: "exe", type: .executable),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        var driverParameters = BuildParameters.Driver()
+        driverParameters.emitSILFiles = true
+        driverParameters.emitIRFiles = true
+        driverParameters.emitOptimizationRecord = true
+
+        let plan = try await mockBuildPlan(
+            config: .release,
+            graph: graph,
+            driverParameters: driverParameters,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let result = try BuildPlanResult(plan: plan)
+        let exe = try result.moduleBuildDescription(for: "exe").swift()
+
+        let args = try exe.emitCommandLine()
+        XCTAssertMatch(args, ["-save-optimization-record"])
+        XCTAssertMatch(args, ["-g"])
+    }
+
+    func testSupplementaryOutputsInWMOMode() async throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+                "/Pkg/Sources/lib/file1.swift",
+                "/Pkg/Sources/lib/file2.swift"
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    targets: [
+                        TargetDescription(name: "lib"),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        var driverParameters = BuildParameters.Driver()
+        driverParameters.emitSILFiles = true
+        driverParameters.emitIRFiles = true
+        driverParameters.emitOptimizationRecord = true
+
+        let plan = try await mockBuildPlan(
+            config: .release,
+            graph: graph,
+            driverParameters: driverParameters,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let result = try BuildPlanResult(plan: plan)
+        let lib = try result.moduleBuildDescription(for: "lib").swift()
+
+        let args = try lib.emitCommandLine()
+        XCTAssertMatch(args, ["-whole-module-optimization"])
+        XCTAssertMatch(args, ["-save-optimization-record"])
+    }
 }
 
 class BuildPlanNativeTests: BuildPlanTestCase {

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -1824,6 +1824,100 @@ struct BuildCommandTestCases {
             ProcessInfo.hostOperatingSystem == .windows
         }
     }
+
+    @Test(
+        .tags(
+            .Feature.CommandLineArguments.BuildSystem,
+        ),
+        .requireSwift6_4,
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func codesizeProfile(
+        buildSystem: BuildSystemProvider.Kind
+    ) async throws {
+        try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
+            let config = BuildConfiguration.release // Use release for WMO
+            let _ = try await build(
+                ["--experimental-enable-codesize-profile"],
+                packagePath: fixturePath,
+                configuration: config,
+                cleanAfterward: false,
+                buildSystem: buildSystem
+            )
+
+            let (binPathOutput, _) = try await execute(
+                ["--show-bin-path"],
+                packagePath: fixturePath,
+                configuration: config,
+                buildSystem: buildSystem
+            )
+            let binPath = try AbsolutePath(validating: binPathOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+
+            switch buildSystem {
+            case .native:
+                let executableBuildDir = binPath.appending("ExecutableNew.build")
+                #expect(localFileSystem.exists(executableBuildDir), "ExecutableNew.build directory should exist")
+
+                let buildDirContents = try localFileSystem.getDirectoryContents(executableBuildDir).filter {
+                    $0.hasSuffix(".sil") || $0.hasSuffix(".ll") || $0.hasSuffix(".opt.yaml")
+                }
+                #expect(!buildDirContents.isEmpty, "Should have supplementary output files (.sil, .ll, .opt.yaml)")
+
+            case .swiftbuild, .xcode:
+                // Swift Build stores intermediates under:
+                // .build/out/Intermediates.noindex/<Target>.build/<Config-platform>/<Variant>.build/Objects-normal/<arch>/
+                // The variant suffix (e.g. "-p" for products) varies by platform, so search recursively.
+                let intermediatesRoot = binPath
+                    .parentDirectory // Products
+                    .parentDirectory // out
+                    .appending(component: "Intermediates.noindex")
+                var foundFiles: [String] = []
+                if let enumerator = FileManager.default.enumerator(atPath: intermediatesRoot.pathString) {
+                    for case let file as String in enumerator {
+                        if file.hasSuffix(".sil") || file.hasSuffix(".ll") || file.hasSuffix(".opt.yaml") {
+                            foundFiles.append(file)
+                        }
+                    }
+                }
+                #expect(!foundFiles.isEmpty, "Should have supplementary output files (.sil, .ll, .opt.yaml) under \(intermediatesRoot)")
+            }
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.CommandLineArguments.BuildSystem,
+        ),
+        .requireSwift6_4,
+        arguments: [BuildSystemProvider.Kind.native]
+    )
+    func codesizeProfileWithCustomOutputDirectory(
+        buildSystem: BuildSystemProvider.Kind
+    ) async throws {
+        try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
+            let config = BuildConfiguration.release
+            let customOutputDir = fixturePath.appending("custom-codesize-output")
+
+            let _ = try await build(
+                ["--experimental-enable-codesize-profile", "--experimental-codesize-profile-output-dir", customOutputDir.pathString],
+                packagePath: fixturePath,
+                configuration: config,
+                cleanAfterward: false,
+                buildSystem: buildSystem
+            )
+
+            #expect(localFileSystem.exists(customOutputDir), "Custom output directory should be created")
+
+            let outputContents = try localFileSystem.getDirectoryContents(customOutputDir)
+            let hasSIL = outputContents.contains { $0.hasSuffix(".sil") }
+            let hasIR = outputContents.contains { $0.hasSuffix(".ll") }
+            let hasOptRecord = outputContents.contains { $0.hasSuffix(".opt.yaml") }
+
+            #expect(hasSIL, "Should have .sil files in custom directory")
+            #expect(hasIR, "Should have .ll files in custom directory")
+            #expect(hasOptRecord, "Should have .opt.yaml files in custom directory")
+        }
+    }
 }
 
 extension Triple {


### PR DESCRIPTION
This option is a convenience option to emit supplementary output such as Swift IL, LLVM IR and optimization records, so that they can be analyzed for code size.

Adds --codesize-profile-output-dir to control the output directory.
Handles both native and swiftbuild backends. 
Handles per-file vs module-level output placement for single-threaded and multi-threaded WMO.

