### PR TITLE
[Swift Build] Pass -Xswiftc flags to swiftc when used as the linker driver

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -936,10 +936,11 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             }
         }
 
+        let swiftCompilerFlags = buildParameters.toolchain.extraFlags.swiftCompilerFlags + buildParameters.flags.swiftCompilerFlags
         let compilerAndLinkerFlags = [
             "OTHER_CFLAGS": buildParameters.toolchain.extraFlags.cCompilerFlags + buildParameters.flags.cCompilerFlags,
             "OTHER_CPLUSPLUSFLAGS": buildParameters.toolchain.extraFlags.cxxCompilerFlags + buildParameters.flags.cxxCompilerFlags,
-            "OTHER_SWIFT_FLAGS": buildParameters.toolchain.extraFlags.swiftCompilerFlags + buildParameters.flags.swiftCompilerFlags,
+            "OTHER_SWIFT_FLAGS": swiftCompilerFlags,
             "OTHER_LDFLAGS": (buildParameters.toolchain.extraFlags.linkerFlags + buildParameters.flags.linkerFlags)
         ]
         for (settingName, buildFlags) in compilerAndLinkerFlags {
@@ -949,6 +950,16 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             }
             settings[settingName] = (verboseFlag + ["$(inherited)"] +
                 rawFlags.map { $0.shellEscaped() }).joined(separator: " ")
+        }
+
+        // Historically, SwiftPM passed -Xswiftc flags to swiftc when used as a linker driver.
+        // To maintain compatibility, forward swift compiler flags to OTHER_LDFLAGS when using
+        // swiftc to link.
+        if !swiftCompilerFlags.rawFlagsForSwiftBuild.isEmpty {
+            settings["OTHER_LDFLAGS_SWIFTC_LINKER_DRIVER_swiftc"] =
+            (["$(inherited)"] + swiftCompilerFlags.rawFlagsForSwiftBuild.map { $0.shellEscaped() }).joined(separator: " ")
+            settings["OTHER_LDFLAGS"] =
+                (settings["OTHER_LDFLAGS"] ?? "$(inherited)") + " $(OTHER_LDFLAGS_SWIFTC_LINKER_DRIVER_$(LINKER_DRIVER))"
         }
 
         if buildParameters.driverParameters.emitSILFiles {

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -662,4 +662,36 @@ struct SwiftBuildSystemTests {
             }
         }
     }
+
+    @Test
+    func swiftCompilerFlagsForwardedToLinkerDriver() async throws {
+        let flags = BuildFlags(
+            swiftCompilerFlags: [
+                BuildFlag(value: "-no-toolchain-stdlib-rpath", source: .commandLineOptions)
+            ]
+        )
+
+        try await withInstantiatedSwiftBuildSystem(
+            fromFixture: "PIFBuilder/Simple",
+            buildParameters: mockBuildParameters(
+                destination: .host,
+                flags: flags,
+                buildSystemKind: .swiftbuild,
+            ),
+        ) { swiftBuild, session, observabilityScope, buildParameters in
+            let buildSettings = try await swiftBuild.makeBuildParameters(
+                session: session,
+                symbolGraphOptions: nil,
+                setToolchainSetting: false
+            )
+
+            let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+            let otherSwiftFlags = try #require(synthesizedArgs.table["OTHER_SWIFT_FLAGS"])
+            #expect(otherSwiftFlags.contains("-no-toolchain-stdlib-rpath"))
+            let ldFlagsSwiftc = try #require(synthesizedArgs.table["OTHER_LDFLAGS_SWIFTC_LINKER_DRIVER_swiftc"])
+            #expect(ldFlagsSwiftc.contains("-no-toolchain-stdlib-rpath"))
+            let otherLDFlags = try #require(synthesizedArgs.table["OTHER_LDFLAGS"])
+            #expect(otherLDFlags.contains("$(OTHER_LDFLAGS_SWIFTC_LINKER_DRIVER_$(LINKER_DRIVER))"))
+        }
+    }
 }


### PR DESCRIPTION
This resolves an issue where swift-driver's build script passed `-Xswiftc -no-toolchain-stdlib-rpath` when building for installation in the toolchain, which had no effect because the flag was only passed to the compile task.