### PR TITLE
PIF: Support package graph with multiple root

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(Basics
   Environment/EnvironmentShims.swift
   Errors.swift
   FileSystem/AbsolutePath.swift
+  FileSystem/CommonParentDirectory.swift
   FileSystem/FileSystem+Extensions.swift
   FileSystem/InMemoryFileSystem.swift
   FileSystem/NativePathExtensions.swift

--- a/Sources/Basics/FileSystem/CommonParentDirectory.swift
+++ b/Sources/Basics/FileSystem/CommonParentDirectory.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Returns the common parent directory of the given absolute paths.
+///
+/// This function finds the deepest directory that is an ancestor of all the provided paths.
+/// If the paths have no common ancestor other than the root directory, it returns the root.
+/// If the array is empty, it returns the root directory.
+///
+/// - Parameter paths: An array of absolute paths to find the common parent for
+/// - Returns: The common parent directory as an AbsolutePath
+///
+/// Examples:
+/// - `["/a/b/c", "/a/b/d"]` → `"/a/b"`
+/// - `["/usr/local/bin", "/usr/local/lib"]` → `"/usr/local"`
+/// - `["/a/b", "/x/y"]` → `"/"`
+/// - `[]` → `"/"`
+public func getCommonParentDirectory(paths: [AbsolutePath]) throws-> AbsolutePath {
+    // Handle empty array case
+    guard !paths.isEmpty else {
+        return AbsolutePath.root
+    }
+
+    // Handle single path case
+    guard paths.count > 1 else {
+        return paths[0]
+    }
+
+    // Get the components of all paths
+    let allComponents = paths.map { $0.components }
+
+    // Find the minimum length to avoid index out of bounds
+    let minLength = allComponents.map { $0.count }.min() ?? 0
+
+    // Find the common prefix by comparing components at each position
+    var commonComponents: [String] = []
+
+    for index in 0..<minLength {
+        let component = allComponents[0][index]
+
+        // Check if this component is the same in all paths
+        let isCommon = allComponents.allSatisfy { $0[index] == component }
+
+        if isCommon {
+            commonComponents.append(component)
+        } else {
+            // Stop at the first different component
+            break
+        }
+    }
+
+    // Handle the case where there are no common components beyond root
+    guard !commonComponents.isEmpty else {
+        return AbsolutePath.root
+    }
+
+    // Build the result path from common components
+    if commonComponents.count == 1 && commonComponents[0] == "/" {
+        return AbsolutePath.root
+    }
+
+    // Join the common components back into a path string
+    let commonPath = commonComponents.joined(separator: "/")
+
+    // Handle the case where the first component is the root separator
+    if commonComponents[0] == "/" {
+        if commonComponents.count == 1 {
+            return AbsolutePath.root
+        }
+        // Skip the first "/" component since AbsolutePath constructor expects paths to start with "/"
+        let pathWithoutLeadingSlash = commonComponents.dropFirst().joined(separator: "/")
+        return try AbsolutePath(validating: "/" + pathWithoutLeadingSlash)
+    }
+
+    if !commonPath.starts(with: "/") {
+        return try AbsolutePath(validating: "/\(commonPath)")
+    }
+    return try AbsolutePath(validating: commonPath)
+}

--- a/Sources/PackageGraph/Resolution/ResolvedPackage.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedPackage.swift
@@ -98,5 +98,11 @@ extension ResolvedPackage: Identifiable {
     public var id: PackageIdentity { self.underlying.identity }
 }
 
+extension ResolvedPackage: Comparable {
+    public static func < (lhs: ResolvedPackage, rhs: ResolvedPackage) -> Bool {
+        return lhs.id < rhs.id
+    }
+}
+
 @available(*, unavailable, message: "Use `Identifiable` conformance or `IdentifiableSet` instead")
 extension ResolvedPackage: Hashable {}

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -209,8 +209,8 @@ public final class PIFBuilder {
     /// Constructs all `PackagePIFBuilder` objects used by the `constructPIF` function.
     /// In particular, this is useful for unit testing the complex `PIFBuilder` class.
     func makePIFBuilders(
-        buildParameters: BuildParameters 
-    ) async throws -> [(ResolvedPackage, PackagePIFBuilder, any PackagePIFBuilder.BuildDelegate)] { 
+        buildParameters: BuildParameters
+    ) async throws -> [(ResolvedPackage, PackagePIFBuilder, any PackagePIFBuilder.BuildDelegate)] {
         let pluginScriptRunner = self.parameters.pluginScriptRunner
         let outputDir = self.parameters.pluginWorkingDirectory.appending("outputs")
 
@@ -432,16 +432,13 @@ public final class PIFBuilder {
     }
 
     /// Constructs a `PIF.TopLevelObject` representing the package graph.
-    package func constructPIF( 
+    package func constructPIF(
         buildParameters: BuildParameters
     ) async throws -> PIF.TopLevelObject {
         return try await memoize(to: &self.cachedPIF) {
-            guard let rootPackage = self.graph.rootPackages.only else {
-                if self.graph.rootPackages.isEmpty {
-                    throw PIFGenerationError.rootPackageNotFound
-                } else {
-                    throw PIFGenerationError.multipleRootPackagesFound
-                }
+            let rootPackages = self.graph.rootPackages
+            guard !rootPackages.isEmpty else {
+                throw PIFGenerationError.rootPackageNotFound
             }
 
             let packagesAndPIFBuilders = try await makePIFBuilders(buildParameters: buildParameters)
@@ -462,10 +459,14 @@ public final class PIFBuilder {
                 )
             )
 
+            let rootPackagesSorted = rootPackages.sorted()
+            let rootPackagesPaths = rootPackagesSorted.map { $0.path }
+            let ids: String = rootPackagesPaths.map { $0.pathString}.joined(separator: ",")
+            let names = rootPackagesSorted.map { $0.manifest.displayName }.joined(separator: ",")
             let workspace = PIF.Workspace(
-                id: "Workspace:\(rootPackage.path.pathString)",
-                name: rootPackage.manifest.displayName, // TODO: use identity instead?
-                path: rootPackage.path,
+                id: "Workspace:\(ids)",
+                name: names,
+                path: try getCommonParentDirectory(paths: rootPackagesPaths),
                 projects: pifProjects
             )
             return PIF.TopLevelObject(workspace: workspace)
@@ -565,11 +566,11 @@ public final class PIFBuilder {
 
 fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelegate {
     let package: ResolvedPackage
-    
+
     init(package: ResolvedPackage) {
         self.package = package
     }
-    
+
     var isRootPackage: Bool {
         self.package.manifest.packageKind.isRoot
     }
@@ -577,27 +578,27 @@ fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelega
     var isRemote: Bool {
         self.package.manifest.packageKind.isRemote
     }
-    
+
     var hostsOnlyPackages: Bool {
         false
     }
-    
+
     var isUserManaged: Bool {
         true
     }
-    
+
     var isBranchOrRevisionBased: Bool {
         false
     }
-    
+
     func customProductType(forExecutable product: PackageModel.Product) -> ProjectModel.Target.ProductType? {
         nil
     }
-    
+
     func deviceFamilyIDs() -> Set<Int> {
         []
     }
-    
+
     func shouldPackagesBuildForARM64e(platform: PackageModel.Platform) -> Bool {
         false
     }
@@ -605,43 +606,43 @@ fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelega
     var isPluginExecutionSandboxingDisabled: Bool {
         false
     }
-    
+
     func configureProjectBuildSettings(_ buildSettings: inout ProjectModel.BuildSettings) {
         /* empty */
     }
-    
+
     func configureSourceModuleBuildSettings(sourceModule: ResolvedModule, settings: inout ProjectModel.BuildSettings) {
         settings[.SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR] = "$(TARGET_BUILD_DIR)/$(CURRENT_ARCH)/\(sourceModule.name).symbolgraphs"
     }
-    
+
     func customInstallPath(product: PackageModel.Product) -> String? {
         nil
     }
-    
+
     func customExecutableName(product: PackageModel.Product) -> String? {
         nil
     }
-    
+
     func customLibraryType(product: PackageModel.Product) -> PackageModel.ProductType.LibraryType? {
         nil
     }
-    
+
     func customSDKOptions(forPlatform: PackageModel.Platform) -> [String] {
         []
     }
-    
+
     func addCustomTargets(pifProject: inout SwiftBuild.ProjectModel.Project) throws -> [PackagePIFBuilder.ModuleOrProduct] {
         return []
     }
-    
+
     func shouldSuppressProductDependency(product: PackageModel.Product, buildSettings: inout SwiftBuild.ProjectModel.BuildSettings) -> Bool {
         false
     }
-    
+
     func shouldSetInstallPathForDynamicLib(productName: String) -> Bool {
         false
     }
-    
+
     func configureLibraryProduct(
         product: PackageModel.Product,
         project: inout ProjectModel.Project,
@@ -650,11 +651,11 @@ fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelega
     ) {
         /* empty */
     }
-    
+
     func suggestAlignedPlatformVersionGiveniOSVersion(platform: PackageModel.Platform, iOSVersion: PackageModel.PlatformVersion) -> String? {
         nil
     }
-    
+
     func validateMacroFingerprint(for macroModule: ResolvedModule) -> Bool {
         true
     }
@@ -667,7 +668,7 @@ fileprivate func buildAggregatePIFProject(
     buildParameters: BuildParameters
 ) throws -> ProjectModel.Project {
     precondition(!packagesAndProjects.isEmpty)
-    
+
     var aggregateProject = ProjectModel.Project(
         id: "AGGREGATE",
         path: packagesAndProjects[0].project.path,
@@ -676,17 +677,17 @@ fileprivate func buildAggregatePIFProject(
         developmentRegion: "en"
     )
     observabilityScope.logPIF(.debug, "Created project '\(aggregateProject.id)' with name '\(aggregateProject.name)'")
-    
+
     var settings = ProjectModel.BuildSettings()
     settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
     settings[.SUPPORTED_PLATFORMS] = ["$(AVAILABLE_PLATFORMS)"]
     settings[.SDKROOT] = "auto"
     settings[.SDK_VARIANT] = "auto"
     settings[.SKIP_INSTALL] = "YES"
-    
+
     aggregateProject.addBuildConfig { id in BuildConfig(id: id, name: "Debug", settings: settings) }
     aggregateProject.addBuildConfig { id in BuildConfig(id: id, name: "Release", settings: settings) }
-    
+
     func addEmptyBuildConfig(
         to targetKeyPath: WritableKeyPath<ProjectModel.Project, ProjectModel.AggregateTarget>,
         name: String
@@ -696,7 +697,7 @@ fileprivate func buildAggregatePIFProject(
             BuildConfig(id: id, name: name, settings: emptySettings)
         }
     }
-    
+
     let allIncludingTestsTargetKeyPath = try aggregateProject.addAggregateTarget { _ in
         ProjectModel.AggregateTarget(
             id: "ALL-INCLUDING-TESTS",
@@ -705,7 +706,7 @@ fileprivate func buildAggregatePIFProject(
     }
     addEmptyBuildConfig(to: allIncludingTestsTargetKeyPath, name: "Debug")
     addEmptyBuildConfig(to: allIncludingTestsTargetKeyPath, name: "Release")
-    
+
     let allExcludingTestsTargetKeyPath = try aggregateProject.addAggregateTarget { _ in
         ProjectModel.AggregateTarget(
             id: "ALL-EXCLUDING-TESTS",
@@ -714,7 +715,7 @@ fileprivate func buildAggregatePIFProject(
     }
     addEmptyBuildConfig(to: allExcludingTestsTargetKeyPath, name: "Debug")
     addEmptyBuildConfig(to: allExcludingTestsTargetKeyPath, name: "Release")
-    
+
     for (package, packageProject) in packagesAndProjects where package.manifest.packageKind.isRoot {
         for target in packageProject.targets {
             switch target {
@@ -750,11 +751,11 @@ fileprivate func buildAggregatePIFProject(
             }
         }
     }
-    
+
     do {
         let allIncludingTests = aggregateProject[keyPath: allIncludingTestsTargetKeyPath]
         let allExcludingTests = aggregateProject[keyPath: allExcludingTestsTargetKeyPath]
-        
+
         observabilityScope.logPIF(
             .debug,
             indent: 1,
@@ -768,13 +769,13 @@ fileprivate func buildAggregatePIFProject(
             "and \(allExcludingTests.common.dependencies.count) (unlinked) dependencies"
         )
     }
-    
+
     return aggregateProject
 }
 
 public enum PIFGenerationError: Error {
-    case rootPackageNotFound, multipleRootPackagesFound
-    
+    case rootPackageNotFound
+
     case unsupportedSwiftLanguageVersions(
         targetName: String,
         versions: [SwiftLanguageVersion],
@@ -790,9 +791,6 @@ extension PIFGenerationError: CustomStringConvertible {
         switch self {
         case .rootPackageNotFound:
             "No root package was found"
-
-        case .multipleRootPackagesFound:
-            "Multiple root packages were found, making the PIF generation (root packages) ordering sensitive"
 
         case .unsupportedSwiftLanguageVersions(
             targetName: let target,

--- a/Tests/BasicsTests/FileSystem/CommonParentDirectoryTests.swift
+++ b/Tests/BasicsTests/FileSystem/CommonParentDirectoryTests.swift
@@ -1,0 +1,156 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import Testing
+
+#if os(Windows)
+private var windows: Bool { true }
+#else
+private var windows: Bool { false }
+#endif
+
+@Suite(
+    .tags(
+        .TestSize.small,
+        .Platform.FileSystem,
+    ),
+)
+struct CommonParentDirectoryTests {
+
+    @Test(
+        arguments: [
+            // Basic cases
+            (id: "identical_paths", paths: ["/a/b/c", "/a/b/c"], expected: "/a/b/c".platformPath),
+            (id: "simple_siblings", paths: ["/a/b/c", "/a/b/d"], expected: "/a/b".platformPath),
+            (id: "simple_cousins", paths: ["/a/b/c/d", "/a/b/e/f"], expected: "/a/b".platformPath),
+            (id: "usr_local_paths", paths: ["/usr/local/bin", "/usr/local/lib"], expected: "/usr/local".platformPath),
+
+            // Multiple paths
+            (id: "three_user_dirs", paths: ["/home/user/docs", "/home/user/music", "/home/user/videos"], expected: "/home/user".platformPath),
+            (id: "multiple_descendants", paths: ["/a/b/c/d", "/a/b/e/f", "/a/b/g"], expected: "/a/b".platformPath),
+
+            // Different depths
+            (id: "ancestor_descendant", paths: ["/a/b", "/a/b/c/d/e"], expected: "/a/b".platformPath),
+            (id: "descendant_ancestor", paths: ["/a/b/c/d/e", "/a/b"], expected: "/a/b".platformPath),
+
+            // Root cases
+            (id: "single_root", paths: ["/"], expected: "/".platformPath),
+            (id: "multiple_roots", paths: ["/", "/"], expected: "/".platformPath),
+            (id: "root_with_subdir", paths: ["/", "/usr"], expected: "/".platformPath),
+            (id: "no_common_parent", paths: ["/a/b", "/x/y"], expected: "/".platformPath),
+            (id: "system_dirs", paths: ["/usr/local", "/var/lib", "/etc/config"], expected: "/".platformPath),
+
+            // Complex scenarios
+            (id: "project_structure", paths: ["/projects/MyApp/Sources/MyApp/main.swift", "/projects/MyApp/Sources/Utils/helper.swift", "/projects/MyApp/Tests/MyAppTests/test.swift", "/projects/MyApp/Package.swift"], expected: "/projects/MyApp".platformPath),
+            (id: "var_subdirs", paths: ["/var/log/system/auth.log", "/var/log/system/kernel.log", "/var/log/apache/access.log"], expected: "/var/log".platformPath),
+            (id: "user_documents", paths: ["/home/alice/documents/work", "/home/alice/documents/personal", "/home/alice/music"], expected: "/home/alice".platformPath),
+
+            // Ancestor relationships
+            (id: "usr_hierarchy", paths: ["/usr", "/usr/local", "/usr/local/bin", "/usr/lib"], expected: "/usr".platformPath),
+            (id: "nested_hierarchy", paths: ["/a/b/c/d/e/f", "/a/b/c", "/a/b/c/d/g"], expected: "/a/b/c".platformPath),
+
+            // Similar prefixes
+            (id: "long_shared_prefix", paths: ["/very/long/shared/path/branch1/file1", "/very/long/shared/path/branch2/file2", "/very/long/shared/path/branch3/subdir/file3"], expected: "/very/long/shared/path".platformPath),
+            (id: "module_paths", paths: ["/app/module/feature/component.swift", "/app/module/feature", "/app/module/other/file.swift"], expected: "/app/module".platformPath),
+
+            // Mixed depth paths
+            (id: "mixed_depths", paths: ["/a/b/c/d/e/f/g/h", "/a/b", "/a/b/c/x/y/z", "/a/b/different"], expected: "/a/b".platformPath),
+
+            // Single path edge case
+            (id: "single_path", paths: ["/home/user/documents"], expected: "/home/user/documents".platformPath),
+
+            // System paths
+            (id: "system_paths_no_common", paths: ["/usr/local/bin", "/home/user", "/var/log", "/etc/config"], expected: "/".platformPath),
+            (id: "var_paths", paths: ["/var/log/messages", "/var/cache/apt", "/var/tmp/temp.txt"], expected: "/var".platformPath),
+
+            // Identical multiple paths
+            (id: "five_identical", paths: ["/home/user/docs", "/home/user/docs", "/home/user/docs", "/home/user/docs", "/home/user/docs"], expected: "/home/user/docs".platformPath),
+
+            // Special characters and edge cases
+            (id: "paths_with_spaces", paths: ["/home/user/My Documents", "/home/user/My Pictures"], expected: "/home/user".platformPath),
+            (id: "paths_with_dots", paths: ["/home/user/.config/app", "/home/user/.cache/app"], expected: "/home/user".platformPath),
+            (id: "paths_with_underscores", paths: ["/var/log/app_error.log", "/var/log/app_debug.log"], expected: "/var/log".platformPath),
+            (id: "paths_with_hyphens", paths: ["/opt/some-app/bin", "/opt/some-app/lib"], expected: "/opt/some-app".platformPath),
+            (id: "paths_with_numbers", paths: ["/backup/2023/january", "/backup/2023/february"], expected: "/backup/2023".platformPath),
+            (id: "mixed_special_chars", paths: ["/projects/app-v1.0_beta/src", "/projects/app-v1.0_beta/test"], expected: "/projects/app-v1.0_beta".platformPath),
+
+            // Normalized path scenarios (testing AbsolutePath normalization)
+            // (id: "paths_with_dot_segments", paths: ["/a/b/./c/d", "/a/b/./e/f"], expected: "/a/b".platformPath),
+            (id: "paths_with_dotdot_segments", paths: ["/a/b/c/../d", "/a/b/e/../f"], expected: "/a/b".platformPath),
+            (id: "mixed_normalization", paths: ["/a/b/./c/../d", "/a/b/e/./f"], expected: "/a/b".platformPath),
+
+            // Deep nesting scenarios
+            (id: "very_deep_paths", paths: ["/a/b/c/d/e/f/g/h/i/j/k/l/m/n", "/a/b/c/d/e/f/g/h/i/j/x/y/z"], expected: "/a/b/c/d/e/f/g/h/i/j".platformPath),
+            (id: "asymmetric_depths", paths: ["/a", "/a/b/c/d/e/f/g/h/i/j/k/l"], expected: "/a".platformPath),
+
+            // File extensions and similar names
+            (id: "files_with_extensions", paths: ["/src/main.swift", "/src/utils.swift", "/src/tests.swift"], expected: "/src".platformPath),
+            (id: "similar_filenames", paths: ["/docs/readme.txt", "/docs/readme.md", "/docs/readme.pdf"], expected: "/docs".platformPath),
+
+            // Unicode and international characters (if supported by AbsolutePath)
+            (id: "unicode_paths", paths: ["/home/用户/文档", "/home/用户/图片"], expected: "/home/用户".platformPath),
+        ] as [(String, [String], String)]
+    )
+    func testGetCommonParentDirectory(id: String, paths: [String], expected: String) throws {
+        let absolutePaths = try paths.map { try AbsolutePath(validating: $0) }
+        let result = try getCommonParentDirectory(paths: absolutePaths)
+        let expectedPath = try AbsolutePath(validating: expected)
+
+        #expect(result == expectedPath, "Test case '\(id)': Expected common parent \(expected) but got \(result.pathString)")
+    }
+
+    @Test(
+        .IssueWindowsPathTestsFailures,
+        .requireHostOS(.windows),
+        arguments: [
+            // Windows-specific path cases
+            (id: "windows_drive_same", paths: [#"\Users/John/Documents"#, "/Users/John/Pictures"], expected: "/Users/John".platformPath),
+            (id: "windows_drive_different", paths: ["/Program Files/App", "/Data/Files"], expected: "/".platformPath),
+            (id: "windows_system_paths", paths: ["/Windows/System32", "/Windows/Temp"], expected: "/Windows".platformPath),
+            (id: "windows_program_files", paths: ["/Program Files/App1", "/Program Files/App2"], expected: "/Program Files".platformPath),
+            (id: "windows_mixed_separators", paths: [#"\Users\John\Documents"#, "/Users/John/Pictures"], expected: "/Users/John".platformPath),
+            (id: "windows_deep_hierarchy", paths: ["/Projects/MyApp/Sources/Utils/helper.cpp", "/Projects/MyApp/Tests/UnitTests/test.cpp"], expected: "/Projects/MyApp".platformPath),
+            (id: "windows_root_only", paths: ["/", "/", #"\"#], expected: "/".platformPath),
+            (id: "windows_single_drive", paths: [#"\"#], expected: "/".platformPath),
+        ] as [(String, [String], String)]
+    )
+    func testGetCommonParentDirectoryWindows(id: String, paths: [String], expected: String) throws {
+        try withKnownIssue("Windows path handling may need adjustment", isIntermittent: true) {
+            let absolutePaths = try paths.map { try AbsolutePath(validating: $0) }
+            let result = try getCommonParentDirectory(paths: absolutePaths)
+            let expectedPath = try AbsolutePath(validating: expected)
+
+            #expect(result == expectedPath, "Windows test case '\(id)': Expected common parent \(expected) but got \(result.pathString)")
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows
+        }
+    }
+
+    @Test("Empty array edge case")
+    func testGetCommonParentDirectoryEmptyArray() throws {
+        let emptyPaths: [AbsolutePath] = []
+        let result = try getCommonParentDirectory(paths: emptyPaths)
+
+        #expect(result == AbsolutePath.root, "Empty array should return root directory")
+    }
+}
+
+fileprivate extension String {
+    var platformPath: String {
+        if ProcessInfo.hostOperatingSystem == .windows {
+            return self.replacing("/", with: #"\"#)
+        }
+        return self
+    }
+}

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -192,6 +192,210 @@ extension BuildConfiguration {
 )
 struct PIFBuilderTests {
 
+    struct RootPackagesTestData {
+        let id: String
+        let rootPackages: [(name: String, path: Basics.AbsolutePath)]
+        let expectedData: (pifPath: Basics.AbsolutePath, pifName: String, pifId: String)
+    }
+    @Test(
+        arguments:[
+            RootPackagesTestData(
+                id: "Single root package, package path at root",
+                rootPackages: [
+                    (name: "fooPackage", path: AbsolutePath("/fooPackage")),
+                ],
+                expectedData: (
+                    pifPath: "/fooPackage",
+                    pifName: "fooPackage",
+                    pifId: "/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Single root package, package path nested ",
+                rootPackages: [
+                    (name: "fooPackage", path: AbsolutePath("/a/b/c/d/fooPackage")),
+                ],
+                expectedData: (
+                    pifPath: "/a/b/c/d/fooPackage",
+                    pifName: "fooPackage",
+                    pifId: "/a/b/c/d/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Two root packages, unordered, no common parent directory",
+                rootPackages: [
+                    (name: "fooPackage", path: AbsolutePath("/fooPackage")),
+                    (name: "barPackage", path: AbsolutePath("/barPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath.root,
+                    pifName: "barPackage,fooPackage",
+                    pifId: "/barPackage,/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Two root packages, ordered, no common parent directory",
+                rootPackages: [
+                    (name: "barPackage", path: AbsolutePath("/barPackage")),
+                    (name: "fooPackage", path: AbsolutePath("/fooPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath.root,
+                    pifName: "barPackage,fooPackage",
+                    pifId: "/barPackage,/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Two root packages, unordered, no common parent directory",
+                rootPackages: [
+                    (name: "fooPackage", path: AbsolutePath("/fooPackage")),
+                    (name: "barPackage", path: AbsolutePath("/barPackage")),
+                    (name: "bazPackage", path: AbsolutePath("/bazPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath.root,
+                    pifName: "barPackage,bazPackage,fooPackage",
+                    pifId: "/barPackage,/bazPackage,/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Multiple root packages, ordered, no common parent directory",
+                rootPackages: [
+                    (name: "barPackage", path: AbsolutePath("/barPackage")),
+                    (name: "bazPackage", path: AbsolutePath("/bazPackage")),
+                    (name: "fooPackage", path: AbsolutePath("/fooPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath.root,
+                    pifName: "barPackage,bazPackage,fooPackage",
+                    pifId: "/barPackage,/bazPackage,/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Two root packages, unordered, contains common directory, packages are sibling",
+                rootPackages: [
+                    (name: "fooPackage", path: AbsolutePath("/a/b/c/fooPackage")),
+                    (name: "barPackage", path: AbsolutePath("/a/b/c/barPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath("/a/b/c"),
+                    pifName: "barPackage,fooPackage",
+                    pifId: "/a/b/c/barPackage,/a/b/c/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Two root packages, ordered, contains common directory, packages are sibling",
+                rootPackages: [
+                    (name: "barPackage", path: AbsolutePath("/a/b/c/barPackage")),
+                    (name: "fooPackage", path: AbsolutePath("/a/b/c/fooPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath("/a/b/c"),
+                    pifName: "barPackage,fooPackage",
+                    pifId: "/a/b/c/barPackage,/a/b/c/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Two root packages, ybordered, contains common directory, packages are not siblings",
+                rootPackages: [
+                    (name: "fooPackage", path: AbsolutePath("/a/b/c/pink/fuzz/fooPackage")),
+                    (name: "barPackage", path: AbsolutePath("/a/b/c/absolute/zero/barPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath("/a/b/c"),
+                    pifName: "barPackage,fooPackage",
+                    pifId: "/a/b/c/absolute/zero/barPackage,/a/b/c/pink/fuzz/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Two root packages, ordered, contains common directory, packages are not siblings",
+                rootPackages: [
+                    (name: "barPackage", path: AbsolutePath("/a/b/c/absolute/zero/barPackage")),
+                    (name: "fooPackage", path: AbsolutePath("/a/b/c/pink/fuzz/fooPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath("/a/b/c"),
+                    pifName: "barPackage,fooPackage",
+                    pifId: "/a/b/c/absolute/zero/barPackage,/a/b/c/pink/fuzz/fooPackage",
+                ),
+            ),
+
+            RootPackagesTestData(
+                id: "Many root packages, unordered, contains common directory, packages are not siblings",
+                rootPackages: [
+                    (name: "fooPackage", path: AbsolutePath("/a/b/c/pink/fuzz/fooPackage")),
+                    (name: "barPackage", path: AbsolutePath("/a/b/c/absolute/zero/barPackage")),
+                    (name: "bazPackage", path: AbsolutePath("/a/b/c/absolute/legend/bazPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath("/a/b/c"),
+                    pifName: "barPackage,bazPackage,fooPackage",
+                    pifId: "/a/b/c/absolute/zero/barPackage,/a/b/c/absolute/legend/bazPackage,/a/b/c/pink/fuzz/fooPackage",
+                ),
+            ),
+            RootPackagesTestData(
+                id: "Many root packages, ordered, contains common directory, packages are not siblings",
+                rootPackages: [
+                    (name: "barPackage", path: AbsolutePath("/a/b/c/absolute/zero/barPackage")),
+                    (name: "bazPackage", path: AbsolutePath("/a/b/c/absolute/legend/bazPackage")),
+                    (name: "fooPackage", path: AbsolutePath("/a/b/c/pink/fuzz/fooPackage")),
+                ],
+                expectedData: (
+                    pifPath: Basics.AbsolutePath("/a/b/c"),
+                    pifName: "barPackage,bazPackage,fooPackage",
+                    pifId: "/a/b/c/absolute/zero/barPackage,/a/b/c/absolute/legend/bazPackage,/a/b/c/pink/fuzz/fooPackage",
+                ),
+            ),
+        ],
+    )
+    func multipleRootPackages(
+        testData: RootPackagesTestData,
+    ) async throws {
+        // Arrange
+        try #require(testData.rootPackages.count >= 1, "Test configuration data error.  No root packages are specified.")
+
+        let fs = InMemoryFileSystem()
+        let observabilityScope = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: testData.rootPackages.map { rootPackage in
+                Manifest.createRootManifest(
+                    displayName: rootPackage.name,
+                    path: rootPackage.path,
+                    products: [],
+                    targets: [],
+                )
+            },
+            observabilityScope: observabilityScope.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: true,
+            ),
+            fileSystem: fs,
+            observabilityScope: observabilityScope.topScope,
+        )
+
+        // Act
+        let pif = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
+        )
+
+        // Assert
+        #expect(
+            pif.workspace.path == testData.expectedData.pifPath,
+            "Actual path is not as expected",
+        )
+        #expect(
+            pif.workspace.name == testData.expectedData.pifName,
+            "Actual pif name is not as expected",
+        )
+
+    }
+
     @Test func platformExecutableModuleLibrarySearchPath() async throws {
         try await withGeneratedPIF(fromFixture: "PIFBuilder/BasicExecutable") { pif, observabilitySystem in
             let releaseConfig = try pif.workspace


### PR DESCRIPTION
There are instances where a graph can have multiple roots packages.  Update the PIF to support this case
