### PR TITLE
CI: Have build-using-self use default build system

### DIFF
--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -133,8 +133,6 @@ def log_environment() -> None:
 
 
 BUILD_OVERRIDES: t.List[str] = [
-    "--build-system",
-    "native",
 ]
 
 


### PR DESCRIPTION
With #9661  merged, ensure the build-using-self script uses the default build system.