### PR TITLE
Allow passing a pluginConfiguration to `SourceKitLSPAPI.BuildDescription`

### DIFF
--- a/Sources/SourceKitLSPAPI/BuildDescription.swift
+++ b/Sources/SourceKitLSPAPI/BuildDescription.swift
@@ -213,6 +213,11 @@ public struct BuildDescription {
         self.inputs = buildPlan.inputs
     }
 
+    /// Temporary initializer to stage in https://github.com/swiftlang/swift-package-manager/pull/9583.
+    public init(buildPlan: Build.BuildPlan, pluginConfiguration: PluginConfiguration) {
+        self.init(buildPlan: buildPlan)
+    }
+
     /// Construct a build description, compiling build tool plugins and generating their output when necessary.
     public static func load(
         destinationBuildParameters: BuildParameters,


### PR DESCRIPTION
To stage in https://github.com/swiftlang/swift-package-manager/pull/9583.

Steps:
1. Merge this PR
2. Change SourceKit-LSP to pass a `pluginConfiguration`
3. Merge https://github.com/swiftlang/swift-package-manager/pull/9583
4. Merge https://github.com/swiftlang/sourcekit-lsp/pull/2446 for a test in SourceKit-LSP
