### PR TITLE
Emit warning when SwiftBuild is not used

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -145,6 +145,11 @@ extension SwiftCommand {
 
         swiftCommandState.releaseLockIfNeeded()
 
+        if globalOptions.build._buildSystem != .swiftbuild {
+            swiftCommandState.observabilityScope.emit(
+                .deprecatedBuildSystem(buildSystem: globalOptions.build._buildSystem)
+            )
+        }
         // wait for all observability items to process
         swiftCommandState.waitForObservabilityEvents(timeout: .now() + 5)
 
@@ -186,6 +191,12 @@ extension AsyncSwiftCommand {
         }
 
         swiftCommandState.releaseLockIfNeeded()
+
+        if globalOptions.build._buildSystem != .swiftbuild {
+            swiftCommandState.observabilityScope.emit(
+                .deprecatedBuildSystem(buildSystem: globalOptions.build._buildSystem)
+            )
+        }
 
         // wait for all observability items to process
         swiftCommandState.waitForObservabilityEvents(timeout: .now() + 5)
@@ -1431,6 +1442,12 @@ extension BuildOptions.DebugInfoFormat {
 extension Basics.Diagnostic {
     public static func mutuallyExclusiveArgumentsError(arguments: [String]) -> Self {
         .error(arguments.map { "'\($0)'" }.spm_localizedJoin(type: .conjunction) + " are mutually exclusive")
+    }
+
+    package static func deprecatedBuildSystem(buildSystem: BuildSystemProvider.Kind) -> Self {
+        .warning(
+            "'--build-system \(buildSystem)' has been deprecated and will be removed in a future release; please report an issue at https://github.com/swiftlang/swift-package-manager/issues if you are unable to adopt the default build system."
+        )
     }
 }
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -5445,8 +5445,10 @@ struct PackageCommandTests {
 
                     try await runPlugin(flags: [], diagnostics: ["print"]) { stdout, stderr in
                         #expect(stdout == isOnlyPrint)
+                        let buidlSystemDeprecationDiag = Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem)
                         let filteredStderr = stderr.components(separatedBy: "\n")
-                            .filter { !$0.contains("Unable to locate libSwiftScan") }.joined(separator: "\n")
+                            .filter { !$0.contains("Unable to locate libSwiftScan") }
+                            .filter { !$0.contains(buidlSystemDeprecationDiag.message)}.joined(separator: "\n")
                         #expect(filteredStderr == isEmpty)
                     }
 
@@ -5839,10 +5841,12 @@ struct PackageCommandTests {
                 )
                 #expect(stdout == isEmpty)
                 // Filter some unrelated output that could show up on stderr.
+                let buidlSystemDeprecationDiag = Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem)
                 let filteredStderr = stderr.components(separatedBy: "\n")
                     .filter { !$0.contains("Unable to locate libSwiftScan") }
                     .filter { !($0.contains("warning: ") && $0.contains("unable to find libclang")) }
                     .filter { !$0.contains("Build description")}
+                    .filter { !$0.contains(buidlSystemDeprecationDiag.message)}
                     .joined(separator: "\n")
                 #expect(filteredStderr == isEmpty)
             }
@@ -5858,10 +5862,12 @@ struct PackageCommandTests {
                 )
                 #expect(stdout.contains(containsLogtext))
                 // Filter some unrelated output that could show up on stderr.
+                let deprecatedBuildSystemDiag = Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem)
                 let filteredStderr = stderr.components(separatedBy: "\n")
                     .filter { !$0.contains("Unable to locate libSwiftScan") }
                     .filter { !($0.contains("warning: ") && $0.contains("unable to find libclang")) }
                     .filter { !$0.contains("Build description")}
+                    .filter { !$0.contains(deprecatedBuildSystemDiag.message)}
                     .joined(separator: "\n")
                 #expect(filteredStderr == isEmpty)
             }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1296,8 +1296,11 @@ struct MiscellaneousTestCase {
                     case .native:
                         let errors = stderr.components(separatedBy: .newlines).filter { !$0.contains("[logging] misuse") && !$0.isEmpty }
                                                                         .filter { !$0.contains("Unable to locate libSwiftScan") }
-                        #expect(errors == [])
-                    case .swiftbuild, .xcode:
+                        #expect(errors == ["warning: \(Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem).message)"])
+                    case  .xcode:
+                        let errors = stderr.components(separatedBy: .newlines)
+                        #expect(errors == ["warning: \(Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem).message)"])
+                    case .swiftbuild:
                         break
                 }
             }

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -339,8 +339,12 @@ struct ResourcesTests{
                     buildSystem: buildSystem,
                 )
                 // Filter some unrelated output that could show up on stderr.
+                let buidlSystemDeprecationDiag = Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem)
                 let filteredStderr = stderr.components(separatedBy: "\n").filter { !$0.contains("[logging]") }
-                                                                        .filter { !$0.contains("Unable to locate libSwiftScan") }.joined(separator: "\n")
+                                                                        .filter { !$0.contains("Unable to locate libSwiftScan") }
+                                                                        .filter {
+                                                                            !$0.contains(Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem).message)
+                                                                        }.joined(separator: "\n")
                 #expect(filteredStderr == "", "unexpectedly received error output: \(stderr)")
 
                 let builtProductsDir = try packageDir.appending(components: buildSystem.binPath(for: configuration))

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -142,11 +142,9 @@ struct TestDiscoveryTests {
                 // in "swift test" build output goes to stderr
                 #expect(stderr.contains("Build complete!"))
                 // we are expecting that no warning is produced
-                withKnownIssue(isIntermittent: true) {
-                    #expect(!stderr.contains("warning:"))
-                } when: {
-                    buildSystem == .swiftbuild
-                }
+                let buidlSystemDeprecationDiag = Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem)
+                let filteredStderr = stderr.components(separatedBy: "\n").filter { !$0.contains(buidlSystemDeprecationDiag.message)}.joined(separator: "\n|")
+                #expect(!filteredStderr.contains("warning:"))
                 // in "swift test" test output goes to stdout
                 #expect(stdout.contains("Executed 0 tests"))
             }
@@ -265,8 +263,10 @@ struct TestDiscoveryTests {
             try await fixture(name: "Miscellaneous/TestDiscovery/Deprecation") { fixturePath in
                 let (stdout, stderr) = try await executeSwiftTest(fixturePath, buildSystem: buildSystem)
                 // in "swift test" test output goes to stdout
+                let buidlSystemDeprecationDiag = Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem)
+                let filteredStderr = stderr.components(separatedBy: "\n").filter { !$0.contains(buidlSystemDeprecationDiag.message)}.joined(separator: "\n")
                 #expect(stdout.contains("Executed 2 tests"))
-                #expect(!stderr.contains("is deprecated"))
+                #expect(!filteredStderr.contains("is deprecated"))
             }
         } when: {
             buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows


### PR DESCRIPTION
Swift Build is now the default build system used in SwiftPM.  In order to get users to remove their possible dependency on other build systems, emit a warning on the console when the build system is explicitely set to something other than Swift Build.
