### PR TITLE
Add a CACHEDIR.TAG file in the scrathpath

### DIFF
--- a/Sources/Commands/PackageCommands/ResetCommands.swift
+++ b/Sources/Commands/PackageCommands/ResetCommands.swift
@@ -52,6 +52,8 @@ extension SwiftPackageCommand {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
+        var addCacheDirTagFile: Bool { false }
+
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             try await swiftCommandState.getActiveWorkspace().reset(observabilityScope: swiftCommandState.observabilityScope)
         }

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -128,6 +128,9 @@ extension SwiftCommand {
             workspaceLoaderProvider: self.workspaceLoaderProvider,
             createPackagePath: self.createPackagePath
         )
+        defer {
+            _ = createCacheDirFile(inDirectory: swiftCommandState.scratchDirectory)
+        }
 
         // We use this to attempt to catch misuse of the locking APIs since we only release the lock from here.
         swiftCommandState.setNeedsLocking()
@@ -154,12 +157,36 @@ extension SwiftCommand {
     }
 }
 
+package func createCacheDirFile(
+    inDirectory directory: AbsolutePath,
+    _ fileSystem: FileSystem = localFileSystem) -> AbsolutePath? {
+    // https://bford.info/cachedir/
+    let path = directory.appending("CACHEDIR.TAG")
+    do {
+        let contents = """
+            Signature: 8a477f597d28d172789f06886806bc55
+            # This file is a cache directory tag created by (Swift Package Manager).
+            # For information about cache directory tags, see:
+            #.   http://www.brynosaurus.com/cachedir/
+            """
+        try fileSystem.createDirectory(path.parentDirectory, recursive: true)
+        try fileSystem.writeFileContents(path, string: contents)
+        return path
+    } catch {
+        // Don't error out if we fail to create the CACHEDIR.TAG file, as this is not critical to the functioning of the tool.
+        return nil
+    }
+
+}
 public protocol AsyncSwiftCommand: AsyncParsableCommand, _SwiftCommand {
     func run(_ swiftCommandState: SwiftCommandState) async throws
+    var addCacheDirTagFile: Bool { get }
 }
 
 extension AsyncSwiftCommand {
     public static var _errorLabel: String { "error" }
+
+    public var addCacheDirTagFile: Bool { true }
 
     // FIXME: It doesn't seem great to have this be duplicated with `SwiftCommand`.
     public func run() async throws {
@@ -170,6 +197,11 @@ extension AsyncSwiftCommand {
             workspaceLoaderProvider: self.workspaceLoaderProvider,
             createPackagePath: self.createPackagePath
         )
+        defer {
+            if self.addCacheDirTagFile {
+                _ = createCacheDirFile(inDirectory: swiftCommandState.scratchDirectory)
+            }
+        }
 
         // We use this to attempt to catch misuse of the locking APIs since we only release the lock from here.
         swiftCommandState.setNeedsLocking()

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3107,7 +3107,7 @@ struct PackageCommandTests {
             )
             expectFileDoesNotExists(at: binFile)
             try #expect(
-                !localFileSystem.getDirectoryContents(buildPath.appending("repositories")).isEmpty
+                localFileSystem.getDirectoryContents(buildPath.appending("repositories")).isEmpty == false
             )
 
             // Fully clean.
@@ -3117,7 +3117,7 @@ struct PackageCommandTests {
                 configuration: config,
                 buildSystem: buildSystem,
             )
-            #expect(!localFileSystem.isDirectory(buildPath))
+            #expect(localFileSystem.isDirectory(buildPath) == false)
 
             // Test that we can successfully run reset again.
             _ = try await execute(

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -28,6 +28,35 @@ import protocol TSCBasic.OutputByteStream
 import enum TSCBasic.SystemError
 import var TSCBasic.stderrStream
 
+import Testing
+
+@Suite()
+struct SwiftCommandStateTestSuites {
+    @Test(
+        .tags(
+            .TestSize.small,
+        ),
+        arguments: [
+            AbsolutePath.root,
+            AbsolutePath.root.appending(component: "cacheDir"),
+            AbsolutePath.root.appending(components: "foo", "bar", "baz"),
+        ]
+    )
+    func cacheDirTagFileContainsExpectedContents(
+        cacheDirectory: AbsolutePath,
+    ) async throws {
+        let fs = InMemoryFileSystem()
+        // let cacheDirectory = AbsolutePath.root.appending(components: components)
+
+        let actual = try #require(createCacheDirFile(inDirectory: cacheDirectory, fs))
+
+        let contents = try fs.readFileContents(actual).description
+        let contentArray = contents.split(whereSeparator: \.isNewline)
+        try #require(contentArray.isEmpty == false, "Content array is empty, when it shouldn't be. Content is: \(contents)")
+        #expect(contentArray[0] == "Signature: 8a477f597d28d172789f06886806bc55")
+    }
+}
+
 final class SwiftCommandStateTests: XCTestCase {
     /// Original working directory before the test ran (if known).
     private var originalWorkingDirectory: AbsolutePath? = .none
@@ -549,6 +578,7 @@ final class SwiftCommandStateTests: XCTestCase {
             }
         }
     }
+
 }
 
 extension SwiftCommandState {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -230,7 +230,7 @@ struct MiscellaneousTestCase {
         try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "Miscellaneous/DependencyEdges/Internal") { fixturePath in
             let binPath = try fixturePath.appending(components: buildSystem.binPath(for: configuration))
-            let executable = binPath.appending(components: "Foo")
+            let executable = binPath.appending(components: executableName("Foo"))
             let execPath = executable.pathString
 
             try await executeSwiftBuild(
@@ -276,11 +276,10 @@ struct MiscellaneousTestCase {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue {
         try await fixture(name: "DependencyResolution/External/Complex", createGitRepo: true) { fixturePath in
             let packageRoot = fixturePath.appending(component: "app")
             let binPath = try packageRoot.appending(components: buildSystem.binPath(for: configuration))
-            let executable = binPath.appending(component: "Dealer")
+            let executable = binPath.appending(component: executableName("Dealer"))
             let execPath = executable.pathString
 
             try await executeSwiftBuild(
@@ -309,10 +308,6 @@ struct MiscellaneousTestCase {
             let output2 = try await AsyncProcess.checkNonZeroExit(args: execPath).withSwiftLineEnding
             #expect(output2 == "♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n♠︎A\n")
         }
-        } when: {
-            (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .native && configuration == .debug)
-            || (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild)
-        }
     }
 
     /**
@@ -333,7 +328,7 @@ struct MiscellaneousTestCase {
         try await fixture(name: "Miscellaneous/DependencyEdges/External", createGitRepo: true) { fixturePath in
             let packageRoot = fixturePath.appending("root")
             let binPath = try packageRoot.appending(components: buildSystem.binPath(for: configuration))
-            let executable = binPath.appending(component: "dep2")
+            let executable = binPath.appending(component: executableName("dep2"))
             let execpath = [executable.pathString]
 
             try await executeSwiftBuild(
@@ -341,7 +336,6 @@ struct MiscellaneousTestCase {
                 configuration: configuration,
                 buildSystem: buildSystem,
             )
-            try await withKnownIssue {
                 try requireFileExists(at: executable)
                 let output = try await AsyncProcess.checkNonZeroExit(arguments: execpath)
                 #expect(output == "Hello\(ProcessInfo.EOL)")
@@ -362,9 +356,6 @@ struct MiscellaneousTestCase {
                 try requireFileExists(at: executable)
                 let output2 = try await AsyncProcess.checkNonZeroExit(arguments: execpath)
                 #expect(output2 == "Goodbye\(ProcessInfo.EOL)")
-            } when: {
-                (ProcessInfo.hostOperatingSystem == .windows)
-            }
         }
     }
 


### PR DESCRIPTION
Many tools, including backup software have options to avoid backing up the contents of a directory that has a `CACHEDIR.TAG` file in it. This makes it easy for backup software to avoid including stuff that is likely to generate a lot of churn in backup archives.

Reference: https://bford.info/cachedir/

Issue: rdar://164880855