### PR TITLE
Set the plugin generated module map path for SwiftBuild

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -387,7 +387,7 @@ extension PackagePIFProjectBuilder {
         // Generate a module map file, if needed.
         var moduleMapFileContents = ""
         let generatedModuleMapDir = "$(GENERATED_MODULEMAP_DIR)"
-        let generatedModuleMapPath = try RelativePath(validating:"\(generatedModuleMapDir)/\(sourceModule.name).modulemap").pathString
+        var generatedModuleMapPath = try RelativePath(validating:"\(generatedModuleMapDir)/\(sourceModule.name).modulemap").pathString
 
         if sourceModule.usesSwift && desiredModuleType != .macro {
             // Generate ObjC compatibility header for Swift library targets.
@@ -404,18 +404,19 @@ extension PackagePIFProjectBuilder {
             impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(generatedModuleMapPath)", "$(inherited)"]
         } else {
             // Otherwise, this is a C library module and we generate a modulemap if one is already not provided.
-            if let generatedModuleMapPath = generatedFiles.moduleMaps.first {
+            if let pluginGeneratedModuleMapPath = generatedFiles.moduleMaps.first {
                 // Warn about ignored generated module maps if more than one
                 if generatedFiles.moduleMaps.count > 1 {
-                    let ignoredFiles = generatedFiles.moduleMaps.filter({ $0 != generatedModuleMapPath })
+                    let ignoredFiles = generatedFiles.moduleMaps.filter({ $0 != pluginGeneratedModuleMapPath })
                     pifBuilder.observabilityScope.emit(
                         severity: .warning,
-                        message: "Plugins generated multiple module maps. Selected \(generatedModuleMapPath) and ignored \(ignoredFiles.map(\.pathString).joined(separator: " "))"
+                        message: "Plugins generated multiple module maps. Selected \(pluginGeneratedModuleMapPath) and ignored \(ignoredFiles.map(\.pathString).joined(separator: " "))"
                     )
                 }
                 // The modulemap was already generated, we should explicitly impart it on dependents,
-                impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(generatedModuleMapPath)", "$(inherited)"]
-                impartedSettings[.OTHER_SWIFT_FLAGS] = ["-Xcc", "-fmodule-map-file=\(generatedModuleMapPath)", "$(inherited)"]
+                impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(pluginGeneratedModuleMapPath)", "$(inherited)"]
+                impartedSettings[.OTHER_SWIFT_FLAGS] = ["-Xcc", "-fmodule-map-file=\(pluginGeneratedModuleMapPath)", "$(inherited)"]
+                generatedModuleMapPath = pluginGeneratedModuleMapPath.pathString
             } else {
                 switch sourceModule.moduleMapType {
                 case nil, .some(.none):

--- a/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
@@ -231,6 +231,9 @@ import SwiftBuild
                 #expect(impartedCFlags.contains(pluginModuleMapArg))
                 let impartedSwiftFlags = try #require(config.impartedBuildProperties.settings[.OTHER_SWIFT_FLAGS])
                 #expect(impartedSwiftFlags.contains(pluginModuleMapArg))
+
+                let moduleMapPath = try #require(config.settings[.MODULEMAP_PATH])
+                #expect(moduleMapPath == pluginModuleMapFile.pathString)
             }
 
             // Make sure our generated source is included


### PR DESCRIPTION
SwiftBuild wasn't properly tracking the module map file when generated by a plugin. This sets the MODULEMAP_PATH so it knows where it is.
