### PR TITLE
Allow using experimental-build-server with a user-controlled build dir

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -164,6 +164,9 @@ public struct LocationOptions: ParsableArguments {
 
     @Flag(name: .customLong("ignore-lock"), help: .hidden)
     public var ignoreLock: Bool = false
+
+    @Flag(name: .customLong("experimental-skip-acquiring-lock"), help: .hidden)
+    public var skipAcquiringLock: Bool = false
 }
 
 public struct CachingOptions: ParsableArguments {

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1141,6 +1141,9 @@ public final class SwiftCommandState {
     }
 
     private func acquireLockIfNeeded() throws {
+        guard !options.locations.skipAcquiringLock else {
+            return
+        }
         guard self.packageRoot != nil else {
             return
         }

--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -124,11 +124,10 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         let connectionToUnderlyingBuildServer = LocalConnection(receiverName: "underlying-swift-build-server")
         self.connectionToUnderlyingBuildServer = connectionToUnderlyingBuildServer
         let connectionFromUnderlyingBuildServer = LocalConnection(receiverName: "swiftpm-build-server")
-        // TODO: fix derived data path, cleanup configured targets list computation
         let buildrequest = try await self.buildSystem.makeBuildRequest(
             session: session.session,
             configuredTargets: [.init(rawValue: "ALL-INCLUDING-TESTS")],
-            derivedDataPath: self.buildSystem.buildParameters.buildPath,
+            derivedDataPath: self.buildSystem.buildParameters.dataPath,
             symbolGraphOptions: nil
         )
         self.underlyingBuildServer = SWBBuildServer(

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -25,7 +25,7 @@ final fileprivate class NotificationCollectingMessageHandler: MessageHandler {
     func handle<Request>(_ request: Request, id: RequestID, reply: @escaping @Sendable (LSPResult<Request.Response>) -> Void) where Request : RequestType {}
 }
 
-fileprivate func withSwiftPMBSP(fixtureName: String, body: (Connection, NotificationCollectingMessageHandler, AbsolutePath) async throws -> Void) async throws {
+fileprivate func withSwiftPMBSP(fixtureName: String, extraBSPArgs: [String] = [], body: (Connection, NotificationCollectingMessageHandler, AbsolutePath) async throws -> Void) async throws {
     await withKnownIssue("Tests occasionally fail to load build description in CI", isIntermittent: true) {
         try await fixture(name: fixtureName) { fixture in
             let inPipe = Pipe()
@@ -44,7 +44,7 @@ fileprivate func withSwiftPMBSP(fixtureName: String, body: (Connection, Notifica
             bspProcess.standardInput = outPipe
             let execPath = SwiftPM.xctestBinaryPath(for: "swift-package").pathString
             bspProcess.executableURL = URL(filePath: execPath)
-            bspProcess.arguments = ["--package-path", fixture.pathString, "experimental-build-server", "--build-system", "swiftbuild"]
+            bspProcess.arguments = ["--package-path", fixture.pathString] + ["experimental-build-server", "--build-system", "swiftbuild"] + extraBSPArgs
             async let terminationPromise: Void = try await bspProcess.run()
             let notificationCollector = NotificationCollectingMessageHandler()
             connection.start(receiveHandler: notificationCollector)
@@ -82,8 +82,8 @@ struct SwiftPMBuildServerTests {
     func buildTargetsListBasics() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, _, _ in
             let response = try await connection.send(WorkspaceBuildTargetsRequest())
-            #expect(response.targets.count == 2)
-            #expect(response.targets.map(\.displayName).sorted() == ["Foo", "Package Manifest"])
+            #expect(response.targets.count == 3)
+            #expect(response.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
         }
     }
 
@@ -91,8 +91,8 @@ struct SwiftPMBuildServerTests {
     func sourcesItemsBasics() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
-            #expect(targetResponse.targets.count == 2)
-            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Package Manifest"])
+            #expect(targetResponse.targets.count == 3)
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
 
             let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
@@ -106,8 +106,8 @@ struct SwiftPMBuildServerTests {
     func compilerArgsBasics() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
-            #expect(targetResponse.targets.count == 2)
-            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Package Manifest"])
+            #expect(targetResponse.targets.count == 3)
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
 
             let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
@@ -127,8 +127,8 @@ struct SwiftPMBuildServerTests {
     func packageReloadBasics() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, _, fixturePath in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
-            #expect(targetResponse.targets.count == 2)
-            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Package Manifest"])
+            #expect(targetResponse.targets.count == 3)
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
 
             let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
             let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
@@ -153,11 +153,36 @@ struct SwiftPMBuildServerTests {
     }
 
     @Test
+    func compilerArgsFromUserInitiatedBuild() async throws {
+        try await withSwiftPMBSP(
+            fixtureName: "Miscellaneous/Simple",
+            extraBSPArgs: ["--experimental-skip-acquiring-lock"]
+        ) { connection, _, fixturePath in
+            // Populate the build folder as we would in a user-initiated build
+            try await SwiftPM.Build.execute(["--build-system", "swiftbuild"], packagePath: fixturePath)
+
+            let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            #expect(targetResponse.targets.count == 3)
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
+
+            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
+            let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
+            let item = try #require(sourcesResponse.items.only?.sources.only)
+            #expect(item.kind == .file)
+            #expect(item.uri.fileURL?.lastPathComponent == "Foo.swift")
+
+            let settingsResponse = try #require(try await connection.send(TextDocumentSourceKitOptionsRequest(textDocument: TextDocumentIdentifier(item.uri), target: fooID, language: .swift)))
+            #expect(settingsResponse.compilerArguments.contains(["-module-name", "Foo"]))
+            try await AsyncProcess.checkNonZeroExit(arguments: [UserToolchain.default.swiftCompilerPath.pathString, "-typecheck"] + settingsResponse.compilerArguments)
+        }
+    }
+
+    @Test
     func manifestArgs() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/VersionSpecificManifest") { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
-            #expect(targetResponse.targets.count == 2)
-            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Package Manifest"])
+            #expect(targetResponse.targets.count == 3)
+            #expect(targetResponse.targets.map(\.displayName).sorted() == ["Foo", "Foo-product", "Package Manifest"])
 
             let manifestTarget = try #require(targetResponse.targets.first(where: { $0.displayName == "Package Manifest" }))
             #expect(manifestTarget.tags.contains(.notBuildable))


### PR DESCRIPTION
- Add a flag to allow the build server to opt out of acquiring the workspace lock, so that manually initiated builds are not blocked by a long-lived build server which isn't being used for preparation
- Fix derivedDataPath when constructing the Swift Build build request
- Update some tests which were out of date

SourceKit-LSP defaults to background indexing with an independent build arena, but it also supports using the products of user-initiated builds. These changes are intended to support this mode when --build-system swiftbuild becomes the default