### PR TITLE
[Swift Build] Only build for the active arch by default in release builds

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -975,6 +975,11 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         // Optionally also set the list of architectures to build for.
         if let architectures = buildParameters.architectures, !architectures.isEmpty {
             settings["ARCHS"] = architectures.joined(separator: " ")
+        } else {
+            // If the user did not explicitly specify a list of architectures, build only the active arch.
+            // We may want to consider building universal binaries by default in Apple-platform release builds
+            // in the future, but for now we maintain compatibility with the old build system.
+            settings["ONLY_ACTIVE_ARCH"] = "YES"
         }
 
         // When building with the CLI for macOS, test bundles should generate entrypoints for compatibility with swiftpm-testing-helper.


### PR DESCRIPTION
Previously, we built universal binaries when targeting Apple platforms. This is arguably better behavior, but in practice it causes compatibility issues in toolchain bootstrapping. Unconditionally set ONLY_ACTIVE_ARCH = YES for now, but we should reconsider this in the future.