### PR TITLE
package collection docs

### DIFF
--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection.md
@@ -1,0 +1,23 @@
+# ``PackageCollectionModel/V1/Collection``
+
+## Topics
+
+### Creating a Collection
+
+- ``init(name:overview:keywords:packages:formatVersion:revision:generatedAt:generatedBy:)``
+
+### Inspecting a Collection
+
+- ``name``
+- ``overview``
+- ``keywords``
+- ``packages``
+- ``formatVersion``
+- ``revision``
+- ``generatedAt``
+- ``generatedBy``
+
+### Supporting Types
+
+- ``Author``
+- ``Package``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Author.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Author.md
@@ -1,0 +1,11 @@
+# ``PackageCollectionModel/V1/Collection/Author``
+
+## Topics
+
+### Creating an Author
+
+- ``init(name:)``
+
+### Inspecting an Author
+
+- ``name``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Package.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Package.md
@@ -1,0 +1,17 @@
+# ``PackageCollectionModel/V1/Collection/Package``
+
+## Topics
+
+### Creating a Package
+
+- ``init(url:identity:summary:keywords:versions:readmeURL:license:)``
+
+### Inspecting a Package
+
+- ``url``
+- ``identity``
+- ``summary``
+- ``keywords``
+- ``versions``
+- ``readmeURL``
+- ``license``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Package_Version.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Package_Version.md
@@ -1,0 +1,24 @@
+# ``PackageCollectionModel/V1/Collection/Package/Version``
+
+## Topics
+
+### Creating a Version
+
+- ``init(version:summary:manifests:defaultToolsVersion:verifiedCompatibility:license:author:signer:createdAt:)``
+
+### Inspecting a Version
+
+- ``version``
+- ``summary``
+- ``manifests``
+- ``defaultToolsVersion``
+- ``verifiedCompatibility``
+- ``license``
+- ``author``
+- ``signer``
+- ``createdAt``
+
+### Supporting Types
+
+- ``Manifest``
+- ``Author``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Package_Version_Author.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Package_Version_Author.md
@@ -1,0 +1,11 @@
+# ``PackageCollectionModel/V1/Collection/Package/Version/Author``
+
+## Topics
+
+### Creating an Author
+
+- ``init(name:)``
+
+### Inspecting an Author
+
+- ``name``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Package_Version_Manifest.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Collection_Package_Version_Manifest.md
@@ -1,0 +1,15 @@
+# ``PackageCollectionModel/V1/Collection/Package/Version/Manifest``
+
+## Topics
+
+### Creating a Manifest
+
+- ``init(toolsVersion:packageName:targets:products:minimumPlatformVersions:)``
+
+### Inspecting a Manifest
+
+- ``toolsVersion``
+- ``packageName``
+- ``targets``
+- ``products``
+- ``minimumPlatformVersions``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Compatibility.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Compatibility.md
@@ -1,0 +1,12 @@
+# ``PackageCollectionModel/V1/Compatibility``
+
+## Topics
+
+### Creating a Compatibility
+
+- ``init(platform:swiftVersion:)``
+
+### Inspecting a Compatibility
+
+- ``platform``
+- ``swiftVersion``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/FormatVersion.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/FormatVersion.md
@@ -1,0 +1,7 @@
+# ``PackageCollectionModel/FormatVersion``
+
+## Topics
+
+### Format Versions
+
+- ``v1_0``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/License.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/License.md
@@ -1,0 +1,12 @@
+# ``PackageCollectionModel/V1/License``
+
+## Topics
+
+### Creating a License
+
+- ``init(name:url:)``
+
+### Inspecting a License
+
+- ``name``
+- ``url``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Platform.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Platform.md
@@ -1,0 +1,11 @@
+# ``PackageCollectionModel/V1/Platform``
+
+## Topics
+
+### Creating a Platform
+
+- ``init(name:)``
+
+### Inspecting a Platform
+
+- ``name``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/PlatformVersion.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/PlatformVersion.md
@@ -1,0 +1,12 @@
+# ``PackageCollectionModel/V1/PlatformVersion``
+
+## Topics
+
+### Creating a Platform Version
+
+- ``init(name:version:)``
+
+### Inspecting a Platform Version
+
+- ``name``
+- ``version``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Product.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Product.md
@@ -1,0 +1,13 @@
+# ``PackageCollectionModel/V1/Product``
+
+## Topics
+
+### Creating a Product
+
+- ``init(name:type:targets:)``
+
+### Inspecting a Product
+
+- ``name``
+- ``type``
+- ``targets``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/ProductType.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/ProductType.md
@@ -1,0 +1,16 @@
+# ``PackageCollectionModel/V1/ProductType``
+
+## Topics
+
+### Product Types
+
+- ``library(_:)``
+- ``executable``
+- ``plugin``
+- ``snippet``
+- ``test``
+- ``macro``
+
+### Supporting Types
+
+- ``LibraryType``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/ProductType_LibraryType.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/ProductType_LibraryType.md
@@ -1,0 +1,9 @@
+# ``PackageCollectionModel/V1/ProductType/LibraryType``
+
+## Topics
+
+### Library Types
+
+- ``static``
+- ``dynamic``
+- ``automatic``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Signature.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Signature.md
@@ -1,0 +1,16 @@
+# ``PackageCollectionModel/V1/Signature``
+
+## Topics
+
+### Creating a Signature
+
+- ``init(signature:certificate:)``
+
+### Inspecting a Signature
+
+- ``signature``
+- ``certificate``
+
+### Supporting Types
+
+- ``Certificate``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Signature_Certificate.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Signature_Certificate.md
@@ -1,0 +1,16 @@
+# ``PackageCollectionModel/V1/Signature/Certificate``
+
+## Topics
+
+### Creating a Certificate
+
+- ``init(subject:issuer:)``
+
+### Inspecting a Certificate
+
+- ``subject``
+- ``issuer``
+
+### Supporting Types
+
+- ``Name``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Signature_Certificate_Name.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Signature_Certificate_Name.md
@@ -1,0 +1,14 @@
+# ``PackageCollectionModel/V1/Signature/Certificate/Name``
+
+## Topics
+
+### Creating a Name
+
+- ``init(userID:commonName:organizationalUnit:organization:)``
+
+### Inspecting a Name
+
+- ``userID``
+- ``commonName``
+- ``organizationalUnit``
+- ``organization``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/SignedCollection.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/SignedCollection.md
@@ -1,0 +1,12 @@
+# ``PackageCollectionModel/V1/SignedCollection``
+
+## Topics
+
+### Creating a Signed Collection
+
+- ``init(collection:signature:)``
+
+### Inspecting a Signed Collection
+
+- ``collection``
+- ``signature``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Signer.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Signer.md
@@ -1,0 +1,14 @@
+# ``PackageCollectionModel/V1/Signer``
+
+## Topics
+
+### Creating a Signer
+
+- ``init(type:commonName:organizationalUnitName:organizationName:)``
+
+### Inspecting a Signer
+
+- ``type``
+- ``commonName``
+- ``organizationalUnitName``
+- ``organizationName``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/Target.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/Target.md
@@ -1,0 +1,12 @@
+# ``PackageCollectionModel/V1/Target``
+
+## Topics
+
+### Creating a Target
+
+- ``init(name:moduleName:)``
+
+### Inspecting a Target
+
+- ``name``
+- ``moduleName``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/V1.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/V1.md
@@ -6,23 +6,23 @@
 
 - ``Collection``
 
-### Targets and Products
+### Defining Targets and Products
 
 - ``Target``
 - ``Product``
 - ``ProductType``
 
-### Platforms and Compatibility
+### Specifying Platforms and Compatibility
 
 - ``PlatformVersion``
 - ``Platform``
 - ``Compatibility``
 
-### Licensing
+### Providing License Information
 
 - ``License``
 
-### Signing
+### Signing Collections
 
 - ``Signer``
 - ``SignedCollection``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Curation/V1.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Curation/V1.md
@@ -1,0 +1,29 @@
+# ``PackageCollectionModel/V1``
+
+## Topics
+
+### Describing a Collection
+
+- ``Collection``
+
+### Targets and Products
+
+- ``Target``
+- ``Product``
+- ``ProductType``
+
+### Platforms and Compatibility
+
+- ``PlatformVersion``
+- ``Platform``
+- ``Compatibility``
+
+### Licensing
+
+- ``License``
+
+### Signing
+
+- ``Signer``
+- ``SignedCollection``
+- ``Signature``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Documentation.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Documentation.md
@@ -11,7 +11,7 @@ Use the types in this module to create, encode, and decode package collection do
 
 ## Topics
 
-### Collection Format
+### Defining the Collection Format
 
 - ``PackageCollectionModel``
 - ``PackageCollectionModel/FormatVersion``
@@ -29,23 +29,23 @@ Use the types in this module to create, encode, and decode package collection do
 - ``PackageCollectionModel/V1/Collection/Package/Version/Manifest``
 - ``PackageCollectionModel/V1/Collection/Package/Version/Author``
 
-### Targets and Products
+### Defining Targets and Products
 
 - ``PackageCollectionModel/V1/Target``
 - ``PackageCollectionModel/V1/Product``
 - ``PackageCollectionModel/V1/ProductType``
 
-### Platforms and Compatibility
+### Specifying Platforms and Compatibility
 
 - ``PackageCollectionModel/V1/PlatformVersion``
 - ``PackageCollectionModel/V1/Platform``
 - ``PackageCollectionModel/V1/Compatibility``
 
-### Licensing
+### Providing License Information
 
 - ``PackageCollectionModel/V1/License``
 
-### Signing
+### Signing Collections
 
 - ``PackageCollectionModel/V1/Signer``
 - ``PackageCollectionModel/V1/SignedCollection``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Documentation.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Documentation.md
@@ -1,0 +1,52 @@
+# ``PackageCollectionsModel``
+
+Models for creating and publishing package collections.
+
+<!-- swift package --disable-sandbox preview-documentation --target PackageCollectionsModel -->
+## Overview
+
+Package collections are JSON documents that group packages for discovery.
+The ``PackageCollectionModel`` enum serves as a namespace for the collection format, versioned under ``PackageCollectionModel/V1``.
+Use the types in this module to create, encode, and decode package collection documents that conform to the v1.0 schema.
+
+## Topics
+
+### Collection Format
+
+- ``PackageCollectionModel``
+- ``PackageCollectionModel/FormatVersion``
+- ``PackageCollectionModel/V1``
+
+### Describing a Collection
+
+- ``PackageCollectionModel/V1/Collection``
+- ``PackageCollectionModel/V1/Collection/Author``
+- ``PackageCollectionModel/V1/Collection/Package``
+
+### Describing Package Versions
+
+- ``PackageCollectionModel/V1/Collection/Package/Version``
+- ``PackageCollectionModel/V1/Collection/Package/Version/Manifest``
+- ``PackageCollectionModel/V1/Collection/Package/Version/Author``
+
+### Targets and Products
+
+- ``PackageCollectionModel/V1/Target``
+- ``PackageCollectionModel/V1/Product``
+- ``PackageCollectionModel/V1/ProductType``
+
+### Platforms and Compatibility
+
+- ``PackageCollectionModel/V1/PlatformVersion``
+- ``PackageCollectionModel/V1/Platform``
+- ``PackageCollectionModel/V1/Compatibility``
+
+### Licensing
+
+- ``PackageCollectionModel/V1/License``
+
+### Signing
+
+- ``PackageCollectionModel/V1/Signer``
+- ``PackageCollectionModel/V1/SignedCollection``
+- ``PackageCollectionModel/V1/Signature``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Documentation.md
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Documentation.md
@@ -11,42 +11,6 @@ Use the types in this module to create, encode, and decode package collection do
 
 ## Topics
 
-### Defining the Collection Format
+### Collection Format
 
 - ``PackageCollectionModel``
-- ``PackageCollectionModel/FormatVersion``
-- ``PackageCollectionModel/V1``
-
-### Describing a Collection
-
-- ``PackageCollectionModel/V1/Collection``
-- ``PackageCollectionModel/V1/Collection/Author``
-- ``PackageCollectionModel/V1/Collection/Package``
-
-### Describing Package Versions
-
-- ``PackageCollectionModel/V1/Collection/Package/Version``
-- ``PackageCollectionModel/V1/Collection/Package/Version/Manifest``
-- ``PackageCollectionModel/V1/Collection/Package/Version/Author``
-
-### Defining Targets and Products
-
-- ``PackageCollectionModel/V1/Target``
-- ``PackageCollectionModel/V1/Product``
-- ``PackageCollectionModel/V1/ProductType``
-
-### Specifying Platforms and Compatibility
-
-- ``PackageCollectionModel/V1/PlatformVersion``
-- ``PackageCollectionModel/V1/Platform``
-- ``PackageCollectionModel/V1/Compatibility``
-
-### Providing License Information
-
-- ``PackageCollectionModel/V1/License``
-
-### Signing Collections
-
-- ``PackageCollectionModel/V1/Signer``
-- ``PackageCollectionModel/V1/SignedCollection``
-- ``PackageCollectionModel/V1/Signature``

--- a/Sources/PackageCollectionsModel/Documentation.docc/Info.plist
+++ b/Sources/PackageCollectionsModel/Documentation.docc/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>PackageCollectionsModel</string>
+	<key>CFBundleDisplayName</key>
+	<string>PackageCollectionsModel</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.swift.swiftpm.packagecollectionsmodel</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleIconFile</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundleIconName</key>
+	<string>DocumentationIcon</string>
+	<key>CFBundlePackageType</key>
+	<string>DOCS</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CDDefaultCodeListingLanguage</key>
+	<string>swift</string>
+	<key>CFBundleVersion</key>
+	<string>0.1.0</string>
+</dict>
+</plist>

--- a/Sources/PackageCollectionsModel/Formats/v1.md
+++ b/Sources/PackageCollectionsModel/Formats/v1.md
@@ -1,7 +1,7 @@
 # Package Collection
 
-Package collections are short, curated lists of packages and associated metadata that can be imported
-by SwiftPM to make package discovery easier. Educators and community influencers can publish
+Package collections are short, curated lists of packages and associated metadata that
+SwiftPM can import to make package discovery easier. Educators and community influencers can publish
 package collections to go along with course materials or blog posts, removing the friction of using
 packages for the first time and the cognitive overload of deciding which packages are useful for
 a particular task. Enterprises may use collections to narrow the decision space for their internal
@@ -15,7 +15,7 @@ To begin, define the top-level metadata about the collection:
 
 * `name`: The name of the package collection, for display purposes only.
 * `overview`: A description of the package collection. **Optional.**
-* `keywords`: An array of keywords that the collection is associated with. **Optional.**
+* `keywords`: An array of keywords for the collection. **Optional.**
 * `formatVersion`: The version of the format to which the collection conforms. Currently, `1.0` is the only allowed value.
 * `revision`: The revision number of this package collection. **Optional.**
 * `generatedAt`: The ISO 8601-formatted datetime string when the package collection was generated.
@@ -23,23 +23,23 @@ To begin, define the top-level metadata about the collection:
     * `name`: The author name.
 * `packages`: A non-empty array of package objects.
 
-#### Add packages to the collection
+### Add packages to the collection
 
 Each item in the `packages` array is a package object with the following properties:
 
-* `url`: The URL of the package. Currently only Git repository URLs are supported. URL should be HTTPS and may contain `.git` suffix.
+* `url`: The URL of the package. The collection format currently supports only Git repository URLs. The URL should be HTTPS and may contain a `.git` suffix.
 * `identity`: The [identity](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md#36-package-identification) of the package if published to registry. **Optional.**
 * `summary`: A description of the package. **Optional.**
-* `keywords`: An array of keywords that the package is associated with. **Optional.**
+* `keywords`: An array of keywords for the package. **Optional.**
 * `readmeURL`: The URL of the package's README. **Optional.**
 * `license`: The package's *current* license information. **Optional.**
     * `url`: The URL of the license file.
     * `name`: License name. [SPDX identifier](https://spdx.org/licenses/) (e.g., `Apache-2.0`, `MIT`, etc.) preferred. Omit if unknown. **Optional.**
 * `versions`: An array of version objects representing the most recent and/or relevant releases of the package.
 
-#### Add versions to a package
+### Add versions to a package
 
-A version object has metadata extracted from `Package.swift` and optionally additional metadata from other sources:
+A version object contains metadata from `Package.swift` and optionally additional metadata from other sources:
 
 * `version`: The semantic version string.
 * `summary`: A description of the package version. **Optional.**
@@ -52,8 +52,8 @@ A version object has metadata extracted from `Package.swift` and optionally addi
     * `products`: An array of the package version's products.
         * `name`: The product name.
         * `type`: The product type. This must have the same JSON representation as SwiftPM's `PackageModel.ProductType`.
-        * `target`: An array of the product’s targets.
-    * `minimumPlatformVersions`: An array of the package version’s supported platforms specified in `Package.swift`. **Optional.** 
+        * `targets`: An array of the product’s targets.
+    * `minimumPlatformVersions`: An array of the package version’s supported platforms specified in `Package.swift`. **Optional.**
 
 ```json
 {
@@ -85,8 +85,8 @@ A version object has metadata extracted from `Package.swift` and optionally addi
 }
 ```
 
-* `defaultToolsVersion`: The Swift tools version of the default manifest. The `manifests` map must contain this in its keys. 
-* `verifiedCompatibility`: An array of compatible platforms and Swift versions that has been tested and verified for. Valid platform names include `macOS`, `iOS`, `tvOS`, `watchOS`, `Linux`, `Android`, and `Windows`. Swift version should be semantic version string and as specific as possible. **Optional.**
+* `defaultToolsVersion`: The Swift tools version of the default manifest. The `manifests` map must contain this in its keys.
+* `verifiedCompatibility`: An array of platforms and Swift versions with verified compatibility. Valid platform names include `macOS`, `iOS`, `tvOS`, `watchOS`, `Linux`, `Android`, and `Windows`. Swift version should be a semantic version string and as specific as possible. **Optional.**
 
 ```json
 {
@@ -106,21 +106,20 @@ A version object has metadata extracted from `Package.swift` and optionally addi
     * `type`: The signer type. Currently the only valid value is `ADP` (Apple Developer Program).
     * `commonName`: The common name of the signing certificate's subject.
     * `organizationalUnitName`: The organizational unit name of the signing certificate's subject.
-    * `organizationName`: The organization name of the signing certificate's subject.           
+    * `organizationName`: The organization name of the signing certificate's subject.
 * `createdAt`: The ISO 8601-formatted datetime string when the package version was created. **Optional.**
 
-##### Version-specific manifests
+#### Version-specific manifests
 
-Package collection generators should include data from the "default" manifest `Package.swift` as well as [version-specific manifest(s)](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-manifest-selection).
+Include data from the "default" manifest `Package.swift` as well as [version-specific manifest(s)](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-manifest-selection) when generating a package collection.
 
 The keys of the `manifests` map are Swift tools (semantic) versions:
-* For `Package.swift`, the tools version specified in `Package.swift` should be used.
-* For version-specific manifests, the tools version specified in the filename should be used. For example, for `Package@swift-4.2.swift` it would be `4.2`. The tools version in the manifest must match that in the filename. 
+* For `Package.swift`, use the tools version specified in `Package.swift`.
+* For version-specific manifests, use the tools version from the filename. For example, for `Package@swift-4.2.swift` it would be `4.2`. The tools version in the manifest must match the filename.
 
-##### Version-specific tags
+#### Version-specific tags
 
-[Version-specific tags](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-tag-selection) are not
-supported by package collections.
+Package collections don't support [version-specific tags](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-tag-selection).
 
 ## Example
 

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -26,10 +26,10 @@ extension PackageCollectionModel.V1 {
         /// A description of the package collection.
         public let overview: String?
 
-        /// An array of keywords that the collection is associated with.
+        /// An array of keywords associated with the collection.
         public let keywords: [String]?
 
-        /// An array of package metadata objects
+        /// An array of package metadata objects.
         public let packages: [PackageCollectionModel.V1.Collection.Package]
 
         /// The version of the format to which the collection conforms.
@@ -38,7 +38,7 @@ extension PackageCollectionModel.V1 {
         /// The revision number of this package collection.
         public let revision: Int?
 
-        /// When the package collection was generated.
+        /// The generation date for this package collection.
         public let generatedAt: Date
 
         /// The author of this package collection.
@@ -83,16 +83,16 @@ extension PackageCollectionModel.V1 {
 extension PackageCollectionModel.V1.Collection {
     /// A package entry in a collection.
     public struct Package: Equatable, Codable {
-        /// The URL of the package. Currently only Git repository URLs are supported.
+        /// The URL of the package. The collection format currently supports only Git repository URLs.
         public let url: URL
         
-        /// Package identity for registry (https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md#36-package-identification).
+        /// The package identity for a registry.
         public let identity: String?
 
         /// A description of the package.
         public let summary: String?
 
-        /// An array of keywords that the package is associated with.
+        /// An array of keywords associated with the package.
         public let keywords: [String]?
 
         /// An array of version objects representing the most recent and/or relevant releases of the package.
@@ -101,7 +101,7 @@ extension PackageCollectionModel.V1.Collection {
         /// The URL of the package's README.
         public let readmeURL: URL?
 
-        /// The package's current license info
+        /// The package's current license information.
         public let license: PackageCollectionModel.V1.License?
 
         /// Creates a `Package`.
@@ -137,10 +137,10 @@ extension PackageCollectionModel.V1.Collection.Package {
         /// Manifests by tools version.
         public let manifests: [String: Manifest]
 
-        /// Tools version of the default manifest.
+        /// The tools version of the default manifest.
         public let defaultToolsVersion: String
 
-        /// An array of compatible platforms and Swift versions that has been tested and verified for.
+        /// An array of platforms and Swift versions with verified compatibility.
         public let verifiedCompatibility: [PackageCollectionModel.V1.Compatibility]?
 
         /// The package version's license.
@@ -152,7 +152,7 @@ extension PackageCollectionModel.V1.Collection.Package {
         /// The signer of the package version.
         public let signer: PackageCollectionModel.V1.Signer?
 
-        /// When the package version was created.
+        /// The creation date for this package version.
         public let createdAt: Date?
 
         /// Creates a `Version`.
@@ -180,7 +180,7 @@ extension PackageCollectionModel.V1.Collection.Package {
 
         /// The package manifest data for a specific tools version.
         public struct Manifest: Equatable, Codable {
-            /// The tools (semantic) version specified in `Package.swift`.
+            /// The semantic tools version specified in `Package.swift`.
             public let toolsVersion: String
 
             /// The name of the package.
@@ -230,7 +230,7 @@ extension PackageCollectionModel.V1 {
         /// The target name.
         public let name: String
 
-        /// The module name if this target can be imported as a module.
+        /// The module name if you can import this target as a module.
         public let moduleName: String?
 
         /// Creates a `Target`.
@@ -265,7 +265,7 @@ extension PackageCollectionModel.V1 {
 
     /// A platform and its minimum version.
     public struct PlatformVersion: Equatable, Codable {
-        /// The name of the platform (e.g., macOS, Linux, etc.).
+        /// The name of the platform (such as macOS and Linux).
         public let name: String
 
         /// The semantic version of the platform.
@@ -278,9 +278,9 @@ extension PackageCollectionModel.V1 {
         }
     }
 
-    /// A platform supported by a package.
+    /// A platform that a package supports.
     public struct Platform: Equatable, Codable {
-        /// The name of the platform (e.g., macOS, Linux, etc.).
+        /// The name of the platform (such as macOS and Linux).
         public let name: String
 
         /// Creates a `Platform`.
@@ -289,12 +289,12 @@ extension PackageCollectionModel.V1 {
         }
     }
 
-    /// Compatible platform and Swift version.
+    /// A compatible platform and Swift version.
     public struct Compatibility: Equatable, Codable {
-        /// The platform (e.g., macOS, Linux, etc.)
+        /// The platform (such as macOS and Linux).
         public let platform: Platform
 
-        /// The Swift version
+        /// The Swift version.
         public let swiftVersion: String
 
         /// Creates a `Compatibility`.
@@ -306,7 +306,7 @@ extension PackageCollectionModel.V1 {
 
     /// License information for a package or package version.
     public struct License: Equatable, Codable {
-        /// License name (e.g., Apache-2.0, MIT, etc.)
+        /// The license name (such as Apache-2.0 and MIT).
         public let name: String?
 
         /// The URL of the license file.
@@ -321,7 +321,7 @@ extension PackageCollectionModel.V1 {
 
     /// The entity that signed a package version.
     public struct Signer: Equatable, Codable {
-        /// The signer type. (e.g., ADP)
+        /// The signer type (such as ADP).
         public let type: String
 
         /// The common name of the signing certificate's subject.
@@ -333,6 +333,7 @@ extension PackageCollectionModel.V1 {
         /// The organization name of the signing certificate's subject.
         public let organizationName: String
 
+        /// Creates a `Signer`.
         public init(
             type: String,
             commonName: String,
@@ -381,7 +382,7 @@ extension PackageCollectionModel.V1 {
             /// Dynamic library.
             case dynamic
 
-            /// The type of library is unspecified and should be decided by package manager.
+            /// The package manager determines the library type.
             case automatic
         }
 
@@ -456,13 +457,12 @@ extension PackageCollectionModel.V1.ProductType: Codable {
 // MARK: - Signed package collection
 
 extension PackageCollectionModel.V1 {
-    /// A signed package collection. The only difference between this and `Collection`
-    /// is the presence of `signature`.
+    /// A signed package collection. This type adds a `signature` to `Collection`.
     public struct SignedCollection: Equatable {
-        /// The package collection
+        /// The package collection.
         public let collection: PackageCollectionModel.V1.Collection
 
-        /// The signature and metadata
+        /// The signature and metadata.
         public let signature: PackageCollectionModel.V1.Signature
 
         /// Creates a `SignedCollection`.
@@ -472,25 +472,26 @@ extension PackageCollectionModel.V1 {
         }
     }
 
-    /// Package collection signature and associated metadata
+    /// A package collection signature and associated metadata.
     public struct Signature: Equatable, Codable {
-        /// The signature
+        /// The signature.
         public let signature: String
 
-        /// Details about the certificate used to generate the signature
+        /// Details about the certificate that generates the signature.
         public let certificate: Certificate
 
+        /// Creates a `Signature`.
         public init(signature: String, certificate: Certificate) {
             self.signature = signature
             self.certificate = certificate
         }
 
-        /// A certificate used to sign a package collection.
+        /// A certificate that signs a package collection.
         public struct Certificate: Equatable, Codable {
-            /// Subject of the certificate
+            /// The subject of the certificate.
             public let subject: Name
 
-            /// Issuer of the certificate
+            /// The issuer of the certificate.
             public let issuer: Name
 
             /// Creates a `Certificate`.
@@ -499,18 +500,18 @@ extension PackageCollectionModel.V1 {
                 self.issuer = issuer
             }
 
-            /// Generic certificate name (e.g., subject, issuer)
+            /// A certificate name (such as subject and issuer).
             public struct Name: Equatable, Codable {
-                /// User ID
+                /// The user ID.
                 public let userID: String?
 
-                /// Common name
+                /// The common name.
                 public let commonName: String?
 
-                /// Organizational unit
+                /// The organizational unit.
                 public let organizationalUnit: String?
 
-                /// Organization
+                /// The organization.
                 public let organization: String?
 
                 /// Creates a `Name`.

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -102,7 +102,7 @@ extension PackageCollectionModel.V1.Collection {
 
         /// An optional package identity that overrides the identity derived from the URL.
         ///
-        /// When `nil`, the package identity is derived from ``url``.
+        /// When `nil`, consumers should derive the identity from ``url``.
         /// Set this when the package is published to a registry or when the
         /// URL-derived identity is not appropriate.
         public let identity: String?
@@ -257,8 +257,7 @@ extension PackageCollectionModel.V1 {
         /// The target name.
         public let name: String
 
-        /// The module name if you can import this target as a module, or `nil` for
-        /// targets that are not importable (such as test targets or resource targets).
+        /// The module name if you can import this target as a module; `nil` otherwise.
         public let moduleName: String?
 
         /// Creates a `Target`.
@@ -518,7 +517,7 @@ extension PackageCollectionModel.V1 {
         /// The signature.
         public let signature: String
 
-        /// Details about the certificate that generates the signature.
+        /// Details about the certificate that generated the signature.
         public let certificate: Certificate
 
         /// Creates a `Signature`.

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -13,10 +13,12 @@
 import Foundation
 
 extension PackageCollectionModel {
+    /// Version 1 of the package collection format.
     public enum V1 {}
 }
 
 extension PackageCollectionModel.V1 {
+    /// A package collection document.
     public struct Collection: Equatable, Codable {
         /// The name of the package collection, for display purposes only.
         public let name: String
@@ -42,7 +44,7 @@ extension PackageCollectionModel.V1 {
         /// The author of this package collection.
         public let generatedBy: Author?
 
-        /// Creates a `Collection`
+        /// Creates a `Collection`.
         public init(
             name: String,
             overview: String?,
@@ -65,11 +67,12 @@ extension PackageCollectionModel.V1 {
             self.generatedBy = generatedBy
         }
 
+        /// The author of the collection.
         public struct Author: Equatable, Codable {
             /// The author name.
             public let name: String
 
-            /// Creates an `Author`
+            /// Creates an `Author`.
             public init(name: String) {
                 self.name = name
             }
@@ -78,6 +81,7 @@ extension PackageCollectionModel.V1 {
 }
 
 extension PackageCollectionModel.V1.Collection {
+    /// A package entry in a collection.
     public struct Package: Equatable, Codable {
         /// The URL of the package. Currently only Git repository URLs are supported.
         public let url: URL
@@ -100,7 +104,7 @@ extension PackageCollectionModel.V1.Collection {
         /// The package's current license info
         public let license: PackageCollectionModel.V1.License?
 
-        /// Creates a `Package`
+        /// Creates a `Package`.
         public init(
             url: URL,
             identity: String? = nil,
@@ -122,6 +126,7 @@ extension PackageCollectionModel.V1.Collection {
 }
 
 extension PackageCollectionModel.V1.Collection.Package {
+    /// A specific version of a package in a collection.
     public struct Version: Equatable, Codable {
         /// The semantic version string.
         public let version: String
@@ -150,7 +155,7 @@ extension PackageCollectionModel.V1.Collection.Package {
         /// When the package version was created.
         public let createdAt: Date?
 
-        /// Creates a `Version`
+        /// Creates a `Version`.
         public init(
             version: String,
             summary: String?,
@@ -173,6 +178,7 @@ extension PackageCollectionModel.V1.Collection.Package {
             self.createdAt = createdAt
         }
 
+        /// The package manifest data for a specific tools version.
         public struct Manifest: Equatable, Codable {
             /// The tools (semantic) version specified in `Package.swift`.
             public let toolsVersion: String
@@ -189,7 +195,7 @@ extension PackageCollectionModel.V1.Collection.Package {
             /// An array of the package version’s supported platforms specified in `Package.swift`.
             public let minimumPlatformVersions: [PackageCollectionModel.V1.PlatformVersion]?
 
-            /// Creates a `Manifest`
+            /// Creates a `Manifest`.
             public init(
                 toolsVersion: String,
                 packageName: String,
@@ -205,11 +211,12 @@ extension PackageCollectionModel.V1.Collection.Package {
             }
         }
 
+        /// The author of a package version.
         public struct Author: Equatable, Codable {
             /// The author name.
             public let name: String
 
-            /// Creates an `Author`
+            /// Creates an `Author`.
             public init(name: String) {
                 self.name = name
             }
@@ -218,6 +225,7 @@ extension PackageCollectionModel.V1.Collection.Package {
 }
 
 extension PackageCollectionModel.V1 {
+    /// A target in a package.
     public struct Target: Equatable, Codable {
         /// The target name.
         public let name: String
@@ -225,13 +233,14 @@ extension PackageCollectionModel.V1 {
         /// The module name if this target can be imported as a module.
         public let moduleName: String?
 
-        /// Creates a `Target`
+        /// Creates a `Target`.
         public init(name: String, moduleName: String?) {
             self.name = name
             self.moduleName = moduleName
         }
     }
 
+    /// A product in a package.
     public struct Product: Equatable, Codable {
         /// The product name.
         public let name: String
@@ -242,7 +251,7 @@ extension PackageCollectionModel.V1 {
         /// An array of the product’s targets.
         public let targets: [String]
 
-        /// Creates a `Product`
+        /// Creates a `Product`.
         public init(
             name: String,
             type: ProductType,
@@ -254,6 +263,7 @@ extension PackageCollectionModel.V1 {
         }
     }
 
+    /// A platform and its minimum version.
     public struct PlatformVersion: Equatable, Codable {
         /// The name of the platform (e.g., macOS, Linux, etc.).
         public let name: String
@@ -261,18 +271,19 @@ extension PackageCollectionModel.V1 {
         /// The semantic version of the platform.
         public let version: String
 
-        /// Creates a `PlatformVersion`
+        /// Creates a `PlatformVersion`.
         public init(name: String, version: String) {
             self.name = name
             self.version = version
         }
     }
 
+    /// A platform supported by a package.
     public struct Platform: Equatable, Codable {
         /// The name of the platform (e.g., macOS, Linux, etc.).
         public let name: String
 
-        /// Creates a `Platform`
+        /// Creates a `Platform`.
         public init(name: String) {
             self.name = name
         }
@@ -286,13 +297,14 @@ extension PackageCollectionModel.V1 {
         /// The Swift version
         public let swiftVersion: String
 
-        /// Creates a `Compatibility`
+        /// Creates a `Compatibility`.
         public init(platform: Platform, swiftVersion: String) {
             self.platform = platform
             self.swiftVersion = swiftVersion
         }
     }
 
+    /// License information for a package or package version.
     public struct License: Equatable, Codable {
         /// License name (e.g., Apache-2.0, MIT, etc.)
         public let name: String?
@@ -300,13 +312,14 @@ extension PackageCollectionModel.V1 {
         /// The URL of the license file.
         public let url: URL
 
-        /// Creates a `License`
+        /// Creates a `License`.
         public init(name: String?, url: URL) {
             self.name = name
             self.url = url
         }
     }
 
+    /// The entity that signed a package version.
     public struct Signer: Equatable, Codable {
         /// The signer type. (e.g., ADP)
         public let type: String
@@ -378,7 +391,7 @@ extension PackageCollectionModel.V1 {
         /// An executable product.
         case executable
 
-        /// An plugin product.
+        /// A plugin product.
         case plugin
         
         /// An executable code snippet.
@@ -443,7 +456,7 @@ extension PackageCollectionModel.V1.ProductType: Codable {
 // MARK: - Signed package collection
 
 extension PackageCollectionModel.V1 {
-    /// A  signed package collection. The only difference between this and `Collection`
+    /// A signed package collection. The only difference between this and `Collection`
     /// is the presence of `signature`.
     public struct SignedCollection: Equatable {
         /// The package collection
@@ -452,7 +465,7 @@ extension PackageCollectionModel.V1 {
         /// The signature and metadata
         public let signature: PackageCollectionModel.V1.Signature
 
-        /// Creates a `SignedCollection`
+        /// Creates a `SignedCollection`.
         public init(collection: PackageCollectionModel.V1.Collection, signature: PackageCollectionModel.V1.Signature) {
             self.collection = collection
             self.signature = signature
@@ -472,6 +485,7 @@ extension PackageCollectionModel.V1 {
             self.certificate = certificate
         }
 
+        /// A certificate used to sign a package collection.
         public struct Certificate: Equatable, Codable {
             /// Subject of the certificate
             public let subject: Name
@@ -479,7 +493,7 @@ extension PackageCollectionModel.V1 {
             /// Issuer of the certificate
             public let issuer: Name
 
-            /// Creates a `Certificate`
+            /// Creates a `Certificate`.
             public init(subject: Name, issuer: Name) {
                 self.subject = subject
                 self.issuer = issuer
@@ -499,7 +513,7 @@ extension PackageCollectionModel.V1 {
                 /// Organization
                 public let organization: String?
 
-                /// Creates a `Name`
+                /// Creates a `Name`.
                 public init(userID: String?,
                             commonName: String?,
                             organizationalUnit: String?,

--- a/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel+v1.swift
@@ -18,7 +18,11 @@ extension PackageCollectionModel {
 }
 
 extension PackageCollectionModel.V1 {
-    /// A package collection document.
+    /// A `Codable` representation of a package collection JSON document.
+    ///
+    /// Encode a `Collection` to JSON to produce a package collection file,
+    /// or decode one from a JSON document. For production distribution,
+    /// wrap the collection in a ``SignedCollection``.
     public struct Collection: Equatable, Codable {
         /// The name of the package collection, for display purposes only.
         public let name: String
@@ -33,6 +37,9 @@ extension PackageCollectionModel.V1 {
         public let packages: [PackageCollectionModel.V1.Collection.Package]
 
         /// The version of the format to which the collection conforms.
+        ///
+        /// Currently, the only supported value is ``PackageCollectionModel/FormatVersion/v1_0``.
+        /// Passing any other value triggers a runtime precondition failure.
         public let formatVersion: PackageCollectionModel.FormatVersion
 
         /// The revision number of this package collection.
@@ -67,9 +74,12 @@ extension PackageCollectionModel.V1 {
             self.generatedBy = generatedBy
         }
 
-        /// The author of the collection.
+        /// The entity that generated the collection, such as a person or organization.
+        ///
+        /// This type is distinct from ``PackageCollectionModel/V1/Collection/Package/Version/Author``,
+        /// which represents the author of a specific package version.
         public struct Author: Equatable, Codable {
-            /// The author name.
+            /// The author name, which may be a person or organization.
             public let name: String
 
             /// Creates an `Author`.
@@ -81,12 +91,20 @@ extension PackageCollectionModel.V1 {
 }
 
 extension PackageCollectionModel.V1.Collection {
-    /// A package entry in a collection.
+    /// Metadata about a package included in a collection, including its URL,
+    /// versions, and license information.
     public struct Package: Equatable, Codable {
-        /// The URL of the package. The collection format currently supports only Git repository URLs.
+        /// The URL of the package.
+        ///
+        /// By convention, this is a Git repository URL. The URL should use HTTPS
+        /// and may contain a `.git` suffix.
         public let url: URL
-        
-        /// The package identity for a registry.
+
+        /// An optional package identity that overrides the identity derived from the URL.
+        ///
+        /// When `nil`, the package identity is derived from ``url``.
+        /// Set this when the package is published to a registry or when the
+        /// URL-derived identity is not appropriate.
         public let identity: String?
 
         /// A description of the package.
@@ -126,7 +144,8 @@ extension PackageCollectionModel.V1.Collection {
 }
 
 extension PackageCollectionModel.V1.Collection.Package {
-    /// A specific version of a package in a collection.
+    /// A specific release of a package, containing one or more manifests keyed by
+    /// Swift tools version along with compatibility and signing information.
     public struct Version: Equatable, Codable {
         /// The semantic version string.
         public let version: String
@@ -134,10 +153,14 @@ extension PackageCollectionModel.V1.Collection.Package {
         /// A description of the package version.
         public let summary: String?
 
-        /// Manifests by tools version.
+        /// Manifests keyed by tools version string.
+        ///
+        /// Each key must match the ``Manifest/toolsVersion`` of its corresponding value.
         public let manifests: [String: Manifest]
 
         /// The tools version of the default manifest.
+        ///
+        /// This value must exist as a key in ``manifests``.
         public let defaultToolsVersion: String
 
         /// An array of platforms and Swift versions with verified compatibility.
@@ -178,9 +201,10 @@ extension PackageCollectionModel.V1.Collection.Package {
             self.createdAt = createdAt
         }
 
-        /// The package manifest data for a specific tools version.
+        /// The resolved manifest data for a specific Swift tools version, including the
+        /// package name, targets, products, and minimum platform versions.
         public struct Manifest: Equatable, Codable {
-            /// The semantic tools version specified in `Package.swift`.
+            /// The Swift tools version specified in `Package.swift` (for example, `5.7` or `5.9.2`).
             public let toolsVersion: String
 
             /// The name of the package.
@@ -212,6 +236,9 @@ extension PackageCollectionModel.V1.Collection.Package {
         }
 
         /// The author of a package version.
+        ///
+        /// This type is distinct from ``PackageCollectionModel/V1/Collection/Author``,
+        /// which represents the author of the collection itself.
         public struct Author: Equatable, Codable {
             /// The author name.
             public let name: String
@@ -225,12 +252,13 @@ extension PackageCollectionModel.V1.Collection.Package {
 }
 
 extension PackageCollectionModel.V1 {
-    /// A target in a package.
+    /// A target within a package, with an optional module name for importable targets.
     public struct Target: Equatable, Codable {
         /// The target name.
         public let name: String
 
-        /// The module name if you can import this target as a module.
+        /// The module name if you can import this target as a module, or `nil` for
+        /// targets that are not importable (such as test targets or resource targets).
         public let moduleName: String?
 
         /// Creates a `Target`.
@@ -263,12 +291,13 @@ extension PackageCollectionModel.V1 {
         }
     }
 
-    /// A platform and its minimum version.
+    /// A platform name paired with its minimum deployment target version string
+    /// (for example, macOS `10.15` or iOS `13.0`).
     public struct PlatformVersion: Equatable, Codable {
         /// The name of the platform (such as macOS and Linux).
         public let name: String
 
-        /// The semantic version of the platform.
+        /// The minimum deployment target version string for the platform (for example, `10.15` or `13.0`).
         public let version: String
 
         /// Creates a `PlatformVersion`.
@@ -278,7 +307,8 @@ extension PackageCollectionModel.V1 {
         }
     }
 
-    /// A platform that a package supports.
+    /// A platform identified by name, used within ``Compatibility``
+    /// to pair with a Swift version.
     public struct Platform: Equatable, Codable {
         /// The name of the platform (such as macOS and Linux).
         public let name: String
@@ -289,7 +319,8 @@ extension PackageCollectionModel.V1 {
         }
     }
 
-    /// A compatible platform and Swift version.
+    /// A verified platform and Swift version combination, indicating that the
+    /// package was successfully built and tested with this configuration.
     public struct Compatibility: Equatable, Codable {
         /// The platform (such as macOS and Linux).
         public let platform: Platform
@@ -304,9 +335,12 @@ extension PackageCollectionModel.V1 {
         }
     }
 
-    /// License information for a package or package version.
+    /// License information for a package or package version, pairing a license
+    /// name with the URL of the license file.
+    ///
+    /// Use an SPDX identifier for the name when possible.
     public struct License: Equatable, Codable {
-        /// The license name (such as Apache-2.0 and MIT).
+        /// The license name, preferably an SPDX identifier (such as `Apache-2.0` or `MIT`).
         public let name: String?
 
         /// The URL of the license file.
@@ -319,9 +353,11 @@ extension PackageCollectionModel.V1 {
         }
     }
 
-    /// The entity that signed a package version.
+    /// The entity that signed a package version, identified by certificate subject fields.
+    ///
+    /// Currently the only valid signer type is `ADP` (Apple Developer Program).
     public struct Signer: Equatable, Codable {
-        /// The signer type (such as ADP).
+        /// The signer type. Currently the only valid value is `ADP` (Apple Developer Program).
         public let type: String
 
         /// The common name of the signing certificate's subject.
@@ -457,7 +493,11 @@ extension PackageCollectionModel.V1.ProductType: Codable {
 // MARK: - Signed package collection
 
 extension PackageCollectionModel.V1 {
-    /// A signed package collection. This type adds a `signature` to `Collection`.
+    /// A package collection paired with a cryptographic signature for verification.
+    ///
+    /// When encoded to JSON, `SignedCollection` produces a flat structure identical
+    /// to ``Collection`` with an additional top-level `signature` key, rather than
+    /// nesting the collection under a separate key.
     public struct SignedCollection: Equatable {
         /// The package collection.
         public let collection: PackageCollectionModel.V1.Collection
@@ -472,7 +512,8 @@ extension PackageCollectionModel.V1 {
         }
     }
 
-    /// A package collection signature and associated metadata.
+    /// A cryptographic signature and the certificate metadata used to verify a
+    /// package collection.
     public struct Signature: Equatable, Codable {
         /// The signature.
         public let signature: String
@@ -486,7 +527,8 @@ extension PackageCollectionModel.V1 {
             self.certificate = certificate
         }
 
-        /// A certificate that signs a package collection.
+        /// The X.509 certificate that signs a package collection, represented by its
+        /// subject and issuer distinguished names.
         public struct Certificate: Equatable, Codable {
             /// The subject of the certificate.
             public let subject: Name
@@ -500,7 +542,8 @@ extension PackageCollectionModel.V1 {
                 self.issuer = issuer
             }
 
-            /// A certificate name (such as subject and issuer).
+            /// The distinguished name fields of a certificate, used to represent
+            /// both the subject and the issuer.
             public struct Name: Equatable, Codable {
                 /// The user ID.
                 public let userID: String?

--- a/Sources/PackageCollectionsModel/PackageCollectionModel.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel.swift
@@ -16,7 +16,7 @@ import Foundation
 public enum PackageCollectionModel {}
 
 extension PackageCollectionModel {
-    /// Representation of package collection (JSON) schema version.
+    /// The package collection JSON schema version.
     public enum FormatVersion: String, Codable {
         case v1_0 = "1.0"
     }

--- a/Sources/PackageCollectionsModel/PackageCollectionModel.swift
+++ b/Sources/PackageCollectionsModel/PackageCollectionModel.swift
@@ -12,11 +12,11 @@
 
 import Foundation
 
-// Models used for creating and publishing package collections
+/// A namespace for package collection model types.
 public enum PackageCollectionModel {}
 
 extension PackageCollectionModel {
-    /// Representation of package collection (JSON) schema version
+    /// Representation of package collection (JSON) schema version.
     public enum FormatVersion: String, Codable {
         case v1_0 = "1.0"
     }


### PR DESCRIPTION
API reference content for PackageCollectionsModel, which provides the model classes for Package Collections as supported by Swift Package Manager.

resolves #8828 

### Motivation:

We've been missing the API from published content - it's primarily model focused, but I still wanted to complete it out.

### Modifications:

- Curation (organization) for the public API types within PackageCollectionsModel
- Updates the doc comments to flesh out the abstracts, align with our patterns and styles for documentation.
- Fixes for spelling, grammar, punctuation, and so forth
- Some revisions of passive voice to active voice for abstracts and discussions on symbols

### Result:

Preview with the command `swift package --disable-sandbox preview-documentation --target PackageCollectionsModel`

<img width="1491" height="1106" alt="Screenshot 2026-04-03 at 3 37 06 PM" src="https://github.com/user-attachments/assets/03e2f66c-e0ca-4ac4-a084-e01963092dbd" />

The curation is heavily embedded under multiple enums with the existing structure, so I leaned into that for organization rather than replicating content at the top level of the catalog. I'm not convinced that's great, but it felt less awkward to read and explore.
