### PR TITLE
[Swift Build] Introduce an umbrella test product which mimics the native build system

### DIFF
--- a/Sources/Build/LLBuildDescription.swift
+++ b/Sources/Build/LLBuildDescription.swift
@@ -142,6 +142,7 @@ public struct BuildDescription: Codable {
         self.builtTestProducts = try plan.buildProducts.filter { $0.product.type == .test }.map { desc in
             try BuiltTestProduct(
                 productName: desc.product.name,
+                umbrellaProductName: nil,
                 binaryPath: desc.binaryPath,
                 packagePath: desc.package.path,
                 testEntryPointPath: desc.product.underlying.testEntryPointPath

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1631,11 +1631,16 @@ private func buildTestsIfNeeded(
     }
 
     if let testProductName = testProduct {
-        guard let selectedTestProduct = testProducts.first(where: { $0.productName == testProductName }) else {
-            throw TestError.testProductNotFound(productName: testProductName)
+        if let selectedTestProduct = testProducts.first(where: { $0.productName == testProductName }) {
+            return [selectedTestProduct]
         }
 
-        return [selectedTestProduct]
+        let selectedTestProducts = testProducts.filter({ $0.umbrellaProductName == testProductName })
+        if !selectedTestProducts.isEmpty {
+            return selectedTestProducts
+        }
+
+        throw TestError.testProductNotFound(productName: testProductName)
     } else {
         return testProducts
     }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1537,7 +1537,7 @@ public final class PackageBuilder {
             // Add suffix 'PackageTests' to test product name so the target name
             // of linux executable don't collide with main package, if present.
             // FIXME: use identity instead
-            let productName = self.manifest.displayName + "PackageTests"
+            let productName = self.manifest.umbrellaPackageTestsProductName
             let testEntryPointPath = try self.findTestEntryPoint(in: testModules)
 
             let product = try Product(
@@ -1825,6 +1825,10 @@ extension Manifest {
             }
         }
         return Set(names)
+    }
+
+    package var umbrellaPackageTestsProductName: String {
+        "\(self.displayName)PackageTests"
     }
 }
 

--- a/Sources/SPMBuildCore/BuiltTestProduct.swift
+++ b/Sources/SPMBuildCore/BuiltTestProduct.swift
@@ -17,6 +17,9 @@ public struct BuiltTestProduct: Codable {
     /// The test product name.
     public let productName: String
 
+    /// The name of the "umbrella" test product (if any) which includes this test product
+    public let umbrellaProductName: String?
+
     /// The path of the test binary.
     public let binaryPath: AbsolutePath
 
@@ -52,8 +55,9 @@ public struct BuiltTestProduct: Codable {
     ///   - binaryPath: The path of the test binary.
     ///   - packagePath: The path to the package this product was declared in.
     ///   - mainSourceFilePath: The path to the main source file used, if any.
-    public init(productName: String, binaryPath: AbsolutePath, packagePath: AbsolutePath, testEntryPointPath: AbsolutePath?) {
+    public init(productName: String, umbrellaProductName: String?, binaryPath: AbsolutePath, packagePath: AbsolutePath, testEntryPointPath: AbsolutePath?) {
         self.productName = productName
+        self.umbrellaProductName = umbrellaProductName
         self.binaryPath = binaryPath
         self.packagePath = packagePath
         self.testEntryPointPath = testEntryPointPath

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -540,6 +540,8 @@ public final class PackagePIFBuilder {
         let customModulesAndProducts = try delegate.addCustomTargets(pifProject: &projectBuilder.project)
         projectBuilder.builtModulesAndProducts.append(contentsOf: customModulesAndProducts)
 
+        try projectBuilder.makePackageTestProduct()
+
         self._pifProject = projectBuilder.project
         return projectBuilder.builtModulesAndProducts
     }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -29,6 +29,7 @@ import struct PackageModel.RegistryReleaseMetadata
 import struct PackageGraph.ResolvedModule
 import struct PackageGraph.ResolvedPackage
 import struct PackageGraph.ResolvedProduct
+import PackageLoading
 
 import enum SwiftBuild.ProjectModel
 
@@ -1125,6 +1126,41 @@ extension PackagePIFProjectBuilder {
             deploymentTargets: self.deploymentTargets
         )
         self.builtModulesAndProducts.append(testRunner)
+    }
+
+    mutating func makePackageTestProduct() throws {
+        let productName = packageManifest.umbrellaPackageTestsProductName
+        let packageIdentity = package.identity
+        let packageTestProductKeyPath = try project.addAggregateTarget { _ in
+            ProjectModel.AggregateTarget(
+                id: PackagePIFBuilder.targetGUID(forProductName: productName, withId: "\(packageIdentity.description)-\(productName)"),
+                name: PackagePIFBuilder.targetName(forProductName: productName)
+            )
+        }
+
+        for config in ["Debug", "Release"] {
+            project[keyPath: packageTestProductKeyPath].common.addBuildConfig { id in
+                BuildConfig(id: id, name: config, settings: BuildSettings())
+            }
+        }
+
+        for target in project.targets {
+            switch target {
+            case .target(let target):
+                switch target.productType {
+                case .unitTest, .swiftpmTestRunner:
+                    project[keyPath: packageTestProductKeyPath].common.addDependency(
+                        on: target.id,
+                        platformFilters: [],
+                        linkProduct: false
+                    )
+                default:
+                    break
+                }
+            case .aggregate:
+                break
+            }
+        }
     }
 }
 

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -246,6 +246,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         builtProducts.append(
                             BuiltTestProduct(
                                 productName: product.name,
+                                umbrellaProductName: package.manifest.umbrellaPackageTestsProductName,
                                 binaryPath: binaryPath,
                                 packagePath: package.path,
                                 testEntryPointPath: product.underlying.testEntryPointPath

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -58,6 +58,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
                         builtProducts.append(
                             BuiltTestProduct(
                                 productName: product.name,
+                                umbrellaProductName: nil,
                                 binaryPath: binaryPath,
                                 packagePath: package.path,
                                 testEntryPointPath: product.underlying.testEntryPointPath

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -367,6 +367,30 @@ struct TestCommandTests {
     }
 
     @Test(
+        .IssueWindowsLongPath,
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func testProductFlag(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await withKnownIssue(isIntermittent: true) {
+            let configuration = BuildConfiguration.debug
+            try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+                let (stdout, _) = try await executeSwiftTest(
+                    fixturePath,
+                    configuration: configuration,
+                    extraArgs: ["--test-product", "SimplePackageTests"],
+                    buildSystem: buildSystem,
+                    throwIfCommandFails: true,
+                )
+                #expect(stdout.contains("Executed 3 tests"))
+            }
+        } when: {
+            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
+        }
+    }
+
+    @Test(
         .tags(
             .Feature.Command.Run,
             .Feature.TargetType.Executable,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -57,14 +57,17 @@ fileprivate func withGeneratedPIF(
     let buildParameters = if let buildParameters {
         buildParameters
     } else {
-       mockBuildParameters(destination: .host)
+        mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
     }
     try await fixture(name: fixtureName) { fixturePath in
         let observabilitySystem: TestingObservability = ObservabilitySystem.makeForTesting(verbose: false)
         let toolchain = try UserToolchain.default
+        var config = WorkspaceConfiguration.default
+        config.shouldCreateMultipleTestProducts = true
         let workspace = try Workspace(
             fileSystem: localFileSystem,
             forRootPackage: fixturePath,
+            configuration: config,
             customManifestLoader: ManifestLoader(toolchain: toolchain),
             delegate: MockWorkspaceDelegate()
         )
@@ -508,7 +511,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let pif = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let remoteProject = try pif.workspace.project(named: "remote-pkg")
@@ -569,7 +572,7 @@ struct PIFBuilderTests {
          ) async throws {
             try await withGeneratedPIF(
                 fromFixture: "PIFBuilder/Simple",
-                buildParameters: mockBuildParameters(destination: .host, indexStoreMode: indexStoreSettingUT),
+                buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, indexStoreMode: indexStoreSettingUT),
             ) { pif, observabilitySystem in
                 // #expect(false, "fail purposefully...")
                 #expect(observabilitySystem.diagnostics.filter {
@@ -593,7 +596,7 @@ struct PIFBuilderTests {
 
                 let testTargetConfig = try pif.workspace
                     .project(named: "Simple")
-                    .target(named: "SimplePackageTests-product")
+                    .target(named: "SimpleTests-product")
                     .buildConfig(named: configuration)
                 switch indexStoreSettingUT {
                     case .on, .off:

--- a/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
@@ -193,6 +193,9 @@ struct PrebuiltsPIFTests {
             "AllExcludingTests",
             "SwiftSyntaxMacros-product",
             "SwiftSyntaxMacrosdynamic-product",
+            "swift-syntaxPackageTests-product",
+            "MyRootPackageTests-product",
+            "MyPackagePackageTests-product",
         ])
 
         let targets = pif.workspace.projects.flatMap({ $0.underlying.targets })


### PR DESCRIPTION
The old backend produced a single test product for all the test targets, while the Swift Build backend produces one test product per test target. This is usually transparent from the user's perspective, except when they explicitly use the fairly obscure --test-product option. To maintain compatibility, the new backend now vends an "umbrella" test product with groups together the granular ones.