### PR TITLE
Fix didFetchPackage incorrectly reporting package was cached

### DIFF
--- a/Sources/Commands/CommandWorkspaceDelegate.swift
+++ b/Sources/Commands/CommandWorkspaceDelegate.swift
@@ -66,7 +66,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     func didFetchPackage(package: PackageIdentity, packageLocation: String?, result: Result<PackageFetchDetails, Error>, duration: DispatchTimeInterval) {
-        guard case .success = result, !self.observabilityScope.errorsReported else {
+        guard case .success(let fetchDetails) = result, !self.observabilityScope.errorsReported else {
             return
         }
 
@@ -81,7 +81,7 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
             }
         }
 
-        self.outputHandler("Fetched \(packageLocation ?? package.description) from cache (\(duration.descriptionInSeconds))", .always)
+        self.outputHandler("Fetched \(packageLocation ?? package.description)\(fetchDetails.fromCache ? " from cache" : "") (\(duration.descriptionInSeconds))", .always)
     }
 
     func fetchingPackage(package: PackageIdentity, packageLocation: String?, progress: Int64, total: Int64?) {


### PR DESCRIPTION
### Motivation:

`CustomWorkspaceDelegate.didFetchPackage` wasn't checking the `fetchDetails.fromCache` flag and was always reporting that packages were fetched from the cache even when they weren't.

### Modifications:

Follow the same pattern as `willFetchPackage` and check the `fromCache` flag, and report correctly.

### Result:

Logs report correctly whether the package was cached or not

Issue: #9172