### PR TITLE
Dev Container: fix typo

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -12,4 +12,4 @@ services:
       # Mount the main git repo dir and the current worktree dir at the same absolute path as the host
       - ${GIT_REPO}:${GIT_REPO}:rw
       - ${WORKSPACE_DIR}:${WORKSPACE_DIR}:rw
-    command: sleep infinityg
+    command: sleep infinity


### PR DESCRIPTION
Fix a typo in the dev container docker-compose.yaml file, that was preventing the container from starting.