### PR TITLE
Run `getTaskAllowEntitlement` test with release configuration

### DIFF
--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -1361,7 +1361,6 @@ struct BuildCommandTestCases {
         // Windows builds of ExecutableNew using swiftbuild can fail because of problem with handling long paths which
         // is root cause of linked issue
         .IssueWindowsPathNoEntry,
-        .issue("https://github.com/swiftlang/swift-package-manager/issues/9745", relationship: .defect),
         .tags(
             .Feature.CommandLineArguments.DisableGetTaskAllowEntitlement,
             .Feature.CommandLineArguments.EnableGetTaskAllowEntitlement,
@@ -1370,12 +1369,11 @@ struct BuildCommandTestCases {
         .tags(
             .Feature.CommandLineArguments.BuildSystem
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
-    func getTaskAllowEntitlement(
-        buildSystem: BuildSystemProvider.Kind,
-    ) async throws {
-        let buildConfiguration = BuildConfiguration.debug
+    func getTaskAllowEntitlement(data: BuildData) async throws {
+        let buildSystem = data.buildSystem
+        let buildConfiguration = data.config
         try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
             #if os(macOS)
             func codesignDisplay(execPath: AbsolutePath) async throws -> PropertyListItem? {


### PR DESCRIPTION
Reverts change to test arguments introduced in cad6c0fef03df94f4e353460e3a93d2d0aa97d44. 

### Motivation:

`getTaskAllowEntitlement` test was written with intention to run in both debug and release configurations. It's because enable and disable options are valid for both of them, so we can produce release binary with get-task-allow entitlement for profiling and debug binary without entitlement (for whatever reason).

### Modifications:

Revert `getTaskAllowEntitlement` to using `BuildData` struct as test input and generate those inputs with `getBuildData(for:)` function.
Removes issue link to #9745 because #9380 actually resolved that issue.

### Result:

`getTaskAllowEntitlement` test runs for both debug and release build configuration for both build systems.
