### PR TITLE
Tests: Remove withKnownIssue in CoverageTests

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -705,7 +705,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             let jsonPath = productsBuildParameters.codeCovAsJSONPath(packageName: rootManifest.displayName)
             try await exportCodeCovAsJSON(
                 to: jsonPath,
-                testBinary: product.binaryPath,
+                testBinary: product.coverageBinaryPath,
                 swiftCommandState: swiftCommandState,
             )
         }

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -363,11 +363,10 @@ enum TestingSupport {
         #else
         // Add path to swift-testing override if there is one
         if let swiftTestingPath = toolchain.swiftTestingPath {
-            if swiftTestingPath.extension == "framework" {
-                env.appendPath(key: "DYLD_FRAMEWORK_PATH", value: swiftTestingPath.pathString)
-            } else {
-                env.appendPath(key: "DYLD_LIBRARY_PATH", value: swiftTestingPath.pathString)
-            }
+            env.appendPath(
+                key: (swiftTestingPath.extension == "framework") ? "DYLD_FRAMEWORK_PATH" : "DYLD_LIBRARY_PATH",
+                value: swiftTestingPath.pathString,
+            )
         }
 
         // Add the sdk platform path if we have it.

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -348,33 +348,69 @@ public struct BuildParameters: Encodable {
         case .library(.automatic), .plugin:
             fatalError("\(#file):\(#line) - Illegal call of function \(#function) with automatica library and plugin")
         case .test:
-            switch buildSystemKind {
-            case .native, .xcode:
-                let base = "\(product.name).xctest"
-                if self.triple.isDarwin() {
-                    return try RelativePath(validating: "\(base)/Contents/MacOS/\(product.name)")
-                } else {
-                    return try RelativePath(validating: base)
-                }
-            case .swiftbuild:
-                if self.triple.isDarwin() {
-                    let base = "\(product.name).xctest"
-                    return try RelativePath(validating: "\(base)/Contents/MacOS/\(product.name)")
-                } else {
-                    var base = "\(product.name)-test-runner"
-                    let ext = self.triple.executableExtension
-                    if !ext.isEmpty {
-                        base += ext
-                    }
-                    return try RelativePath(validating: base)
-                }
-            }
+            return try testBinaryRelativePath(forTestProductName: product.name)
         case .macro:
             #if BUILD_MACROS_AS_DYLIBS
             return try dynamicLibraryPath(for: product.name)
             #else
             return try executablePath(for: product.name)
             #endif
+        }
+    }
+
+    /// Returns the path (relative to the build directory) of the file you launch to run
+    /// the tests in a test product.
+    ///
+    /// For most build-system + platform combinations this is the single binary that
+    /// contains the compiled test code. On SwiftBuild + non-Darwin it's a thin launcher
+    /// that `dlopen`s the sibling shared library — in that case the test code (and its
+    /// coverage mapping) lives in ``testCoverageBinaryRelativePath(forTestProductName:)``.
+    public func testBinaryRelativePath(forTestProductName name: String) throws -> Basics.RelativePath {
+        switch buildSystemKind {
+        case .native, .xcode:
+            let base = "\(name).xctest"
+            if self.triple.isDarwin() {
+                return try RelativePath(validating: "\(base)/Contents/MacOS/\(name)")
+            } else {
+                return try RelativePath(validating: base)
+            }
+        case .swiftbuild:
+            if self.triple.isDarwin() {
+                let base = "\(name).xctest"
+                return try RelativePath(validating: "\(base)/Contents/MacOS/\(name)")
+            } else {
+                var base = "\(name)-test-runner"
+                let ext = self.triple.executableExtension
+                if !ext.isEmpty {
+                    base += ext
+                }
+                return try RelativePath(validating: base)
+            }
+        }
+    }
+
+    /// Returns the path (relative to the build directory) of the artifact whose coverage
+    /// mapping should be passed to `llvm-cov export`.
+    ///
+    /// For every build system + platform combination except SwiftBuild on non-Darwin this
+    /// is the same file returned by ``testBinaryRelativePath(forTestProductName:)``.
+    /// SwiftBuild on non-Darwin splits a test product into a `-test-runner` launcher plus
+    /// a sibling shared library (`<name>.so` / `<name>.dll`); the instrumented test code
+    /// lives in the shared library, so that's what `llvm-cov` needs to read. Pointing
+    /// `llvm-cov` at the launcher would report coverage only for the synthesized
+    /// `test_entry_point.swift` and hide every user source file (see rdar://168006617).
+    public func testCoverageBinaryRelativePath(forTestProductName name: String) throws -> Basics.RelativePath {
+        switch buildSystemKind {
+        case .native, .xcode:
+            return try testBinaryRelativePath(forTestProductName: name)
+        case .swiftbuild:
+            if self.triple.isDarwin() {
+                return try testBinaryRelativePath(forTestProductName: name)
+            } else {
+                // SwiftBuild's non-Darwin test product is `<name>{.so,.dll}` — no `lib` prefix,
+                // no platform suffix — sitting next to the `-test-runner` launcher.
+                return try RelativePath(validating: "\(name)\(self.triple.dynamicLibraryExtension)")
+            }
         }
     }
 }

--- a/Sources/SPMBuildCore/BuiltTestProduct.swift
+++ b/Sources/SPMBuildCore/BuiltTestProduct.swift
@@ -23,6 +23,14 @@ public struct BuiltTestProduct: Codable, Hashable {
     /// The path of the test binary.
     public let binaryPath: AbsolutePath
 
+    /// The path of the artifact whose coverage mapping should be passed to `llvm-cov export`.
+    ///
+    /// For most build systems this is equal to ``binaryPath``. On SwiftBuild + non-Darwin,
+    /// where ``binaryPath`` points at a thin `-test-runner` launcher, this points at the
+    /// sibling shared library that actually holds the compiled test code (and therefore
+    /// its coverage mapping).
+    public let coverageBinaryPath: AbsolutePath
+
     /// The path to the package this product was declared in.
     public let packagePath: AbsolutePath
 
@@ -41,7 +49,7 @@ public struct BuiltTestProduct: Codable, Hashable {
         guard let bundlePath = hierarchySequence.first(where: { $0.basename.hasSuffix(pathExtension) }) else {
             fatalError("could not find test bundle path from '\(binaryPath)'")
         }
-        
+
         return bundlePath
     }
 
@@ -55,11 +63,22 @@ public struct BuiltTestProduct: Codable, Hashable {
     ///   - binaryPath: The path of the test binary.
     ///   - packagePath: The path to the package this product was declared in.
     ///   - mainSourceFilePath: The path to the main source file used, if any.
-    public init(productName: String, umbrellaProductName: String?, binaryPath: AbsolutePath, packagePath: AbsolutePath, testEntryPointPath: AbsolutePath?) {
+    ///   - coverageBinaryPath: The path of the artifact whose coverage mapping should be
+    ///     fed to `llvm-cov`. Defaults to `binaryPath`; callers that build a test product
+    ///     as a separate launcher + shared library should pass the shared library here.
+    public init(
+        productName: String,
+        umbrellaProductName: String?,
+        binaryPath: AbsolutePath,
+        packagePath: AbsolutePath,
+        testEntryPointPath: AbsolutePath?,
+        coverageBinaryPath: AbsolutePath? = nil,
+    ) {
         self.productName = productName
         self.umbrellaProductName = umbrellaProductName
         self.binaryPath = binaryPath
         self.packagePath = packagePath
         self.testEntryPointPath = testEntryPointPath
+        self.coverageBinaryPath = coverageBinaryPath ?? binaryPath
     }
 }

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -275,13 +275,17 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 for package in graph.rootPackages {
                     for product in package.products where product.type == .test {
                         let binaryPath = try buildParameters.binaryPath(for: product)
+                        let coverageBinaryPath = try buildParameters.buildPath.appending(
+                            buildParameters.testCoverageBinaryRelativePath(forTestProductName: product.name)
+                        )
                         builtProducts.append(
                             BuiltTestProduct(
                                 productName: product.name,
                                 umbrellaProductName: package.manifest.umbrellaPackageTestsProductName,
                                 binaryPath: binaryPath,
                                 packagePath: package.path,
-                                testEntryPointPath: product.underlying.testEntryPointPath
+                                testEntryPointPath: product.underlying.testEntryPointPath,
+                                coverageBinaryPath: coverageBinaryPath,
                             )
                         )
                     }

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -1293,7 +1293,7 @@ struct BuildCommandTestCases {
     @Test(
         // Windows builds of ExecutableNew using swiftbuild can fail because of problem with handling long paths which
         // is root cause of linked issue
-        .issue("https://github.com/swiftlang/swift-package-manager/issues/9420", relationship: .defect),
+        .IssueWindowsPathNoEntry,
         .issue("https://github.com/swiftlang/swift-package-manager/issues/9745", relationship: .defect),
         .tags(
             .Feature.CommandLineArguments.DisableGetTaskAllowEntitlement,

--- a/Tests/CommandsTests/CoverageTests.swift
+++ b/Tests/CommandsTests/CoverageTests.swift
@@ -42,7 +42,6 @@ struct CoverageTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let config = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
                 _ = try await executeSwiftBuild(
                     path,
@@ -50,7 +49,6 @@ struct CoverageTests {
                     extraArgs: ["--build-tests"],
                     buildSystem: buildSystem,
                 )
-                await withKnownIssue(isIntermittent: true) {
                 await #expect(throws: (any Error).self ) {
                     try await executeSwiftTest(
                         path,
@@ -63,13 +61,7 @@ struct CoverageTests {
                         throwIfCommandFails: true,
                     )
                 }
-                } when: {
-                    ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
-                }
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
-        }
     }
 
     @Test(
@@ -86,7 +78,6 @@ struct CoverageTests {
     ) async throws {
         let config = BuildConfiguration.debug
         // Test that enabling code coverage during building produces the expected folder.
-        try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { path in
             let codeCovPathString = try await getCoveragePath(
                 path,
@@ -121,9 +112,6 @@ struct CoverageTests {
                 let codeCovFiles = try localFileSystem.getDirectoryContents(codeCovPath.parentDirectory)
                 #expect(codeCovFiles.count > 0)
         }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild // This was no longer an issue when I tested at-desk
-        }
     }
 
     @Test(
@@ -151,7 +139,6 @@ struct CoverageTests {
             try #require(!localFileSystem.exists(coveragePath))
 
             // WHEN we test with coverage enabled
-            try await withKnownIssue(isIntermittent: true) {
                 try await executeSwiftTest(
                     path,
                     configuration: config,
@@ -164,9 +151,6 @@ struct CoverageTests {
 
                 // THEN we expect the file to exists
                 #expect(localFileSystem.exists(coveragePath))
-            } when: {
-                (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild)
-            }
         }
     }
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -1494,6 +1494,7 @@ struct TestCommandTests {
     }
 
     @Test(
+        .IssueWindowsPathNoEntry,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func defaultInteropMode(
@@ -1515,6 +1516,7 @@ struct TestCommandTests {
     }
 
     @Test(
+        .IssueWindowsPathNoEntry,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func noDefaultInteropMode(
@@ -1536,6 +1538,7 @@ struct TestCommandTests {
     }
 
     @Test(
+        .IssueWindowsPathNoEntry,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func respectUserOverrideInteropMode(

--- a/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/Tests/IntegrationTests/SwiftPMTests.swift
@@ -234,6 +234,8 @@ private struct SwiftPMTests {
     @Test(
         .requireSwift6_2,
         .issue("https://github.com/swiftlang/swift-package-manager/issues/9588", relationship: .defect),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9600", relationship: .defect),
+        .IssueWindowsPathNoEntry,
         .tags(
             .UserWorkflow,
             .Feature.CodeCoverage,
@@ -243,7 +245,7 @@ private struct SwiftPMTests {
             .Feature.PackageType.Empty,
             .Feature.TargetType.Test,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testCodeCoverageMergedAcrossSubprocesses(
         buildSystem: BuildSystemProvider.Kind,
@@ -330,11 +332,14 @@ private struct SwiftPMTests {
 
             // Check for 100% coverage for Subject.swift, which should happen because the per-PID files got merged.
             try withKnownIssue(isIntermittent: true) {
-                let data = try #require(coverage.data.first, "covege JSON = \(coverage)")
-                let subjectCoverage = try #require(data.files.first(where: { $0.filename.hasSuffix("Subject.swift") }), "covege JSON = \(data.files)")
+                let data = try #require(coverage.data.first, "coverage JSON = \(coverage)")
+                let subjectCoverage = try #require(data.files.first(where: { $0.filename.hasSuffix("Subject.swift") }), "coverage data files JSON = \(data.files)")
                 #expect(subjectCoverage.summary.functions.count == 2)
                 #expect(subjectCoverage.summary.functions.covered == 2)
                 #expect(subjectCoverage.summary.functions.percent == 100)
+            } when: {
+                [.windows, .linux].contains(ProcessInfo.hostOperatingSystem) && buildSystem == .swiftbuild
+            }
 
                 // Check the directory with the coverage path contains the profraw files.
                 let coverageDirectory = coveragePath.parentDirectory
@@ -347,7 +352,10 @@ private struct SwiftPMTests {
                 // Then check that %p expanded as we expected: to something that plausibly looks like a PID.
                 for profrawFile in profrawFiles {
                     let shouldBePID = try #require(profrawFile.split(separator: ".").dropLast().last)
-                    #expect(Int(shouldBePID) != nil)
+                    #expect(
+                        Int(shouldBePID) != nil,
+                        "last component of rofraw filename (\(profrawFile)) is not a valid pid",
+                    )
                 }
 
                 // Group the files by binary identifier (have a different prefix, before the per-PID suffix).
@@ -355,11 +363,11 @@ private struct SwiftPMTests {
 
                 // Check each group has 3 files: one per PID (the above suite has 2 exit tests => 2 forks => 3 PIDs total).
                 for binarySpecificProfrawFiles in groups {
-                    #expect(binarySpecificProfrawFiles.count == 3)
+                    #expect(
+                        binarySpecificProfrawFiles.count == 3,
+                        "Binary Specific profraw files are: \(binarySpecificProfrawFiles)"
+                    )
                 }
-            } when: {
-                [.linux, .windows].contains(ProcessInfo.hostOperatingSystem) && buildSystem == .swiftbuild
-            }
         }
         } when: {
             ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild

--- a/Tests/SPMBuildCoreTests/BuildParametersTests.swift
+++ b/Tests/SPMBuildCoreTests/BuildParametersTests.swift
@@ -13,6 +13,7 @@
 @testable import SPMBuildCore
 import Basics
 import struct PackageModel.BuildEnvironment
+import struct PackageModel.Platform
 import _InternalTestSupport
 import Testing
 
@@ -27,5 +28,52 @@ struct BuildParametersTests {
         #expect(parameters.enableTestability)
         parameters.configuration = .release
         #expect(!parameters.enableTestability)
+    }
+
+    /// Covers the path that `llvm-cov export` must be given so that it can read the
+    /// coverage mapping embedded in the compiled test code. For every build-system +
+    /// platform combination this is the same file that gets launched to run the tests —
+    /// *except* for SwiftBuild on non-Darwin, where the launched file is a thin
+    /// `-test-runner` executable and the instrumented test code lives in a sibling
+    /// shared library. Passing the runner to `llvm-cov` hides every user source file
+    /// from the coverage report (see rdar://168006617).
+    ///
+    /// The Windows rows are a best-guess extrapolation (swiftbuild produces `<name>.dll`
+    /// alongside `<name>-test-runner.exe`, mirroring the Linux `.so` pattern). The real
+    /// behaviour hasn't been observed end-to-end yet; if it turns out to differ, update
+    /// the expectations here and in `testCoverageBinaryRelativePath`.
+    @Test(
+        .tags(
+            .TestSize.small,
+        ),
+        arguments: [
+            // (build system, platform, test product name, expected relative path)
+            (BuildSystemProvider.Kind.native,     Platform.linux,   "ReproTests",  "ReproTests.xctest"),
+            (BuildSystemProvider.Kind.native,     Platform.macOS,   "ReproTests",  RelativePath("ReproTests.xctest/Contents/MacOS/ReproTests").pathString),
+            (BuildSystemProvider.Kind.native,     Platform.windows, "ReproTests",  "ReproTests.xctest"),
+            (BuildSystemProvider.Kind.swiftbuild, Platform.macOS,   "ReproTests",  RelativePath("ReproTests.xctest/Contents/MacOS/ReproTests").pathString),
+            // The originally failing case: on non-Darwin swiftbuild, coverage mapping lives in
+            // the shared library, not the `-test-runner` launcher.
+            (BuildSystemProvider.Kind.swiftbuild, Platform.linux,   "ReproTests",  "ReproTests.so"),
+            (BuildSystemProvider.Kind.swiftbuild, Platform.windows, "ReproTests",  "ReproTests.dll"),
+            // A differently-named product exercises that the name is not hard-coded anywhere.
+            (BuildSystemProvider.Kind.swiftbuild, Platform.linux,   "MyPkgTests",  "MyPkgTests.so"),
+        ],
+    )
+    func testCoverageBinaryRelativePath_returnsArtifactWithInstrumentedCoverage(
+        buildSystem: BuildSystemProvider.Kind,
+        platform: Platform,
+        testProductName: String,
+        expectedPath: String,
+    ) throws {
+        let parameters = mockBuildParameters(
+            destination: .host,
+            environment: BuildEnvironment(platform: platform, configuration: .debug),
+            buildSystem: buildSystem,
+        )
+
+        let path = try parameters.testCoverageBinaryRelativePath(forTestProductName: testProductName)
+
+        #expect(path.pathString == expectedPath)
     }
 }


### PR DESCRIPTION
All platform issues that were causing this test to fail have been fixed. Remove the `withKnownIssue` statement that was added in these tests.

Fixes: #9588
Issue: rdar://168006617