### PR TITLE
Fix plain-text compiler error handling for -print-target-info (#9703)

### DIFF
--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -9,7 +9,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-
+import Foundation
 import TSCUtility
 import enum TSCBasic.JSON
 
@@ -112,6 +112,12 @@ extension Triple {
         do {
             parsedTargetInfo = try JSON(string: compilerOutput)
         } catch {
+            let trimmedOutput = compilerOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedOutput.hasPrefix("{") && !trimmedOutput.hasPrefix("[") {
+                // It's plain text, throw cleanly without the JSON error
+                throw StringError("Failed to parse target info: \(trimmedOutput)")
+            }
+
             throw InternalError(
                 "Failed to parse target info (\(error.interpolationDescription)).\nRaw compiler output: \(compilerOutput)"
             )

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -217,8 +217,14 @@ public final class UserToolchain: Toolchain {
         do {
             return try JSON(string: compilerOutput)
         } catch {
+            let trimmedOutput = compilerOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedOutput.hasPrefix("{") && !trimmedOutput.hasPrefix("[") {
+                // It's plain text, throw cleanly without the JSON error
+                throw StringError("Failed to parse target info: \(trimmedOutput)")
+            }
+
             throw InternalError(
-                "Failed to parse target info (\(error.interpolationDescription)).\nCompiler exited with staus \(result.exitStatus).\nRaw compiler stdout: \(compilerOutput)\nRaw compiler stderr: \(compilerStderr)"
+                "Failed to parse target info (\(error.interpolationDescription)).\nCompiler exited with status \(result.exitStatus).\nRaw compiler stdout: \(compilerOutput)\nRaw compiler stderr: \(compilerStderr)"
             )
         }
     }

--- a/Tests/BasicsTests/TripleTests.swift
+++ b/Tests/BasicsTests/TripleTests.swift
@@ -12,6 +12,7 @@
 import Foundation
 
 import Basics
+import _InternalTestSupport
 import Testing
 
 struct TripleTests {
@@ -357,5 +358,27 @@ struct TripleTests {
         let triple = try Triple(firstTripleName)
         let other = try Triple(secondTripleName)
         #expect(triple.isRuntimeCompatible(with: other) == isCompatible)
+    }
+
+    @Test
+    func testTargetInfoPlainTextError() throws {
+        try testWithTemporaryDirectory { tmpDir in
+            let fakeSwiftc = tmpDir.appending(component: "fake-swiftc")
+            try localFileSystem.writeFileContents(fakeSwiftc, string: """
+                #!/bin/sh
+                echo "error: permissionDenied"
+                """)
+            try localFileSystem.chmod(.executable, path: fakeSwiftc)
+
+            do {
+                _ = try Triple.getHostTriple(usingSwiftCompiler: fakeSwiftc)
+                Issue.record("Should have thrown InternalError")
+            } catch {
+                let errorDescription = error.interpolationDescription
+                #expect(errorDescription.contains("Failed to parse target info: error: permissionDenied"))
+                #expect(!errorDescription.contains("NSCocoaErrorDomain"))
+                #expect(!errorDescription.contains("JSON"))
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix plain-text compiler error handling for -print-target-info (#9703)

Motivation:

When swiftc fails and outputs plain text instead of JSON, SwiftPM tries to parse it anyway. This masks the real compiler error and throws a confusing InternalError (usually a JSON decoding or NSCocoaErrorDomain crash).

Modifications:

Error Handling (Triple+Basics.swift, UserToolchain.swift): Added a check to see if the trimmed compiler output starts with { or [. If not, it bails out of JSON parsing and throws a clean StringError containing the raw text.

Tests (TripleTests.swift): Added testTargetInfoPlainTextError using a mocked fake-swiftc script to verify the plain-text bypass works.

Result:

Plain-text compiler errors are now printed directly to the terminal instead of causing a JSON decoding crash.

Manual Verification:
Created a temporary DummyPackage with a failing mocked compiler to verify the clean terminal output:

<img width="1024" height="416" alt="image" src="https://github.com/user-attachments/assets/009bf3e0-ce55-4e40-9e66-f2b375a2febb" />