### PR TITLE
Explicitly set SUPPORTED_PLATFORMS on macro targets

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -667,6 +667,7 @@ extension PackagePIFProjectBuilder {
 
         if desiredModuleType == .macro {
             settings[.SWIFT_IMPLEMENTS_MACROS_FOR_MODULE_NAMES] = [sourceModule.c99name]
+            settings[.SUPPORTED_PLATFORMS] = ["$(HOST_PLATFORM)"]
 
             // Don't install the Swift module when building the macro executable, lest it conflict with the testable variant.
             // The contents of the testable variant's module will exactly match the binary linked by dependencies (test targets).

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -966,4 +966,24 @@ struct PIFBuilderTests {
             )
         }
     }
+
+    @Test func macroPackageSupportedPlatforms() async throws {
+        try await withGeneratedPIF(fromFixture: "Macros/MinimalMacroPackage") { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+            let project = try pif.workspace.project(named: "MinimalMacroPackage")
+            let projectPlatforms = try project.buildConfig(named: .debug).settings[.SUPPORTED_PLATFORMS]
+            #expect(projectPlatforms == ["$(AVAILABLE_PLATFORMS)"])
+            let targets = project.underlying.targets
+            for target in targets {
+                let id = target.common.id.value
+                let config = try target.buildConfig(named: .debug)
+                let platforms = config.settings[.SUPPORTED_PLATFORMS]
+                if id == "PACKAGE-TARGET:MacroImpl" {
+                    #expect(platforms == ["$(HOST_PLATFORM)"], "target \(id) did not have the expected supported platform setting")
+                } else {
+                    #expect(platforms == nil, "target \(id) has supported platforms set, unexpectedly")
+                }
+            }
+        }
+    }
 }

--- a/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
@@ -378,7 +378,7 @@ struct PrebuiltsPIFTests {
 
         let targets = pif.workspace.projects.flatMap({ $0.underlying.targets })
         for target in targets {
-            guard target.common.name != "Plugin" else {
+            guard !["Plugin", "Macros"].contains(target.common.name) else {
                 // The Plugin target does have HOST_PLATFORM test
                 continue
             }


### PR DESCRIPTION
Previously, we relied on the hostBuildTool product type's OverridingBuildSettings to set SUPPORTED_PLATFORMS=$(HOST_PLATFORM) for macros. This worked for builtin SDKs, but was subtly wrong because the product type properties aren't pushed at the very beginning of platform/SDK resolution. As a result we'd sometimes make decisions based on the SUPPORTED_PLATFORMS=$(AVAILABLE_PLATFORMS) project level setting instead and specialize macros for the destination platform when cross-compiling with a Swift SDK. Set SUPPORTED_PLATFORMS in the target PIF instead, like we do for build plugins.