### PR TITLE
Deduplicate diagnostics in new --experimental-diagnostics-dedup mode

### DIFF
--- a/Sources/Build/LLBuildProgressTracker.swift
+++ b/Sources/Build/LLBuildProgressTracker.swift
@@ -147,6 +147,11 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
     private let observabilityScope: ObservabilityScope
     private var cancelled: Bool = false
 
+    /// Diagnostic header lines already printed across all jobs, used to suppress duplicates.
+    /// Keyed by the full diagnostic header line (path:line:col: severity: message).
+    /// All access is serialized through `queue`.
+    private var seenDiagnosticHeaders: Set<String> = []
+
     /// Swift parsers keyed by llbuild command name.
     private var swiftParsers: [String: SwiftCompilerOutputParser] = [:]
 
@@ -453,7 +458,15 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
                     self.progressAnimation.clear()
                 }
 
-                self.outputStream.send(output)
+                if let filtered = self.filteringDuplicateDiagnostics(output) {
+                    for line in filtered {
+                        self.outputStream.send(line)
+                        self.outputStream.send("\n")
+                    }
+                } else {
+                    // No filtering, emit every output as-is
+                    self.outputStream.send(output)
+                }
                 self.outputStream.flush()
 
                 // next we want to try and scoop out any errors from the output (if reasonable size, otherwise this
@@ -474,6 +487,57 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
         let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
         self.observabilityScope.emit(.swiftCompilerOutputParsingError(message))
         self.hadCommandFailure()
+    }
+
+    /// Filters out diagnostic blocks whose header has already been seen. Returns the deduplicated output.
+    /// A diagnostic block starts with a header line matching `:LINE:COL: severity:` and continues
+    /// until the next header line. ANSI escape codes are stripped before matching.
+    /// 
+    /// Returns nil if filtering is not enabled at all, and an empty array if the entire output should be filtered out.
+    /// The resulting array, if not empty, should be printed line-by-line and is the filtered output.
+    func filteringDuplicateDiagnostics(_ output: String) -> [String]? {
+        guard self.buildExecutionContext.productsBuildParameters.outputParameters.enableDiagnosticsDedup else {
+            return nil // pass-through unless de-dup was enabled \
+        }
+
+        var resultLines: [String] = []
+        var skipBlock = false
+
+        for line in output.components(separatedBy: "\n") {
+            let stripped = Self.stripANSI(line)
+            if Self.isDiagnosticHeader(stripped) {
+                if seenDiagnosticHeaders.contains(stripped) {
+                    self.observabilityScope.emit(.swiftCompilerOutputDuplicateDiagnosticSwallowed(stripped))
+                    skipBlock = true
+                } else {
+                    seenDiagnosticHeaders.insert(stripped)
+                    skipBlock = false
+                }
+            }
+            if !skipBlock {
+                resultLines.append(line)
+            }
+        }
+
+        return resultLines
+    }
+
+    private static func stripANSI(_ s: String) -> String {
+        s.replacing(#/\u{1b}\[[0-9;]*[a-zA-Z]/#, with: "")
+    }
+
+    /// Returns true if `line` is a Swift compiler diagnostic header of the form
+    ///   <path>:<line>:<col>: (error|warning|note|remark): <message>
+    /// Source-context lines (indented with spaces/pipes) and inline caret annotations
+    /// are intentionally excluded.
+    private static func isDiagnosticHeader(_ line: String) -> Bool {
+        // Fast pre-check: context lines always start with whitespace or a digit (source listing).
+        guard let first = line.first, first != " ", first != "\t", !first.isNumber else { return false }
+        // Match :LINE:COL: severity: anywhere in the line after a non-empty path prefix.
+        return line.range(
+            of: #":\d+:\d+: (?:error|warning|note|remark):"#,
+            options: .regularExpression
+        ) != nil
     }
 
     func buildStart(configuration: BuildConfiguration) {
@@ -675,6 +739,10 @@ extension Basics.Diagnostic {
 
     fileprivate static func swiftCompilerOutputParsingError(_ error: String) -> Self {
         .error("failed parsing the Swift compiler output: \(error)")
+    }
+
+    fileprivate static func swiftCompilerOutputDuplicateDiagnosticSwallowed(_ diagnosticHeader: String) -> Self {
+        .debug("prevented emission of duplicate diagnostic: \(diagnosticHeader)")
     }
 }
 

--- a/Sources/Build/LLBuildProgressTracker.swift
+++ b/Sources/Build/LLBuildProgressTracker.swift
@@ -150,7 +150,7 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
     /// Diagnostic header lines already printed across all jobs, used to suppress duplicates.
     /// Keyed by the full diagnostic header line (path:line:col: severity: message).
     /// All access is serialized through `queue`.
-    private var seenDiagnosticHeaders: Set<String> = []
+    private var seenKeyDiagnosticHeaders: Set<String> = []
 
     /// Swift parsers keyed by llbuild command name.
     private var swiftParsers: [String: SwiftCompilerOutputParser] = [:]
@@ -492,29 +492,41 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
     /// Filters out diagnostic blocks whose header has already been seen. Returns the deduplicated output.
     /// A diagnostic block starts with a header line matching `:LINE:COL: severity:` and continues
     /// until the next header line. ANSI escape codes are stripped before matching.
-    /// 
+    ///
     /// Returns nil if filtering is not enabled at all, and an empty array if the entire output should be filtered out.
     /// The resulting array, if not empty, should be printed line-by-line and is the filtered output.
     func filteringDuplicateDiagnostics(_ output: String) -> [String]? {
         guard self.buildExecutionContext.productsBuildParameters.outputParameters.enableDiagnosticsDedup else {
-            return nil // pass-through unless de-dup was enabled \
+            return nil // pass-through unless de-dup was enabled
         }
 
+        return Self.deduplicateDiagnostics(output, seenKeyDiagnosticHeaders: &seenKeyDiagnosticHeaders)
+    }
+
+    /// Only `error` and `warning` headers are used as dedup keys; `note` and `remark` lines
+    /// inherit the skip/emit state from their parent error/warning block.
+    package static func deduplicateDiagnostics(
+        _ output: String,
+        seenKeyDiagnosticHeaders: inout Set<String>
+    ) -> [String] {
         var resultLines: [String] = []
-        var skipBlock = false
+        var skip = false
 
         for line in output.components(separatedBy: "\n") {
             let stripped = Self.stripANSI(line)
-            if Self.isDiagnosticHeader(stripped) {
-                if seenDiagnosticHeaders.contains(stripped) {
-                    self.observabilityScope.emit(.swiftCompilerOutputDuplicateDiagnosticSwallowed(stripped))
-                    skipBlock = true
+            if Self.isKeyDiagnosticHeader(stripped) {
+                // error/warning: deduplicate on the full header line
+                if seenKeyDiagnosticHeaders.contains(stripped) {
+                    skip = true
                 } else {
-                    seenDiagnosticHeaders.insert(stripped)
-                    skipBlock = false
+                    seenKeyDiagnosticHeaders.insert(stripped)
+                    skip = false
                 }
+            } else if Self.isDiagnosticHeader(stripped) {
+                // note/remark: inherit skip from parent error/warning
             }
-            if !skipBlock {
+
+            if !skip {
                 resultLines.append(line)
             }
         }
@@ -522,20 +534,33 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
         return resultLines
     }
 
-    private static func stripANSI(_ s: String) -> String {
+    package static func stripANSI(_ s: String) -> String {
         s.replacing(#/\u{1b}\[[0-9;]*[a-zA-Z]/#, with: "")
     }
 
     /// Returns true if `line` is a Swift compiler diagnostic header of the form
     ///   <path>:<line>:<col>: (error|warning|note|remark): <message>
     /// Source-context lines (indented with spaces/pipes) and inline caret annotations
-    /// are intentionally excluded.
-    private static func isDiagnosticHeader(_ line: String) -> Bool {
-        // Fast pre-check: context lines always start with whitespace or a digit (source listing).
+    /// are intentionally excluded
+    package static func isDiagnosticHeader(_ line: String) -> Bool {
+        // Fast pre-check
         guard let first = line.first, first != " ", first != "\t", !first.isNumber else { return false }
-        // Match :LINE:COL: severity: anywhere in the line after a non-empty path prefix.
+
         return line.range(
             of: #":\d+:\d+: (?:error|warning|note|remark):"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    /// Returns true if `line` is an error or warning diagnostic header -- the dedup boundary.
+    /// Notes and remarks are treated as continuations of their parent error/warning block
+    /// rather than independent dedup keys
+    package static func isKeyDiagnosticHeader(_ line: String) -> Bool {
+        // Fast pre-check
+        guard let first = line.first, first != " ", first != "\t", !first.isNumber else { return false }
+        
+        return line.range(
+            of: #":\d+:\d+: (?:error|warning):"#,
             options: .regularExpression
         ) != nil
     }
@@ -739,6 +764,10 @@ extension Basics.Diagnostic {
 
     fileprivate static func swiftCompilerOutputParsingError(_ error: String) -> Self {
         .error("failed parsing the Swift compiler output: \(error)")
+    }
+
+    fileprivate static func swiftCompilerOutputDuplicateKeyDiagnosticSwallowed(_ diagnosticHeader: String) -> Self {
+        .debug("prevented emission of duplicate key diagnostic: \(diagnosticHeader)")
     }
 
     fileprivate static func swiftCompilerOutputDuplicateDiagnosticSwallowed(_ diagnosticHeader: String) -> Self {

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -599,6 +599,10 @@ public struct BuildOptions: ParsableArguments {
     @Flag(name: .customLong("experimental-task-backtraces"), help: .hidden)
     public var enableTaskBacktraces: Bool = false
 
+    // Whether to enable deduplication of diagnostics across parallel build jobs.
+    @Flag(name: .customLong("experimental-diagnostics-dedup"), help: .hidden)
+    public var enableDiagnosticsDedup: Bool = false
+
     // Build dynamic library targets as frameworks (only available for Darwin targets and only when using the 'swiftbuild' build-system (currently used for tests).
     @Flag(name: .customLong("experimental-build-dylibs-as-frameworks"), help: .hidden )
     public var shouldBuildDylibsAsFrameworks: Bool = false

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -974,7 +974,8 @@ public final class SwiftCommandState {
             outputParameters: .init(
                 isColorized: self.options.logging.colorDiagnostics,
                 isVerbose: self.logLevel <= .info,
-                enableTaskBacktraces: self.options.build.enableTaskBacktraces
+                enableTaskBacktraces: self.options.build.enableTaskBacktraces,
+                enableDiagnosticsDedup: self.options.build.enableDiagnosticsDedup
             ),
             testingParameters: .init(
                 forceTestDiscovery: self.options.build.enableTestDiscovery,

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Output.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Output.swift
@@ -16,11 +16,13 @@ extension BuildParameters {
         public init(
             isColorized: Bool = false,
             isVerbose: Bool = false,
-            enableTaskBacktraces: Bool = false
+            enableTaskBacktraces: Bool = false,
+            enableDiagnosticsDedup: Bool = false
         ) {
             self.isColorized = isColorized
             self.isVerbose = isVerbose
             self.enableTaskBacktraces = enableTaskBacktraces
+            self.enableDiagnosticsDedup = enableDiagnosticsDedup
         }
 
         public var isColorized: Bool
@@ -28,5 +30,7 @@ extension BuildParameters {
         public var isVerbose: Bool
 
         public var enableTaskBacktraces: Bool
+
+        public var enableDiagnosticsDedup: Bool
     }
 }


### PR DESCRIPTION
## Problem description

When compiling swift we're using many jobs to drive the compilation, sometimes files are compiled not as primary file, but still emit warnings or errors. This means that the same error/warning may be emitted up to N times where N is the number of jobs or times a file is included as non primary file in a compilation.

I've seen error duplication as high as 5 or 8 times, times the numbs of real errors and we're getting some huge amounts of duplication here really.

This is a huge problem for:

- Humans reading the logs in command line, which includes CI outputs etc. because it seems like we have e.g. 25 errors, but we just have 5.
  - This is bad for experienced developers and CI systems just because of the amount of noise it introduces.
  - It is even worse for beginners of people evaluating Swift, emitting duplicate errors like this makes Swift seem unstable and "shocking" because so many errors are emitted for a trivial mistake, flooding terminal output visually.

- AI assistants because as they grep for error: they find N many more times outputs, each of those outputs can have multiple notes attached, which quickly burns through token counts.

Reproducer project: [HelloWorldApp.zip](https://github.com/user-attachments/files/25831256/HelloWorldApp.zip). We have one error here in the project, however it is diagnosed as:

```
/private/tmp/HelloWorldApp/Sources/HelloWorldApp/UserStore.swift:3:51: error: extra argument 'lastName' in call
 1 | struct UserStore {
 2 |     private let users: [User] = [
 3 |         User(id: 1, firstName: "Alice", lastName: "Smith", email: "alice@example.com"),
   |                                                   `- error: extra argument 'lastName' in call
 4 |         // User(id: 2, firstName: "Bob", lastName: "Jones", email: "bob@example.com"),
 5 |         // User(id: 3, firstName: "Carol", lastName: "White", email: "carol@example.com"),
error: emit-module command failed with exit code 1 (use -v to see invocation)
/private/tmp/HelloWorldApp/Sources/HelloWorldApp/UserStore.swift:3:51: error: extra argument 'lastName' in call
 1 | struct UserStore {
 2 |     private let users: [User] = [
 3 |         User(id: 1, firstName: "Alice", lastName: "Smith", email: "alice@example.com"),
   |                                                   `- error: extra argument 'lastName' in call
 4 |         // User(id: 2, firstName: "Bob", lastName: "Jones", email: "bob@example.com"),
 5 |         // User(id: 3, firstName: "Carol", lastName: "White", email: "carol@example.com"),
/private/tmp/HelloWorldApp/Sources/HelloWorldApp/UserStore.swift:3:51: error: extra argument 'lastName' in call
 1 | struct UserStore {
 2 |     private let users: [User] = [
 3 |         User(id: 1, firstName: "Alice", lastName: "Smith", email: "alice@example.com"),
   |                                                   `- error: extra argument 'lastName' in call
 4 |         // User(id: 2, firstName: "Bob", lastName: "Jones", email: "bob@example.com"),
 5 |         // User(id: 3, firstName: "Carol", lastName: "White", email: "carol@example.com"),
/private/tmp/HelloWorldApp/Sources/HelloWorldApp/UserStore.swift:3:51: error: extra argument 'lastName' in call
 1 | struct UserStore {
 2 |     private let users: [User] = [
 3 |         User(id: 1, firstName: "Alice", lastName: "Smith", email: "alice@example.com"),
   |                                                   `- error: extra argument 'lastName' in call
 4 |         // User(id: 2, firstName: "Bob", lastName: "Jones", email: "bob@example.com"),
 5 |         // User(id: 3, firstName: "Carol", lastName: "White", email: "carol@example.com"),
```

which is the exact error, just repeated 4 times.

With this fix, we get exactly 1 error diagnostic.

We should also see if swift-frontend can try to deduplicate the errors a little bit and I have some PoC of that as well, but it cannot do that 100% because we may still have multiple frontend tasks try to compile the same file as secondary and cause the same error again, so I think we must deduplicate this in swiftpm layer

I have initially discussed this with @bripeticca  and look forward to at least landing it as experimental flag for the time being.

## Changes

Introduce a new flag --experimental-diagnostics-dedup to enable this new de-duplicating mode.

In this mode, we key each emitted diagnostic in the `LLBuildProgressTracker` by its `file`/`line`/`col` and exact error message. If an error message would be emitted twice, we do not emit it.

## Results

- Removes duplicated diagnostics:

```
-> % rm -rf .build ; ~/code/swift-project/swiftpm/.build/release/swift-build --experimental-diagnostics-dedup
Building for debugging...
/private/tmp/HelloWorldApp/Sources/HelloWorldApp/UserStore.swift:3:51: error: extra argument 'lastName' in call
 1 | struct UserStore {
 2 |     private let users: [User] = [
 3 |         User(id: 1, firstName: "Alice", lastName: "Smith", email: "alice@example.com"),
   |                                                   `- error: extra argument 'lastName' in call
 4 |         // User(id: 2, firstName: "Bob", lastName: "Jones", email: "bob@example.com"),
 5 |         // User(id: 3, firstName: "Carol", lastName: "White", email: "carol@example.com"),
```

A single instance of the error, not 4!

And we're logging the dupe prevention in `--very-verbose` as well:

```
/private/tmp/HelloWorldApp/Sources/HelloWorldApp/UserStore.swift:3:51: error: extra argument 'lastName' in call
...
debug: prevented emission of duplicate diagnostic: /private/tmp/HelloWorldApp/Sources/HelloWorldApp/UserStore.swift:3:51: error: extra argument 'lastName' in call
debug: prevented emission of duplicate diagnostic: /private/tmp/HelloWorldApp/Sources/HelloWorldApp/UserStore.swift:3:51: error: extra argument 'lastName' in call
debug: prevented emission of duplicate diagnostic: /private/tmp/HelloWorldApp/Sources/HelloWorldApp/UserStore.swift:3:51: error: extra argument 'lastName' in call
```

- Resolves rdar://84599581