### PR TITLE
[Swift Build] filter warning control flags from the build of remote packages

### DIFF
--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -19,6 +19,7 @@ import struct PackageGraph.ResolvedModule
 import struct SPMBuildCore.BuildParameters
 import struct SPMBuildCore.BuildToolPluginInvocationResult
 import struct SPMBuildCore.CommandPluginResult
+import enum SPMBuildCore.WarningControlFlags
 
 @available(*, deprecated, renamed: "ClangModuleBuildDescription")
 public typealias ClangTargetBuildDescription = ClangModuleBuildDescription
@@ -368,16 +369,7 @@ public final class ClangModuleBuildDescription {
         // suppress warnings if the package is remote
         if self.package.isRemote {
             // `-w` (suppress warnings) and the other warning control flags are mutually exclusive
-            args = args.filter { arg in
-                // we consider the following flags:
-                // -Wxxxx
-                // -Wno-xxxx
-                // -Werror
-                // -Werror=xxxx
-                // -Wno-error
-                // -Wno-error=xxxx
-                arg.count <= 2 || !arg.starts(with: "-W")
-            }
+            args = WarningControlFlags.filterClangWarningControlFlags(args)
             args += ["-w"]
         }
 

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -608,26 +608,7 @@ public final class SwiftModuleBuildDescription {
 
         // suppress warnings if the package is remote
         if self.package.isRemote {
-            // suppress-warnings and the other warning control flags are mutually exclusive
-            var removeNextArg = false
-            args = args.filter { arg in
-                if removeNextArg {
-                    removeNextArg = false
-                    return false
-                }
-                switch arg {
-                case "-warnings-as-errors", "-no-warnings-as-errors":
-                    return false
-                case "-Wwarning", "-Werror":
-                    removeNextArg = true
-                    return false
-                default:
-                    return true
-                }
-            }
-            guard !removeNextArg else {
-                throw InternalError("Unexpected '-Wwarning' or '-Werror' at the end of args")
-            }
+            args = try WarningControlFlags.filterSwiftWarningControlFlags(args)
             args += ["-suppress-warnings"]
         }
 

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -1369,12 +1369,7 @@ extension Basics.Triple {
 
 extension ResolvedPackage {
     var isRemote: Bool {
-        switch self.underlying.manifest.packageKind {
-        case .registry, .remoteSourceControl, .localSourceControl:
-            return true
-        case .root, .fileSystem:
-            return false
-        }
+        self.underlying.manifest.packageKind.isRemote
     }
 }
 

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -81,6 +81,15 @@ public struct PackageReference {
                 return false
             }
         }
+
+        public var isRemote: Bool {
+            switch self {
+            case .registry, .remoteSourceControl, .localSourceControl:
+                return true
+            case .root, .fileSystem:
+                return false
+            }
+        }
     }
 
     /// The identity of the package.

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(SPMBuildCore
   MainAttrDetection.swift
   ResolvedPackage+Extensions.swift
   Triple+Extensions.swift
+  WarningControlFlags.swift
   XCFrameworkMetadata.swift
   XcodeProjectRepresentation.swift)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet

--- a/Sources/SPMBuildCore/WarningControlFlags.swift
+++ b/Sources/SPMBuildCore/WarningControlFlags.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package enum WarningControlFlags {
+    package static func filterSwiftWarningControlFlags(_ args: [String]) -> [String] {
+        var filtered: [String] = []
+        var skipNextArg = false
+
+        for arg in args {
+            if skipNextArg {
+                skipNextArg = false
+                continue
+            }
+
+            switch arg {
+            case "-warnings-as-errors", "-no-warnings-as-errors":
+                break
+            case "-Wwarning", "-Werror":
+                skipNextArg = true
+            default:
+                filtered.append(arg)
+            }
+        }
+        return filtered
+    }
+
+    package static func filterClangWarningControlFlags(_ args: [String]) -> [String] {
+        args.filter { arg in
+            // Filter out warning control flags:
+            // -Wxxxx
+            // -Wno-xxxx
+            // -Werror
+            // -Werror=xxxx
+            // -Wno-error
+            // -Wno-error=xxxx
+            arg.count <= 2 || !arg.starts(with: "-W")
+        }
+    }
+}

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -567,6 +567,10 @@ fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelega
     var isRootPackage: Bool {
         self.package.manifest.packageKind.isRoot
     }
+
+    var isRemote: Bool {
+        self.package.manifest.packageKind.isRemote
+    }
     
     var hostsOnlyPackages: Bool {
         false

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -79,6 +79,9 @@ public final class PackagePIFBuilder {
         /// Is this the root package?
         var isRootPackage: Bool { get }
 
+        /// Is this a remote package?
+        var isRemote: Bool { get }
+
         // TODO: Maybe move these 3-4 properties to the `PIFBuilder.PIFBuilderParameters` struct.
 
         /// If a pure Swift package is open in the workspace.
@@ -571,7 +574,7 @@ public final class PackagePIFBuilder {
         // (If we want to be extra careful with differences to the existing PIF in the SwiftPM.)
         settings[.OTHER_CFLAGS] = ["$(inherited)", "-DXcode"]
 
-        if !self.delegate.isRootPackage {
+        if self.delegate.isRemote {
             if self.suppressWarningsForPackageDependencies {
                 settings[.SUPPRESS_WARNINGS] = "YES"
             }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -763,7 +763,7 @@ extension PackagePIFProjectBuilder {
         var debugSettings = settings
         var releaseSettings = settings
 
-        let allBuildSettings = sourceModule.computeAllBuildSettings(observabilityScope: pifBuilder.observabilityScope)
+        let allBuildSettings = sourceModule.computeAllBuildSettings(observabilityScope: pifBuilder.observabilityScope, forRemotePackage: pifBuilder.delegate.isRemote)
 
         // Apply target-specific build settings defined in the manifest.
         allBuildSettings.apply(to: &debugSettings, for: .debug)

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -499,7 +499,7 @@ extension PackagePIFProjectBuilder {
         var releaseSettings: ProjectModel.BuildSettings = settings
 
         // Apply target-specific build settings defined in the manifest.
-        let allBuildSettings = mainModule.computeAllBuildSettings(observabilityScope: pifBuilder.observabilityScope)
+        let allBuildSettings = mainModule.computeAllBuildSettings(observabilityScope: pifBuilder.observabilityScope, forRemotePackage: pifBuilder.delegate.isRemote)
         
         // Apply settings using the convenience methods
         allBuildSettings.apply(to: &debugSettings, for: .debug)


### PR DESCRIPTION
Two changes to match SE-0480 more closely:
- Don't suppress warnings for non-root local packages
- Filter warning control flags for remote packages so they do not conflict with -suppress-warnings