### PR TITLE
Fix normalization of MSVC linker flags on Windows

### DIFF
--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -428,10 +428,14 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         })
         flags += prebuiltLibPaths.flatMap({ ["-L", $0] }) + prebuiltLibraries.map({ "-l" + $0 })
 
-        // Other linker flags.
         for target in self.staticTargets {
             let scope = self.buildParameters.createScope(for: target)
-            flags += scope.evaluate(.OTHER_LDFLAGS)
+            let ldFlags = scope.evaluate(.OTHER_LDFLAGS)
+            if self.buildParameters.triple.isWindows() {
+                flags += ldFlags.asSwiftcLinkerFlags()
+            } else {
+                flags += ldFlags
+            }
         }
 
         return flags

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -7765,4 +7765,46 @@ class BuildPlanSwiftBuildTests: BuildPlanTestCase {
         try await super.testPackageNameFlag()
     }
 
+    func testWindowsLinkerFlagsIssue9738() async throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Pkg/Sources/exe/main.swift"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    targets: [
+                        TargetDescription(
+                            name: "exe",
+                            dependencies: [],
+                            type: .executable,
+                            settings: [
+                                .init(tool: .linker, kind: .unsafeFlags(["/include:SomeSymbol"]))
+                            ]
+                        )
+                    ]
+                )
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let windowsTriple = try Triple("x86_64-unknown-windows-msvc")
+
+        let plan = try await mockBuildPlan(
+            triple: windowsTriple,
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let result = try BuildPlanResult(plan: plan)
+        let productDescription = try result.buildProduct(for: "exe")
+        let linkArgs = try productDescription.linkArguments()
+        
+        XCTAssertTrue(linkArgs.contains("/include:SomeSymbol"), "Should contain exact linker flag")
+    }
 }


### PR DESCRIPTION
Resolves Issue #9738.

### Motivation:
When building for Windows, MSVC-style linker flags that begin with a forward slash e.g., `/include:SomeSymbol` passed via `.unsafeFlags` were being incorrectly interpreted by the Swift driver as abs file paths. This caused the driver to normalize '/' into `\` , resulting in linker failures : `lld-link: error: could not open '\include:SomeSymbol'`

### Modifications:
* Updated `ProductBuildDescription.swift` to append `.asSwiftcLinkerFlags()` to target-level `OTHER_LDFLAGS`. 
* This ensures that target-level linker flags are properly wrapped with `-Xlinker` when passed to the Swift driver, preventing the driver from attempting to path-normalize them.
* Added `testWindowsLinkerFlagsIssue9738` to `BuildPlanTests.swift` using a Windows MSVC target triple (`x86_64-unknown-windows-msvc`) to verify that flags starting with `/` remain completely unmodified in the generated build plan.

### Result:
MSVC-style linker flags are now safely passed through the Swift driver to the underlying linker without being erroneously mangled into Windows file paths.
