### PR TITLE
Track the source of swift BuildFlags and filter them when redundant

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -368,9 +368,9 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         // building for Darwin in debug configuration.
         args += self.swiftASTs.flatMap { ["-Xlinker", "-add_ast_path", "-Xlinker", $0.pathString] }
 
-        args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags
+        args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags.rawFlags
         // User arguments (from -Xswiftc) should follow generated arguments to allow user overrides
-        args += self.buildParameters.flags.swiftCompilerFlags
+        args += self.buildParameters.flags.swiftCompilerFlags.rawFlags
 
         args += self.buildParameters.toolchain.extraFlags.linkerFlags.asSwiftcLinkerFlags()
         // User arguments (from -Xlinker) should follow generated arguments to allow user overrides

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -577,9 +577,9 @@ public final class SwiftModuleBuildDescription {
             ]
         }
 
-        args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags
+        args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags.rawFlags
         // User arguments (from -Xswiftc) should follow generated arguments to allow user overrides
-        args += self.buildParameters.flags.swiftCompilerFlags
+        args += self.buildParameters.flags.swiftCompilerFlags.rawFlags
 
         args += self.buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
         // User arguments (from -Xcc) should follow generated arguments to allow user overrides
@@ -654,7 +654,7 @@ public final class SwiftModuleBuildDescription {
         args += try self.cxxInteroperabilityModeArguments(
             propagateFromCurrentModuleOtherSwiftFlags: true)
 
-        args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags
+        args += self.buildParameters.toolchain.extraFlags.swiftCompilerFlags.rawFlags
 
         // Include search paths determined during planning
         args += self.additionalFlags
@@ -1030,10 +1030,10 @@ public final class SwiftModuleBuildDescription {
         let queryFlags = ["-enable-experimental-feature", "Embedded"]
 
         let toolchainFlags = self.buildParameters.toolchain.extraFlags.swiftCompilerFlags
-        if toolchainFlags.contains(queryFlags) { return true }
+        if toolchainFlags.rawFlags.contains(queryFlags) { return true }
 
         let generalFlags = self.buildParameters.flags.swiftCompilerFlags
-        if generalFlags.contains(queryFlags) { return true }
+        if generalFlags.rawFlags.contains(queryFlags) { return true }
 
         return false
     }

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -542,10 +542,10 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
         // similar to how we filter out the library search path unless
         // explicitly requested.
         var extraSwiftCFlags = self.destinationBuildParameters.toolchain.extraFlags.swiftCompilerFlags
-            .filter { !$0.starts(with: "-use-ld=") }
+            .filter { !$0.value.starts(with: "-use-ld=") }
         if !includeLibrarySearchPaths {
             for index in extraSwiftCFlags.indices.dropLast().reversed() {
-                if extraSwiftCFlags[index] == "-L" {
+                if extraSwiftCFlags[index].value == "-L" {
                     // Remove the flag
                     extraSwiftCFlags.remove(at: index)
                     // Remove the argument
@@ -553,7 +553,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
                 }
             }
         }
-        arguments += extraSwiftCFlags
+        arguments += extraSwiftCFlags.rawFlags
 
         // Add search paths to the directories containing module maps and Swift modules.
         for target in self.targets {

--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -444,12 +444,13 @@ final class PackageStructureCommand: CustomLLBuildCommand {
         buildParameters.workers = 1
 
         let optionTable = OptionTable()
-        let parsedOptions = try optionTable.parse(Array(buildParameters.flags.swiftCompilerFlags), for: .batch)
+        let parsedOptions = try optionTable.parse(Array(buildParameters.flags.swiftCompilerFlags.rawFlags), for: .batch)
         let buildRecordInfoHash = BuildRecordArguments.computeHash(parsedOptions)
 
         // Replace the swiftCompilerFlags with a hash of themselves where arguments that
         // do not affect incremental builds are removed.
-        buildParameters.flags.swiftCompilerFlags = [buildRecordInfoHash]
+        // FIXME: This should use a type other than BuildFlags
+        buildParameters.flags.swiftCompilerFlags = [buildRecordInfoHash].constructBuildFlags(source: nil)
 
         return buildParameters
     }

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -130,7 +130,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         }
         buildParameters.flags.cCompilerFlags.append(contentsOf: parameters.otherCFlags)
         buildParameters.flags.cxxCompilerFlags.append(contentsOf: parameters.otherCxxFlags)
-        buildParameters.flags.swiftCompilerFlags.append(contentsOf: parameters.otherSwiftcFlags)
+        buildParameters.flags.swiftCompilerFlags.append(contentsOf: parameters.otherSwiftcFlags.constructBuildFlags(source: nil))
         buildParameters.flags.linkerFlags.append(contentsOf: parameters.otherLinkerFlags)
 
         // Configure the verbosity of the output.

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -453,7 +453,7 @@ public struct BuildOptions: ParsableArguments {
         BuildFlags(
             cCompilerFlags: self.cCompilerFlags,
             cxxCompilerFlags: self.cxxCompilerFlags,
-            swiftCompilerFlags: self.swiftCompilerFlags,
+            swiftCompilerFlags: self.swiftCompilerFlags.constructBuildFlags(source: .commandLineOptions),
             linkerFlags: self.linkerFlags,
             xcbuildFlags: self.xcbuildFlags
         )

--- a/Sources/PackageModel/BuildFlags.swift
+++ b/Sources/PackageModel/BuildFlags.swift
@@ -10,6 +10,38 @@
 //
 //===----------------------------------------------------------------------===//
 
+public struct BuildFlag: Hashable, Sendable, Encodable {
+    public var value: String
+
+    /// Describes the origin of this flag, for example if it was sourced from a Swift SDK, or added as a builtin option by SwiftPM.
+    public var source: Source?
+
+    public init(value: String, source: Source? = nil) {
+        self.value = value
+        self.source = source
+    }
+
+    public enum Source: Sendable, Hashable, Codable {
+        case defaultSwiftTestingSearchPath
+        case swiftSDK
+        case commandLineOptions
+    }
+}
+
+extension [BuildFlag] {
+    public var rawFlags: [String] {
+        return self.map(\.value)
+    }
+}
+
+extension [String] {
+    public func constructBuildFlags(source: BuildFlag.Source?) -> [BuildFlag] {
+        return self.map {
+            BuildFlag(value: $0, source: source)
+        }
+    }
+}
+
 /// Build-tool independent flags.
 public struct BuildFlags: Equatable, Encodable {
     /// Flags to pass to the C compiler.
@@ -19,7 +51,7 @@ public struct BuildFlags: Equatable, Encodable {
     public var cxxCompilerFlags: [String]
 
     /// Flags to pass to the Swift compiler.
-    public var swiftCompilerFlags: [String]
+    public var swiftCompilerFlags: [BuildFlag]
 
     /// Flags to pass to the linker.
     public var linkerFlags: [String]
@@ -30,13 +62,29 @@ public struct BuildFlags: Equatable, Encodable {
     public init(
         cCompilerFlags: [String] = [],
         cxxCompilerFlags: [String] = [],
-        swiftCompilerFlags: [String] = [],
+        swiftCompilerFlags: [BuildFlag] = [],
         linkerFlags: [String] = [],
         xcbuildFlags: [String] = []
     ) {
         self.cCompilerFlags = cCompilerFlags
         self.cxxCompilerFlags = cxxCompilerFlags
         self.swiftCompilerFlags = swiftCompilerFlags
+        self.linkerFlags = linkerFlags
+        self.xcbuildFlags = xcbuildFlags
+    }
+
+    // Kept to allow SourceKitLSP time to migrate to the new initializer.
+    @available(*, deprecated, message: "Use the overload which accepts swiftCompilerFlags as [BuildFlag] instead")
+    public init(
+        cCompilerFlags: [String],
+        cxxCompilerFlags: [String],
+        swiftCompilerFlags: [String],
+        linkerFlags: [String],
+        xcbuildFlags: [String] = []
+    ) {
+        self.cCompilerFlags = cCompilerFlags
+        self.cxxCompilerFlags = cxxCompilerFlags
+        self.swiftCompilerFlags = swiftCompilerFlags.constructBuildFlags(source: nil)
         self.linkerFlags = linkerFlags
         self.xcbuildFlags = xcbuildFlags
     }

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -239,7 +239,7 @@ public struct SwiftSDK: Equatable {
     /// Additional flags to be passed to the Swift compiler.
     @available(*, deprecated, message: "use `toolset` and its properties instead")
     public var extraSwiftCFlags: [String] {
-        extraFlags.swiftCompilerFlags
+        extraFlags.swiftCompilerFlags.rawFlags
     }
 
     /// Additional flags to be passed to the C++ compiler.
@@ -251,10 +251,11 @@ public struct SwiftSDK: Equatable {
     /// Additional flags to be passed to the build tools.
     @available(*, deprecated, message: "use `toolset` and its properties instead")
     public var extraFlags: BuildFlags {
-        .init(
+        let swiftCompilerFlags = (toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []).constructBuildFlags(source: .swiftSDK)
+        return .init(
             cCompilerFlags: toolset.knownTools[.cCompiler]?.extraCLIOptions ?? [],
             cxxCompilerFlags: toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? [],
-            swiftCompilerFlags: toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? [],
+            swiftCompilerFlags: swiftCompilerFlags,
             linkerFlags: toolset.knownTools[.linker]?.extraCLIOptions ?? [],
             xcbuildFlags: toolset.knownTools[.xcbuild]?.extraCLIOptions ?? []
         )
@@ -448,6 +449,7 @@ public struct SwiftSDK: Equatable {
         extraSwiftCFlags: [String] = [],
         extraCPPFlags: [String] = []
     ) {
+        let extraSwiftCFlags = extraSwiftCFlags.constructBuildFlags(source: .swiftSDK)
         self.init(
             targetTriple: target,
             sdkRootDir: sdk,
@@ -1058,7 +1060,7 @@ extension SwiftSDK {
                     buildFlags: .init(
                         cCompilerFlags: serializedMetadata.extraCCFlags,
                         cxxCompilerFlags: serializedMetadata.extraCPPFlags,
-                        swiftCompilerFlags: serializedMetadata.extraSwiftCFlags
+                        swiftCompilerFlags: serializedMetadata.extraSwiftCFlags.constructBuildFlags(source: .swiftSDK)
                     )
                 ),
                 pathsConfiguration: .init(sdkRootPath: serializedMetadata.sdk)
@@ -1078,7 +1080,7 @@ extension SwiftSDK {
                     buildFlags: .init(
                         cCompilerFlags: serializedMetadata.extraCCFlags,
                         cxxCompilerFlags: serializedMetadata.extraCXXFlags,
-                        swiftCompilerFlags: serializedMetadata.extraSwiftCFlags,
+                        swiftCompilerFlags: serializedMetadata.extraSwiftCFlags.constructBuildFlags(source: .swiftSDK),
                         linkerFlags: serializedMetadata.extraLinkerFlags
                     )
                 ),

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -154,7 +154,7 @@ extension Toolchain {
     }
     
     public var extraSwiftCFlags: [String] {
-        extraFlags.swiftCompilerFlags
+        extraFlags.swiftCompilerFlags.rawFlags
     }
 
     package static func toolchainLibDir(swiftCompilerPath: AbsolutePath) throws -> AbsolutePath {

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -166,7 +166,7 @@ extension Toolset {
         self.knownTools = [
             .cCompiler: .init(extraCLIOptions: buildFlags.cCompilerFlags),
             .cxxCompiler: .init(extraCLIOptions: buildFlags.cxxCompilerFlags),
-            .swiftCompiler: .init(extraCLIOptions: buildFlags.swiftCompilerFlags),
+            .swiftCompiler: .init(extraCLIOptions: buildFlags.swiftCompilerFlags.rawFlags),
             .linker: .init(extraCLIOptions: buildFlags.linkerFlags),
             .xcbuild: .init(extraCLIOptions: buildFlags.xcbuildFlags ?? []),
         ]

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -806,7 +806,7 @@ public final class UserToolchain: Toolchain {
 
         self.targetTriple = triple
 
-        var swiftCompilerFlags: [String] = []
+        var swiftCompilerFlags: [BuildFlag] = []
         var extraLinkerFlags: [String] = []
 
         let swiftTestingPath: AbsolutePath? = try Self.deriveSwiftTestingPath(
@@ -817,14 +817,15 @@ public final class UserToolchain: Toolchain {
             fileSystem: fileSystem
         )
 
+        var swiftTestingFlags: [String] = []
         if triple.isMacOSX, let swiftTestingPath {
             // Swift Testing is a framework (e.g. from CommandLineTools) so use -F.
             if swiftTestingPath.extension == "framework" {
-                swiftCompilerFlags += ["-F", swiftTestingPath.pathString]
+                swiftTestingFlags += ["-F", swiftTestingPath.pathString]
 
             // Otherwise Swift Testing is assumed to be a swiftmodule + library, so use -I and -L.
             } else {
-                swiftCompilerFlags += [
+                swiftTestingFlags += [
                     "-I", swiftTestingPath.pathString,
                     "-L", swiftTestingPath.pathString,
                 ]
@@ -837,15 +838,21 @@ public final class UserToolchain: Toolchain {
             derivedSwiftCompiler: swiftCompilers.compile,
             fileSystem: fileSystem
         ) {
-            swiftCompilerFlags += ["-plugin-path", swiftTestingPluginPath.pathString]
+            swiftTestingFlags += ["-plugin-path", swiftTestingPluginPath.pathString]
         }
+
+        swiftCompilerFlags.append(contentsOf: swiftTestingFlags.map {
+            BuildFlag(value: $0, source: .defaultSwiftTestingSearchPath)
+        })
 
         swiftCompilerFlags += try Self.deriveSwiftCFlags(
             triple: triple,
             swiftSDK: swiftSDK,
             environment: environment,
             fileSystem: fileSystem
-        )
+        ).map {
+            BuildFlag(value: $0, source: nil)
+        }
 
         extraLinkerFlags += swiftSDK.toolset.knownTools[.linker]?.extraCLIOptions ?? []
 
@@ -865,7 +872,7 @@ public final class UserToolchain: Toolchain {
             useXcrun: useXcrun,
             environment: environment,
             searchPaths: envSearchPaths,
-            extraSwiftFlags: self.extraFlags.swiftCompilerFlags,
+            extraSwiftFlags: self.extraFlags.swiftCompilerFlags.rawFlags,
             fileSystem: fileSystem
         )
 
@@ -936,7 +943,7 @@ public final class UserToolchain: Toolchain {
         self.configuration = .init(
             librarianPath: librarianPath,
             swiftCompilerPath: swiftCompilers.manifest,
-            swiftCompilerFlags: self.extraFlags.swiftCompilerFlags,
+            swiftCompilerFlags: self.extraFlags.swiftCompilerFlags.rawFlags,
             swiftCompilerEnvironment: environment,
             swiftPMLibrariesLocation: swiftPMLibrariesLocation,
             sdkRootPath: self.swiftSDK.pathsConfiguration.sdkRootPath,

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -203,9 +203,9 @@ public struct BuildParameters: Encodable {
             self.flags = flags.merging(triple.isWindows() ? BuildFlags(
                 cCompilerFlags: ["-gdwarf"],
                 cxxCompilerFlags: ["-gdwarf"],
-                swiftCompilerFlags: ["-g", "-use-ld=lld"],
+                swiftCompilerFlags: ["-g", "-use-ld=lld"].constructBuildFlags(source: nil),
                 linkerFlags: ["-debug:dwarf"]
-            ) : BuildFlags(cCompilerFlags: ["-g"], cxxCompilerFlags: ["-g"], swiftCompilerFlags: ["-g"]))
+            ) : BuildFlags(cCompilerFlags: ["-g"], cxxCompilerFlags: ["-g"], swiftCompilerFlags: [BuildFlag(value: "-g")]))
         case .codeview:
             if !triple.isWindows() {
                 throw StringError("CodeView debug information is currently not supported on \(triple.osName)")
@@ -214,7 +214,7 @@ public struct BuildParameters: Encodable {
             self.flags = flags.merging(BuildFlags(
                 cCompilerFlags: ["-g"],
                 cxxCompilerFlags: ["-g"],
-                swiftCompilerFlags: ["-g", "-debug-info-format=codeview"],
+                swiftCompilerFlags: ["-g", "-debug-info-format=codeview"].constructBuildFlags(source: nil),
                 linkerFlags: ["-debug"]
             ))
         case .none:
@@ -222,7 +222,7 @@ public struct BuildParameters: Encodable {
             self.flags = flags.merging(BuildFlags(
                 cCompilerFlags: ["-g0"],
                 cxxCompilerFlags: ["-g0"],
-                swiftCompilerFlags: ["-gnone"]
+                swiftCompilerFlags: [BuildFlag(value: "-gnone")]
             ))
         }
         self.pkgConfigDirectories = pkgConfigDirectories

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -919,11 +919,31 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 + buildParameters.toolchain.extraFlags.cxxCompilerFlags.map { $0.shellEscaped() }
                 + buildParameters.flags.cxxCompilerFlags.map { $0.shellEscaped() }
         ).joined(separator: " ")
+
+        let otherSwiftFlags = (
+            buildParameters.toolchain.extraFlags.swiftCompilerFlags +
+            buildParameters.flags.swiftCompilerFlags
+        ).filter {
+            switch $0.source {
+            case .defaultSwiftTestingSearchPath:
+                // Swift Build computes these internally. It's important not to add them a second time here
+                // as it can break the intended search path ordering, for example, if the user is building
+                // Swift Testing as a package dependency.
+                return false
+            case .swiftSDK:
+                // Swift Build loads Swift SDK flags internally, and may introspect them to override build
+                // settings. Don't duplicate them here.
+                return false
+            case .commandLineOptions, nil:
+                return true
+            }
+        }.map {
+            $0.value.shellEscaped()
+        }
         settings["OTHER_SWIFT_FLAGS"] = (
             verboseFlag +
-            ["$(inherited)"]
-                + buildParameters.toolchain.extraFlags.swiftCompilerFlags.map { $0.shellEscaped() }
-                + buildParameters.flags.swiftCompilerFlags.map { $0.shellEscaped() }
+            ["$(inherited)"] +
+            otherSwiftFlags
         ).joined(separator: " ")
 
         let inherited = ["$(inherited)"]

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -288,8 +288,8 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         ).joined(separator: " ")
         settings["OTHER_SWIFT_FLAGS"] = (
             ["$(inherited)"]
-                + buildParameters.toolchain.extraFlags.swiftCompilerFlags.map { $0.spm_shellEscaped() }
-                + buildParameters.flags.swiftCompilerFlags.map { $0.spm_shellEscaped() }
+            + buildParameters.toolchain.extraFlags.swiftCompilerFlags.rawFlags.map { $0.spm_shellEscaped() }
+            + buildParameters.flags.swiftCompilerFlags.rawFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_LDFLAGS"] = (
             ["$(inherited)"]

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -153,7 +153,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
         BuildFlags(
             cCompilerFlags: self.cCompilerFlags,
             cxxCompilerFlags: self.cxxCompilerFlags,
-            swiftCompilerFlags: self.swiftCompilerFlags,
+            swiftCompilerFlags: self.swiftCompilerFlags.constructBuildFlags(source: .commandLineOptions),
             linkerFlags: self.linkerFlags,
             xcbuildFlags: self.xcbuildFlags
         )

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -5038,7 +5038,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         )
         let commonFlags = BuildFlags(
             cCompilerFlags: ["-clang-command-line-flag"],
-            swiftCompilerFlags: ["-swift-command-line-flag"]
+            swiftCompilerFlags: [BuildFlag(value: "-swift-command-line-flag")]
         )
 
         let result = try await BuildPlanResult(plan: mockBuildPlan(
@@ -5165,14 +5165,14 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         )
 
         XCTAssertEqual(
-            mockToolchain.extraFlags.swiftCompilerFlags,
+            mockToolchain.extraFlags.swiftCompilerFlags.rawFlags,
             [
                 "-plugin-path", "/fake/path/lib/swift/host/plugins/testing",
                 "-sdk", "/fake/sdk",
             ]
         )
         XCTAssertNoMatch(mockToolchain.extraFlags.linkerFlags, ["-rpath"])
-        XCTAssertNoMatch(mockToolchain.extraFlags.swiftCompilerFlags, [
+        XCTAssertNoMatch(mockToolchain.extraFlags.swiftCompilerFlags.rawFlags, [
             "-I", "/fake/path/lib/swift/macosx/testing",
             "-L", "/fake/path/lib/swift/macosx/testing",
         ])
@@ -5284,7 +5284,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         )
 
         XCTAssertEqual(
-            mockToolchain.extraFlags.swiftCompilerFlags,
+            mockToolchain.extraFlags.swiftCompilerFlags.rawFlags,
             [
                 "-I", "/fake/path/lib/swift/macosx/testing",
                 "-L", "/fake/path/lib/swift/macosx/testing",
@@ -5416,7 +5416,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             commonFlags: BuildFlags(
                 cCompilerFlags: [cliFlag(tool: .cCompiler)],
                 cxxCompilerFlags: [cliFlag(tool: .cxxCompiler)],
-                swiftCompilerFlags: [cliFlag(tool: .swiftCompiler)],
+                swiftCompilerFlags: [cliFlag(tool: .swiftCompiler)].constructBuildFlags(source: nil),
                 linkerFlags: [cliFlag(tool: .linker)]
             ),
             fileSystem: fileSystem,

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -43,7 +43,7 @@ private let destinationV1 = (
         "toolchain-bin-dir": "\#(bundleRootPath.appending(toolchainBinDir))",
         "target": "\#(linuxGNUTargetTriple.tripleString)",
         "extra-cc-flags": \#(extraFlags.cCompilerFlags),
-        "extra-swiftc-flags": \#(extraFlags.swiftCompilerFlags),
+        "extra-swiftc-flags": \#(extraFlags.swiftCompilerFlags.rawFlags),
         "extra-cpp-flags": \#(extraFlags.cxxCompilerFlags)
     }
     """# as SerializedJSON
@@ -59,7 +59,7 @@ private let destinationV2 = (
         "hostTriples": ["\#(hostTriple.tripleString)"],
         "targetTriples": ["\#(linuxGNUTargetTriple.tripleString)"],
         "extraCCFlags": \#(extraFlags.cCompilerFlags),
-        "extraSwiftCFlags": \#(extraFlags.swiftCompilerFlags),
+        "extraSwiftCFlags": \#(extraFlags.swiftCompilerFlags.rawFlags),
         "extraCXXFlags": \#(extraFlags.cxxCompilerFlags),
         "extraLinkerFlags": \#(extraFlags.linkerFlags)
     }


### PR DESCRIPTION
The motivation behind this change was that when using the Swift Build backend, we added the Swift Testing search paths twice. First, SwiftPM inserted them via OTHER_SWIFT_FLAGS ahead of the built products dir search paths, and then Swift Build added them internally in the correct order. This broke the build of packages which build Swift Testing from source, because the macro implementation and module got mismatched.

This change adds a new BuildFlag type which tracks both the spelling of a flag and its source (default search path, Swift SDK, etc.). We can incrementally adopt this mechanism over time and use it to filter out some flags which Swift Build will compute itself based on platform/SDK/run destination. For now, I've only adopted it for Swift flags to keep the change relatively small.