### PR TITLE
Fix definition of --install-only.

### DIFF
--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -123,6 +123,7 @@ def add_global_args(parser):
         help="whether to always reconfigure cmake")
     parser.add_argument(
         "--install-only",
+        dest="install_only",
         action="store_true",
         default=False)
 


### PR DESCRIPTION

### Motivation:

The flag was apparently not behaving as intended. 

### Modifications:

It is likely the flag variable when used was not initialized properly. Instead, use the dest attribute on the flag.

### Result:

Setting flag true behaves as intended. 
