### PR TITLE
Refactor more properties to use the new BuildFlags type

### DIFF
--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -357,15 +357,15 @@ public final class ClangModuleBuildDescription {
             args += ["-include", resourceAccessorHeaderFile.pathString]
         }
 
-        args += self.buildParameters.toolchain.extraFlags.cCompilerFlags
+        args += self.buildParameters.toolchain.extraFlags.cCompilerFlags.rawFlags
         // User arguments (from -Xcc) should follow generated arguments to allow user overrides
-        args += self.buildParameters.flags.cCompilerFlags
+        args += self.buildParameters.flags.cCompilerFlags.rawFlags
 
         // Add extra C++ flags if this target contains C++ files.
         if isCXX {
-            args += self.buildParameters.toolchain.extraFlags.cxxCompilerFlags
+            args += self.buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags
             // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
-            args += self.buildParameters.flags.cxxCompilerFlags
+            args += self.buildParameters.flags.cxxCompilerFlags.rawFlags
         }
 
         // Enable the correct lto mode if requested.

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -372,9 +372,9 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         // User arguments (from -Xswiftc) should follow generated arguments to allow user overrides
         args += self.buildParameters.flags.swiftCompilerFlags.rawFlags
 
-        args += self.buildParameters.toolchain.extraFlags.linkerFlags.asSwiftcLinkerFlags()
+        args += self.buildParameters.toolchain.extraFlags.linkerFlags.rawFlags.asSwiftcLinkerFlags()
         // User arguments (from -Xlinker) should follow generated arguments to allow user overrides
-        args += self.buildParameters.flags.linkerFlags.asSwiftcLinkerFlags()
+        args += self.buildParameters.flags.linkerFlags.rawFlags.asSwiftcLinkerFlags()
 
         // Enable the correct lto mode if requested.
         switch self.buildParameters.linkingParameters.linkTimeOptimizationMode {

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -610,15 +610,15 @@ public final class SwiftModuleBuildDescription {
         // User arguments (from -Xswiftc) should follow generated arguments to allow user overrides
         args += self.buildParameters.flags.swiftCompilerFlags.rawFlags
 
-        args += self.buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
+        args += self.buildParameters.toolchain.extraFlags.cCompilerFlags.rawFlags.asSwiftcCCompilerFlags()
         // User arguments (from -Xcc) should follow generated arguments to allow user overrides
-        args += self.buildParameters.flags.cCompilerFlags.asSwiftcCCompilerFlags()
+        args += self.buildParameters.flags.cCompilerFlags.rawFlags.asSwiftcCCompilerFlags()
 
         // TODO: Pass -Xcxx flags to swiftc (#6491)
         // Uncomment when downstream support arrives.
-        // args += self.buildParameters.toolchain.extraFlags.cxxCompilerFlags.asSwiftcCXXCompilerFlags()
+        // args += self.buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()
         // // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
-        // args += self.buildParameters.flags.cxxCompilerFlags.asSwiftcCXXCompilerFlags()
+        // args += self.buildParameters.flags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()
 
         // Enable the correct LTO mode if requested.
         switch self.buildParameters.linkingParameters.linkTimeOptimizationMode {

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -128,10 +128,10 @@ final class PluginDelegate: PluginInvocationDelegate {
             // --configuration command line parameter.   We don't need to do anything to inherit it.
             break
         }
-        buildParameters.flags.cCompilerFlags.append(contentsOf: parameters.otherCFlags)
-        buildParameters.flags.cxxCompilerFlags.append(contentsOf: parameters.otherCxxFlags)
-        buildParameters.flags.swiftCompilerFlags.append(contentsOf: parameters.otherSwiftcFlags.constructBuildFlags(source: nil))
-        buildParameters.flags.linkerFlags.append(contentsOf: parameters.otherLinkerFlags)
+        buildParameters.flags.cCompilerFlags.append(contentsOf: parameters.otherCFlags.constructBuildFlags(source: .plugin))
+        buildParameters.flags.cxxCompilerFlags.append(contentsOf: parameters.otherCxxFlags.constructBuildFlags(source: .plugin))
+        buildParameters.flags.swiftCompilerFlags.append(contentsOf: parameters.otherSwiftcFlags.constructBuildFlags(source: .plugin))
+        buildParameters.flags.linkerFlags.append(contentsOf: parameters.otherLinkerFlags.constructBuildFlags(source: .plugin))
 
         // Configure the verbosity of the output.
         let logLevel: Basics.Diagnostic.Severity

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -451,10 +451,10 @@ public struct BuildOptions: ParsableArguments {
 
     public var buildFlags: BuildFlags {
         BuildFlags(
-            cCompilerFlags: self.cCompilerFlags,
-            cxxCompilerFlags: self.cxxCompilerFlags,
+            cCompilerFlags: self.cCompilerFlags.constructBuildFlags(source: .commandLineOptions),
+            cxxCompilerFlags: self.cxxCompilerFlags.constructBuildFlags(source: .commandLineOptions),
             swiftCompilerFlags: self.swiftCompilerFlags.constructBuildFlags(source: .commandLineOptions),
-            linkerFlags: self.linkerFlags,
+            linkerFlags: self.linkerFlags.constructBuildFlags(source: .commandLineOptions),
             xcbuildFlags: self.xcbuildFlags
         )
     }

--- a/Sources/PackageModel/BuildFlags.swift
+++ b/Sources/PackageModel/BuildFlags.swift
@@ -16,14 +16,18 @@ public struct BuildFlag: Hashable, Sendable, Encodable {
     /// Describes the origin of this flag, for example if it was sourced from a Swift SDK, or added as a builtin option by SwiftPM.
     public var source: Source?
 
-    public init(value: String, source: Source? = nil) {
+    public init(value: String, source: Source?) {
         self.value = value
         self.source = source
     }
 
     public enum Source: Sendable, Hashable, Codable {
         case defaultSwiftTestingSearchPath
+        case defaultWindowsSettings
         case swiftSDK
+        case toolset
+        case debugging
+        case plugin
         case commandLineOptions
     }
 }
@@ -45,25 +49,25 @@ extension [String] {
 /// Build-tool independent flags.
 public struct BuildFlags: Equatable, Encodable {
     /// Flags to pass to the C compiler.
-    public var cCompilerFlags: [String]
+    public var cCompilerFlags: [BuildFlag]
 
     /// Flags to pass to the C++ compiler.
-    public var cxxCompilerFlags: [String]
+    public var cxxCompilerFlags: [BuildFlag]
 
     /// Flags to pass to the Swift compiler.
     public var swiftCompilerFlags: [BuildFlag]
 
     /// Flags to pass to the linker.
-    public var linkerFlags: [String]
+    public var linkerFlags: [BuildFlag]
 
     /// Flags to pass to xcbuild.
     public var xcbuildFlags: [String]?
 
     public init(
-        cCompilerFlags: [String] = [],
-        cxxCompilerFlags: [String] = [],
+        cCompilerFlags: [BuildFlag] = [],
+        cxxCompilerFlags: [BuildFlag] = [],
         swiftCompilerFlags: [BuildFlag] = [],
-        linkerFlags: [String] = [],
+        linkerFlags: [BuildFlag] = [],
         xcbuildFlags: [String] = []
     ) {
         self.cCompilerFlags = cCompilerFlags
@@ -73,8 +77,8 @@ public struct BuildFlags: Equatable, Encodable {
         self.xcbuildFlags = xcbuildFlags
     }
 
-    // Kept to allow SourceKitLSP time to migrate to the new initializer.
-    @available(*, deprecated, message: "Use the overload which accepts swiftCompilerFlags as [BuildFlag] instead")
+    // Kept to allow callers time to migrate to the new initializer.
+    @available(*, deprecated, message: "Use the overload which accepts compiler flags as [BuildFlag] instead")
     public init(
         cCompilerFlags: [String],
         cxxCompilerFlags: [String],
@@ -82,10 +86,10 @@ public struct BuildFlags: Equatable, Encodable {
         linkerFlags: [String],
         xcbuildFlags: [String] = []
     ) {
-        self.cCompilerFlags = cCompilerFlags
-        self.cxxCompilerFlags = cxxCompilerFlags
+        self.cCompilerFlags = cCompilerFlags.constructBuildFlags(source: nil)
+        self.cxxCompilerFlags = cxxCompilerFlags.constructBuildFlags(source: nil)
         self.swiftCompilerFlags = swiftCompilerFlags.constructBuildFlags(source: nil)
-        self.linkerFlags = linkerFlags
+        self.linkerFlags = linkerFlags.constructBuildFlags(source: nil)
         self.xcbuildFlags = xcbuildFlags
     }
 

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -233,7 +233,7 @@ public struct SwiftSDK: Equatable {
     /// Additional flags to be passed to the C compiler.
     @available(*, deprecated, message: "use `toolset` and its properties instead")
     public var extraCCFlags: [String] {
-        extraFlags.cCompilerFlags
+        extraFlags.cCompilerFlags.rawFlags
     }
 
     /// Additional flags to be passed to the Swift compiler.
@@ -245,18 +245,17 @@ public struct SwiftSDK: Equatable {
     /// Additional flags to be passed to the C++ compiler.
     @available(*, deprecated, message: "use `toolset` and its properties instead")
     public var extraCPPFlags: [String] {
-        extraFlags.cxxCompilerFlags
+        extraFlags.cxxCompilerFlags.rawFlags
     }
 
     /// Additional flags to be passed to the build tools.
     @available(*, deprecated, message: "use `toolset` and its properties instead")
     public var extraFlags: BuildFlags {
-        let swiftCompilerFlags = (toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []).constructBuildFlags(source: .swiftSDK)
         return .init(
-            cCompilerFlags: toolset.knownTools[.cCompiler]?.extraCLIOptions ?? [],
-            cxxCompilerFlags: toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? [],
-            swiftCompilerFlags: swiftCompilerFlags,
-            linkerFlags: toolset.knownTools[.linker]?.extraCLIOptions ?? [],
+            cCompilerFlags: (toolset.knownTools[.cCompiler]?.extraCLIOptions ?? []).constructBuildFlags(source: .toolset),
+            cxxCompilerFlags: (toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? []).constructBuildFlags(source: .toolset),
+            swiftCompilerFlags: (toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []).constructBuildFlags(source: .toolset),
+            linkerFlags: (toolset.knownTools[.linker]?.extraCLIOptions ?? []).constructBuildFlags(source: .toolset),
             xcbuildFlags: toolset.knownTools[.xcbuild]?.extraCLIOptions ?? []
         )
     }
@@ -346,7 +345,7 @@ public struct SwiftSDK: Equatable {
         ///   - properties: properties of a Swift SDK for the given triple.
         ///   - swiftSDKDirectory: directory used for converting relative paths in `properties` to absolute paths.
         fileprivate init(
-            _ properties: SwiftSDKMetadataV4.TripleProperties, 
+            _ properties: SwiftSDKMetadataV4.TripleProperties,
             swiftSDKDirectory: Basics.AbsolutePath? = nil
         ) throws where Path == Basics.AbsolutePath {
             self.init(
@@ -449,15 +448,14 @@ public struct SwiftSDK: Equatable {
         extraSwiftCFlags: [String] = [],
         extraCPPFlags: [String] = []
     ) {
-        let extraSwiftCFlags = extraSwiftCFlags.constructBuildFlags(source: .swiftSDK)
         self.init(
             targetTriple: target,
             sdkRootDir: sdk,
             toolchainBinDir: binDir,
             extraFlags: BuildFlags(
-                cCompilerFlags: extraCCFlags,
-                cxxCompilerFlags: extraCPPFlags,
-                swiftCompilerFlags: extraSwiftCFlags
+                cCompilerFlags: extraCCFlags.constructBuildFlags(source: .swiftSDK),
+                cxxCompilerFlags: extraCPPFlags.constructBuildFlags(source: .swiftSDK),
+                swiftCompilerFlags: extraSwiftCFlags.constructBuildFlags(source: .swiftSDK)
             )
         )
     }
@@ -1049,7 +1047,7 @@ extension SwiftSDK {
         switch version.version {
         case 1:
             let serializedMetadata = try decoder.decode(
-                path: path, 
+                path: path,
                 fileSystem: fileSystem,
                 as: SerializedDestinationV1.self
             )
@@ -1058,8 +1056,8 @@ extension SwiftSDK {
                 toolset: .init(
                     toolchainBinDir: serializedMetadata.binDir,
                     buildFlags: .init(
-                        cCompilerFlags: serializedMetadata.extraCCFlags,
-                        cxxCompilerFlags: serializedMetadata.extraCPPFlags,
+                        cCompilerFlags: serializedMetadata.extraCCFlags.constructBuildFlags(source: .swiftSDK),
+                        cxxCompilerFlags: serializedMetadata.extraCPPFlags.constructBuildFlags(source: .swiftSDK),
                         swiftCompilerFlags: serializedMetadata.extraSwiftCFlags.constructBuildFlags(source: .swiftSDK)
                     )
                 ),
@@ -1078,10 +1076,10 @@ extension SwiftSDK {
                         relativeTo: swiftSDKDirectory
                     ),
                     buildFlags: .init(
-                        cCompilerFlags: serializedMetadata.extraCCFlags,
-                        cxxCompilerFlags: serializedMetadata.extraCXXFlags,
+                        cCompilerFlags: serializedMetadata.extraCCFlags.constructBuildFlags(source: .swiftSDK),
+                        cxxCompilerFlags: serializedMetadata.extraCXXFlags.constructBuildFlags(source: .swiftSDK),
                         swiftCompilerFlags: serializedMetadata.extraSwiftCFlags.constructBuildFlags(source: .swiftSDK),
-                        linkerFlags: serializedMetadata.extraLinkerFlags
+                        linkerFlags: serializedMetadata.extraLinkerFlags.constructBuildFlags(source: .swiftSDK)
                     )
                 ),
                 pathsConfiguration: .init(
@@ -1102,7 +1100,7 @@ extension SwiftSDK {
             guard let targetTriple = self.targetTriple, let sdkRootDir = self.pathsConfiguration.sdkRootPath else {
                 throw SwiftSDKError.unserializableMetadata
             }
-            
+
             return (
                 targetTriple,
                 .init(

--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -146,11 +146,11 @@ extension Toolchain {
     }
 
     public var extraCCFlags: [String] {
-        extraFlags.cCompilerFlags
+        extraFlags.cCompilerFlags.rawFlags
     }
-    
+
     public var extraCPPFlags: [String] {
-        extraFlags.cxxCompilerFlags
+        extraFlags.cxxCompilerFlags.rawFlags
     }
     
     public var extraSwiftCFlags: [String] {

--- a/Sources/PackageModel/Toolset.swift
+++ b/Sources/PackageModel/Toolset.swift
@@ -164,10 +164,10 @@ extension Toolset {
     public init(toolchainBinDir: AbsolutePath, buildFlags: BuildFlags = .init()) {
         self.rootPaths = [toolchainBinDir]
         self.knownTools = [
-            .cCompiler: .init(extraCLIOptions: buildFlags.cCompilerFlags),
-            .cxxCompiler: .init(extraCLIOptions: buildFlags.cxxCompilerFlags),
+            .cCompiler: .init(extraCLIOptions: buildFlags.cCompilerFlags.rawFlags),
+            .cxxCompiler: .init(extraCLIOptions: buildFlags.cxxCompilerFlags.rawFlags),
             .swiftCompiler: .init(extraCLIOptions: buildFlags.swiftCompilerFlags.rawFlags),
-            .linker: .init(extraCLIOptions: buildFlags.linkerFlags),
+            .linker: .init(extraCLIOptions: buildFlags.linkerFlags.rawFlags),
             .xcbuild: .init(extraCLIOptions: buildFlags.xcbuildFlags ?? []),
         ]
     }

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -581,11 +581,11 @@ public final class UserToolchain: Toolchain {
         swiftSDK: SwiftSDK,
         environment: Environment,
         fileSystem: any FileSystem
-    ) throws -> [String] {
-        var swiftCompilerFlags = swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []
+    ) throws -> [BuildFlag] {
+        var swiftCompilerFlags = (swiftSDK.toolset.knownTools[.swiftCompiler]?.extraCLIOptions ?? []).map { BuildFlag(value: $0, source: .toolset)}
 
         if let linker = swiftSDK.toolset.knownTools[.linker]?.path {
-            swiftCompilerFlags += ["-ld-path=\(linker)"]
+            swiftCompilerFlags += [BuildFlag(value: "-ld-path=\(linker)", source: .toolset)]
         }
 
         guard let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath else {
@@ -594,10 +594,10 @@ public final class UserToolchain: Toolchain {
                 // the SDK.  This is not the same value as the SDKROOT parameter
                 // in Xcode, however, the value represents a similar concept.
                 if let sdkroot = environment.windowsSDKRoot {
-                    var runtime: [String] = []
-                    var xctest: [String] = []
-                    var swiftTesting: [String] = []
-                    var extraSwiftCFlags: [String] = []
+                    var runtime: [BuildFlag] = []
+                    var xctest: [BuildFlag] = []
+                    var swiftTesting: [BuildFlag] = []
+                    var extraSwiftCFlags: [BuildFlag] = []
 
                     if let settings = WindowsSDKSettings(
                         reading: sdkroot.appending("SDKSettings.plist"),
@@ -606,13 +606,21 @@ public final class UserToolchain: Toolchain {
                     ) {
                         switch settings.defaults.runtime {
                         case .multithreadedDebugDLL:
-                            runtime = ["-libc", "MDd"]
+                            runtime = ["-libc", "MDd"].map {
+                                BuildFlag(value: $0, source: .defaultWindowsSettings)
+                            }
                         case .multithreadedDLL:
-                            runtime = ["-libc", "MD"]
+                            runtime = ["-libc", "MD"].map {
+                                BuildFlag(value: $0, source: .defaultWindowsSettings)
+                            }
                         case .multithreadedDebug:
-                            runtime = ["-libc", "MTd"]
+                            runtime = ["-libc", "MTd"].map {
+                                BuildFlag(value: $0, source: .defaultWindowsSettings)
+                            }
                         case .multithreaded:
-                            runtime = ["-libc", "MT"]
+                            runtime = ["-libc", "MT"].map {
+                                BuildFlag(value: $0, source: .defaultWindowsSettings)
+                            }
                         }
                     }
 
@@ -659,7 +667,7 @@ public final class UserToolchain: Toolchain {
                                 validating: "usr/lib/swift/windows/\(triple.archName)",
                                 relativeTo: XCTestInstallation
                             ).pathString,
-                        ]
+                        ].map { BuildFlag(value: $0, source: .defaultWindowsSettings) }
 
                         // Migration Path
                         //
@@ -674,7 +682,9 @@ public final class UserToolchain: Toolchain {
                             relativeTo: XCTestInstallation
                         )
                         if fileSystem.exists(implib) {
-                            xctest.append(contentsOf: ["-L", implib.parentDirectory.pathString])
+                            xctest.append(contentsOf: ["-L", implib.parentDirectory.pathString].map {
+                                BuildFlag(value: $0, source: .defaultWindowsSettings)
+                            })
                         }
 
                         if let swiftTestingVersion = info.defaults.swiftTestingVersion {
@@ -694,13 +704,15 @@ public final class UserToolchain: Toolchain {
                                     validating: "usr/lib/swift/windows/\(triple.archName)",
                                     relativeTo: swiftTestingInstallation
                                 ).pathString
-                            ]
+                            ].map { BuildFlag(value: $0, source: .defaultWindowsSettings) }
                         }
 
-                        extraSwiftCFlags = info.defaults.extraSwiftCFlags ?? []
+                        extraSwiftCFlags = (info.defaults.extraSwiftCFlags ?? []).map {
+                            BuildFlag(value: $0, source: .defaultWindowsSettings)
+                        }
                     }
 
-                    return ["-sdk", sdkroot.pathString] + runtime + xctest + swiftTesting + extraSwiftCFlags
+                    return (["-sdk", sdkroot.pathString].map { BuildFlag(value: $0, source: .swiftSDK) } + runtime + xctest + swiftTesting + extraSwiftCFlags)
                 }
             }
 
@@ -709,7 +721,7 @@ public final class UserToolchain: Toolchain {
 
         return (
             triple.isDarwin() || triple.isAndroid() || triple.isWASI() || triple.isWindows()
-                ? ["-sdk", sdkDir.pathString]
+                ? ["-sdk", sdkDir.pathString].map { BuildFlag(value: $0, source: .swiftSDK) }
                 : []
         ) + swiftCompilerFlags
     }
@@ -810,7 +822,7 @@ public final class UserToolchain: Toolchain {
         self.targetTriple = triple
 
         var swiftCompilerFlags: [BuildFlag] = []
-        var extraLinkerFlags: [String] = []
+        var extraLinkerFlags: [BuildFlag] = []
 
         let swiftTestingPath: AbsolutePath? = try Self.deriveSwiftTestingPath(
             derivedSwiftCompiler: swiftCompilers.compile,
@@ -853,15 +865,13 @@ public final class UserToolchain: Toolchain {
             swiftSDK: swiftSDK,
             environment: environment,
             fileSystem: fileSystem
-        ).map {
-            BuildFlag(value: $0, source: nil)
-        }
+        )
 
-        extraLinkerFlags += swiftSDK.toolset.knownTools[.linker]?.extraCLIOptions ?? []
+        extraLinkerFlags += (swiftSDK.toolset.knownTools[.linker]?.extraCLIOptions ?? []).constructBuildFlags(source: .toolset)
 
         self.extraFlags = BuildFlags(
-            cCompilerFlags: swiftSDK.toolset.knownTools[.cCompiler]?.extraCLIOptions ?? [],
-            cxxCompilerFlags: swiftSDK.toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? [],
+            cCompilerFlags: (swiftSDK.toolset.knownTools[.cCompiler]?.extraCLIOptions ?? []).constructBuildFlags(source: .toolset),
+            cxxCompilerFlags: (swiftSDK.toolset.knownTools[.cxxCompiler]?.extraCLIOptions ?? []).constructBuildFlags(source: .toolset),
             swiftCompilerFlags: swiftCompilerFlags,
             linkerFlags: extraLinkerFlags,
             xcbuildFlags: swiftSDK.toolset.knownTools[.xcbuild]?.extraCLIOptions ?? [])
@@ -881,7 +891,7 @@ public final class UserToolchain: Toolchain {
 
         if let sdkDir = swiftSDK.pathsConfiguration.sdkRootPath {
             let sysrootFlags = [triple.isDarwin() ? "-isysroot" : "--sysroot", sdkDir.pathString]
-            self.extraFlags.cCompilerFlags.insert(contentsOf: sysrootFlags, at: 0)
+            self.extraFlags.cCompilerFlags.insert(contentsOf: sysrootFlags.constructBuildFlags(source: .swiftSDK), at: 0)
         }
 
         if triple.isWindows() {
@@ -901,22 +911,22 @@ public final class UserToolchain: Toolchain {
                             "-D_DLL",
                             "-Xclang",
                             "--dependent-lib=msvcrtd",
-                        ]
+                        ].constructBuildFlags(source: .defaultWindowsSettings)
 
                     case .multithreadedDLL:
                         // Defines _MT, and _DLL
                         // Linker uses MSVCRT.lib
-                        self.extraFlags.cCompilerFlags += ["-D_MT", "-D_DLL", "-Xclang", "--dependent-lib=msvcrt"]
+                        self.extraFlags.cCompilerFlags += ["-D_MT", "-D_DLL", "-Xclang", "--dependent-lib=msvcrt"].constructBuildFlags(source: .defaultWindowsSettings)
 
                     case .multithreadedDebug:
                         // Defines _DEBUG, and _MT
                         // Linker uses LIBCMTD.lib
-                        self.extraFlags.cCompilerFlags += ["-D_DEBUG", "-D_MT", "-Xclang", "--dependent-lib=libcmtd"]
+                        self.extraFlags.cCompilerFlags += ["-D_DEBUG", "-D_MT", "-Xclang", "--dependent-lib=libcmtd"].constructBuildFlags(source: .defaultWindowsSettings)
 
                     case .multithreaded:
                         // Defines _MT
                         // Linker uses LIBCMT.lib
-                        self.extraFlags.cCompilerFlags += ["-D_MT", "-Xclang", "--dependent-lib=libcmt"]
+                        self.extraFlags.cCompilerFlags += ["-D_MT", "-Xclang", "--dependent-lib=libcmt"].constructBuildFlags(source: .defaultWindowsSettings)
                     }
                 }
             }

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -201,28 +201,28 @@ public struct BuildParameters: Encodable {
             var flags = flags
             // DWARF requires lld as link.exe expects CodeView debug info.
             self.flags = flags.merging(triple.isWindows() ? BuildFlags(
-                cCompilerFlags: ["-gdwarf"],
-                cxxCompilerFlags: ["-gdwarf"],
-                swiftCompilerFlags: ["-g", "-use-ld=lld"].constructBuildFlags(source: nil),
-                linkerFlags: ["-debug:dwarf"]
-            ) : BuildFlags(cCompilerFlags: ["-g"], cxxCompilerFlags: ["-g"], swiftCompilerFlags: [BuildFlag(value: "-g")]))
+                cCompilerFlags: ["-gdwarf"].constructBuildFlags(source: .debugging),
+                cxxCompilerFlags: ["-gdwarf"].constructBuildFlags(source: .debugging),
+                swiftCompilerFlags: ["-g", "-use-ld=lld"].constructBuildFlags(source: .debugging),
+                linkerFlags: ["-debug:dwarf"].constructBuildFlags(source: .debugging)
+            ) : BuildFlags(cCompilerFlags: ["-g"].constructBuildFlags(source: .debugging), cxxCompilerFlags: ["-g"].constructBuildFlags(source: .debugging), swiftCompilerFlags: [BuildFlag(value: "-g", source: .debugging)]))
         case .codeview:
             if !triple.isWindows() {
                 throw StringError("CodeView debug information is currently not supported on \(triple.osName)")
             }
             var flags = flags
             self.flags = flags.merging(BuildFlags(
-                cCompilerFlags: ["-g"],
-                cxxCompilerFlags: ["-g"],
-                swiftCompilerFlags: ["-g", "-debug-info-format=codeview"].constructBuildFlags(source: nil),
-                linkerFlags: ["-debug"]
+                cCompilerFlags: ["-g"].constructBuildFlags(source: .debugging),
+                cxxCompilerFlags: ["-g"].constructBuildFlags(source: .debugging),
+                swiftCompilerFlags: ["-g", "-debug-info-format=codeview"].constructBuildFlags(source: .debugging),
+                linkerFlags: ["-debug"].constructBuildFlags(source: .debugging)
             ))
         case .none:
             var flags = flags
             self.flags = flags.merging(BuildFlags(
-                cCompilerFlags: ["-g0"],
-                cxxCompilerFlags: ["-g0"],
-                swiftCompilerFlags: [BuildFlag(value: "-gnone")]
+                cCompilerFlags: ["-g0"].constructBuildFlags(source: .debugging),
+                cxxCompilerFlags: ["-g0"].constructBuildFlags(source: .debugging),
+                swiftCompilerFlags: [BuildFlag(value: "-gnone", source: .debugging)]
             ))
         }
         self.pkgConfigDirectories = pkgConfigDirectories

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -904,44 +904,21 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         }
 
         settings["LIBRARY_SEARCH_PATHS"] = try "$(inherited) \(buildParameters.toolchain.toolchainLibDir.pathString)"
-        settings["OTHER_CFLAGS"] = (
-            verboseFlag +
-            ["$(inherited)"]
-                + buildParameters.toolchain.extraFlags.cCompilerFlags.map { $0.shellEscaped() }
-                + buildParameters.flags.cCompilerFlags.map { $0.shellEscaped() }
-        ).joined(separator: " ")
-        settings["OTHER_CPLUSPLUSFLAGS"] = (
-            verboseFlag +
-            ["$(inherited)"]
-                + buildParameters.toolchain.extraFlags.cxxCompilerFlags.map { $0.shellEscaped() }
-                + buildParameters.flags.cxxCompilerFlags.map { $0.shellEscaped() }
-        ).joined(separator: " ")
 
-        let otherSwiftFlags = (
-            buildParameters.toolchain.extraFlags.swiftCompilerFlags +
-            buildParameters.flags.swiftCompilerFlags
-        ).filter {
-            switch $0.source {
-            case .defaultSwiftTestingSearchPath:
-                // Swift Build computes these internally. It's important not to add them a second time here
-                // as it can break the intended search path ordering, for example, if the user is building
-                // Swift Testing as a package dependency.
-                return false
-            case .swiftSDK:
-                // Swift Build loads Swift SDK flags internally, and may introspect them to override build
-                // settings. Don't duplicate them here.
-                return false
-            case .commandLineOptions, nil:
-                return true
+        let compilerAndLinkerFlags = [
+            "OTHER_CFLAGS": buildParameters.toolchain.extraFlags.cCompilerFlags + buildParameters.flags.cCompilerFlags,
+            "OTHER_CPLUSPLUSFLAGS": buildParameters.toolchain.extraFlags.cxxCompilerFlags + buildParameters.flags.cxxCompilerFlags,
+            "OTHER_SWIFT_FLAGS": buildParameters.toolchain.extraFlags.swiftCompilerFlags + buildParameters.flags.swiftCompilerFlags,
+            "OTHER_LDFLAGS": (buildParameters.toolchain.extraFlags.linkerFlags + buildParameters.flags.linkerFlags)
+        ]
+        for (settingName, buildFlags) in compilerAndLinkerFlags {
+            var rawFlags = buildFlags.rawFlagsForSwiftBuild
+            if settingName == "OTHER_LDFLAGS" {
+                rawFlags = rawFlags.asSwiftcLinkerFlags()
             }
-        }.map {
-            $0.value.shellEscaped()
+            settings[settingName] = (verboseFlag + ["$(inherited)"] +
+                rawFlags.map { $0.shellEscaped() }).joined(separator: " ")
         }
-        settings["OTHER_SWIFT_FLAGS"] = (
-            verboseFlag +
-            ["$(inherited)"] +
-            otherSwiftFlags
-        ).joined(separator: " ")
 
         if buildParameters.driverParameters.emitSILFiles {
             settings["SWIFT_EMIT_SIL_FILES"] = "YES"
@@ -968,20 +945,6 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             // dSYM generation is required to attribute code size to source locations
             settings["DEBUG_INFORMATION_FORMAT"] = "dwarf-with-dsym"
         }
-
-        let inherited = ["$(inherited)"]
-
-        let buildParametersLinkFlags =
-            buildParameters.toolchain.extraFlags.linkerFlags.asSwiftcLinkerFlags().map { $0.shellEscaped() }
-            + buildParameters.flags.linkerFlags.asSwiftcLinkerFlags().map { $0.shellEscaped() }
-
-        var otherLdFlags =
-                verboseFlag  // clang will be invoked to link so the verbose flag is valid for it
-                + inherited
-
-        otherLdFlags += buildParametersLinkFlags
-
-        settings["OTHER_LDFLAGS"] = otherLdFlags.joined(separator: " ")
 
         // Optionally also set the list of architectures to build for.
         if let architectures = buildParameters.architectures, !architectures.isEmpty {
@@ -1347,5 +1310,35 @@ fileprivate extension Triple {
             components.removeLast()
         }
         return components.map { String($0) }.joined(separator: ".")
+    }
+}
+
+fileprivate extension [BuildFlag] {
+    var rawFlagsForSwiftBuild: [String] {
+        filter {
+            switch $0.source {
+            case .commandLineOptions:
+                // Flags specified by the user. These are generally the only ones that should be passed on.
+                return true
+            case .plugin, .debugging, .toolset:
+                // FIXME: Not yet handled
+                return true
+            case .defaultSwiftTestingSearchPath:
+                // Swift Build computes these internally. It's important not to add them a second time here
+                // as it can break the intended search path ordering, for example, if the user is building
+                // Swift Testing as a package dependency.
+                return false
+            case .defaultWindowsSettings:
+                // Swift Build computes these internally.
+                return false
+            case .swiftSDK:
+                // Swift Build loads Swift SDK flags internally, and may introspect them to override build
+                // settings. Don't duplicate them here.
+                return false
+            case nil:
+                // Remaining flags are legacy build system specific (one occurrence only), or in tests.
+                return false
+            }
+        }.map { $0.value }
     }
 }

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -279,13 +279,13 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         settings["LIBRARY_SEARCH_PATHS"] = try "$(inherited) \(buildParameters.toolchain.toolchainLibDir.pathString)"
         settings["OTHER_CFLAGS"] = (
             ["$(inherited)"]
-                + buildParameters.toolchain.extraFlags.cCompilerFlags.map { $0.spm_shellEscaped() }
-                + buildParameters.flags.cCompilerFlags.map { $0.spm_shellEscaped() }
+                + buildParameters.toolchain.extraFlags.cCompilerFlags.rawFlags.map { $0.spm_shellEscaped() }
+                + buildParameters.flags.cCompilerFlags.rawFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_CPLUSPLUSFLAGS"] = (
             ["$(inherited)"]
-                + buildParameters.toolchain.extraFlags.cxxCompilerFlags.map { $0.spm_shellEscaped() }
-                + buildParameters.flags.cxxCompilerFlags.map { $0.spm_shellEscaped() }
+                + buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags.map { $0.spm_shellEscaped() }
+                + buildParameters.flags.cxxCompilerFlags.rawFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
         settings["OTHER_SWIFT_FLAGS"] = (
             ["$(inherited)"]
@@ -294,8 +294,8 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
         ).joined(separator: " ")
         settings["OTHER_LDFLAGS"] = (
             ["$(inherited)"]
-                + buildParameters.toolchain.extraFlags.linkerFlags.map { $0.spm_shellEscaped() }
-                + buildParameters.flags.linkerFlags.map { $0.spm_shellEscaped() }
+                + buildParameters.toolchain.extraFlags.linkerFlags.rawFlags.map { $0.spm_shellEscaped() }
+                + buildParameters.flags.linkerFlags.rawFlags.map { $0.spm_shellEscaped() }
         ).joined(separator: " ")
 
         // Optionally also set the list of architectures to build for.

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -151,10 +151,10 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
 
     public var buildFlags: BuildFlags {
         BuildFlags(
-            cCompilerFlags: self.cCompilerFlags,
-            cxxCompilerFlags: self.cxxCompilerFlags,
+            cCompilerFlags: self.cCompilerFlags.constructBuildFlags(source: .commandLineOptions),
+            cxxCompilerFlags: self.cxxCompilerFlags.constructBuildFlags(source: .commandLineOptions),
             swiftCompilerFlags: self.swiftCompilerFlags.constructBuildFlags(source: .commandLineOptions),
-            linkerFlags: self.linkerFlags,
+            linkerFlags: self.linkerFlags.constructBuildFlags(source: .commandLineOptions),
             xcbuildFlags: self.xcbuildFlags
         )
     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -4954,7 +4954,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
 
         var flags = BuildFlags()
-        flags.linkerFlags = ["-L", "/path/to/foo", "-L/path/to/foo", "-rpath=foo", "-rpath", "foo"]
+        flags.linkerFlags = ["-L", "/path/to/foo", "-L/path/to/foo", "-rpath=foo", "-rpath", "foo"].constructBuildFlags(source: nil)
         let result = try await BuildPlanResult(plan: mockBuildPlan(
             graph: graph,
             commonFlags: flags,
@@ -5037,8 +5037,8 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             fileSystem: fs
         )
         let commonFlags = BuildFlags(
-            cCompilerFlags: ["-clang-command-line-flag"],
-            swiftCompilerFlags: [BuildFlag(value: "-swift-command-line-flag")]
+            cCompilerFlags: [BuildFlag(value: "-clang-command-line-flag", source: nil)],
+            swiftCompilerFlags: [BuildFlag(value: "-swift-command-line-flag", source: nil)]
         )
 
         let result = try await BuildPlanResult(plan: mockBuildPlan(
@@ -5171,7 +5171,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 "-sdk", "/fake/sdk",
             ]
         )
-        XCTAssertNoMatch(mockToolchain.extraFlags.linkerFlags, ["-rpath"])
+        XCTAssertNoMatch(mockToolchain.extraFlags.linkerFlags.rawFlags, ["-rpath"])
         XCTAssertNoMatch(mockToolchain.extraFlags.swiftCompilerFlags.rawFlags, [
             "-I", "/fake/path/lib/swift/macosx/testing",
             "-L", "/fake/path/lib/swift/macosx/testing",
@@ -5292,7 +5292,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
                 "-sdk", "/fake/sdk",
             ]
         )
-        XCTAssertNoMatch(mockToolchain.extraFlags.linkerFlags, ["-rpath"])
+        XCTAssertNoMatch(mockToolchain.extraFlags.linkerFlags.rawFlags, ["-rpath"])
 
         let observability = ObservabilitySystem.makeForTesting()
         let graph = try loadModulesGraph(
@@ -5414,10 +5414,10 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             toolchain: toolchain,
             graph: graph,
             commonFlags: BuildFlags(
-                cCompilerFlags: [cliFlag(tool: .cCompiler)],
-                cxxCompilerFlags: [cliFlag(tool: .cxxCompiler)],
+                cCompilerFlags: [cliFlag(tool: .cCompiler)].constructBuildFlags(source: nil),
+                cxxCompilerFlags: [cliFlag(tool: .cxxCompiler)].constructBuildFlags(source: nil),
                 swiftCompilerFlags: [cliFlag(tool: .swiftCompiler)].constructBuildFlags(source: nil),
-                linkerFlags: [cliFlag(tool: .linker)]
+                linkerFlags: [cliFlag(tool: .linker)].constructBuildFlags(source: nil)
             ),
             fileSystem: fileSystem,
             observabilityScope: observability.topScope

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -80,7 +80,7 @@ final class PackageModelTests: XCTestCase {
                 swiftSDK: swiftSDK,
                 environment: .current,
                 fileSystem: fileSystem
-            ),
+            ).map { $0.value },
             [
                 // Needed when cross‐compiling for Android. 2020‐03‐01
                 "-sdk",

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -28,10 +28,10 @@ private let linuxMuslTargetTriple = try! Triple("x86_64-unknown-linux-musl")
 private let androidTargetTriple = try! Triple("aarch64-unknown-linux-android28")
 private let wasiTargetTriple = try! Triple("wasm32-unknown-wasi")
 private let extraFlags = BuildFlags(
-    cCompilerFlags: ["-fintegrated-as"],
-    cxxCompilerFlags: ["-fno-exceptions"],
-    swiftCompilerFlags: ["-enable-experimental-cxx-interop", "-use-ld=lld"],
-    linkerFlags: ["-R/usr/lib/swift/linux/"]
+    cCompilerFlags: ["-fintegrated-as"].constructBuildFlags(source: .swiftSDK),
+    cxxCompilerFlags: ["-fno-exceptions"].constructBuildFlags(source: .swiftSDK),
+    swiftCompilerFlags: ["-enable-experimental-cxx-interop", "-use-ld=lld"].constructBuildFlags(source: .swiftSDK),
+    linkerFlags: ["-R/usr/lib/swift/linux/"].constructBuildFlags(source: .swiftSDK)
 )
 
 private let destinationV1 = (
@@ -42,9 +42,9 @@ private let destinationV1 = (
         "sdk": "\#(bundleRootPath.appending(sdkRootDir))",
         "toolchain-bin-dir": "\#(bundleRootPath.appending(toolchainBinDir))",
         "target": "\#(linuxGNUTargetTriple.tripleString)",
-        "extra-cc-flags": \#(extraFlags.cCompilerFlags),
+        "extra-cc-flags": \#(extraFlags.cCompilerFlags.rawFlags),
         "extra-swiftc-flags": \#(extraFlags.swiftCompilerFlags.rawFlags),
-        "extra-cpp-flags": \#(extraFlags.cxxCompilerFlags)
+        "extra-cpp-flags": \#(extraFlags.cxxCompilerFlags.rawFlags)
     }
     """# as SerializedJSON
 )
@@ -58,10 +58,10 @@ private let destinationV2 = (
         "toolchainBinDir": "\#(toolchainBinDir)",
         "hostTriples": ["\#(hostTriple.tripleString)"],
         "targetTriples": ["\#(linuxGNUTargetTriple.tripleString)"],
-        "extraCCFlags": \#(extraFlags.cCompilerFlags),
+        "extraCCFlags": \#(extraFlags.cCompilerFlags.rawFlags),
         "extraSwiftCFlags": \#(extraFlags.swiftCompilerFlags.rawFlags),
-        "extraCXXFlags": \#(extraFlags.cxxCompilerFlags),
-        "extraLinkerFlags": \#(extraFlags.linkerFlags)
+        "extraCXXFlags": \#(extraFlags.cxxCompilerFlags.rawFlags),
+        "extraLinkerFlags": \#(extraFlags.linkerFlags.rawFlags)
     }
     """# as SerializedJSON
 )


### PR DESCRIPTION
This brings us further along on not passing redundant and incompatible flags to Swift Build (#9756).

There is only one remaining unannotated flag, in Sources/Build/LLBuildCommands.swift, which appears to be specific only to the legacy build system. The remaining ones are in a deprecated constructor not used within SwiftPM itself, and in tests.