### PR TITLE
PackageLoading: cache manifest git context per repository

### DIFF
--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_library(PackageLoading
   ContextModel.swift
   Diagnostics.swift
+  ManifestGitInformationCache.swift
   ManifestJSONParser.swift
   ManifestLoader.swift
   ManifestLoader+Validation.swift

--- a/Sources/PackageLoading/ManifestGitInformationCache.swift
+++ b/Sources/PackageLoading/ManifestGitInformationCache.swift
@@ -1,0 +1,245 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Dispatch
+import Foundation
+import SourceControl
+
+import struct TSCBasic.ByteString
+
+// FIXME: Use Synchronization.Mutex when available in SwiftPM's supported deployment targets.
+private final class Mutex<Value>: @unchecked Sendable {
+    var lock: NSLock
+    var value: Value
+
+    init(value: Value) {
+        self.lock = .init()
+        self.value = value
+    }
+
+    func withLock<Result>(_ body: (inout Value) -> Result) -> Result {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return body(&self.value)
+    }
+}
+
+/// Caches repository identity and git context used by manifest loading.
+package final class ManifestGitInformationCache: @unchecked Sendable {
+    private enum ScopeKey: Hashable {
+        case repository(AbsolutePath)
+        case directory(AbsolutePath)
+    }
+
+    private enum RepositoryKey: Equatable {
+        case repository(AbsolutePath)
+        case notRepository
+    }
+
+    private enum LookupAction {
+        case returnValue(ContextModel.GitInformation?)
+        case wait(InFlight)
+        case load(InFlight, epoch: UInt64)
+    }
+
+    private final class InFlight: @unchecked Sendable {
+        private let group = DispatchGroup()
+
+        init() {
+            self.group.enter()
+        }
+
+        func wait() {
+            self.group.wait()
+        }
+
+        func finish() {
+            self.group.leave()
+        }
+    }
+
+    private struct State {
+        var epoch: UInt64 = 0
+        var repositoryKeyCache: [AbsolutePath: RepositoryKey] = [:]
+        var gitInformationByRepository: [AbsolutePath: ContextModel.GitInformation?] = [:]
+        var gitInformationByDirectory: [AbsolutePath: ContextModel.GitInformation?] = [:]
+        var inFlightByScope: [ScopeKey: InFlight] = [:]
+
+        mutating func storeRepositoryKey(_ key: RepositoryKey, for paths: [AbsolutePath]) {
+            for path in paths {
+                self.repositoryKeyCache[path] = key
+            }
+        }
+    }
+
+    private let state = Mutex(value: State())
+
+    package init() {}
+
+    package func clear() {
+        self.state.withLock { state in
+            let nextEpoch = state.epoch &+ 1
+            state = .init()
+            state.epoch = nextEpoch
+        }
+    }
+
+    func gitInformation(for directory: AbsolutePath) -> ContextModel.GitInformation? {
+        while true {
+            let repositoryKey = self.repositoryKey(for: directory)
+            let scopeKey = Self.scopeKey(for: directory, repositoryKey: repositoryKey)
+
+            switch self.lookupAction(for: directory, repositoryKey: repositoryKey, scopeKey: scopeKey) {
+            case .returnValue(let gitInformation):
+                return gitInformation
+            case .wait(let inFlight):
+                inFlight.wait()
+            case .load(let inFlight, let epoch):
+                defer { inFlight.finish() }
+
+                let gitInformation = Self.loadGitInformation(for: directory)
+
+                self.state.withLock { state in
+                    if state.epoch == epoch {
+                        state.gitInformationByDirectory.updateValue(gitInformation, forKey: directory)
+                        if case .repository(let gitDirectory) = repositoryKey {
+                            state.gitInformationByRepository.updateValue(gitInformation, forKey: gitDirectory)
+                        }
+                    }
+
+                    if let currentInFlight = state.inFlightByScope[scopeKey],
+                       currentInFlight === inFlight
+                    {
+                        state.inFlightByScope.removeValue(forKey: scopeKey)
+                    }
+                }
+
+                return gitInformation
+            }
+        }
+    }
+
+    private func repositoryKey(for directory: AbsolutePath) -> RepositoryKey {
+        var visitedPaths: [AbsolutePath] = []
+        var currentPath = directory
+
+        while true {
+            if let cached = self.state.withLock({ $0.repositoryKeyCache[currentPath] }) {
+                if !visitedPaths.isEmpty {
+                    self.state.withLock { $0.storeRepositoryKey(cached, for: visitedPaths) }
+                }
+                return cached
+            }
+
+            visitedPaths.append(currentPath)
+
+            if let repositoryPath = Self.repositoryPathIfAny(for: currentPath) {
+                let normalizedPath = (try? resolveSymlinks(repositoryPath)) ?? repositoryPath
+                let key = RepositoryKey.repository(normalizedPath)
+                self.state.withLock { $0.storeRepositoryKey(key, for: visitedPaths) }
+                return key
+            }
+
+            guard !currentPath.isRoot else {
+                self.state.withLock { $0.storeRepositoryKey(.notRepository, for: visitedPaths) }
+                return .notRepository
+            }
+
+            currentPath = currentPath.parentDirectory
+        }
+    }
+
+    private func lookupAction(
+        for directory: AbsolutePath,
+        repositoryKey: RepositoryKey,
+        scopeKey: ScopeKey
+    ) -> LookupAction {
+        self.state.withLock { state in
+            if let cached = state.gitInformationByDirectory[directory] {
+                return .returnValue(cached)
+            }
+
+            if case .repository(let gitDirectory) = repositoryKey,
+               let cached = state.gitInformationByRepository[gitDirectory]
+            {
+                state.gitInformationByDirectory.updateValue(cached, forKey: directory)
+                return .returnValue(cached)
+            }
+
+            if let inFlight = state.inFlightByScope[scopeKey] {
+                return .wait(inFlight)
+            }
+
+            let inFlight = InFlight()
+            state.inFlightByScope[scopeKey] = inFlight
+            return .load(inFlight, epoch: state.epoch)
+        }
+    }
+
+    private static func scopeKey(for directory: AbsolutePath, repositoryKey: RepositoryKey) -> ScopeKey {
+        switch repositoryKey {
+        case .repository(let gitDirectory):
+            .repository(gitDirectory)
+        case .notRepository:
+            .directory(directory)
+        }
+    }
+
+    // Git worktrees use a `.git` file containing `gitdir: <path>` instead of a `.git` directory.
+    private static func repositoryPathIfAny(for directory: AbsolutePath) -> AbsolutePath? {
+        let gitPath = directory.appending(component: ".git")
+        if localFileSystem.isDirectory(gitPath) {
+            return gitPath
+        }
+
+        guard localFileSystem.isFile(gitPath),
+              let gitPathContents = try? localFileSystem.readFileContents(gitPath)
+        else {
+            return nil
+        }
+
+        let contentString = String(decoding: gitPathContents.contents, as: UTF8.self)
+        guard let firstLine = contentString.split(whereSeparator: \.isNewline).first else {
+            return nil
+        }
+
+        let expectedPrefix = "gitdir:"
+        let firstLineString = String(firstLine)
+        // Key is case-insensitive; path is extracted from the original string to preserve case.
+        guard firstLineString.lowercased().hasPrefix(expectedPrefix) else {
+            return nil
+        }
+
+        let gitDirectoryString = firstLineString
+            .dropFirst(expectedPrefix.count)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !gitDirectoryString.isEmpty else {
+            return nil
+        }
+
+        return try? AbsolutePath(validating: gitDirectoryString, relativeTo: directory)
+    }
+
+    private static func loadGitInformation(for directory: AbsolutePath) -> ContextModel.GitInformation? {
+        do {
+            let repo = GitRepository(path: directory)
+            return try ContextModel.GitInformation(
+                currentTag: repo.getCurrentTag(),
+                currentCommit: repo.getCurrentRevision().identifier,
+                hasUncommittedChanges: repo.hasUncommittedChanges()
+            )
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -274,6 +274,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
 
     private let useInMemoryCache: Bool
     private let memoryCacheActor = ManifestCacheActor()
+    private let gitInformationCache = ManifestGitInformationCache()
 
     public init(
         toolchain: UserToolchain,
@@ -850,19 +851,9 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             do {
                 let packageDirectory = manifestPath.parentDirectory.pathString
 
-                let gitInformation: ContextModel.GitInformation?
-                do {
-                    let repo = GitRepository(path: manifestPath.parentDirectory)
-                    // These Git operations might block, consider making them async if performance is critical
-                    gitInformation = ContextModel.GitInformation(
-                        currentTag: repo.getCurrentTag(),
-                        currentCommit: try repo.getCurrentRevision().identifier,
-                        hasUncommittedChanges: repo.hasUncommittedChanges()
-                    )
-                } catch {
-                    // Ignore errors getting git info
-                    gitInformation = nil
-                }
+                let gitInformation = self.gitInformationCache.gitInformation(
+                    for: manifestPath.parentDirectory
+                )
 
                 let contextModel = ContextModel(
                     packageDirectory: packageDirectory,
@@ -985,6 +976,7 @@ public final class ManifestLoader: ManifestLoaderProtocol {
     /// reset internal cache
     public func resetCache(observabilityScope: ObservabilityScope) async {
         await self.memoryCacheActor.clear()
+        self.gitInformationCache.clear()
     }
 
     /// reset internal state and purge shared cache

--- a/Tests/PackageLoadingTests/ManifestGitInformationCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestGitInformationCacheTests.swift
@@ -1,0 +1,171 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import _InternalTestSupport
+@testable import Basics
+@testable import PackageLoading
+import SourceControl
+import Testing
+
+import enum TSCUtility.Git
+
+struct ManifestGitInformationCacheTests {
+    @Test
+    func cacheReusesGitInformationAcrossDirectoriesInSameRepository() async throws {
+        try await testWithTemporaryDirectory { path in
+            let repository = try Self.createRepository(at: path)
+
+            let packageAPath = path.appending(components: "Packages", "A")
+            let packageBPath = path.appending(components: "Packages", "B")
+            try localFileSystem.createDirectory(packageAPath, recursive: true)
+            try localFileSystem.createDirectory(packageBPath, recursive: true)
+
+            let packageAReadme = packageAPath.appending("README.md")
+            let packageBReadme = packageBPath.appending("README.md")
+            try localFileSystem.writeFileContents(packageAReadme, string: "A")
+            try localFileSystem.writeFileContents(packageBReadme, string: "B")
+            try repository.stage(file: packageAReadme.pathString)
+            try repository.stage(file: packageBReadme.pathString)
+            try repository.commit(message: "add package directories")
+
+            let transientFile = path.appending("dirty.txt")
+            try localFileSystem.writeFileContents(transientFile, string: "dirty")
+
+            let cache = ManifestGitInformationCache()
+
+            let first = cache.gitInformation(for: packageAPath)
+            #expect(first?.hasUncommittedChanges == true)
+
+            try localFileSystem.removeFileTree(transientFile)
+
+            let second = cache.gitInformation(for: packageBPath)
+            #expect(second?.hasUncommittedChanges == true)
+            #expect(second?.currentCommit == first?.currentCommit)
+            #expect(second?.currentTag == first?.currentTag)
+        }
+    }
+
+    @Test
+    func clearDropsCachedRepositoryState() async throws {
+        try await testWithTemporaryDirectory { path in
+            _ = try Self.createRepository(at: path)
+
+            let packageAPath = path.appending(components: "Packages", "A")
+            let packageBPath = path.appending(components: "Packages", "B")
+            try localFileSystem.createDirectory(packageAPath, recursive: true)
+            try localFileSystem.createDirectory(packageBPath, recursive: true)
+
+            let dirtyFile = path.appending("dirty.txt")
+            try localFileSystem.writeFileContents(dirtyFile, string: "dirty")
+
+            let cache = ManifestGitInformationCache()
+
+            let first = cache.gitInformation(for: packageAPath)
+            #expect(first?.hasUncommittedChanges == true)
+
+            try localFileSystem.removeFileTree(dirtyFile)
+            cache.clear()
+
+            let second = cache.gitInformation(for: packageBPath)
+            #expect(second?.hasUncommittedChanges == false)
+            #expect(second?.currentCommit == first?.currentCommit)
+            #expect(second?.currentTag == first?.currentTag)
+        }
+    }
+
+    @Test
+    func cacheDetectsGitDirPointerRepository() async throws {
+        try await testWithTemporaryDirectory { path in
+            let repositoryRoot = path.appending("repo")
+            try localFileSystem.createDirectory(repositoryRoot, recursive: true)
+            let repository = try Self.createRepository(at: repositoryRoot)
+
+            let trackedFile = repositoryRoot.appending("tracked.txt")
+            try localFileSystem.writeFileContents(trackedFile, string: "hello")
+            try repository.stage(file: trackedFile.pathString)
+            try repository.commit(message: "initial")
+
+            let worktreePath = path.appending("worktree")
+            _ = try await AsyncProcess.checkNonZeroExit(
+                args: Git.tool,
+                "-C", repositoryRoot.pathString,
+                "worktree", "add", "--detach", worktreePath.pathString
+            )
+
+            #expect(localFileSystem.isFile(worktreePath.appending(component: ".git")))
+
+            let nestedPath = worktreePath.appending(components: "Nested", "Package")
+            try localFileSystem.createDirectory(nestedPath, recursive: true)
+
+            let cache = ManifestGitInformationCache()
+            let cachedInfo = cache.gitInformation(for: nestedPath)
+            let expectedCommit = try GitRepository(path: worktreePath).getCurrentRevision().identifier
+
+            #expect(cachedInfo?.currentCommit == expectedCommit)
+        }
+    }
+
+    @Test
+    func concurrentRepositoryKeyLookupIsSafeAndConsistent() async throws {
+        try await testWithTemporaryDirectory { path in
+            let repository = try Self.createRepository(at: path)
+            let trackedFile = path.appending("file.txt")
+            try localFileSystem.writeFileContents(trackedFile, string: "hello")
+            try repository.stage(file: trackedFile.pathString)
+            try repository.commit(message: "add file")
+
+            let packagePaths = (0..<8).map { path.appending(components: "Packages", "P\($0)") }
+            for p in packagePaths { try localFileSystem.createDirectory(p, recursive: true) }
+
+            let cache = ManifestGitInformationCache()
+            let results = await withTaskGroup(of: ContextModel.GitInformation?.self) { group in
+                for p in packagePaths { group.addTask { cache.gitInformation(for: p) } }
+                return await group.reduce(into: []) { $0.append($1) }
+            }
+
+            let expectedCommit = results.first??.currentCommit
+            for result in results {
+                #expect(result?.currentCommit == expectedCommit)
+                #expect(result?.hasUncommittedChanges == false)
+            }
+        }
+    }
+
+    @Test
+    func gitInformationIsNilForDirectoryOutsideAnyRepository() async throws {
+        try await testWithTemporaryDirectory { path in
+            let cache = ManifestGitInformationCache()
+            #expect(cache.gitInformation(for: path) == nil)
+        }
+    }
+
+    @Test
+    func cachedNilResultIsReturnedOnSubsequentLookup() async throws {
+        try await testWithTemporaryDirectory { path in
+            let cache = ManifestGitInformationCache()
+            #expect(cache.gitInformation(for: path) == nil)
+            #expect(cache.gitInformation(for: path) == nil)
+        }
+    }
+
+    private static func createRepository(at path: AbsolutePath) throws -> GitRepository {
+        let repository = GitRepository(path: path)
+        try repository.create()
+
+        let bootstrapFile = path.appending("bootstrap.txt")
+        try localFileSystem.writeFileContents(bootstrapFile, string: "bootstrap")
+        try repository.stage(file: bootstrapFile.pathString)
+        try repository.commit(message: "bootstrap")
+
+        return repository
+    }
+}


### PR DESCRIPTION
Cache manifest git context per repository to speed up package resolution in monorepos with many local packages.

### Motivation:

Manifest evaluation currently fetches git information from each package directory independently. In monorepos with many local packages this repeats the same git operations across directories in the same repository.

### Modifications:

This change introduces `ManifestGitInformationCacheActor` to cache repository identity and git information across manifest evaluations:

- detects repository roots via .git directories and .git pointer files (worktree-aware)
- caches git information once per repository and reuses it for sibling package directories
- keeps per-directory memoization and clears cache state in `resetCache`
- routes manifest context git-information lookups through the shared cache actor

### Result:

No user-visible behavior changes are expected.
This change only deduplicates `GitInformation` lookups per repository during a single resolution.
If anything, resolution becomes more consistent: previously, two packages in the same repository could observe different GitInformation values if the repository changed between separate lookups. With this change, they share a single cached snapshot per repository for that resolution.

Here's the benchmark with and without this patch for our monorepo with ~200 local packages:

| Metric | Baseline (main) | Patched | Improvement |
|---|---:|---:|---:|
| Dependencies resolved in | 546.01s | 411.39s | -134.62s (-24.66%) |
| `git status -s` calls | 313 | 110 | -203 (-64.86%) |

