### PR TITLE
Revert "[CMake] Use a separate ABI name for the SwiftSyntax used in SwiftPM"

### DIFF
--- a/BuildSupport/SwiftSyntax/CMakeLists.txt
+++ b/BuildSupport/SwiftSyntax/CMakeLists.txt
@@ -1,46 +1,16 @@
 include(FetchContent)
 
-# Ensure that the SwiftSyntax symbols we use are disjoint from elsewhere in
-# the compiler toolchain.
-set(SWIFT_MODULE_ABI_NAME_PREFIX "_PM")
-
-# Use separate target names so the underlying libraries have a prefix separate
-# from the rest of the toolchain.
-set(SWIFTSYNTAX_TARGET_NAMESPACE "_PM")
-
-# Handle installation on our own.
-set(SWIFT_SYNTAX_INSTALL_TARGETS NO)
-if(DEFINED SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE)
-  file(TO_CMAKE_PATH "${SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE}" swift_syntax_path)
-  FetchContent_Declare(SwiftSyntax
-    SOURCE_DIR "${swift_syntax_path}")
-else()
-  FetchContent_Declare(SwiftSyntax
-    GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
-    GIT_TAG main)
+find_package(SwiftSyntax CONFIG GLOBAL)
+if(NOT SwiftSyntax_FOUND)
+  set(SWIFT_SYNTAX_INSTALL_TARGETS YES)
+  if(DEFINED SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE)
+    file(TO_CMAKE_PATH "${SWIFTPM_PATH_TO_SWIFT_SYNTAX_SOURCE}" swift_syntax_path)
+    FetchContent_Declare(SwiftSyntax
+      SOURCE_DIR "${swift_syntax_path}")
+  else()
+    FetchContent_Declare(SwiftSyntax
+      GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
+      GIT_TAG main)
+  endif()
+  FetchContent_MakeAvailable(SwiftSyntax)
 endif()
-FetchContent_MakeAvailable(SwiftSyntax)
-
-# FIXME: Use FetchContent_Declare's EXCLUDE_FROM_ALL after CMake 3.28
-FetchContent_GetProperties(SwiftSyntax BINARY_DIR binary_dir)
-set_property(DIRECTORY "${binary_dir}" PROPERTY EXCLUDE_FROM_ALL TRUE)
-
-# Install SwiftPM versions of the swift-syntax libraries we use.
-set(SWIFTPM_SWIFT_SYNTAX_MODULES
-  _PMSwiftBasicFormat
-  _PMSwiftDiagnostics
-  _PMSwiftIDEUtils
-  _PMSwiftParser
-  _PMSwiftParserDiagnostics
-  _PMSwiftRefactor
-  _PMSwiftSyntax
-  _PMSwiftSyntaxBuilder
-)
-
-set(SWIFT_HOST_LIBRARIES_SUBDIRECTORY "swift/host")
-foreach(target ${SWIFTPM_SWIFT_SYNTAX_MODULES})
-    install(TARGETS ${target}
-      LIBRARY DESTINATION lib/${SWIFT_HOST_LIBRARIES_SUBDIRECTORY}
-      RUNTIME DESTINATION bin
-    )
-endforeach()

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -62,7 +62,7 @@ add_library(Commands
   Utilities/XCTEvents.swift)
 target_link_libraries(Commands PUBLIC
   SwiftCollections::OrderedCollections
-  SwiftSyntax::_PMSwiftRefactor
+  SwiftSyntax::SwiftRefactor
   SwiftSystem::SystemPackage
   ArgumentParser
   Basics

--- a/Sources/SwiftFixIt/CMakeLists.txt
+++ b/Sources/SwiftFixIt/CMakeLists.txt
@@ -11,10 +11,10 @@ add_library(SwiftFixIt STATIC
 target_link_libraries(SwiftFixIt PUBLIC
   Basics
 
-  SwiftSyntax::_PMSwiftDiagnostics
-  SwiftSyntax::_PMSwiftIDEUtils
-  SwiftSyntax::_PMSwiftParser
-  SwiftSyntax::_PMSwiftSyntax
+  SwiftSyntax::SwiftDiagnostics
+  SwiftSyntax::SwiftIDEUtils
+  SwiftSyntax::SwiftParser
+  SwiftSyntax::SwiftSyntax
 
   TSCBasic
   TSCUtility)


### PR DESCRIPTION
Reverts swiftlang/swift-package-manager#9883. Separating these libraries seems to cause more problems than it fixes.