### PR TITLE
Don't pass toolset flags

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -935,6 +935,7 @@ public final class SwiftCommandState {
             flags: options.build.buildFlags,
             buildSystemKind: options.build.buildSystem,
             pkgConfigDirectories: options.locations.pkgConfigDirectories,
+            customToolsetPaths: options.locations.toolsetPaths,
             architectures: options.build.architectures,
             workers: options.build.jobs,
             shouldCreateDylibForDynamicProducts: !self.options.build.shouldBuildDylibsAsFrameworks,

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -72,6 +72,9 @@ public struct BuildParameters: Encodable {
     /// An array of paths to search for pkg-config `.pc` files.
     public var pkgConfigDirectories: [Basics.AbsolutePath]
 
+    /// Paths to toolset files specified on the command line via `--toolset`.
+    public var customToolsetPaths: [Basics.AbsolutePath]
+
     /// The architectures to build for.
     // FIXME: this may be inconsistent with `targetTriple`.
     public var architectures: [String]?
@@ -162,6 +165,7 @@ public struct BuildParameters: Encodable {
         flags: BuildFlags,
         buildSystemKind: BuildSystemProvider.Kind,
         pkgConfigDirectories: [Basics.AbsolutePath] = [],
+        customToolsetPaths: [Basics.AbsolutePath] = [],
         architectures: [String]? = nil,
         workers: UInt32 = UInt32(ProcessInfo.processInfo.activeProcessorCount),
         shouldCreateDylibForDynamicProducts: Bool = true,
@@ -226,6 +230,7 @@ public struct BuildParameters: Encodable {
             ))
         }
         self.pkgConfigDirectories = pkgConfigDirectories
+        self.customToolsetPaths = customToolsetPaths
         self.architectures = architectures
         self.workers = workers
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -912,6 +912,12 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             }
         }
 
+        if !buildParameters.customToolsetPaths.isEmpty {
+            settings["SWIFT_SDK_TOOLSETS"] =
+                (["$(inherited)"] + buildParameters.customToolsetPaths.map { $0.pathString })
+                .joined(separator: " ")
+        }
+
         let normalizedTriple = Triple(buildParameters.triple.triple, normalizing: true)
         if let deploymentTargetSettingName = normalizedTriple.deploymentTargetSettingName, let value = normalizedTriple.deploymentTargetVersionString {
             // Only override the deployment target if a version is explicitly specified;
@@ -1347,9 +1353,17 @@ fileprivate extension [BuildFlag] {
             case .commandLineOptions:
                 // Flags specified by the user. These are generally the only ones that should be passed on.
                 return true
-            case .plugin, .debugging, .toolset:
+            case .plugin:
                 // FIXME: Not yet handled
                 return true
+            case .debugging:
+                // FIXME: Not yet handled
+                return true
+            case .toolset:
+                // Swift Build loads toolset flags internally as part of loading Swift SDKs, or by passing the custom toolsets
+                // via the SWIFT_SDK_TOOLSETS build setting, and may introspect them to override build settings.
+                // Don't duplicate them here.
+                return false
             case .defaultSwiftTestingSearchPath:
                 // Swift Build computes these internally. It's important not to add them a second time here
                 // as it can break the intended search path ordering, for example, if the user is building


### PR DESCRIPTION
Not needed when using Swift SDKs, as those are handled internally. For custom toolsets on the command line, pass those via a build setting override.

This is further progress on #9756