### PR TITLE
[Swift Build] Fix build tool plugin tool lookup when cross-compiling

### DIFF
--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -123,6 +123,7 @@ private struct SwiftBuildSystemFactory: BuildSystemFactory {
     ) throws -> any BuildSystem {
         return try SwiftBuildSystem(
             buildParameters: productsBuildParameters ?? self.swiftCommandState.productsBuildParameters,
+            hostBuildParameters: toolsBuildParameters ?? self.swiftCommandState.toolsBuildParameters,
             packageGraphLoader: packageGraphLoader ?? {
                 try await self.swiftCommandState.loadPackageGraph(
                     explicitProduct: explicitProduct,

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -151,7 +151,8 @@ public final class PIFBuilder {
         prettyPrint: Bool = true,
         preservePIFModelStructure: Bool = false,
         printPIFManifestGraphviz: Bool = false,
-        buildParameters: BuildParameters
+        buildParameters: BuildParameters,
+        hostBuildParameters: BuildParameters
     ) async throws -> String {
         let encoder = prettyPrint ? JSONEncoder.makeWithDefaults() : JSONEncoder()
 
@@ -159,7 +160,7 @@ public final class PIFBuilder {
             encoder.userInfo[.encodeForSwiftBuild] = true
         }
 
-        let topLevelObject = try await self.constructPIF(buildParameters: buildParameters)
+        let topLevelObject = try await self.constructPIF(buildParameters: buildParameters, hostBuildParameters: hostBuildParameters)
 
         // Sign the PIF objects before encoding it for Swift Build.
         try PIF.sign(workspace: topLevelObject.workspace)
@@ -186,6 +187,7 @@ public final class PIFBuilder {
     private func availableBuildPluginTools(
         graph: ModulesGraph,
         buildParameters: BuildParameters,
+        hostBuildParameters: BuildParameters,
         pluginsPerModule: [ResolvedModule.ID: [ResolvedModule]],
         hostTriple: Basics.Triple
     ) async throws -> [ResolvedModule.ID: [String: PluginTool]] {
@@ -200,7 +202,7 @@ public final class PIFBuilder {
                     environment: buildParameters.buildEnvironment,
                     for: hostTriple
                 ) { name, path in
-                    return buildParameters.buildPath.appending(path)
+                    return hostBuildParameters.buildPath.appending(path)
                 }
 
                 accessibleToolsPerPlugin[plugin.id] = accessibleTools
@@ -213,7 +215,8 @@ public final class PIFBuilder {
     /// Constructs all `PackagePIFBuilder` objects used by the `constructPIF` function.
     /// In particular, this is useful for unit testing the complex `PIFBuilder` class.
     func makePIFBuilders(
-        buildParameters: BuildParameters
+        buildParameters: BuildParameters,
+        hostBuildParameters: BuildParameters
     ) async throws -> [(ResolvedPackage, PackagePIFBuilder, any PackagePIFBuilder.BuildDelegate)] {
         let pluginScriptRunner = self.parameters.pluginScriptRunner
         let outputDir = self.parameters.pluginWorkingDirectory.appending("outputs")
@@ -225,6 +228,7 @@ public final class PIFBuilder {
         let availablePluginTools = try await availableBuildPluginTools(
             graph: graph,
             buildParameters: buildParameters,
+            hostBuildParameters: hostBuildParameters,
             pluginsPerModule: pluginsPerModule,
             hostTriple: try pluginScriptRunner.hostTriple
         )
@@ -438,7 +442,8 @@ public final class PIFBuilder {
 
     /// Constructs a `PIF.TopLevelObject` representing the package graph.
     package func constructPIF(
-        buildParameters: BuildParameters
+        buildParameters: BuildParameters,
+        hostBuildParameters: BuildParameters
     ) async throws -> PIF.TopLevelObject {
         return try await memoize(to: &self.cachedPIF) {
             let rootPackages = self.graph.rootPackages
@@ -446,7 +451,7 @@ public final class PIFBuilder {
                 throw PIFGenerationError.rootPackageNotFound
             }
 
-            let packagesAndPIFBuilders = try await makePIFBuilders(buildParameters: buildParameters)
+            let packagesAndPIFBuilders = try await makePIFBuilders(buildParameters: buildParameters, hostBuildParameters: hostBuildParameters)
 
             let packagesAndPIFProjects = try packagesAndPIFBuilders.map { (package, pifBuilder, _) in
                 try pifBuilder.build()
@@ -537,6 +542,7 @@ public final class PIFBuilder {
     // Convenience method for generating PIF.
     public static func generatePIF(
         buildParameters: BuildParameters,
+        hostBuildParameters: BuildParameters,
         packageGraph: ModulesGraph,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
@@ -568,7 +574,7 @@ public final class PIFBuilder {
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )
-        return try await builder.generatePIF(preservePIFModelStructure: preservePIFModelStructure, buildParameters: buildParameters)
+        return try await builder.generatePIF(preservePIFModelStructure: preservePIFModelStructure, buildParameters: buildParameters, hostBuildParameters: hostBuildParameters)
     }
 }
 

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -243,6 +243,7 @@ package final class SwiftBuildSystemPlanningOperationDelegate: SWBPlanningOperat
 
 public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
     package let buildParameters: BuildParameters
+    package let hostBuildParameters: BuildParameters
     private let packageGraphLoader: () async throws -> ModulesGraph
     private let packageManagerResourcesDirectory: Basics.AbsolutePath?
     private let logLevel: Basics.Diagnostic.Severity
@@ -307,6 +308,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
     public init(
         buildParameters: BuildParameters,
+        hostBuildParameters: BuildParameters,
         packageGraphLoader: @escaping () async throws -> ModulesGraph,
         packageManagerResourcesDirectory: Basics.AbsolutePath?,
         additionalFileRules: [FileRuleDescription],
@@ -318,6 +320,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         delegate: BuildSystemDelegate?
     ) throws {
         self.buildParameters = buildParameters
+        self.hostBuildParameters = hostBuildParameters
         self.packageGraphLoader = packageGraphLoader
         self.packageManagerResourcesDirectory = packageManagerResourcesDirectory
         self.additionalFileRules = additionalFileRules
@@ -419,34 +422,6 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             pifTargetName: subset.pifTargetName,
             buildOutputs: buildOutputs,
         )
-    }
-
-    /// Compute the available build tools, and their destination build path for host for each plugin.
-    private func availableBuildPluginTools(
-        graph: ModulesGraph,
-        buildParameters: BuildParameters,
-        pluginsPerModule: [ResolvedModule.ID: [ResolvedModule]],
-        hostTriple: Basics.Triple
-    ) async throws -> [ResolvedModule.ID: [String: PluginTool]] {
-        var accessibleToolsPerPlugin: [ResolvedModule.ID: [String: PluginTool]] = [:]
-
-        for (_, plugins) in pluginsPerModule {
-            for plugin in plugins where accessibleToolsPerPlugin[plugin.id] == nil {
-                // Determine the tools to which this plugin has access, and create a name-to-path mapping from tool
-                // names to the corresponding paths. Built tools are assumed to be in the build tools directory.
-                let accessibleTools = try await plugin.preparePluginTools(
-                    fileSystem: fileSystem,
-                    environment: buildParameters.buildEnvironment,
-                    for: hostTriple
-                ) { name, path in
-                    return buildParameters.buildPath.appending(path)
-                }
-
-                accessibleToolsPerPlugin[plugin.id] = accessibleTools
-            }
-        }
-
-        return accessibleToolsPerPlugin
     }
 
     /// Compiles any plugins specified or implied by the build subset, returning
@@ -1284,7 +1259,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         let pif = try await pifBuilder.generatePIF(
             preservePIFModelStructure: preserveStructure,
             printPIFManifestGraphviz: buildParameters.printPIFManifestGraphviz,
-            buildParameters: buildParameters
+            buildParameters: buildParameters,
+            hostBuildParameters: hostBuildParameters
         )
         return pif
     }

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -423,6 +423,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
 
                 return try SwiftBuildSystem(
                     buildParameters: buildParameters,
+                    hostBuildParameters: buildParameters,
                     packageGraphLoader: asyncUnsafePackageGraphLoader,
                     packageManagerResourcesDirectory: nil,
                     additionalFileRules: [],

--- a/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
@@ -194,6 +194,10 @@ import SwiftBuild
             buildParameters: mockBuildParameters(
                 destination: .host,
                 buildSystemKind: .swiftbuild,
+            ),
+            hostBuildParameters: mockBuildParameters(
+                destination: .host,
+                buildSystemKind: .swiftbuild,
             )
         )
     }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -59,10 +59,16 @@ fileprivate func withGeneratedPIF(
     addLocalRpaths: Bool = true,
     shouldCreateDylibForDynamicProducts: Bool = true,
     buildParameters: BuildParameters? = nil,
+    hostBuildParameters: BuildParameters? = nil,
     do doIt: (SwiftBuildSupport.PIF.TopLevelObject, TestingObservability) async throws -> ()
 ) async throws {
     let buildParameters = if let buildParameters {
         buildParameters
+    } else {
+        mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+    }
+    let hostBuildParameters = if let hostBuildParameters {
+        hostBuildParameters
     } else {
         mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
     }
@@ -95,6 +101,7 @@ fileprivate func withGeneratedPIF(
         )
         let pif = try await builder.constructPIF(
             buildParameters: buildParameters,
+            hostBuildParameters: hostBuildParameters
         )
         try await doIt(pif, observabilitySystem)
     }
@@ -386,6 +393,7 @@ struct PIFBuilderTests {
         // Act
         let pif = try await pifBuilder.constructPIF(
             buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
+            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         // Assert
@@ -497,6 +505,35 @@ struct PIFBuilderTests {
                 $0.message.contains("found binary artifact")
             }
             #expect(binaryArtifactMessages.count > 0, "Expected to find binary artifact processing messages")
+        }
+    }
+
+    @Test func buildToolPluginCommandLineUsesHostBuildPath() async throws {
+        let hostBuildPath = AbsolutePath("/path/to/host/build")
+        let destBuildPath = AbsolutePath("/path/to/dest/build")
+        let hostBuildParams = mockBuildParameters(
+            destination: .host,
+            buildPath: hostBuildPath,
+            buildSystemKind: .swiftbuild
+        )
+        let destBuildParams = mockBuildParameters(
+            destination: .host,
+            buildPath: destBuildPath,
+            buildSystemKind: .swiftbuild
+        )
+
+        try await withGeneratedPIF(
+            fromFixture: "Miscellaneous/Plugins/MySourceGenPlugin",
+            buildParameters: destBuildParams,
+            hostBuildParameters: hostBuildParams
+        ) { pif, observabilitySystem in
+            let project = try pif.workspace.project(named: "MySourceGenPlugin")
+            let target = try project.target(named: "MyLocalTool-product")
+            for task in target.common.customTasks {
+                let commandLine = task.commandLine
+                #expect(commandLine.contains { $0.contains(hostBuildPath.pathString) })
+                #expect(!commandLine.contains { $0.contains(destBuildPath.pathString) })
+            }
         }
     }
 
@@ -790,7 +827,8 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let pif = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
+            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let remoteProject = try pif.workspace.project(named: "remote-pkg")
@@ -928,7 +966,8 @@ struct PIFBuilderTests {
         )
 
         let pif = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
+            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let project = try pif.workspace.project(named: "Root")

--- a/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
@@ -174,7 +174,8 @@ struct PrebuiltsPIFTests {
             observabilityScope: observability.topScope
         )
         let pif = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
+            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let hostTargets = Set([
@@ -373,7 +374,8 @@ struct PrebuiltsPIFTests {
             observabilityScope: observability.topScope
         )
         let pif = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
+            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let targets = pif.workspace.projects.flatMap({ $0.underlying.targets })

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -65,6 +65,7 @@ func withInstantiatedSwiftBuildSystem(
 
             let swBuild = try SwiftBuildSystem(
                 buildParameters: buildParameters,
+                hostBuildParameters: buildParameters,
                 packageGraphLoader: graphLoader,
                 packageManagerResourcesDirectory: nil,
                 additionalFileRules: [],


### PR DESCRIPTION
Custom tasks were not consistently computing the correct path to tool executables looked up by plugins when cross-compiling. Thread through the hostBuildParameters to ensure  this is sound