### PR TITLE
[Swift Build] Handle FREEBSD_DEPLOYMENT_TARGET

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1275,6 +1275,8 @@ fileprivate extension Triple {
             return "WATCHOS_DEPLOYMENT_TARGET"
         case (_, .android):
             return "ANDROID_DEPLOYMENT_TARGET"
+        case (.freebsd, _):
+            return "FREEBSD_DEPLOYMENT_TARGET"
         default:
             return nil
         }


### PR DESCRIPTION
This will ensure the triple version is handled correctly by Swift Build.