### PR TITLE
Add library paths so that test runner executables are able to find the corresponding test libraries

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -542,7 +542,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             toolchain: toolchain,
             destinationBuildParameters: productsBuildParameters,
             sanitizers: globalOptions.build.sanitizers,
-            library: library
+            library: library,
+            testProductPaths: testProducts.map(\.bundlePath)
         )
 
         let runnerPaths: [AbsolutePath] = switch library {
@@ -828,7 +829,8 @@ extension SwiftTestCommand {
                 toolchain: toolchain,
                 destinationBuildParameters: productsBuildParameters,
                 sanitizers: globalOptions.build.sanitizers,
-                library: .swiftTesting
+                library: .swiftTesting,
+                testProductPaths: testProducts.map(\.bundlePath)
             )
 
             if testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
@@ -1213,7 +1215,8 @@ final class ParallelTestRunner {
             toolchain: self.toolchain,
             destinationBuildParameters: self.productsBuildParameters,
             sanitizers: self.buildOptions.sanitizers,
-            library: .xctest // swift-testing does not use ParallelTestRunner
+            library: .xctest, // swift-testing does not use ParallelTestRunner
+            testProductPaths: bundlePaths
         )
 
         // Enqueue all the tests.

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -237,11 +237,12 @@ final class PluginDelegate: PluginInvocationDelegate {
         }
 
         // Construct the environment we'll pass down to the tests.
-        let testEnvironment = try TestingSupport.constructTestEnvironment(
+        let testEnvironment = try await TestingSupport.constructTestEnvironment(
             toolchain: toolchain,
             destinationBuildParameters: toolsBuildParameters,
             sanitizers: swiftCommandState.options.build.sanitizers,
-            library: .xctest // FIXME: support both libraries
+            library: .xctest, // FIXME: support both libraries
+            testProductPaths: buildSystem.builtTestProducts.map(\.bundlePath)
         )
 
         // Iterate over the tests and run those that match the filter.

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -123,7 +123,8 @@ enum TestingSupport {
                     experimentalTestOutput: experimentalTestOutput
                 ).productsBuildParameters,
                 sanitizers: sanitizers,
-                library: .xctest
+                library: .xctest,
+                testProductPaths: [path]
             )
             try Self.runProcessWithExistenceCheck(
                 path: path,
@@ -143,7 +144,8 @@ enum TestingSupport {
                 shouldSkipBuilding: shouldSkipBuilding
             ).productsBuildParameters,
             sanitizers: sanitizers,
-            library: .xctest
+            library: .xctest,
+            testProductPaths: [path]
         )
         args = [path.description, "--dump-tests-json"]
         let data = try Self.runProcessWithExistenceCheck(
@@ -181,7 +183,8 @@ enum TestingSupport {
         toolchain: UserToolchain,
         destinationBuildParameters buildParameters: BuildParameters,
         sanitizers: [Sanitizer],
-        library: TestingLibrary
+        library: TestingLibrary,
+        testProductPaths: [AbsolutePath]
     ) throws -> Environment {
         var env = Environment.current
 
@@ -191,6 +194,13 @@ enum TestingSupport {
         // codes to their output. SEE: https://www.no-color.org
         if !stdoutStream.isTTY || !stderrStream.isTTY {
             env["NO_COLOR"] = "1"
+        }
+
+        // Add library paths so that test runner executables are able to find the
+        // corresponding test libraries, even if local rpaths were disabled in the
+        // build.
+        for path in testProductPaths {
+            env.appendPath(key: .libraryPath, value: path.parentDirectory.pathString)
         }
 
         // Add the code coverage related variables.

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -1215,6 +1215,34 @@ struct TestCommandTests {
         .tags(
             .Feature.TargetType.Executable,
         ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func testingWithLocalRpathsDisabled(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await withKnownIssue("Fails to find the test executable") {
+            try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
+                let (stdout, stderr) = try await execute(
+                    ["--disable-local-rpath"],
+                    packagePath: fixturePath,
+                    configuration: configuration,
+                    buildSystem: buildSystem,
+                )
+                #expect(
+                    stdout.contains(#"Test "SOME TEST FUNCTION" started"#),
+                    "Expectation not met.  got '\(stdout)'\nstderr: '\(stderr)'"
+                )
+            }
+        } when: {
+            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.TargetType.Executable,
+        ),
         .skipHostOS(.macOS),  // because this was guarded with `#if !canImport(Darwin)`
         .SWBINTTODO("This is a PIF builder missing GUID problem. Further investigation is needed."),
         .IssueWindowsPathNoEntry,


### PR DESCRIPTION
... even if local rpaths were disabled in the build.

Alternative to https://github.com/swiftlang/swift-package-manager/pull/9807 which doesn't special case the rpaths of test runners