### PR TITLE
Install Swift Module for applications

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -117,9 +117,16 @@ extension PackagePIFProjectBuilder {
         settings[.TARGET_TEMP_DIR_SUFFIX] = "-p"
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "regular"
         settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
-        // We must use the main module name here instead of the product name, because they're not guranteed to be the same, and the users may have authored e.g. tests which rely on an executable's module name.
-        settings[.PRODUCT_MODULE_NAME] = mainModule.c99name
-        if product.type == .executable {
+        if pifProductType == .application {
+            // Use product name for applications to enable features such as SwiftUI Previews.
+            settings[.PRODUCT_MODULE_NAME] = product.c99name
+        } else {
+            // We must use the main module name here instead of the product name, because they're not
+            // guaranteed to be the same, and the users may have authored e.g. tests which rely on an
+            // executable's module name.
+            settings[.PRODUCT_MODULE_NAME] = mainModule.c99name
+        }
+        if product.type == .executable && pifProductType != .application {
             // Don't install the Swift module of the executable product, lest it conflict with the testable variant.
             // The contents of the testable variant's module will exactly match the binary linked by dependencies (test targets).
             // Also, multiple executable products may incorporate sources from the same executable target, while the testable


### PR DESCRIPTION
For cases such as Swift Playground applications, the Swift module is required to enable features such as SwiftUI previews.

### Motivation:

Ensure that previews work correctly for SwiftUI applications.

### Modifications:

- Do not set the `SWIFT_INSTALL_MODULE` setting to `NO` for product types of applications
- Use the `product` name instead of `mainModule` name for applications

### Result:

The .swiftmodule folder is now present for applications.

### Testing:
Confirmed that Previews now work correctly for Swift Playground applications instead of giving errors.
