### PR TITLE
Add scudo sanitizer support

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -863,7 +863,9 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     settings["ENABLE_THREAD_SANITIZER"] = "YES"
                 case .undefined:
                     settings["ENABLE_UNDEFINED_BEHAVIOR_SANITIZER"] = "YES"
-                case .fuzzer, .scudo:
+                case .scudo:
+                    settings["ENABLE_SCUDO_SANITIZER"] = "YES"
+                case .fuzzer:
                     throw StringError("\(sanitizer) is not currently supported with this build system.")
             }
         }

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -115,8 +115,8 @@ func withInstantiatedSwiftBuildSystem(
 extension PackageModel.Sanitizer {
     var hasSwiftBuildSupport: Bool {
         switch self {
-            case .address, .thread, .undefined: true
-            case .fuzzer, .scudo: false
+            case .address, .thread, .undefined, .scudo: true
+            case .fuzzer: false
         }
     }
 
@@ -125,7 +125,8 @@ extension PackageModel.Sanitizer {
             case .address: "ENABLE_ADDRESS_SANITIZER"
             case .thread: "ENABLE_THREAD_SANITIZER"
             case .undefined: "ENABLE_UNDEFINED_BEHAVIOR_SANITIZER"
-            case .fuzzer, .scudo: nil
+            case .scudo: "ENABLE_SCUDO_SANITIZER"
+            case .fuzzer: nil
         }
 
     }


### PR DESCRIPTION
Add `scudo` sanitizer support in SwiftPM when running against SwiftBuild build backend.

Depends on: https://github.com/swiftlang/swift-build/pull/1253
Fixes: #9448 