### PR TITLE
[Swift Build] Test runner executables should be exempted from --disable-local-rpath

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -1074,12 +1074,12 @@ extension PackagePIFProjectBuilder {
 
         // A test-runner should always be adjacent to the dynamic library containing the tests,
         // so add the appropriate rpaths.
-        if pifBuilder.addLocalRpaths {
-            settings[.LD_RUNPATH_SEARCH_PATHS] = [
-                "$(inherited)",
-                "$(RPATH_ORIGIN)"
-            ]
-        }
+        // We intentionally ignore the value of addLocalRpaths here, because test runners are generally
+        // not designed to be relocatable and `swift test` will not work without this local rpath.
+        settings[.LD_RUNPATH_SEARCH_PATHS] = [
+            "$(inherited)",
+            "$(RPATH_ORIGIN)"
+        ]
 
         let deploymentTargets = unitTestProduct.deploymentTargets
         settings[.MACOSX_DEPLOYMENT_TARGET] = deploymentTargets?[.macOS] ?? nil

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -682,6 +682,23 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test(arguments: [true, false])
+    func testRunnerAlwaysHasLocalRpath(addLocalRpaths: Bool) async throws {
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/Simple", addLocalRpaths: addLocalRpaths) { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+            for configuration in BuildConfiguration.allCases {
+                let config = try pif.workspace
+                    .project(named: "Simple")
+                    .target(named: "SimpleTests-test-runner")
+                    .buildConfig(named: configuration)
+
+                // Test runners should have an rpath even if addLocalRpaths=false
+                #expect(config.settings[.LD_RUNPATH_SEARCH_PATHS] == ["$(inherited)", "$(RPATH_ORIGIN)"],
+                        "unexpected rpath setting (config: \(configuration), rpathSetting: \(addLocalRpaths))")
+            }
+        }
+    }
+
     @Test func warningSettingsInRemotePackage() async throws {
         let observability = ObservabilitySystem.makeForTesting()
 


### PR DESCRIPTION
Test runner executables are not currently designed to be relocatable and must be able to load the shared library in the same directory containing the actual tests. I think it makes sense to exempt them from --disable-local-rpath for now.