### PR TITLE
Add a single public symbol to the library template so it builds without warnings

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -663,7 +663,9 @@ public final class InitPackage {
             content = """
                 // The Swift Programming Language
                 // https://docs.swift.org/swift-book
-
+                public func hello() {
+                    print("Hello, world!")
+                }
                 """
         case .executable:
             content = """


### PR DESCRIPTION
If a library target is composed of objects which have no symbols, it will emit a warning when linked as a static archive on macOS. Add a single placeholder public function to the library template so it builds without warnings out of the box.