### PR TITLE
Workaround test crash when compiling against 6.2 corelibs-foundation

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -33,6 +33,16 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    public static func requireCompiledWith6_3OrLater(_ comment: Comment? = nil) -> Self {
+        enabled(comment ?? "This needs to have been compiled with Swift 6.3 or later.") {
+            #if compiler(>=6.3)
+            true
+            #else
+            false
+            #endif
+        }
+    }
+
     /// Enabled only if toolchain support swift concurrency
     public static var requiresSwiftConcurrencySupport: Self {
         enabled("skipping because test environment doesn't support concurrency") {

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -135,6 +135,7 @@ extension PackageModel.Sanitizer {
     .tags(
         .TestSize.medium,
     ),
+    .requireCompiledWith6_3OrLater("https://github.com/swiftlang/swift-corelibs-foundation/pull/5269")
 )
 struct SwiftBuildSystemTests {
 


### PR DESCRIPTION
These tests sometimes crash when compiled against a foundation without the fix in https://github.com/swiftlang/swift-corelibs-foundation/pull/5269. Only run them when compiled with a 6.3 or later compiler