### PR TITLE
Make Bundle.module nonisolated

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -420,7 +420,7 @@ public final class SwiftModuleBuildDescription {
             import Foundation
 
             extension Foundation.Bundle {
-                static let module: Bundle = {
+                static nonisolated let module: Bundle = {
                     let mainPath = \(mainPathSubstitution)
                     let buildPath = "\(bundlePath.pathString.asSwiftStringLiteralConstant)"
 


### PR DESCRIPTION
Swift Packages behave like static libraries and their build produces just one static library. To allow Packages to contain resources, the build system synthesizes one bundle per Package, and places the associated resources in it.
To make this generated bundle accessible to the Package's code, the build system generates `Bundle.module`.

The generated bundle accessor naturally follows the default isolation strategy for the Package: when the package uses MainActor isolation via `.defaultIsolation(MainActor.self)`, the generated accessor is MainActor-isolated too.

This is an unnecessary limitation, because Bundle is `sendable`, and there is no need to isolate access to `Bundle.module` to any Actor. 

This PR marks `Bundle.module` as `nonisolated` to allow access from any isolation domain. With this fix, code that is `nonisolated` itself — or not running on the MainActor (in case of an MainActor default-isolated configuration) — can access `Bundle.module` too.


Related PR targeting `main`: https://github.com/swiftlang/swift-package-manager/pull/9849
Related PR in swift-build (`main`): https://github.com/swiftlang/swift-build/pull/1241
Related PR in swift-build (`release/6.3`): https://github.com/swiftlang/swift-build/pull/1240