### PR TITLE
Don't output cancelled tasks to console [swiftbuild]

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
@@ -130,7 +130,11 @@ public final class SwiftBuildSystemMessageHandler {
         }
 
         guard info.result == .success else {
-            emitFailedTaskOutput(info, startedInfo)
+            // Don't emit error output for tasks that were cancelled (e.g. collateral damage
+            // when another task failed and the build was aborted). These are not real errors.
+            if info.result != .cancelled {
+                emitFailedTaskOutput(info, startedInfo)
+            }
             return
         }
 


### PR DESCRIPTION
When an error occurs, swift-build will cancel any inflight tasks, these end of flooding the console as errors with no actutal failure, and the really error get lost as the very top of the output.
