### PR TITLE
Normalize the wording and structure for the CLI arguments across Swift Package Manager

### DIFF
--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -60,7 +60,7 @@ struct APIDiff: AsyncSwiftCommand {
     @Option(help: """
     The path to a text file containing breaking changes which should be ignored by the API comparison. \
     Each ignored breaking change in the file should appear on its own line and contain the exact message \
-    to be ignored (e.g. 'API breakage: func foo() has been removed').
+    to be ignored (for example, 'API breakage: func foo() has been removed').
     """)
     var breakageAllowlistPath: Basics.AbsolutePath?
 

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -49,7 +49,7 @@ extension SwiftPackageCommand {
         @OptionGroup()
         var testLibraryOptions: TestLibraryOptions
 
-        @Option(name: .customLong("name"), help: "Provide custom package name.")
+        @Option(name: .customLong("name"), help: "Provide a custom package name.")
         var packageName: String?
 
         // This command should support creating the supplied --package-path if it isn't created.

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -82,7 +82,7 @@ struct BuildCommandOptions: ParsableArguments {
     /// Whether to enable code coverage.
     @Flag(name: .customLong("code-coverage"),
           inversion: .prefixedEnableDisable,
-          help: "Enable code coverage.")
+          help: "Determines whether the build measures code coverage.")
     var enableCodeCoverage: Bool = false
 
     /// If the binary output path should be printed.
@@ -115,7 +115,7 @@ struct BuildCommandOptions: ParsableArguments {
     var testLibraryOptions: TestLibraryOptions
 
     /// If should link the Swift stdlib statically.
-    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Link Swift stdlib statically.")
+    @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Determines whether Swift stdlib links statically.")
     public var shouldLinkStaticSwiftStdlib: Bool = false
 
     @OptionGroup(title: "Software Bill of Materials (SBOM)")

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -154,7 +154,7 @@ struct TestCommandOptions: ParsableArguments {
     /// If tests should run in parallel mode.
     @Flag(name: .customLong("parallel"),
           inversion: .prefixedNo,
-          help: "Run the tests in parallel.")
+          help: "Determines whether tests run in parallel.")
     var shouldRunInParallel: Bool = false
 
     /// Number of tests to execute in parallel
@@ -170,7 +170,7 @@ struct TestCommandOptions: ParsableArguments {
 
     /// List the tests and exit.
     @Flag(name: [.customLong("list-tests"), .customShort("l")],
-          help: "Lists test methods in specifier format.")
+          help: "List test methods in specifier format.")
     var _deprecated_shouldListTests: Bool = false
 
     /// If the path of the exported code coverage JSON should be printed.
@@ -190,13 +190,13 @@ struct TestCommandOptions: ParsableArguments {
     var _testCaseSpecifier: String?
 
     @Option(help: """
-        Run test cases that match a regular expression, Format: '<test-target>.<test-case>' \
-        or '<test-target>.<test-case>/<test>'.
+        Run test cases that match a regular expression. \
+        Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>.
         """)
     var filter: [String] = []
 
     @Option(name: .customLong("skip"),
-            help: "Skip test cases that match a regular expression, Example: '--skip PerformanceTests'.")
+            help: "Skip test cases that match a regular expression. For example: '--skip PerformanceTests'.")
     var _testCaseSkip: [String] = []
 
     /// Path where the xUnit xml file should be generated.
@@ -214,13 +214,13 @@ struct TestCommandOptions: ParsableArguments {
     var shouldShowDetailedFailureMessage: Bool = false
 
     /// Generate LinuxMain entries and exit.
-    @Flag(name: .customLong("testable-imports"), inversion: .prefixedEnableDisable, help: "Enable or disable testable imports. Enabled by default.")
+    @Flag(name: .customLong("testable-imports"), inversion: .prefixedEnableDisable, help: "Determines whether test modules use @testable imports.")
     var enableTestableImports: Bool = true
 
     /// Whether to enable code coverage.
     @Flag(name: .customLong("code-coverage"),
           inversion: .prefixedEnableDisable,
-          help: "Enable code coverage.")
+          help: "Determines whether testing measures code coverage.")
     var enableCodeCoverage: Bool = false
 
     /// Configure test output.

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -170,10 +170,9 @@ public struct CachingOptions: ParsableArguments {
     public init() {}
 
     /// Disables package caching.
-    @Flag(
-        name: .customLong("dependency-cache"),
+    @Flag(name: .customLong("dependency-cache"),
         inversion: .prefixedEnableDisable,
-        help: "Use a shared cache when fetching dependencies."
+        help: "Determines whether dependency fetching uses a shared cache."
     )
     public var useDependenciesCache: Bool = true
 
@@ -205,7 +204,7 @@ public struct CachingOptions: ParsableArguments {
     /// Whether to use macro prebuilts or not
     @Flag(name: .customLong("experimental-prebuilts"),
           inversion: .prefixedEnableDisable,
-          help: "Whether to use prebuilt swift-syntax libraries for macros.")
+          help: "Determines whether macros use prebuilt swift-syntax libraries.")
     public var usePrebuilts: Bool = true
 
     /// Hidden option to override the prebuilts download location for testing
@@ -241,7 +240,7 @@ public struct LoggingOptions: ParsableArguments {
           inversion: .prefixedNo,
           help:
             """
-            Enables or disables color diagnostics when printing to a TTY.
+            Determines whether color diagnostics appear when printing to a TTY.
             By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.
             """)
     public var colorDiagnostics: Bool = ProcessInfo.processInfo.environment["NO_COLOR"] == nil
@@ -251,7 +250,7 @@ public struct SecurityOptions: ParsableArguments {
     public init() {}
 
     /// Disables sandboxing when executing subprocesses.
-    @Flag(name: .customLong("disable-sandbox"), help: "Disable using the sandbox when executing subprocesses.")
+    @Flag(name: .customLong("disable-sandbox"), help: "Disable the sandbox when executing subprocesses.")
     public var shouldDisableSandbox: Bool = false
 
     /// Force usage of the netrc file even in cases where it is not allowed.
@@ -264,7 +263,7 @@ public struct SecurityOptions: ParsableArguments {
     @Flag(
         inversion: .prefixedEnableDisable,
         exclusivity: .exclusive,
-        help: "Load credentials from a netrc file."
+        help: "Determines whether SwiftPM loads credentials from a netrc file."
     )
     public var netrc: Bool = true
 
@@ -283,7 +282,7 @@ public struct SecurityOptions: ParsableArguments {
     @Flag(
         inversion: .prefixedEnableDisable,
         exclusivity: .exclusive,
-        help: "Search credentials in macOS keychain."
+        help: "Determines whether SwiftPM searches for credentials in the macOS keychain."
     )
     public var keychain: Bool = true
     #else
@@ -304,7 +303,7 @@ public struct SecurityOptions: ParsableArguments {
     @Flag(
         inversion: .prefixedEnableDisable,
         exclusivity: .exclusive,
-        help: "Validate signature of a signed package release downloaded from registry."
+        help: "Determines whether SwiftPM validates signatures on package releases downloaded from the registry."
     )
     public var signatureValidation: Bool = true
 }
@@ -378,7 +377,7 @@ public struct BuildOptions: ParsableArguments {
     public init() {}
 
     /// Build configuration.
-    @Option(name: .shortAndLong, help: "Build with configuration")
+    @Option(name: .shortAndLong, help: "Build with the specified configuration.")
     public var configuration: BuildConfiguration?
 
     @Option(
@@ -475,7 +474,7 @@ public struct BuildOptions: ParsableArguments {
     @Option(
         name: .customLong("arch"),
         help: ArgumentHelp(
-            "Build the package for the these architectures",
+            "Build the package for the specified architectures.",
             visibility: .hidden
         )
     )
@@ -502,7 +501,7 @@ public struct BuildOptions: ParsableArguments {
         EnabledSanitizers(Set(sanitizers))
     }
 
-    @Flag(help: "Enable or disable indexing-while-building feature.")
+    @Flag(help: "Determines whether to automatically index while building.")
     public var indexStoreMode: StoreMode = .autoIndexStore
 
     /// Instead of building the target, perform the minimal amount of work to prepare it for indexing.
@@ -543,7 +542,7 @@ public struct BuildOptions: ParsableArguments {
 
     /// A flag that indicates this build should check whether targets only import
     /// their explicitly-declared dependencies
-    @Option(help: "A flag that indicates this build should check whether targets only import their explicitly-declared dependencies.")
+    @Option(help: "Check that targets only import their explicitly declared dependencies.")
     public var explicitTargetDependencyImportCheck: TargetDependencyImportCheckingMode = .none
 
     /// The build system to use.
@@ -651,7 +650,7 @@ public struct LinkerOptions: ParsableArguments {
     @Flag(
         name: .customLong("dead-strip"),
         inversion: .prefixedEnableDisable,
-        help: "Disable/enable dead code stripping by the linker."
+        help: "Determines whether the linker strips dead code."
     )
     public var linkerDeadStrip: Bool = true
 
@@ -671,7 +670,7 @@ public struct TestLibraryOptions: ParsableArguments {
     /// have the correct default value if the user didn't specify one.
     @Flag(name: .customLong("xctest"),
           inversion: .prefixedEnableDisable,
-          help: "Enable support for XCTest.")
+          help: "Determines whether the build includes XCTest support.")
     public var explicitlyEnableXCTestSupport: Bool?
 
     /// Whether to enable support for Swift Testing (as explicitly specified by the user.)
@@ -680,7 +679,7 @@ public struct TestLibraryOptions: ParsableArguments {
     /// have the correct default value if the user didn't specify one.
     @Flag(name: .customLong("swift-testing"),
           inversion: .prefixedEnableDisable,
-          help: "Enable support for Swift Testing.")
+          help: "Determines whether the build includes Swift Testing support.")
     public var explicitlyEnableSwiftTestingLibrarySupport: Bool?
 
     /// Legacy experimental equivalent of ``explicitlyEnableSwiftTestingLibrarySupport``.
@@ -729,7 +728,7 @@ public struct TraitOptions: ParsableArguments {
     /// The traits to enable for the package.
     @Option(
         name: .customLong("traits"),
-        help: "Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list, for example `--traits Trait1,Trait2`. When enabling specific traits the default traits also need to explicitly enabled as well by passing `defaults` to this command."
+        help: "Enable the specified traits of the package. Specify multiple traits as a comma-separated list, for example: `--traits Trait1,Trait2`. When enabling specific traits, the default traits must also be explicitly enabled by passing `defaults` to this option."
     )
     package var _enabledTraits: String?
 
@@ -741,14 +740,14 @@ public struct TraitOptions: ParsableArguments {
     /// Enables all traits of the package.
     @Flag(
         name: .customLong("enable-all-traits"),
-        help: "Enables all traits of the package."
+        help: "Enable all traits of the package."
     )
     public var enableAllTraits: Bool = false
 
     /// Disables all default traits of the package.
     @Flag(
         name: .customLong("disable-default-traits"),
-        help: "Disables all default traits of the package."
+        help: "Disable all default traits of the package."
     )
     public var disableDefaultTraits: Bool = false
 }
@@ -775,14 +774,14 @@ public struct SBOMOptions: ParsableArguments {
     /// SBOM specification(s) to generate.
     @Option(
         name: .customLong("sbom-spec"),
-        help: ArgumentHelp("Set the SBOM specification(s) and generate SBOM(s).")
+        help: ArgumentHelp("Set the SBOM specification and generate an SBOM.")
     )
     package var _sbomSpecs: [SBOMModel.Spec] = []
 
     /// Directory path to generate SBOM(s) in.
     @Option(
         name: .customLong("sbom-output-dir"),
-        help: ArgumentHelp("The absolute or relative directory path to generate the SBOM(s) in. Must be used with --sbom-spec."),
+        help: ArgumentHelp("The absolute or relative directory path to generate the SBOM(s) in. Must be used with --sbom-spec. (default: <scratch_path>/sboms)."),
         completion: .directory
     )
     package var _sbomDirectory: AbsolutePath?
@@ -790,7 +789,7 @@ public struct SBOMOptions: ParsableArguments {
     /// Filter SBOM components and dependencies by entity.
     @Option(
         name: .customLong("sbom-filter"),
-        help: ArgumentHelp("Filter the SBOM components and dependencies by type. Must be used with --sbom-spec.")
+        help: ArgumentHelp("Filter the SBOM components and dependencies by products and/or packages. Must be used with --sbom-spec.")
     )
     package var _sbomFilter: SBOMModel.Filter? = nil
 

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -149,7 +149,7 @@ extension PackageRegistryCommand {
         )
         var tokenFilePath: AbsolutePath?
 
-        @Flag(help: "Allow writing to netrc file without confirmation.")
+        @Flag(help: "Write to the netrc file without asking for confirmation.")
         var noConfirm: Bool = false
 
         private static let PLACEHOLDER_TOKEN_USER = "token"
@@ -326,13 +326,13 @@ extension PackageRegistryCommand {
 
     struct Logout: AsyncSwiftCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Log out from a registry"
+            abstract: "Log out from a registry."
         )
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Argument(help: "The registry URL")
+        @Argument(help: "The registry URL.")
         var url: URL?
 
         var registryURL: URL? {

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -55,7 +55,7 @@ extension PackageRegistryCommand {
 
         @Option(
             name: .customLong("scratch-directory"),
-            help: "The path of the directory where working file(s) will be written."
+            help: "The path to the directory for working files."
         )
         var customWorkingDirectory: AbsolutePath?
 
@@ -83,10 +83,10 @@ extension PackageRegistryCommand {
         )
         var certificateChainPaths: [AbsolutePath] = []
 
-        @Flag(name: .customLong("allow-insecure-http"), help: "Allow using a non-HTTPS registry URL.")
+        @Flag(name: .customLong("allow-insecure-http"), help: "Use a non-HTTPS registry URL.")
         var allowInsecureHTTP: Bool = false
 
-        @Flag(help: "Dry run only; prepare the archive and sign it but do not publish to the registry.")
+        @Flag(help: "Prepare and sign the archive without publishing it to the registry.")
         var dryRun: Bool = false
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand.swift
@@ -55,7 +55,7 @@ public struct PackageRegistryCommand: AsyncParsableCommand {
         @Option(help: "Associate the registry with a given scope.")
         var scope: String?
 
-        @Flag(name: .customLong("allow-insecure-http"), help: "Allow using a non-HTTPS registry URL.")
+        @Flag(name: .customLong("allow-insecure-http"), help: "Use a non-HTTPS registry URL.")
         var allowInsecureHTTP: Bool = false
 
         @Argument(help: "The registry URL.")

--- a/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
@@ -50,7 +50,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
     @Option(
         parsing: .singleValue,
         help: """
-        "A path to a directory containing libraries. Multiple paths can be specified by providing this option multiple \
+        A path to a directory containing libraries. Multiple paths can be specified by providing this option multiple \
         times to the command.
         """
     )
@@ -59,7 +59,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
     @Option(
         parsing: .singleValue,
         help: """
-        "A path to a toolset file. Multiple paths can be specified by providing this option multiple times to the command.
+        A path to a toolset file. Multiple paths can be specified by providing this option multiple times to the command.
         """
     )
     var toolsetPath: [String] = []
@@ -67,7 +67,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
     @Flag(
         name: .customLong("reset"),
         help: """
-        Resets configuration properties currently applied to a given Swift SDK and target triple. If no specific \
+        Reset configuration properties currently applied to a given Swift SDK and target triple. If no specific \
         property is specified, all of them are reset for the Swift SDK.
         """
     )
@@ -76,7 +76,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
     @Flag(
         name: .customLong("show-configuration"),
         help: """
-        Prints all configuration properties currently applied to a given Swift SDK and target triple.
+        Print all configuration properties currently applied to a given Swift SDK and target triple.
         """
     )
     var shouldShowConfiguration: Bool = false

--- a/Sources/SwiftSDKCommand/InstallSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/InstallSwiftSDK.swift
@@ -42,7 +42,7 @@ struct InstallSwiftSDK: SwiftSDKSubcommand {
         name: .customLong("color-diagnostics"),
         inversion: .prefixedNo,
         help: """
-            Enables or disables color diagnostics when printing to a TTY. 
+            Determines whether color diagnostics appear when printing to a TTY.
             By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.
             """
     )


### PR DESCRIPTION
While reviewing another PR (#9766), I realized a number of the common arguments that are displayed across a number of command-line tools have a few typos, wording inconsistencies, punctuation mistakes, and so on.

This PR bundles up a variety of changes, including re-framing the `@Flag()` arguments so that the phrasing worked with both "enable-..." and "disable-..." variants that the argument parser offers.