### PR TITLE
[Build] Fix --static-swift-stdlib flag being ignored on FreeBSD

### DIFF
--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -1363,7 +1363,7 @@ func generateResourceInfoPlist(
 
 extension Basics.Triple {
     var isSupportingStaticStdlib: Bool {
-        isLinux() || arch == .wasm32
+        isLinux() || isFreeBSD() || arch == .wasm32
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/swiftlang/swift-package-manager/issues/9779 
Fixes #9072

Should OpenBSD be included there? I managed to trace it after looking at how `-static-swift-stdlib` works, and it looks like it’s working.