### PR TITLE
Fix ToolsVersion Codable backward compatibility 

### DIFF
--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -90,15 +90,15 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     public enum ExperimentalFeature: String, Sendable, Codable {
         case experimentalCGen
     }
-    public let experimentalFeatures: Set<ExperimentalFeature>
+    public let experimentalFeatures: Set<ExperimentalFeature>?
 
     /// Helpers for experimental
     public var experimentalCGen: Bool {
-        self >= .v6_3 && experimentalFeatures.contains(.experimentalCGen)
+        self >= .v6_3 && experimentalFeatures?.contains(.experimentalCGen) == true
     }
 
     /// Create an instance of tools version from a given string.
-    public init?(string: String, experimentalFeatures: Set<ExperimentalFeature> = []) {
+    public init?(string: String, experimentalFeatures: Set<ExperimentalFeature>) {
         guard let match = ToolsVersion.toolsVersionRegex.firstMatch(
             in: string, options: [], range: NSRange(location: 0, length: string.count)) else {
             return nil
@@ -112,7 +112,25 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
         let patch = patchRange.location != NSNotFound ? Int(string.substring(with: patchRange))! : 0
         // We ignore storing pre-release and build identifiers for now.
         _version = Version(major, minor, patch)
-        self.experimentalFeatures = experimentalFeatures
+        self.experimentalFeatures = experimentalFeatures.isEmpty ? nil : experimentalFeatures
+    }
+
+    /// Create an instance of tools version from a given string.
+    public init?(string: String) {
+        guard let match = ToolsVersion.toolsVersionRegex.firstMatch(
+            in: string, options: [], range: NSRange(location: 0, length: string.count)) else {
+            return nil
+        }
+        // The regex succeeded, compute individual components.
+        assert(match.numberOfRanges == 6)
+        let string = NSString(string: string)
+        let major = Int(string.substring(with: match.range(at: 1)))!
+        let minor = Int(string.substring(with: match.range(at: 2)))!
+        let patchRange = match.range(at: 3)
+        let patch = patchRange.location != NSNotFound ? Int(string.substring(with: patchRange))! : 0
+        // We ignore storing pre-release and build identifiers for now.
+        _version = Version(major, minor, patch)
+        self.experimentalFeatures = nil
     }
 
     /// Create instance of tools version from a given version.
@@ -120,17 +138,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     /// - precondition: prereleaseIdentifiers and buildMetadataIdentifier should not be present.
     public init(version: Version) {
         _version = version
-        experimentalFeatures = []
-    }
-
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self._version = try container.decode(Version.self, forKey: ._version)
-        self.experimentalFeatures = try container.decodeIfPresent(
-            Set<ExperimentalFeature>.self,
-            forKey: .experimentalFeatures
-        ) ?? []
+        experimentalFeatures = nil
     }
 
     /// Override equality to ignore experimental features

--- a/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
+++ b/Tests/PackageLoadingTests/ToolsVersionParserTests.swift
@@ -841,10 +841,10 @@ final class ToolsVersionParserTests: XCTestCase {
     func testExperimentalFlag() throws {
         let version = try ToolsVersionParser.parse(utf8String: "// swift-tools-version: 6.3;(experimentalCGen)")
         XCTAssertEqual(version, ToolsVersion(version: .init(6, 3, 0)))
-        XCTAssertTrue(version.experimentalFeatures.contains(.experimentalCGen))
+        XCTAssertTrue(version.experimentalFeatures?.contains(.experimentalCGen) == true)
 
         let version2 = try ToolsVersionParser.parse(utf8String: "// swift-tools-version: 6.3;(experimentalIgnored)")
         XCTAssertEqual(version2, ToolsVersion(version: .init(6, 3, 0)))
-        XCTAssertTrue(version2.experimentalFeatures.isEmpty)
+        XCTAssertNil(version2.experimentalFeatures)
     }
 }

--- a/Tests/PackageModelTests/ToolsVersionTests.swift
+++ b/Tests/PackageModelTests/ToolsVersionTests.swift
@@ -131,7 +131,7 @@ struct ToolsVersionTests {
             from: Data(json.utf8)
         )
         #expect(decoded == ToolsVersion.v5_8)
-        #expect(decoded.experimentalFeatures.isEmpty)
+        #expect(decoded.experimentalFeatures == nil)
     }
 
     @Test


### PR DESCRIPTION
Fix `ToolsVersion` Codable backward compatibility by safely decoding `experimentalFeatures`.
**issue** :  #9823

### Motivation:

Older cached registry fingerprints (such as those from a Swift 5.8 toolchain) currently fail to decode in recent snapshots, throwing a `keyNotFound` error for `experimentalFeatures`. it occurs because the recent addition of the `experimentalFeatures` property caused the auto-synthesized `Decodable` conformance to expect the key to always be present, breaking backward compatibility with existing cache files. 

### Modifications:

* Added a custom `init(from decoder: Decoder)` to the `ToolsVersion` struct.
* Implemented `decodeIfPresent` for the `experimentalFeatures` property, defaulting it to an empty set (`[]`) if the key is missing from the JSON payload.
* Added unit tests to `ToolsVersionTests` to verify that JSON missing the `experimentalFeatures` key decodes successfully and that modern JSON containing the key round-trips correctly.

### Result:

Swift Package Manager successfully decodes older cached version fingerprints that lack the `experimentalFeatures` key. This restores backward compatibility for existing user caches without affecting how new fingerprints are encoded going forward :)