### PR TITLE
Enable toolchain rpaths for back deployment in --build-system swiftbuild

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1030,6 +1030,10 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             break
         }
 
+        // Added for compatibility with --build-system native, but we should try to phase these out in the future
+        settings["ADD_TOOLCHAIN_CONCURRENCY_BACK_DEPLOY_RPATH"] = "YES"
+        settings["ADD_TOOLCHAIN_SPAN_BACK_DEPLOY_RPATH"] = "YES"
+
         func reportConflict(_ a: String, _ b: String) throws -> String {
             throw StringError("Build parameters constructed conflicting settings overrides '\(a)' and '\(b)'")
         }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -1216,7 +1216,7 @@ struct TestCommandTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue("Fails to find the test executable") {
+        try await withKnownIssue("Fails to find the test executable", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestDiscovery/SwiftTesting") { fixturePath in
                 let (stdout, stderr) = try await execute(
                     ["--disable-local-rpath"],


### PR DESCRIPTION
Adopt the changes in https://github.com/swiftlang/swift-build/pull/1252/changes