### PR TITLE
Use a branch of `swift-tools-protocols` instead of a tag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1230,7 +1230,7 @@ if !shouldUseSwiftBuildFramework {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         package.dependencies += [
             .package(url: "https://github.com/swiftlang/swift-build.git", branch: relatedDependenciesBranch),
-            .package(url: "https://github.com/swiftlang/swift-tools-protocols.git", revision: "0.0.10"),
+            .package(url: "https://github.com/swiftlang/swift-tools-protocols.git", branch: relatedDependenciesBranch),
         ]
     } else {
         package.dependencies += [


### PR DESCRIPTION
swift-tools-protocols is now fully setup. swiftpm:main should be in sync with the latest swift-tools-protocols.

related:
https://github.com/swiftlang/sourcekit-lsp/pull/2559
https://github.com/swiftlang/swift-build/pull/1204
https://github.com/swiftlang/swift/pull/87886