### PR TITLE
Fix manifest cache invalidation when accessing gitInformation

### DIFF
--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -1032,6 +1032,8 @@ extension ManifestLoader {
               fileSystem: FileSystem
         ) throws {
             let manifestContents = try fileSystem.readFileContents(manifestPath).contents
+            let gitDirectoryPath = manifestPath.parentDirectory.appending(".git")
+            let gitDirectoryExists = fileSystem.exists(gitDirectoryPath)
             let sha256Checksum = try Self.computeSHA256Checksum(
                 packageIdentity: packageIdentity,
                 packageLocation: packageLocation,
@@ -1039,7 +1041,8 @@ extension ManifestLoader {
                 toolsVersion: toolsVersion,
                 env: env,
                 extraManifestFlags: extraManifestFlags,
-                swiftpmVersion: swiftpmVersion
+                swiftpmVersion: swiftpmVersion,
+                gitDirectoryExists: gitDirectoryExists
             )
 
             self.packageIdentity = packageIdentity
@@ -1062,7 +1065,8 @@ extension ManifestLoader {
             toolsVersion: ToolsVersion,
             env: Environment,
             extraManifestFlags: [String],
-            swiftpmVersion: String
+            swiftpmVersion: String,
+            gitDirectoryExists: Bool
         ) throws -> String {
             let stream = BufferedOutputByteStream()
             stream.send(packageIdentity)
@@ -1076,6 +1080,7 @@ extension ManifestLoader {
             for flag in extraManifestFlags {
                 stream.send(flag)
             }
+            stream.send(gitDirectoryExists.description)
             return stream.bytes.sha256Checksum
         }
     }

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -13,6 +13,7 @@
 @testable import Basics
 @testable import PackageLoading
 import PackageModel
+import SourceControl
 import _InternalTestSupport
 import XCTest
 
@@ -586,6 +587,72 @@ final class ManifestLoaderCacheTests: XCTestCase {
             let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
             XCTAssertEqual(deps["foo"], .remoteSourceControl(url: "https://scm.com/foo", requirement: .upToNextMajor(from: "1.0.0")))
             XCTAssertEqual(deps["bar"], .remoteSourceControl(url: "https://scm.com/bar", requirement: .upToNextMajor(from: "2.1.0")))
+        }
+    }
+
+    func testCacheInvalidationOnGitDirectoryCreation() async throws {
+        try await testWithTemporaryDirectory { path in
+            let fileSystem = localFileSystem
+            let observability = ObservabilitySystem.makeForTesting()
+
+            let manifestPath = path.appending(components: "pkg", "Package.swift")
+            try fileSystem.createDirectory(manifestPath.parentDirectory, recursive: true)
+            try fileSystem.writeFileContents(
+                manifestPath,
+                string: """
+                    import PackageDescription
+                    let package = Package(
+                        name: "Trivial",
+                        targets: [
+                            .target(
+                                name: "foo",
+                                dependencies: []),
+                        ]
+                    )
+                    """
+            )
+
+            let delegate = ManifestTestDelegate()
+
+            let manifestLoader = ManifestLoader(
+                toolchain: try UserToolchain.default,
+                useInMemoryCache: false,
+                cacheDir: path,
+                delegate: delegate
+            )
+
+            func check(loader: ManifestLoader, expectCached: Bool) async throws {
+                delegate.clear()
+
+                let manifest = try await XCTAsyncUnwrap(try await loader.load(
+                    manifestPath: manifestPath,
+                    packageKind: .root(manifestPath.parentDirectory),
+                    toolsVersion: .current,
+                    fileSystem: fileSystem,
+                    observabilityScope: observability.topScope
+                ))
+
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)), [manifestPath])
+                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, (expectCached ? 0 : 1))
+                XCTAssertEqual(manifest.displayName, "Trivial")
+                XCTAssertEqual(manifest.targets[0].name, "foo")
+            }
+
+            try await check(loader: manifestLoader, expectCached: false)
+            try await check(loader: manifestLoader, expectCached: true)
+
+            let repo = GitRepository(path: manifestPath.parentDirectory)
+            try repo.create()
+            try repo.stage(file: manifestPath.pathString)
+            try repo.commit(message: "initial")
+
+            try await check(loader: manifestLoader, expectCached: false)
+            try await check(loader: manifestLoader, expectCached: true)
+
+            await manifestLoader.purgeCache(observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            try fileSystem.removeFileTree(path)
         }
     }
 }


### PR DESCRIPTION
Fix manifest cache invalidation when accessing `Context.gitInformation`.
Issue : #9800

### Motivation:

Currently, `Context.gitInformation?.currentCommit` evaluates to `nil` if the `.git` directory is added *after* an initial `swift package resolve`. This occurs because the manifest `CacheKey` checksum does not include the state of the `.git` directory. If a manifest is evaluated before the `.git` directory exists, that evaluation is cached. Subsequent builds use this stale cache even after the `.git` directory is created, resulting in missing or incorrect git information. This resolves Issue #9800.

### Modifications:

* Updated `ManifestLoader.CacheKey` to check for the existence of the package's `.git` directory (`gitDirectoryExists`).
* Included the `gitDirectoryExists` boolean in the `computeSHA256Checksum` function so that the cache key directly depends on the directory's presence.
* Added `testCacheInvalidationOnGitDirectoryCreation` to `ManifestLoaderCacheTests.swift` to verify that creating a git repository after an initial cached load correctly invalidates the cache and forces a re-evaluation.

### Result:

The manifest cache will now correctly invalidate when a `.git` folder is initialized or copied into the directory after the initial dependency resolution, allowing `Context.gitInformation` to fetch the correct commit hash. 

Image : 
<img width="551" height="429" alt="Image" src="https://github.com/user-attachments/assets/838b28b9-1ca1-44ab-9986-535b6634e524" />
