### PR TITLE
Source archive download: Git protocol v2 tag discovery and shallow clone support [part 2]

### DIFF
--- a/Sources/Basics/GitProtocolV2.swift
+++ b/Sources/Basics/GitProtocolV2.swift
@@ -1,0 +1,184 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Git HTTP smart protocol and protocol v2 implementation for tag discovery.
+// https://git-scm.com/docs/http-protocol
+// https://git-scm.com/docs/protocol-v2
+
+import Foundation
+
+import struct TSCUtility.Version
+
+/// A resolved git tag with its name, the commit SHA it points to, and the
+/// parsed semantic version (so callers don't need to re-parse it).
+public struct ResolvedTag: Equatable, Sendable {
+    public let name: String
+    public let commitSHA: String
+    public let version: Version
+
+    public init(name: String, commitSHA: String, version: Version) {
+        self.name = name
+        self.commitSHA = commitSHA
+        self.version = version
+    }
+}
+
+// MARK: - Git HTTP Protocol v2
+
+/// HTTP-based git protocol v2 helpers for tag discovery without forking
+/// a `git` process.
+package enum GitHTTPProtocolV2 {
+    /// Builds the pkt-line encoded request body for a protocol v2 `ls-refs`
+    /// command with ref-prefix hints for semver-like tags.
+    ///
+    /// Uses 20 `ref-prefix` lines (`refs/tags/0` through `refs/tags/9` plus
+    /// `refs/tags/v0` through `refs/tags/v9`) as an optimization hint to
+    /// reduce the response size. Per the spec, `ref-prefix` is advisory —
+    /// servers MAY return refs not matching the prefix, so callers must
+    /// still filter results (which `resolvedTags(from:)` does via
+    /// `Version(tag:)`).
+    package static func makeTagRefsRequestBody(serverCapabilities: [String] = []) -> Data {
+        var body = Data()
+        body.append(PktLine.encode("command=ls-refs\n"))
+        if serverCapabilities.contains(where: { $0.hasPrefix("agent=") }) {
+            body.append(PktLine.encode("agent=SwiftPackageManager/\(SwiftVersion.current.displayString)\n"))
+        }
+        body.append(PktLine.delimiter)
+        body.append(PktLine.encode("peel\n"))
+        for digit in 0...9 {
+            body.append(PktLine.encode("ref-prefix refs/tags/\(digit)\n"))
+            body.append(PktLine.encode("ref-prefix refs/tags/v\(digit)\n"))
+        }
+        body.append(PktLine.flush)
+        return body
+    }
+
+    /// Constructs the smart HTTP endpoint URLs for a repository.
+    ///
+    /// Returns the `info/refs` discovery URL and the `git-upload-pack` URL,
+    /// or `nil` for non-HTTP schemes (ssh, git, scp-style).
+    package static func makeSmartHTTPURLs(
+        from repoURL: String
+    ) -> (infoRefs: URL, uploadPack: URL)? {
+        guard let url = URL(string: repoURL) else { return nil }
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "http" else { return nil }
+
+        let base = repoURL.hasSuffix("/") ? String(repoURL.dropLast()) : repoURL
+        guard let infoRefs = URL(string: "\(base)/info/refs?service=git-upload-pack"),
+              let uploadPack = URL(string: "\(base)/git-upload-pack") else { return nil }
+        return (infoRefs: infoRefs, uploadPack: uploadPack)
+    }
+
+    /// Parses protocol v2 `ls-refs` response lines directly into resolved
+    /// tags with their commit SHAs.
+    ///
+    /// Each line has the format:
+    /// ```
+    /// <sha> refs/tags/<name>
+    /// <sha> refs/tags/<name> peeled:<commit-sha>
+    /// ```
+    ///
+    /// For annotated tags (with `peeled:` suffix), the peeled commit SHA is
+    /// used. Lightweight tags use the SHA directly. Only tags that parse as
+    /// valid semantic versions are included.
+    package static func resolvedTags(from lines: [String]) -> [ResolvedTag] {
+        let tagsPrefix = "refs/tags/"
+        let peeledPrefix = "peeled:"
+        var results: [ResolvedTag] = []
+        for line in lines {
+            // Split on ASCII space via UTF8 view to avoid Character-level scanning.
+            let utf8 = line.utf8
+            guard let firstSpace = utf8.firstIndex(of: UInt8(ascii: " ")) else { continue }
+            let refStart = utf8.index(after: firstSpace)
+            guard refStart < utf8.endIndex else { continue }
+
+            // Find optional second space (peeled SHA follows it).
+            let secondSpace = utf8[refStart...].firstIndex(of: UInt8(ascii: " "))
+            let refEnd = secondSpace ?? utf8.endIndex
+            let ref = line[refStart..<refEnd]
+
+            guard ref.hasPrefix(tagsPrefix) else { continue }
+            let tagName = String(ref.dropFirst(tagsPrefix.count))
+
+            let sha: String
+            if let sp = secondSpace {
+                let rest = line[line.index(after: sp)...]
+                if rest.hasPrefix(peeledPrefix) {
+                    sha = String(rest.dropFirst(peeledPrefix.count))
+                } else {
+                    sha = String(line[utf8.startIndex..<firstSpace])
+                }
+            } else {
+                sha = String(line[utf8.startIndex..<firstSpace])
+            }
+
+            guard let version = Version(tag: tagName) else { continue }
+            results.append(ResolvedTag(name: tagName, commitSHA: sha, version: version))
+        }
+        return results
+    }
+}
+
+// MARK: - Pkt-line Framing
+
+/// Encoder and decoder for the git pkt-line framing format.
+///
+/// Each pkt-line is a 4-character hex length prefix (including the prefix
+/// itself) followed by the payload. Special packets use fixed values:
+/// `0000` (flush) terminates a message, `0001` (delimiter) separates
+/// the command from its arguments.
+///
+/// See https://git-scm.com/docs/protocol-common#_pkt_line_format
+package enum PktLine {
+    /// Encodes a string as a single pkt-line.
+    package static func encode(_ s: String) -> Data {
+        let payload = Data(s.utf8)
+        let len = payload.count + 4
+        var d = Data(String(format: "%04x", len).utf8)
+        d.append(payload)
+        return d
+    }
+
+    package static let flush = Data("0000".utf8)
+    package static let delimiter = Data("0001".utf8)
+
+    private static let headerSize = 4
+
+    /// Decodes pkt-line framed data into content strings.
+    /// Flush and delimiter packets are skipped. Payloads that are not
+    /// valid UTF-8 are decoded with replacement characters so that
+    /// server error messages (e.g. `ERR`) are never silently lost.
+    package static func decode(_ data: Data) -> [String] {
+        var lines: [String] = []
+        var i = data.startIndex
+        while i + headerSize <= data.endIndex {
+            guard let hex = String(data: data[i..<i + headerSize], encoding: .ascii),
+                  let len = UInt16(hex, radix: 16) else { break }
+            if len <= UInt16(headerSize) { i += headerSize; continue }
+            var end = min(i + Int(len), data.endIndex)
+            let payloadStart = i + headerSize
+            // Strip trailing newline bytes directly from the data slice
+            // instead of allocating through Foundation's trimmingCharacters.
+            while end > payloadStart && (data[end - 1] == 0x0A || data[end - 1] == 0x0D) {
+                end -= 1
+            }
+            if let line = String(data: data[payloadStart..<end], encoding: .utf8) {
+                lines.append(line)
+            } else {
+                lines.append(String(decoding: data[payloadStart..<end], as: UTF8.self))
+            }
+            i = min(i + Int(len), data.endIndex)
+        }
+        return lines
+    }
+}

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -367,6 +367,106 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
         GitRepository(git: self.git, path: path)
     }
 
+    // MARK: - Source Archive Support
+
+    /// Performs a shallow clone of a repository at a specific tag.
+    ///
+    /// Uses `--depth 1 --branch <tag>` with optional submodule support.
+    /// Goes through the same `clone()` / `callGit` infrastructure as all
+    /// other git operations, getting git config flags, environment setup,
+    /// cancellation support, and proper error wrapping for free.
+    public func shallowClone(
+        repository: RepositorySpecifier,
+        tag: String,
+        to path: AbsolutePath,
+        recurseSubmodules: Bool = false,
+        progressHandler: FetchProgress.Handler? = nil
+    ) async throws {
+        guard !localFileSystem.exists(path) else {
+            throw InternalError("\(path) already exists")
+        }
+
+        var options = ["--depth", "1", "--branch", tag]
+        if recurseSubmodules {
+            options += ["--recurse-submodules", "--shallow-submodules"]
+        }
+
+        try self.clone(
+            repository,
+            repository.location.gitURL,
+            path.pathString,
+            options,
+            progress: progressHandler
+        )
+    }
+
+    /// Clones a repository from a remote URL for editing purposes.
+    ///
+    /// Unlike `createWorkingCopy` which clones from a local bare cache,
+    /// this clones directly from the remote — used for source archive
+    /// dependencies that have no local bare repo.
+    public func cloneForEditing(
+        repository: RepositorySpecifier,
+        tag: String,
+        to path: AbsolutePath,
+        revision: Revision? = nil,
+        newBranch: String? = nil,
+        shallow: Bool = false,
+        recurseSubmodules: Bool = false,
+        progressHandler: FetchProgress.Handler? = nil
+    ) async throws -> WorkingCheckout {
+        var options = ["--branch", tag]
+        if shallow {
+            options += ["--depth", "1"]
+        }
+        if recurseSubmodules {
+            options += ["--recurse-submodules"]
+            if shallow {
+                options += ["--shallow-submodules"]
+            }
+        }
+
+        try self.clone(
+            repository,
+            repository.location.gitURL,
+            path.pathString,
+            options,
+            progress: progressHandler
+        )
+
+        let workingCopy = try self.openWorkingCopy(at: path)
+
+        if let revision {
+            try workingCopy.checkout(revision: revision)
+        }
+        if let newBranch {
+            try workingCopy.checkout(newBranch: newBranch)
+        }
+
+        return workingCopy
+    }
+
+    /// Lists remote tags via `git ls-remote --tags`.
+    ///
+    /// Returns the raw stdout output for parsing by the caller.
+    public func lsRemoteTags(
+        for repository: RepositorySpecifier
+    ) async throws -> String {
+        let process = AsyncProcess(
+            arguments: ["git", "ls-remote", "--tags", repository.location.gitURL]
+        )
+        _ = try process.launch()
+        let result = try await process.waitUntilExit()
+        guard result.exitStatus == .terminated(code: 0) else {
+            throw GitCloneError(
+                repository: repository,
+                message: "Failed to list remote tags",
+                result: result
+            )
+        }
+        return try result.utf8Output()
+    }
+
     public func cancel(deadline: DispatchTime) throws {
         try self.cancellator.cancel(deadline: deadline)
     }

--- a/Tests/BasicsTests/GitProtocolV2Tests.swift
+++ b/Tests/BasicsTests/GitProtocolV2Tests.swift
@@ -1,0 +1,322 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@testable import Basics
+import Foundation
+import _InternalTestSupport
+import Testing
+
+import class Basics.AsyncProcess
+import struct TSCUtility.Version
+
+// MARK: - PktLine
+
+@Suite("PktLine")
+struct PktLineTests {
+
+    @Test("encode produces correct hex-prefixed pkt-line")
+    func encode() {
+        let encoded = PktLine.encode("command=ls-refs\n")
+        let str = String(data: encoded, encoding: .ascii)!
+        #expect(str == "0014command=ls-refs\n")
+    }
+
+    @Test("encode without trailing newline")
+    func encodeNoNewline() {
+        let encoded = PktLine.encode("agent=git/2.50.1-Darwin")
+        let str = String(data: encoded, encoding: .ascii)!
+        #expect(str == "001bagent=git/2.50.1-Darwin")
+    }
+
+    @Test("decode parses pkt-line response, skipping flush and delimiter")
+    func decode() {
+        var data = Data()
+        data.append(PktLine.encode("first line\n"))
+        data.append(PktLine.delimiter)
+        data.append(PktLine.encode("second line\n"))
+        data.append(PktLine.flush)
+
+        let lines = PktLine.decode(data)
+        #expect(lines == ["first line", "second line"])
+    }
+
+    @Test("decode handles empty data")
+    func decodeEmpty() {
+        #expect(PktLine.decode(Data()).isEmpty)
+    }
+
+    @Test("decode handles truncated length prefix")
+    func decodeTruncated() {
+        let data = Data("00".utf8)
+        #expect(PktLine.decode(data).isEmpty)
+    }
+
+    @Test("encode-decode round trip")
+    func roundTrip() {
+        let original = "abc123 refs/tags/v1.0.0 peeled:def456"
+        var data = Data()
+        data.append(PktLine.encode(original))
+        data.append(PktLine.flush)
+        let decoded = PktLine.decode(data)
+        #expect(decoded == [original])
+    }
+}
+
+// MARK: - GitHTTPProtocolV2 URL construction
+
+struct SmartHTTPURLCase: CustomTestStringConvertible, Sendable {
+    let input: String
+    let infoRefs: String?
+    let uploadPack: String?
+
+    var testDescription: String { input }
+}
+
+@Suite("GitHTTPProtocolV2.makeSmartHTTPURLs")
+struct SmartHTTPURLTests {
+
+    static let cases: [SmartHTTPURLCase] = [
+        SmartHTTPURLCase(
+            input: "https://github.com/apple/swift-log.git",
+            infoRefs: "https://github.com/apple/swift-log.git/info/refs?service=git-upload-pack",
+            uploadPack: "https://github.com/apple/swift-log.git/git-upload-pack"
+        ),
+        SmartHTTPURLCase(
+            input: "https://github.com/apple/swift-log",
+            infoRefs: "https://github.com/apple/swift-log/info/refs?service=git-upload-pack",
+            uploadPack: "https://github.com/apple/swift-log/git-upload-pack"
+        ),
+        SmartHTTPURLCase(
+            input: "http://example.com/repo.git",
+            infoRefs: "http://example.com/repo.git/info/refs?service=git-upload-pack",
+            uploadPack: "http://example.com/repo.git/git-upload-pack"
+        ),
+        SmartHTTPURLCase(
+            input: "https://github.com/apple/swift-log.git/",
+            infoRefs: "https://github.com/apple/swift-log.git/info/refs?service=git-upload-pack",
+            uploadPack: "https://github.com/apple/swift-log.git/git-upload-pack"
+        ),
+        SmartHTTPURLCase(input: "ssh://git@github.com/apple/swift-log.git", infoRefs: nil, uploadPack: nil),
+        SmartHTTPURLCase(input: "git@github.com:apple/swift-log.git", infoRefs: nil, uploadPack: nil),
+    ]
+
+    @Test("constructs correct URLs or returns nil", arguments: cases)
+    func urlConstruction(testCase: SmartHTTPURLCase) {
+        let urls = GitHTTPProtocolV2.makeSmartHTTPURLs(from: testCase.input)
+        #expect(urls?.infoRefs.absoluteString == testCase.infoRefs)
+        #expect(urls?.uploadPack.absoluteString == testCase.uploadPack)
+    }
+}
+
+// MARK: - GitHTTPProtocolV2.resolvedTags
+
+@Suite("GitHTTPProtocolV2.resolvedTags")
+struct ParseTagRefsTests {
+
+    @Test("lightweight semver tag")
+    func lightweight() {
+        let lines = ["abc123 refs/tags/1.0.0"]
+        let tags = GitHTTPProtocolV2.resolvedTags(from: lines)
+        #expect(tags == [ResolvedTag(name:"1.0.0", commitSHA: "abc123", version: Version(1, 0, 0))])
+    }
+
+    @Test("annotated tag uses peeled SHA")
+    func annotatedPeeled() {
+        let lines = ["tagobj123 refs/tags/v2.0.0 peeled:commit456"]
+        let tags = GitHTTPProtocolV2.resolvedTags(from: lines)
+        #expect(tags == [ResolvedTag(name:"v2.0.0", commitSHA: "commit456", version: Version(2, 0, 0))])
+    }
+
+    @Test("non-semver tags are filtered out")
+    func nonSemver() {
+        let lines = [
+            "aaa refs/tags/1.0.0",
+            "bbb refs/tags/not-a-version",
+            "ccc refs/tags/v3.0.0-rc.1",
+        ]
+        let tags = GitHTTPProtocolV2.resolvedTags(from: lines)
+        #expect(tags.count == 2)
+        #expect(tags[0].name == "1.0.0")
+        #expect(tags[1].name == "v3.0.0-rc.1")
+    }
+
+    @Test("mixed lightweight and annotated tags")
+    func mixed() {
+        let lines = [
+            "aaa refs/tags/1.0.0",
+            "bbb refs/tags/v2.0.0 peeled:ccc",
+            "ddd refs/tags/3.0.0",
+        ]
+        let tags = GitHTTPProtocolV2.resolvedTags(from: lines)
+        #expect(tags.count == 3)
+        #expect(tags[0] == ResolvedTag(name:"1.0.0", commitSHA: "aaa", version: Version(1, 0, 0)))
+        #expect(tags[1] == ResolvedTag(name:"v2.0.0", commitSHA: "ccc", version: Version(2, 0, 0)))
+        #expect(tags[2] == ResolvedTag(name:"3.0.0", commitSHA: "ddd", version: Version(3, 0, 0)))
+    }
+
+    @Test("empty input returns empty")
+    func empty() {
+        #expect(GitHTTPProtocolV2.resolvedTags(from: []).isEmpty)
+    }
+
+    @Test("malformed lines are skipped")
+    func malformed() {
+        let lines = ["", "no-space-line", "abc refs/heads/main"]
+        #expect(GitHTTPProtocolV2.resolvedTags(from: lines).isEmpty)
+    }
+}
+
+// MARK: - makeTagRefsRequestBody
+
+@Suite("GitHTTPProtocolV2.makeTagRefsRequestBody")
+struct LsRefsTagsBodyTests {
+
+    @Test("body emits per-digit ref-prefix lines for semver filtering")
+    func bodyStructure() {
+        let body = GitHTTPProtocolV2.makeTagRefsRequestBody()
+        let lines = PktLine.decode(body)
+        #expect(lines.contains("command=ls-refs"))
+        #expect(!lines.contains { $0.hasPrefix("agent=") }, "agent must not be sent without server capability")
+        #expect(lines.contains { $0.contains("peel") })
+        for digit in 0...9 {
+            #expect(lines.contains("ref-prefix refs/tags/\(digit)"))
+            #expect(lines.contains("ref-prefix refs/tags/v\(digit)"))
+        }
+    }
+
+    @Test("agent line included when server advertises agent capability")
+    func agentIncludedWhenAdvertised() {
+        let body = GitHTTPProtocolV2.makeTagRefsRequestBody(
+            serverCapabilities: ["agent=git/2.45.0", "ls-refs=unborn"]
+        )
+        let lines = PktLine.decode(body)
+        #expect(lines.contains { $0.hasPrefix("agent=SwiftPackageManager/") })
+    }
+}
+
+// MARK: - End-to-end against a real git repo
+
+@Suite("PktLine + resolvedTags against real git upload-pack", .tags(.TestSize.large))
+struct GitProtocolV2E2ETests {
+
+    @Test("pkt-line parser and resolvedTags handle real git upload-pack output")
+    func realUploadPack() async throws {
+        try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
+            let bareRepoPath = tmpDir.appending(component: "test-repo.git")
+            let workTreePath = tmpDir.appending(component: "work")
+
+            try await git("init", "--bare", bareRepoPath.pathString)
+            try await git("clone", bareRepoPath.pathString, workTreePath.pathString)
+            try await git("-C", workTreePath.pathString, "config", "user.email", "test@test.com")
+            try await git("-C", workTreePath.pathString, "config", "user.name", "Test")
+
+            // First commit + lightweight tag.
+            try localFileSystem.writeFileContents(
+                workTreePath.appending(component: "file.txt"), string: "v1\n"
+            )
+            try await git("-C", workTreePath.pathString, "add", ".")
+            try await git("-C", workTreePath.pathString, "commit", "-m", "First")
+            try await git("-C", workTreePath.pathString, "tag", "1.0.0")
+
+            // Second commit + annotated tag.
+            try localFileSystem.writeFileContents(
+                workTreePath.appending(component: "file.txt"), string: "v2\n"
+            )
+            try await git("-C", workTreePath.pathString, "add", ".")
+            try await git("-C", workTreePath.pathString, "commit", "-m", "Second")
+            try await git("-C", workTreePath.pathString, "tag", "-a", "v2.0.0", "-m", "Release 2.0.0")
+
+            // Non-semver tag (should be filtered out).
+            try await git("-C", workTreePath.pathString, "tag", "nightly-2025-01-01")
+
+            try await git("-C", workTreePath.pathString, "push", "origin", "HEAD", "--tags")
+
+            // Pipe our pkt-line ls-refs request into git upload-pack --stateless-rpc
+            // via a shell pipe so we don't need package-scoped AsyncProcess.launch().
+            let requestBody = GitHTTPProtocolV2.makeTagRefsRequestBody()
+            let requestPath = tmpDir.appending(component: "request.bin")
+            try localFileSystem.writeFileContents(requestPath, bytes: .init(requestBody))
+
+            let responseData = try await uploadPack(
+                repoPath: bareRepoPath.pathString,
+                requestPath: requestPath.pathString
+            )
+
+            // Full pipeline: PktLine.decode → resolvedTags
+            let lines = PktLine.decode(responseData)
+            let tags = GitHTTPProtocolV2.resolvedTags(from: lines)
+
+            // resolvedTags(from:) filters to valid semver — non-semver tags
+            // like "nightly-2025-01-01" are excluded regardless of whether
+            // the server honoured the ref-prefix hint.
+            let tagNames = Set(tags.map(\.name))
+            #expect(tagNames.contains("1.0.0"), "lightweight tag missing")
+            #expect(tagNames.contains("v2.0.0"), "annotated tag missing")
+            #expect(!tagNames.contains("nightly-2025-01-01"), "non-semver tag should be filtered by client")
+            #expect(tags.count >= 2, "expected at least the 2 semver tags")
+
+            for tag in tags {
+                #expect(tag.commitSHA.count == 40, "SHA should be 40 hex chars, got '\(tag.commitSHA)'")
+                #expect(tag.commitSHA.allSatisfy { $0.isHexDigit }, "SHA contains non-hex: '\(tag.commitSHA)'")
+            }
+
+            // Annotated tag must resolve to the commit SHA (peeled), not the tag object.
+            let v1SHA = tags.first { $0.name == "1.0.0" }?.commitSHA
+            let v2SHA = tags.first { $0.name == "v2.0.0" }?.commitSHA
+            #expect(v1SHA != v2SHA, "different commits should have different SHAs")
+
+            let expectedV2CommitSHA = try await git(
+                "-C", bareRepoPath.pathString, "rev-parse", "v2.0.0^{commit}"
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(v2SHA == expectedV2CommitSHA, "annotated tag should peel to commit SHA")
+
+            #expect(tags.first { $0.name == "1.0.0" }?.version == Version(1, 0, 0))
+            #expect(tags.first { $0.name == "v2.0.0" }?.version == Version(2, 0, 0))
+        }
+    }
+
+    @discardableResult
+    private func git(_ args: String...) async throws -> String {
+        try await AsyncProcess.checkNonZeroExit(arguments: ["git"] + args)
+    }
+
+    /// Runs `git upload-pack --stateless-rpc` with GIT_PROTOCOL=version=2,
+    /// piping the request file to stdin and returning the raw response bytes.
+    private func uploadPack(repoPath: String, requestPath: String) async throws -> Data {
+        let process = Foundation.Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "upload-pack", "--stateless-rpc", repoPath]
+        process.environment = ProcessInfo.processInfo.environment.merging(
+            ["GIT_PROTOCOL": "version=2"]
+        ) { _, new in new }
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+
+        let requestData = try Data(contentsOf: URL(fileURLWithPath: requestPath))
+        stdinPipe.fileHandleForWriting.write(requestData)
+        stdinPipe.fileHandleForWriting.closeFile()
+
+        let responseData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw StringError("git upload-pack exited with status \(process.terminationStatus)")
+        }
+        return responseData
+    }
+}

--- a/Tests/WorkspaceTests/ShallowCloneManagerTests.swift
+++ b/Tests/WorkspaceTests/ShallowCloneManagerTests.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import _InternalTestSupport
+import SourceControl
+import Testing
+
+@Suite(
+    .tags(
+        .FunctionalArea.Workspace,
+    ),
+)
+struct ShallowCloneTests {
+
+    @Test(.tags(.TestSize.medium))
+    func shallowCloneLocalBareRepo() async throws {
+        try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
+            let fs = localFileSystem
+
+            let bareRepo = tmpDir.appending("bare.git")
+            let workRepo = tmpDir.appending("work")
+
+            try await run(["git", "init", "--bare", bareRepo.pathString])
+            try await run(["git", "clone", bareRepo.pathString, workRepo.pathString])
+
+            try fs.writeFileContents(
+                workRepo.appending("Package.swift"),
+                string: "// swift-tools-version: 5.9\nimport PackageDescription\nlet package = Package(name: \"TestPkg\")\n"
+            )
+            try await run(["git", "-C", workRepo.pathString, "add", "."])
+            try await run(["git", "-C", workRepo.pathString, "-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "Initial commit"])
+            try await run(["git", "-C", workRepo.pathString, "tag", "1.0.0"])
+            try await run(["git", "-C", workRepo.pathString, "push", "origin", "HEAD", "--tags"])
+
+            let destination = tmpDir.appending("cloned")
+            let provider = GitRepositoryProvider()
+            let repository = RepositorySpecifier(path: bareRepo)
+
+            try await provider.shallowClone(
+                repository: repository,
+                tag: "1.0.0",
+                to: destination,
+                recurseSubmodules: false
+            )
+
+            #expect(fs.exists(destination.appending("Package.swift")))
+
+            try fs.removeFileTree(destination)
+            #expect(!fs.exists(destination))
+        }
+    }
+
+    @Test(.tags(.TestSize.medium))
+    func shallowCloneFailsForInvalidTag() async throws {
+        try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
+            let bareRepo = tmpDir.appending("bare.git")
+            try await run(["git", "init", "--bare", bareRepo.pathString])
+
+            let destination = tmpDir.appending("cloned")
+            let provider = GitRepositoryProvider()
+            let repository = RepositorySpecifier(path: bareRepo)
+
+            await #expect(throws: (any Error).self) {
+                try await provider.shallowClone(
+                    repository: repository,
+                    tag: "nonexistent-tag",
+                    to: destination,
+                    recurseSubmodules: false
+                )
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func run(_ arguments: [String]) async throws {
+        let process = AsyncProcess(arguments: arguments)
+        _ = try process.launch()
+        let result = try await process.waitUntilExit()
+        guard result.exitStatus == .terminated(code: 0) else {
+            let stderr = (try? result.utf8stderrOutput()) ?? ""
+            throw StringError("command failed: \(arguments.joined(separator: " "))\n\(stderr)")
+        }
+    }
+}


### PR DESCRIPTION
Git protocol v2 tag discovery and shallow clone support

### Motivation:

Second in a series of PRs adding source archive download support to SwiftPM. https://github.com/swiftlang/swift-package-manager/pull/9870

SPM currently forks a git process per dependency for tag discovery. Each process establishes its own TCP connection and TLS handshake - two network round-trips per repo, repeated sequentially through the dependency graph. For a project with ~30 dependencies this adds up to several seconds of wall time just for tag discovery.

Additionally, when a package has submodules and cannot use a ZIP archive, there is no way to do a shallow clone - SPM always clones the full history.

### Modifications:

- Git HTTP smart protocol v2 implementation (GitProtocolV2.swift) for in-process tag discovery without forking git. Implements pkt-line encoding/decoding and `ls-refs` command per https://git-scm.com/docs/protocol-v2. Uses `ref-prefix` filtering to request only semver-like tags, reducing response size significantly - e.g. swift-syntax tag response drops from 402KB to 10KB by filtering out hundreds of DEVELOPMENT-SNAPSHOT tags.
- ResolvedTag type that pairs a tag name with its peeled commit SHA and parsed semantic version, avoiding repeated parsing downstream.
- Shallow clone and clone-for-editing methods on GitRepositoryProvider for packages that need git (submodules, git-lfs) but not full history.

### Result:

- Tag discovery can be done via HTTP without forking git, enabling connection reuse and parallelism across repos in later PRs
- Packages with submodules can be shallow cloned instead of full cloned
- Benchmark on ~30 dependency project (apple/containerization): tag discovery drops from ~3900ms (sequential git fetch) to ~2000ms (parallel HTTP with session reuse)
