### PR TITLE
Fixes windows linking against a .dynamic product

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -49,6 +49,9 @@ package struct PIFBuilderParameters {
     /// Eagerly materialize static archive products.
     let materializeStaticArchiveProductsForRootPackages: Bool
 
+    /// Create dynamic library variants for automatic library products.
+    let createDynamicVariantsForLibraryProducts: Bool
+
     /// The path to the library directory of the active toolchain.
     let toolchainLibDir: AbsolutePath
 
@@ -75,11 +78,12 @@ package struct PIFBuilderParameters {
     /// the build products to a different location.
     let addLocalRpaths: Bool
 
-    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRPaths: Bool) {
+    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRPaths: Bool) {
         self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
         self.enableTestability = enableTestability
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
         self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
+        self.createDynamicVariantsForLibraryProducts = createDynamicVariantsForLibraryProducts
         self.toolchainLibDir = toolchainLibDir
         self.pkgConfigDirectories = pkgConfigDirectories
         self.supportedSwiftVersions = supportedSwiftVersions
@@ -418,6 +422,7 @@ public final class PIFBuilder {
                 buildToolPluginResultsByTargetName: buildToolPluginResultsByTargetName,
                 createDylibForDynamicProducts: self.parameters.shouldCreateDylibForDynamicProducts,
                 materializeStaticArchiveProductsForRootPackages: self.parameters.materializeStaticArchiveProductsForRootPackages,
+                createDynamicVariantsForLibraryProducts: self.parameters.createDynamicVariantsForLibraryProducts,
                 addLocalRpaths: self.parameters.addLocalRpaths,
                 packageDisplayVersion: package.manifest.displayName,
                 pkgConfigDirectories: self.parameters.pkgConfigDirectories,
@@ -542,7 +547,8 @@ public final class PIFBuilder {
         pkgConfigDirectories: [Basics.AbsolutePath],
         additionalFileRules: [FileRuleDescription],
         addLocalRpaths: Bool,
-        materializeStaticArchiveProductsForRootPackages: Bool
+        materializeStaticArchiveProductsForRootPackages: Bool,
+        createDynamicVariantsForLibraryProducts: Bool
     ) async throws -> String {
         let parameters = PIFBuilderParameters(
             buildParameters,
@@ -552,7 +558,9 @@ public final class PIFBuilder {
             pluginWorkingDirectory: pluginWorkingDirectory,
             additionalFileRules: additionalFileRules,
             addLocalRpaths: addLocalRpaths,
-            materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages
+            materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
+            createDynamicVariantsForLibraryProducts: createDynamicVariantsForLibraryProducts
+
         )
         let builder = Self(
             graph: packageGraph,
@@ -818,12 +826,14 @@ extension PIFBuilderParameters {
         additionalFileRules: [FileRuleDescription],
         addLocalRpaths: Bool,
         materializeStaticArchiveProductsForRootPackages: Bool,
+        createDynamicVariantsForLibraryProducts: Bool
     ) {
         self.init(
             isPackageAccessModifierSupported: buildParameters.driverParameters.isPackageAccessModifierSupported,
             enableTestability: buildParameters.enableTestability,
             shouldCreateDylibForDynamicProducts: buildParameters.shouldCreateDylibForDynamicProducts,
             materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
+            createDynamicVariantsForLibraryProducts: createDynamicVariantsForLibraryProducts,
             toolchainLibDir: (try? buildParameters.toolchain.toolchainLibDir) ?? .root,
             pkgConfigDirectories: buildParameters.pkgConfigDirectories,
             supportedSwiftVersions: supportedSwiftVersions,

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -180,6 +180,9 @@ public final class PackagePIFBuilder {
     /// built from source in the same build to consume it without eagerly linking it into a product.
     let materializeStaticArchiveProductsForRootPackages: Bool
 
+    /// Create dynamic library variants for automatic library products, for use by development-time features such as Previews and Swift Playgrounds.
+    let createDynamicVariantsForLibraryProducts: Bool
+
     /// Add rpaths which allow loading libraries adjacent to the current image at runtime. This is desirable
     /// when launching build products from the build directory, but should often be disabled when deploying
     /// the build products to a different location.
@@ -215,6 +218,7 @@ public final class PackagePIFBuilder {
         buildToolPluginResultsByTargetName: [String: [BuildToolPluginInvocationResult]],
         createDylibForDynamicProducts: Bool = false,
         materializeStaticArchiveProductsForRootPackages: Bool = false,
+        createDynamicVariantsForLibraryProducts: Bool = true,
         addLocalRpaths: Bool = true,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
@@ -228,6 +232,7 @@ public final class PackagePIFBuilder {
         self.buildToolPluginResultsByTargetName = buildToolPluginResultsByTargetName
         self.createDylibForDynamicProducts = createDylibForDynamicProducts
         self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
+        self.createDynamicVariantsForLibraryProducts = createDynamicVariantsForLibraryProducts
         self.packageDisplayVersion = packageDisplayVersion
         self.pkgConfigDirectories = pkgConfigDirectories
         self.fileSystem = fileSystem
@@ -243,6 +248,7 @@ public final class PackagePIFBuilder {
         buildToolPluginResultsByTargetName: [String: BuildToolPluginInvocationResult],
         createDylibForDynamicProducts: Bool = false,
         materializeStaticArchiveProductsForRootPackages: Bool = false,
+        createDynamicVariantsForLibraryProducts: Bool = true,
         addLocalRpaths: Bool = true,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
@@ -256,6 +262,7 @@ public final class PackagePIFBuilder {
         self.buildToolPluginResultsByTargetName = buildToolPluginResultsByTargetName.mapValues { [$0] }
         self.createDylibForDynamicProducts = createDylibForDynamicProducts
         self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
+        self.createDynamicVariantsForLibraryProducts = createDynamicVariantsForLibraryProducts
         self.addLocalRpaths = addLocalRpaths
         self.packageDisplayVersion = packageDisplayVersion
         self.pkgConfigDirectories = pkgConfigDirectories

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -473,6 +473,12 @@ extension PackagePIFProjectBuilder {
 
             settings[.SWIFT_PACKAGE_NAME] = sourceModule.packageName
 
+            // On Windows, disable static linking mode when this module is a dependency of a dynamic library.
+            // This ensures the module is compiled correctly for linking into a dynamic library.
+            if self.modulesInDynamicLibraries.contains(sourceModule.name) {
+                settings[.SWIFT_COMPILE_FOR_STATIC_LINKING, .windows] = "NO"
+            }
+
             // This entrypoint is only used for the testable variant of executable and macro targets. The primary PIF generation
             // for executables is in makeMainModuleProduct.
             if desiredModuleType == .executable {

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -512,7 +512,7 @@ extension PackagePIFProjectBuilder {
 
         // Apply target-specific build settings defined in the manifest.
         let allBuildSettings = mainModule.computeAllBuildSettings(observabilityScope: pifBuilder.observabilityScope, forRemotePackage: pifBuilder.delegate.isRemote)
-        
+
         // Apply settings using the convenience methods
         allBuildSettings.apply(to: &debugSettings, for: .debug)
         allBuildSettings.apply(to: &releaseSettings, for: .release)
@@ -592,7 +592,7 @@ extension PackagePIFProjectBuilder {
 
         // Also create a dynamic product for use by development-time features such as Previews and Swift Playgrounds.
         // If all targets this product is comprised of are binaries, we should *not* create a dynamic variant.
-        if libraryType == .automatic && libraryProduct.hasSourceTargets {
+        if libraryType == .automatic && libraryProduct.hasSourceTargets && pifBuilder.createDynamicVariantsForLibraryProducts {
             var dynamicLibraryVariant = try self.buildLibraryProduct(
                 libraryProduct,
                 type: .dynamic,
@@ -730,6 +730,13 @@ extension PackagePIFProjectBuilder {
             // An empty sources phase is required in order to trigger linking.
             self.project[keyPath: libraryUmbrellaTargetKeyPath].common.addSourcesBuildPhase { id in
                 ProjectModel.SourcesBuildPhase(id: id)
+            }
+
+            // For dynamic libraries, track which source modules are DIRECT dependencies so we can set
+            // SWIFT_COMPILE_FOR_STATIC_LINKING=NO on Windows for those modules.
+            // Collect only DIRECT module dependencies (not recursive)
+            for module in product.modules where module.isSourceModule {
+                self.modulesInDynamicLibraries.insert(module.name)
             }
         } else if productType == .staticArchive {
             settings[.TARGET_NAME] = product.targetName()
@@ -1188,4 +1195,3 @@ private struct PackageRegistrySignature: Encodable {
     let source: Source
     let formatVersion = 2
 }
-

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -64,6 +64,10 @@ struct PackagePIFProjectBuilder {
     /// Current set of names of any package products that are explicitly declared dynamic libraries.
     private let dynamicLibraryProductNames: Set<String>
 
+    /// Module names that are direct dependencies of dynamic library products.
+    /// These modules should be compiled without static linking on Windows.
+    var modulesInDynamicLibraries: Set<String> = []
+
     /// FIXME: We should eventually clean this up but right now we have to carry over this
     /// bit of information from processing the *products* to processing the *targets*.
     var mainModuleTargetNamesWithResources: Set<String> = []
@@ -269,7 +273,7 @@ struct PackagePIFProjectBuilder {
         // If resourceBundleTarget is nil, we add resources to the sourceModuleTarget instead.
         let targetForResourcesKeyPath: WritableKeyPath<ProjectModel.Project, ProjectModel.Target> =
             resourceBundleTargetKeyPath ?? sourceModuleTargetKeyPath
-        
+
         // Generated resources get a default treatment for rule and localization.
         let generatedResources = generatedResourceFiles.compactMap {
             PackagePIFBuilder.Resource(path: $0, rule: .process(localization: nil))
@@ -365,7 +369,7 @@ struct PackagePIFProjectBuilder {
         } else {
             resourceBundleTargetName = nil
         }
-        
+
         return PackagePIFBuilder.EmbedResourcesResult(
             bundleName: resourceBundleTargetName,
             shouldGenerateBundleAccessor: shouldGenerateBundleAccessor,
@@ -579,4 +583,3 @@ struct PackagePIFProjectBuilder {
         !self.dynamicLibraryProductNames.contains(targetName)
     }
 }
-

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -360,7 +360,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             return uniquePaths
         }
 
-        // TODO: Need to determine how to get the inlude path of package system library dependencies
+        // TODO: Need to determine how to get the include path of package system library dependencies
         let includePaths = try await getUniqueBuildSettingsIncludingDependencies(
             of: request.configuredTargets,
             buildSettings: [
@@ -1226,7 +1226,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     pluginWorkingDirectory: self.pluginConfiguration.workDirectory,
                     additionalFileRules: additionalFileRules,
                     addLocalRpaths: !self.buildParameters.linkingParameters.shouldDisableLocalRpath,
-                    materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages
+                    materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
+                    createDynamicVariantsForLibraryProducts: false,
                 ),
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -37,6 +37,7 @@ extension PIFBuilderParameters {
             enableTestability: false,
             shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts,
             materializeStaticArchiveProductsForRootPackages: true,
+            createDynamicVariantsForLibraryProducts: false,
             toolchainLibDir: temporaryDirectory.appending(component: "toolchain-lib-dir"),
             pkgConfigDirectories: [],
             supportedSwiftVersions: [.v4, .v4_2, .v5, .v6],
@@ -883,6 +884,86 @@ struct PIFBuilderTests {
                         #expect(testTargetConfig.settings[.SWIFT_INDEX_STORE_ENABLE] == "YES")
                 }
             }
+        }
+    }
+
+    @Test func swiftCompileForStaticLinkingInDynamicLibraries() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/ModuleA/ModuleA.swift",
+            "/Root/Sources/ModuleB/ModuleB.swift",
+            "/Root/Sources/ModuleC/ModuleC.swift",
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v6_0,
+                    products: [
+                        ProductDescription(name: "DynamicLib", type: .library(.dynamic), targets: ["ModuleA", "ModuleB"]),
+                        ProductDescription(name: "StaticLib", type: .library(.static), targets: ["ModuleC"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "ModuleA"),
+                        TargetDescription(name: "ModuleB"),
+                        TargetDescription(name: "ModuleC"),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: true
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let pif = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let project = try pif.workspace.project(named: "Root")
+
+        // Modules that are direct dependencies of dynamic library products should have
+        // SWIFT_COMPILE_FOR_STATIC_LINKING = "NO" on Windows
+        for moduleName in ["ModuleA", "ModuleB"] {
+            let moduleTarget = try project.target(named: moduleName)
+            let config = try moduleTarget.buildConfig(named: .release)
+
+            // Check that the setting is "NO" on Windows
+            #expect(
+                config.settings[.SWIFT_COMPILE_FOR_STATIC_LINKING, .windows] == "NO",
+                "Module \(moduleName) in dynamic library should have SWIFT_COMPILE_FOR_STATIC_LINKING=NO on Windows"
+            )
+
+            // Check that the setting is not set on other platforms
+            for platform in SwiftBuild.ProjectModel.BuildSettings.Platform.allCases where platform != .windows {
+                #expect(
+                    config.settings[.SWIFT_COMPILE_FOR_STATIC_LINKING, platform] == nil,
+                    "Module \(moduleName) should not have SWIFT_COMPILE_FOR_STATIC_LINKING on platform \(platform)"
+                )
+            }
+        }
+
+        // Modules that are NOT in dynamic library products should not have this setting
+        let moduleC = try project.target(named: "ModuleC")
+        let moduleCConfig = try moduleC.buildConfig(named: .release)
+
+        for platform in ProjectModel.BuildSettings.Platform.allCases {
+            let setting = moduleCConfig.settings[.SWIFT_COMPILE_FOR_STATIC_LINKING, platform]
+            #expect(
+                setting == nil,
+                "Module ModuleC (not in dynamic library) should not have SWIFT_COMPILE_FOR_STATIC_LINKING on platform \(platform)"
+            )
         }
     }
 }


### PR DESCRIPTION
When linking against a dll on windows, the source module(s) for the module(s) that that are in the dll (product) was still being built with -static, this resulted in undefined symbols at link time, this change mimics native build behavior where the products immediate deps (but not there transitive deps) are what is built without -static as these module(s) are considered the exported interface for the dll.

close: https://github.com/swiftlang/swift-package-manager/issues/9421
