### PR TITLE
Remove testSDKTracking test which didn't actually run an incremental build

### DIFF
--- a/Tests/BuildTests/IncrementalBuildTests.swift
+++ b/Tests/BuildTests/IncrementalBuildTests.swift
@@ -151,32 +151,4 @@ final class IncrementalBuildTests: XCTestCase {
             XCTAssertNoMatch(log2, .contains("Planning build"))
         }
     }
-    // testing the fix for tracking SDK dependencies to avoid triggering rebuilds when the SDK changes (rdar://115777026)
-    func testSDKTracking() async throws {
-#if os(macOS)
-        try XCTSkipIf(!UserToolchain.default.supportsSDKDependentTests(), "skipping because test environment doesn't support this test")
-
-        try await fixtureXCTest(name: "ValidLayouts/SingleModule/Library") { fixturePath in
-            let dummySwiftcPath = SwiftPM.xctestBinaryPath(for: "dummy-swiftc")
-            let swiftCompilerPath = try UserToolchain.default.swiftCompilerPath
-            let environment: Environment = [
-                "SWIFT_EXEC": dummySwiftcPath.pathString,
-                "SWIFT_ORIGINAL_PATH": swiftCompilerPath.pathString
-            ]
-            let sdkPathStr = try await AsyncProcess.checkNonZeroExit(
-                arguments: ["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-path"],
-                environment: environment
-            ).spm_chomp()
-
-            let newSdkPathStr = "/tmp/../\(sdkPathStr)"
-            // Perform a full build again because SDK changed.
-            let log1 = try await executeSwiftBuild(
-                fixturePath,
-                env: ["SDKROOT": newSdkPathStr],
-                buildSystem: .native,
-            ).stdout
-            XCTAssertMatch(log1, .contains("Compiling Library"))
-        }
-#endif
-    }
 }


### PR DESCRIPTION
This test only ran a single clean build, so it wasn't actually testing incrementally, and that's better to test at the build system layer instead. Also, /tmp / /private/tmp symlink resolution issues were causing this to fail in swift-build GitHub actions CI. Drop this test entirely since it isn't very useful