### PR TITLE
Tests: Remove known issue from parseable module interface

### DIFF
--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -769,7 +769,7 @@ struct BuildCommandTestCases {
     }
 
     @Test(
-        .issue("https://github.com/swiftlang/swift-package-manager/pull/9130", relationship: .fixedBy),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9324", relationship: .verifies),
         .tags(
             .Feature.CommandLineArguments.EnableParseableModuleInterfaces,
         ),
@@ -780,7 +780,6 @@ struct BuildCommandTestCases {
     ) async throws {
         let config = BuildConfiguration.debug
         try await fixture(name: "Miscellaneous/ParseableInterfaces") { fixturePath in
-            try await withKnownIssue(isIntermittent: true) {
                 let result = try await build(
                     ["--enable-parseable-module-interfaces"],
                     packagePath: fixturePath,
@@ -797,10 +796,6 @@ struct BuildCommandTestCases {
                         #expect(result.moduleContents.contains { $0.contains(moduleARegex) })
                         #expect(result.moduleContents.contains { $0.contains(moduleBRegex) })
                 }
-            } when: {
-                // errors with SwiftBuild on Windows possibly due to long path on windows only for swift build
-                ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
-            }
         }
     }
 
@@ -816,7 +811,6 @@ struct BuildCommandTestCases {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let config = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/LibraryEvolution") { fixturePath in
                 let result = try await build(
                     [],
@@ -837,9 +831,6 @@ struct BuildCommandTestCases {
                         Issue.record("Test configuration error. Build backend is not intended to be tested.")
                 }
             }
-        } when: {
-            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
-        }
     }
 
     @Test


### PR DESCRIPTION
Remote the withKnownIssue on the parseable module interfaces tests as the underlying issue impacting windows should be fixed.

Related to: #9324
Issue: rdar://163961896
