### PR TITLE
Add an --experimental-trace-events-file flag to emit a timeline of build tasks

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -601,6 +601,10 @@ public struct BuildOptions: ParsableArguments {
     @Flag(name: .customLong("experimental-task-backtraces"), help: .hidden)
     public var enableTaskBacktraces: Bool = false
 
+    // Path to write a Trace Event Format JSON file with build task timeline data.
+    @Option(name: .customLong("experimental-trace-events-file"), help: .hidden)
+    public var traceEventsFilePath: String? = nil
+
     // Build dynamic library targets as frameworks (only available for Darwin targets and only when using the 'swiftbuild' build-system (currently used for tests).
     @Flag(name: .customLong("experimental-build-dylibs-as-frameworks"), help: .hidden )
     public var shouldBuildDylibsAsFrameworks: Bool = false

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -476,6 +476,14 @@ public final class SwiftCommandState {
                 )
             }
         }
+
+        if options.build.traceEventsFilePath != nil {
+            if options.build.buildSystem != .swiftbuild {
+                observabilityScope.emit(
+                    warning: "'--experimental-trace-events-file' is only supported when using '--build-system swiftbuild'"
+                )
+            }
+        }
     }
 
     func waitForObservabilityEvents(timeout: DispatchTime) {
@@ -975,7 +983,13 @@ public final class SwiftCommandState {
             outputParameters: .init(
                 isColorized: self.options.logging.colorDiagnostics,
                 isVerbose: self.logLevel <= .info,
-                enableTaskBacktraces: self.options.build.enableTaskBacktraces
+                enableTaskBacktraces: self.options.build.enableTaskBacktraces,
+                traceEventsFilePath: try self.options.build.traceEventsFilePath.map {
+                    try AbsolutePath(
+                        validating: $0,
+                        relativeTo: self.fileSystem.currentWorkingDirectory ?? .root
+                    )
+                }
             ),
             testingParameters: .init(
                 forceTestDiscovery: self.options.build.enableTestDiscovery,

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters+Output.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters+Output.swift
@@ -10,17 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
+
 extension BuildParameters {
     /// Build parameters related to output and logging grouped in a single type to aggregate those in one place.
     public struct Output: Encodable {
         public init(
             isColorized: Bool = false,
             isVerbose: Bool = false,
-            enableTaskBacktraces: Bool = false
+            enableTaskBacktraces: Bool = false,
+            traceEventsFilePath: AbsolutePath? = nil
         ) {
             self.isColorized = isColorized
             self.isVerbose = isVerbose
             self.enableTaskBacktraces = enableTaskBacktraces
+            self.traceEventsFilePath = traceEventsFilePath
         }
 
         public var isColorized: Bool
@@ -28,5 +32,7 @@ extension BuildParameters {
         public var isVerbose: Bool
 
         public var enableTaskBacktraces: Bool
+
+        public var traceEventsFilePath: AbsolutePath?
     }
 }

--- a/Sources/SwiftBuildSupport/CMakeLists.txt
+++ b/Sources/SwiftBuildSupport/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_library(SwiftBuildSupport
   BuildSystem.swift
+  TraceEventsWriter.swift
   Diagnostics+Extensions.swift
   DotPIFSerializer.swift
   PackagePIFBuilder.swift

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -616,7 +616,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 outputStream: self.outputStream,
                 logLevel: self.logLevel,
                 enableBacktraces: self.enableTaskBacktraces,
-                buildDelegate: self.delegate
+                buildDelegate: self.delegate,
+                traceEventsFilePath: self.buildParameters.outputParameters.traceEventsFilePath
             )
 
             do {

--- a/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
@@ -29,6 +29,7 @@ public final class SwiftBuildSystemMessageHandler {
     private var buildState: BuildState = .init()
     private let enableBacktraces: Bool
     private let buildDelegate: SPMBuildCore.BuildSystemDelegate?
+    private var traceEventsWriter: TraceEventsWriter?
 
     public typealias BuildSystemCallback = (SwiftBuildSystem) -> Void
 
@@ -56,7 +57,8 @@ public final class SwiftBuildSystemMessageHandler {
         outputStream: OutputByteStream,
         logLevel: Basics.Diagnostic.Severity,
         enableBacktraces: Bool = false,
-        buildDelegate: SPMBuildCore.BuildSystemDelegate? = nil
+        buildDelegate: SPMBuildCore.BuildSystemDelegate? = nil,
+        traceEventsFilePath: Basics.AbsolutePath? = nil
     )
     {
         self.observabilityScope = observabilityScope
@@ -69,6 +71,16 @@ public final class SwiftBuildSystemMessageHandler {
         )
         self.enableBacktraces = enableBacktraces
         self.buildDelegate = buildDelegate
+        if let traceEventsFilePath {
+            do {
+                self.traceEventsWriter = try TraceEventsWriter(path: traceEventsFilePath)
+            } catch {
+                observabilityScope.emit(warning: "Failed to open trace events file: \(error)")
+                self.traceEventsWriter = nil
+            }
+        } else {
+            self.traceEventsWriter = nil
+        }
     }
 
     private func emitInfoAsDiagnostic(info: SwiftBuildMessage.DiagnosticInfo) {
@@ -207,6 +219,7 @@ public final class SwiftBuildSystemMessageHandler {
         guard !self.logLevel.isQuiet else { return callback }
         switch message {
         case .buildCompleted(let info):
+            self.traceEventsWriter?.close()
             progressAnimation.complete(success: info.result == .ok)
             if info.result == .cancelled {
                 callback = { [weak self] buildSystem in
@@ -251,6 +264,7 @@ public final class SwiftBuildSystemMessageHandler {
             buildState.appendToBuffer(info)
         case .taskStarted(let info):
             try buildState.started(task: info, self.logLevel)
+            self.traceEventsWriter?.taskStarted(info)
 
             let targetInfo = try buildState.target(for: info)
             callback = { [weak self] buildSystem in
@@ -259,6 +273,11 @@ public final class SwiftBuildSystemMessageHandler {
             }
         case .taskComplete(let info):
             let startedInfo = try buildState.completed(task: info)
+
+            traceEventsWriter?.taskCompleted(
+                info,
+                startedInfo: startedInfo,
+            )
 
             // Handler for task output, handling failures if applicable.
             try self.handleTaskOutput(info, startedInfo, self.enableBacktraces)

--- a/Sources/SwiftBuildSupport/TraceEventsWriter.swift
+++ b/Sources/SwiftBuildSupport/TraceEventsWriter.swift
@@ -1,0 +1,224 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import SwiftBuild
+
+/// Streams build task events to a file in Trace Event JSON Array Format. The format is documented at:
+/// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+package final class TraceEventsWriter {
+    package enum ArgValue: Codable, Equatable {
+        case string(String)
+        case int(Int)
+
+        package func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .string(let s): try container.encode(s)
+            case .int(let i): try container.encode(i)
+            }
+        }
+
+        package init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let i = try? container.decode(Int.self) {
+                self = .int(i)
+            } else {
+                self = .string(try container.decode(String.self))
+            }
+        }
+    }
+
+    package enum Phase: String, Codable {
+        case complete = "X"
+        case metadata = "M"
+    }
+
+    package enum Category: String, Codable {
+        case build
+        case none = ""
+    }
+
+    package struct LaneID: Hashable, Comparable, Codable {
+        package let rawValue: Int
+
+        package init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        package static let metadata = LaneID(rawValue: 0)
+        package static let firstTask = LaneID(rawValue: 1)
+
+        package func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(rawValue)
+        }
+
+        package init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            self.rawValue = try container.decode(Int.self)
+        }
+
+        package static func < (lhs: LaneID, rhs: LaneID) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+
+        func next() -> LaneID {
+            LaneID(rawValue: rawValue + 1)
+        }
+    }
+
+    struct TaskID: Hashable {
+        let rawValue: Int
+
+        init(_ rawValue: Int) {
+            self.rawValue = rawValue
+        }
+    }
+
+    package struct TraceEvent: Codable, Equatable {
+        package let name: String
+        package let category: Category
+        package let phase: Phase
+        package let timestamp: Int64
+        package let duration: Int64
+        package let processID: Int
+        package let threadID: LaneID
+        package let arguments: [String: ArgValue]?
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case category = "cat"
+            case phase = "ph"
+            case timestamp = "ts"
+            case duration = "dur"
+            case processID = "pid"
+            case threadID = "tid"
+            case arguments = "args"
+        }
+    }
+
+    private let fileHandle: FileHandle
+    private let encoder: JSONEncoder
+    private let buildStartTime: ContinuousClock.Instant
+    private var laneAssignments: [TaskID: LaneID] = [:]
+    private var availableLanes: [LaneID] = []
+    private var nextLane: LaneID = .firstTask
+    private var taskStartTimes: [TaskID: ContinuousClock.Instant] = [:]
+    private var needsComma: Bool = false
+
+    package init(path: Basics.AbsolutePath) throws {
+        let url = URL(fileURLWithPath: path.pathString)
+        if !FileManager.default.fileExists(atPath: path.pathString) {
+            FileManager.default.createFile(atPath: path.pathString, contents: nil)
+        }
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.truncate(atOffset: 0)
+        handle.write(Data("[\n".utf8))
+        self.fileHandle = handle
+        self.encoder = JSONEncoder()
+        self.encoder.outputFormatting = [.sortedKeys]
+        self.buildStartTime = ContinuousClock.now
+    }
+
+    package func taskStarted(_ info: SwiftBuildMessage.TaskStartedInfo) {
+        let taskID = TaskID(info.taskID)
+        let lane: LaneID
+        if let reusedLane = availableLanes.popLast() {
+            lane = reusedLane
+        } else {
+            lane = nextLane
+            nextLane = nextLane.next()
+        }
+        laneAssignments[taskID] = lane
+        taskStartTimes[taskID] = .now
+    }
+
+    package func taskCompleted(
+        _ info: SwiftBuildMessage.TaskCompleteInfo,
+        startedInfo: SwiftBuildMessage.TaskStartedInfo,
+    ) {
+        let taskID = TaskID(info.taskID)
+        let endInstant = ContinuousClock.now
+        guard let lane = laneAssignments.removeValue(forKey: taskID),
+              let startInstant = taskStartTimes.removeValue(forKey: taskID) else {
+            return
+        }
+
+        // Return lane to the pool, maintaining descending order.
+        let insertionIndex = availableLanes.firstIndex(where: { $0 < lane }) ?? availableLanes.endIndex
+        availableLanes.insert(lane, at: insertionIndex)
+
+        let startMicroseconds = (startInstant - buildStartTime).microseconds
+        let durationMicroseconds = (endInstant - startInstant).microseconds
+
+        var args: [String: ArgValue] = [:]
+        args["description"] = .string(startedInfo.executionDescription)
+        if let cmdLine = startedInfo.commandLineDisplayString {
+            args["commandLine"] = .string(cmdLine)
+        }
+        args["result"] = .string("\(info.result)")
+        appendEvent(TraceEvent(
+            name: startedInfo.executionDescription,
+            category: .build,
+            phase: .complete,
+            timestamp: startMicroseconds,
+            duration: durationMicroseconds,
+            processID: 1,
+            threadID: lane,
+            arguments: args
+        ))
+    }
+
+    package func close() {
+        appendEvent(TraceEvent(
+            name: "process_name", category: .none, phase: .metadata,
+            timestamp: 0, duration: 0, processID: 1, threadID: .metadata,
+            arguments: ["name": .string("Build")]
+        ))
+
+        var lane = LaneID.firstTask
+        while lane < nextLane {
+            appendEvent(TraceEvent(
+                name: "thread_name", category: .none, phase: .metadata,
+                timestamp: 0, duration: 0, processID: 1, threadID: lane,
+                arguments: ["name": .string("Lane \(lane.rawValue)")]
+            ))
+            appendEvent(TraceEvent(
+                name: "thread_sort_index", category: .none, phase: .metadata,
+                timestamp: 0, duration: 0, processID: 1, threadID: lane,
+                arguments: ["sort_index": .int(lane.rawValue)]
+            ))
+            lane = lane.next()
+        }
+
+        fileHandle.write(Data("\n]\n".utf8))
+        fileHandle.closeFile()
+    }
+
+    private func appendEvent(_ event: TraceEvent) {
+        guard let data = try? encoder.encode(event) else { return }
+        if needsComma {
+            fileHandle.write(Data(",\n".utf8))
+        }
+        fileHandle.write(data)
+        needsComma = true
+    }
+}
+
+private extension Duration {
+    var microseconds: Int64 {
+        let (seconds, attoseconds) = components
+        return seconds * 1_000_000 + attoseconds / 1_000_000_000_000
+    }
+}

--- a/Tests/SwiftBuildSupportTests/TraceEventsWriterTests.swift
+++ b/Tests/SwiftBuildSupportTests/TraceEventsWriterTests.swift
@@ -1,0 +1,209 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+import Basics
+import Foundation
+@_spi(Testing) import SwiftBuild
+import SwiftBuildSupport
+
+@Suite
+struct TraceEventsWriterTests {
+    @Test
+    func testSingleTask() throws {
+        let events = try buildTrace { writer in
+            writer.taskStarted(.init(taskID: 1))
+            writer.taskCompleted(
+                .init(taskID: 1, result: .success),
+                startedInfo: .init(taskID: 1, executionDescription: "Compiling main.swift")
+            )
+        }
+
+        let taskEvents = events.filter { $0.phase == .complete }
+        #expect(taskEvents.count == 1)
+
+        let event = try #require(taskEvents.first)
+        #expect(event.name == "Compiling main.swift")
+        #expect(event.category == .build)
+        #expect(event.processID == 1)
+        #expect(event.threadID >= .firstTask)
+        #expect(event.timestamp > 0)
+        #expect(event.duration >= 0)
+    }
+
+    @Test
+    func testConcurrentTasksGetSeparateLanes() throws {
+        let events = try buildTrace { writer in
+            writer.taskStarted(.init(taskID: 1))
+            writer.taskStarted(.init(taskID: 2))
+            writer.taskStarted(.init(taskID: 3))
+
+            writer.taskCompleted(
+                .init(taskID: 1, result: .success),
+                startedInfo: .init(taskID: 1, executionDescription: "Task A")
+            )
+            writer.taskCompleted(
+                .init(taskID: 2, result: .success),
+                startedInfo: .init(taskID: 2, executionDescription: "Task B")
+            )
+            writer.taskCompleted(
+                .init(taskID: 3, result: .success),
+                startedInfo: .init(taskID: 3, executionDescription: "Task C")
+            )
+        }
+
+        let taskEvents = events.filter { $0.phase == .complete }
+        let lanes = Set(taskEvents.map(\.threadID))
+        #expect(lanes.count == 3)
+        #expect(lanes == Set([.init(rawValue: 1), .init(rawValue: 2), .init(rawValue: 3)]))
+    }
+
+    @Test
+    func testLaneReuse() throws {
+        let events = try buildTrace { writer in
+            writer.taskStarted(.init(taskID: 1))
+            writer.taskStarted(.init(taskID: 2))
+
+            writer.taskCompleted(
+                .init(taskID: 1, result: .success),
+                startedInfo: .init(taskID: 1, executionDescription: "Task A")
+            )
+
+            writer.taskStarted(.init(taskID: 3))
+            writer.taskCompleted(
+                .init(taskID: 3, result: .success),
+                startedInfo: .init(taskID: 3, executionDescription: "Task C")
+            )
+            writer.taskCompleted(
+                .init(taskID: 2, result: .success),
+                startedInfo: .init(taskID: 2, executionDescription: "Task B")
+            )
+        }
+
+        let taskEvents = events.filter { $0.phase == .complete }
+        let eventsByName = Dictionary(uniqueKeysWithValues: taskEvents.map { ($0.name, $0) })
+
+        #expect(eventsByName["Task A"]?.threadID == .init(rawValue: 1))
+        #expect(eventsByName["Task B"]?.threadID == .init(rawValue: 2))
+        #expect(eventsByName["Task C"]?.threadID == .init(rawValue: 1))
+    }
+
+    @Test
+    func testLowestLaneReusedFirst() throws {
+        let events = try buildTrace { writer in
+            writer.taskStarted(.init(taskID: 1))
+            writer.taskStarted(.init(taskID: 2))
+            writer.taskStarted(.init(taskID: 3))
+            writer.taskStarted(.init(taskID: 4))
+
+            writer.taskCompleted(
+                .init(taskID: 3, result: .success),
+                startedInfo: .init(taskID: 3, executionDescription: "Task C")
+            )
+            writer.taskCompleted(
+                .init(taskID: 1, result: .success),
+                startedInfo: .init(taskID: 1, executionDescription: "Task A")
+            )
+
+            writer.taskStarted(.init(taskID: 5))
+            writer.taskCompleted(
+                .init(taskID: 5, result: .success),
+                startedInfo: .init(taskID: 5, executionDescription: "Task E")
+            )
+
+            writer.taskCompleted(
+                .init(taskID: 2, result: .success),
+                startedInfo: .init(taskID: 2, executionDescription: "Task B")
+            )
+            writer.taskCompleted(
+                .init(taskID: 4, result: .success),
+                startedInfo: .init(taskID: 4, executionDescription: "Task D")
+            )
+        }
+
+        let taskEvents = events.filter { $0.phase == .complete }
+        let eventsByName = Dictionary(uniqueKeysWithValues: taskEvents.map { ($0.name, $0) })
+
+        #expect(eventsByName["Task E"]?.threadID == .init(rawValue: 1))
+    }
+
+    @Test
+    func testArgsIncludeTaskMetadata() throws {
+        let events = try buildTrace { writer in
+            writer.taskStarted(.init(taskID: 1))
+            writer.taskCompleted(
+                .init(taskID: 1, result: .failed),
+                startedInfo: .init(
+                    taskID: 1,
+                    executionDescription: "Compiling Foo.swift",
+                    commandLineDisplayString: "/usr/bin/swiftc -c Foo.swift"
+                )
+            )
+        }
+
+        let taskEvent = try #require(events.first(where: { $0.phase == .complete }))
+
+        #expect(taskEvent.arguments?["description"] == .string("Compiling Foo.swift"))
+        #expect(taskEvent.arguments?["commandLine"] == .string("/usr/bin/swiftc -c Foo.swift"))
+        #expect(taskEvent.arguments?["result"] == .string("failed"))
+    }
+
+    fileprivate func buildTrace(
+        _ body: (TraceEventsWriter) throws -> Void
+    ) throws -> [TraceEventsWriter.TraceEvent] {
+        let tmpFile = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("trace-test-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let path = try Basics.AbsolutePath(validating: tmpFile.path)
+        let writer = try TraceEventsWriter(path: path)
+        try body(writer)
+        writer.close()
+
+        let data = try Data(contentsOf: tmpFile)
+        let text = String(decoding: data, as: UTF8.self)
+        let events = try JSONDecoder().decode([TraceEventsWriter.TraceEvent].self, from: data)
+
+        return events
+    }
+}
+
+extension SwiftBuildMessage.TaskStartedInfo {
+    fileprivate init(
+        taskID: Int = 0,
+        executionDescription: String = "",
+        commandLineDisplayString: String? = nil,
+        ruleInfo: String = ""
+    ) {
+        self.init(
+            taskID: taskID,
+            targetID: nil,
+            taskSignature: "",
+            parentTaskID: nil,
+            ruleInfo: ruleInfo,
+            interestingPath: nil,
+            commandLineDisplayString: commandLineDisplayString,
+            executionDescription: executionDescription,
+            serializedDiagnosticsPaths: []
+        )
+    }
+}
+
+extension SwiftBuildMessage.TaskCompleteInfo {
+    fileprivate init(
+        taskID: Int = 0,
+        result: SwiftBuildMessage.TaskCompleteInfo.Result = .success
+    ) {
+        self.init(taskID: taskID, taskSignature: "", result: result, signalled: false, metrics: nil)
+    }
+}


### PR DESCRIPTION
This is useful for debugging build perf and incremental build issues. The resulting traces can be opened in a tool like `chrome://tracing` or Perfetto.