### PR TITLE
[Swift Build] Avoid case-insensitive intermediates dir collisions between products/targets

### DIFF
--- a/Fixtures/Miscellaneous/CaseCollision/Package.swift
+++ b/Fixtures/Miscellaneous/CaseCollision/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+let package = Package(
+    name: "CaseInsensitiveCollisions",
+    products: [
+        .executable(name: "foo", targets: ["footool"]),
+    ],
+    targets: [
+        .executableTarget(name: "footool", dependencies: ["Foo"]),
+        .target(name: "Foo"),
+    ]
+)

--- a/Fixtures/Miscellaneous/CaseCollision/Sources/Foo/Foo.swift
+++ b/Fixtures/Miscellaneous/CaseCollision/Sources/Foo/Foo.swift
@@ -1,0 +1,3 @@
+public func greeting() -> String {
+    "Hello, world!"
+}

--- a/Fixtures/Miscellaneous/CaseCollision/Sources/footool/main.swift
+++ b/Fixtures/Miscellaneous/CaseCollision/Sources/footool/main.swift
@@ -1,0 +1,3 @@
+import Foo
+
+print(greeting())

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -1054,6 +1054,7 @@ extension ProjectModel.BuildSettings {
         delegate: PackagePIFBuilder.BuildDelegate,
     ) {
         self[.TARGET_NAME] = targetName
+        self[.TARGET_TEMP_DIR_SUFFIX] = "-t"
         self[.PRODUCT_NAME] = productName
         self[.PRODUCT_MODULE_NAME] = productName
         self[.PRODUCT_BUNDLE_IDENTIFIER] = "\(packageIdentity).\(productName)".spm_mangledToBundleIdentifier()

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -366,6 +366,9 @@ extension PackagePIFProjectBuilder {
         // Configure the target-wide build settings. The details depend on the kind of product we're building.
         var settings: BuildSettings = self.package.underlying.packageBaseBuildSettings
 
+        // Ensure the intermediates for this target don't clash with the intermediates of a target representing a package product with the same name
+        settings[.TARGET_TEMP_DIR_SUFFIX] = "-t"
+
         if sourceModule.platformConstraint == .host {
             settings[.SUPPORTED_PLATFORMS] = ["$(HOST_PLATFORM)"]
         }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -111,6 +111,7 @@ extension PackagePIFProjectBuilder {
         // but are in general the ones that are suitable for end-product artifacts such as executables and test bundles.
         var settings: ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
         settings[.TARGET_NAME] = product.name
+        settings[.TARGET_TEMP_DIR_SUFFIX] = "-p"
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "regular"
         settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
         // We must use the main module name here instead of the product name, because they're not guranteed to be the same, and the users may have authored e.g. tests which rely on an executable's module name.
@@ -721,6 +722,7 @@ extension PackagePIFProjectBuilder {
             }
         } else if productType == .staticArchive {
             settings[.TARGET_NAME] = product.targetName()
+            settings[.TARGET_TEMP_DIR_SUFFIX] = "-p"
             settings[.PRODUCT_NAME] = product.name
 
             // This should really be swift-build defaults set in the .xcspec files, but changing that requires

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -207,6 +207,7 @@ struct PackagePIFProjectBuilder {
 
         var settings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
         settings[.TARGET_NAME] = bundleName
+        settings[.TARGET_TEMP_DIR_SUFFIX] = "-b"
         settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
         settings[.PRODUCT_MODULE_NAME] = bundleName
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(module.name).resources"

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1337,4 +1337,19 @@ struct MiscellaneousSwiftTestingTests {
             )
         }
     }
+
+    @Test(
+        .tags(.Feature.Command.Build),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func caseInsensitiveCollisions(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/CaseCollision") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                buildSystem: buildSystem,
+            )
+        }
+    }
 }


### PR DESCRIPTION
Use TARGET_TEMP_DIR_SUFFIX to ensure that TARGET_TEMP_DIRs for products and targets cannot collide, leading to build failures.

Depends on https://github.com/swiftlang/swift-build/pull/1140