### PR TITLE
Speed up partial package updates

### DIFF
--- a/Sources/PackageGraph/Resolution/PubGrub/ContainerProvider.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/ContainerProvider.swift
@@ -25,6 +25,9 @@ final class ContainerProvider {
     /// Whether to perform update (git fetch) on existing cloned repositories or not.
     private let skipUpdate: Bool
 
+    /// Whether pinned packages from `Package.resolved` should avoid eager repository updates.
+    private let skipUpdateForResolvedPackages: Bool
+
     /// `Package.resolved` file representation.
     private let resolvedPackages: ResolvedPackagesStore.ResolvedPackages
 
@@ -40,13 +43,39 @@ final class ContainerProvider {
     init(
         provider underlying: PackageContainerProvider,
         skipUpdate: Bool,
+        skipUpdateForResolvedPackages: Bool,
         resolvedPackages: ResolvedPackagesStore.ResolvedPackages,
         observabilityScope: ObservabilityScope
     ) {
         self.underlying = underlying
         self.skipUpdate = skipUpdate
+        self.skipUpdateForResolvedPackages = skipUpdateForResolvedPackages
         self.resolvedPackages = resolvedPackages
         self.observabilityScope = observabilityScope
+    }
+
+    private func updateStrategy(for package: PackageReference) -> ContainerUpdateStrategy {
+        guard !self.skipUpdate else {
+            return .never
+        }
+
+        guard
+            self.skipUpdateForResolvedPackages,
+            let resolvedPackage = self.resolvedPackages[package.identity]
+        else {
+            return .always
+        }
+
+        switch resolvedPackage.state {
+        case .branch(_, let revision), .revision(let revision), .version(_, .some(let revision)):
+            return .ifNeeded(revision: revision)
+        case .version(_, .none):
+            return .never
+        }
+    }
+
+    private func trustPinnedVersions(for package: PackageReference) -> Bool {
+        self.skipUpdateForResolvedPackages && self.resolvedPackages[package.identity] != nil
     }
 
     /// Get a cached container for the given identifier, asserting / throwing if not found.
@@ -83,12 +112,19 @@ final class ContainerProvider {
             // Otherwise, fetch the container from the provider
             self.underlying.getContainer(
                 for: package,
-                updateStrategy: self.skipUpdate ? .never : .always, // TODO: make this more elaborate
-                observabilityScope: self.observabilityScope.makeChildScope(description: "getting package container", metadata: package.diagnosticsMetadata),
+                updateStrategy: self.updateStrategy(for: package),
+                observabilityScope: self.observabilityScope.makeChildScope(
+                    description: "getting package container",
+                    metadata: package.diagnosticsMetadata
+                ),
                 on: .sharedConcurrent
             ) { result in
                 let result = result.tryMap { container -> PubGrubPackageContainer in
-                    let pubGrubContainer = PubGrubPackageContainer(underlying: container, resolvedPackages: self.resolvedPackages)
+                    let pubGrubContainer = PubGrubPackageContainer(
+                        underlying: container,
+                        resolvedPackages: self.resolvedPackages,
+                        trustPinnedVersions: self.trustPinnedVersions(for: package)
+                    )
                     // only cache positive results
                     self.containersCache[package] = pubGrubContainer
                     return pubGrubContainer
@@ -112,14 +148,21 @@ final class ContainerProvider {
             if needsFetching {
                 self.underlying.getContainer(
                     for: identifier,
-                    updateStrategy: self.skipUpdate ? .never : .always, // TODO: make this more elaborate
-                    observabilityScope: self.observabilityScope.makeChildScope(description: "prefetching package container", metadata: identifier.diagnosticsMetadata),
+                    updateStrategy: self.updateStrategy(for: identifier),
+                    observabilityScope: self.observabilityScope.makeChildScope(
+                        description: "prefetching package container",
+                        metadata: identifier.diagnosticsMetadata
+                    ),
                     on: .sharedConcurrent
                 ) { result in
                     defer { self.prefetches[identifier]?.leave() }
                     // only cache positive results
                     if case .success(let container) = result {
-                        self.containersCache[identifier] = PubGrubPackageContainer(underlying: container, resolvedPackages: self.resolvedPackages)
+                        self.containersCache[identifier] = PubGrubPackageContainer(
+                            underlying: container,
+                            resolvedPackages: self.resolvedPackages,
+                            trustPinnedVersions: self.trustPinnedVersions(for: identifier)
+                        )
                     }
                 }
             }

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -147,6 +147,7 @@ public struct PubGrubDependencyResolver {
         provider: PackageContainerProvider,
         resolvedPackages: ResolvedPackagesStore.ResolvedPackages = [:],
         skipDependenciesUpdates: Bool = false,
+        skipUpdateForResolvedPackages: Bool = false,
         prefetchBasedOnResolvedFile: Bool = false,
         observabilityScope: ObservabilityScope,
         delegate: DependencyResolverDelegate? = nil
@@ -158,6 +159,7 @@ public struct PubGrubDependencyResolver {
         self.provider = ContainerProvider(
             provider: self.packageContainerProvider,
             skipUpdate: self.skipDependenciesUpdates,
+            skipUpdateForResolvedPackages: skipUpdateForResolvedPackages,
             resolvedPackages: self.resolvedPackages,
             observabilityScope: observabilityScope
         )

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
@@ -25,10 +25,16 @@ final class PubGrubPackageContainer {
 
     /// `Package.resolved` in-memory representation.
     private let resolvedPackages: ResolvedPackagesStore.ResolvedPackages
+    private let trustPinnedVersions: Bool
 
-    init(underlying: PackageContainer, resolvedPackages: ResolvedPackagesStore.ResolvedPackages) {
+    init(
+        underlying: PackageContainer,
+        resolvedPackages: ResolvedPackagesStore.ResolvedPackages,
+        trustPinnedVersions: Bool = false
+    ) {
         self.underlying = underlying
         self.resolvedPackages = resolvedPackages
+        self.trustPinnedVersions = trustPinnedVersions
     }
 
     var package: PackageReference {
@@ -78,13 +84,13 @@ final class PubGrubPackageContainer {
     /// Returns the best available version for a given term.
     func getBestAvailableVersion(for term: Term) async throws -> Version? {
         assert(term.isPositive, "Expected term to be positive")
-        var versionSet = term.requirement
+        let versionSet = term.requirement
 
         // Restrict the selection to the pinned version if is allowed by the current requirements.
         if let pinnedVersion = self.pinnedVersion {
             if versionSet.contains(pinnedVersion) {
-                if !self.underlying.shouldInvalidatePinnedVersions {
-                    versionSet = .exact(pinnedVersion)
+                if self.trustPinnedVersions || !self.underlying.shouldInvalidatePinnedVersions {
+                    return pinnedVersion
                 } else {
                     // Make sure the pinned version is still available
                     let version = try await self.underlying.versionsDescending().first { pinnedVersion == $0 }

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -44,14 +44,24 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
     /// The tools version currently in use.
     let currentToolsVersion: ToolsVersion
 
+    /// Restricts which packages should be served from local manifests.
+    let allowedLocalPackageIdentities: Set<PackageIdentity>?
+
+    /// Fallback provider for packages that should not or cannot be served locally.
+    let fallbackProvider: PackageContainerProvider?
+
     init(
         root: PackageGraphRoot,
         dependencyManifests: Workspace.DependencyManifests,
-        currentToolsVersion: ToolsVersion = ToolsVersion.current
+        currentToolsVersion: ToolsVersion = ToolsVersion.current,
+        allowedLocalPackageIdentities: Set<PackageIdentity>? = nil,
+        fallbackProvider: PackageContainerProvider? = nil
     ) {
         self.root = root
         self.dependencyManifests = dependencyManifests
         self.currentToolsVersion = currentToolsVersion
+        self.allowedLocalPackageIdentities = allowedLocalPackageIdentities
+        self.fallbackProvider = fallbackProvider
     }
 
     func getContainer(
@@ -59,26 +69,41 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
         updateStrategy: ContainerUpdateStrategy,
         observabilityScope: ObservabilityScope
     ) async throws -> PackageContainer {
-        // Start by searching manifests from the Workspace's resolved dependencies.
-        if let manifest = self.dependencyManifests.dependencies.first(where: { _, managed, _, _ in managed.packageRef == package }) {
-            let container = LocalPackageContainer(
-                package: package,
-                manifest: manifest.manifest,
-                dependency: manifest.dependency,
-                currentToolsVersion: self.currentToolsVersion
-            )
-            return container
+        let canUseLocalContainer = self.allowedLocalPackageIdentities?
+            .contains(package.identity) ?? true
+        if canUseLocalContainer {
+            // Start by searching manifests from the Workspace's resolved dependencies.
+            if let manifest = self.dependencyManifests.dependencies.first(where: { _, managed, _, _ in
+                managed.packageRef.equalsIncludingLocation(package)
+                    || managed.packageRef.identity == package.identity
+            }) {
+                let container = LocalPackageContainer(
+                    package: package,
+                    manifest: manifest.manifest,
+                    dependency: manifest.dependency,
+                    currentToolsVersion: self.currentToolsVersion
+                )
+                return container
+            }
+
+            // Continue searching from the Workspace's root manifests.
+            if let rootPackage = self.dependencyManifests.root.packages[package.identity] {
+                let container = LocalPackageContainer(
+                    package: package,
+                    manifest: rootPackage.manifest,
+                    dependency: nil,
+                    currentToolsVersion: self.currentToolsVersion
+                )
+                return container
+            }
         }
 
-        // Continue searching from the Workspace's root manifests.
-        if let rootPackage = self.dependencyManifests.root.packages[package.identity] {
-            let container = LocalPackageContainer(
-                package: package,
-                manifest: rootPackage.manifest,
-                dependency: nil,
-                currentToolsVersion: self.currentToolsVersion
+        if let fallbackProvider {
+            return try await fallbackProvider.getContainer(
+                for: package,
+                updateStrategy: updateStrategy,
+                observabilityScope: observabilityScope
             )
-            return container
         }
 
         // As we don't have anything else locally, error out.

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -73,10 +73,7 @@ struct ResolverPrecomputationProvider: PackageContainerProvider {
             .contains(package.identity) ?? true
         if canUseLocalContainer {
             // Start by searching manifests from the Workspace's resolved dependencies.
-            if let manifest = self.dependencyManifests.dependencies.first(where: { _, managed, _, _ in
-                managed.packageRef.equalsIncludingLocation(package)
-                    || managed.packageRef.identity == package.identity
-            }) {
+            if let manifest = self.dependencyManifests.dependencies.first(where: { _, managed, _, _ in managed.packageRef == package }) {
                 let container = LocalPackageContainer(
                     package: package,
                     manifest: manifest.manifest,

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -33,6 +33,7 @@ import struct PackageGraph.Incompatibility
 import struct PackageGraph.MultiplexResolverDelegate
 import struct PackageGraph.ObservabilityDependencyResolverDelegate
 import struct PackageGraph.PackageContainerConstraint
+import protocol PackageGraph.PackageContainerProvider
 import struct PackageGraph.PackageGraphRoot
 import struct PackageGraph.PackageGraphRootInput
 import class PackageGraph.ResolvedPackagesStore
@@ -95,7 +96,11 @@ extension Workspace {
         )
 
         // Abort if we're unable to load the `Package.resolved` store or have any diagnostics.
-        guard let resolvedPackagesStore = observabilityScope.trap({ try self.resolvedPackagesStore.load() }) else { return nil }
+        guard let resolvedPackagesStore = observabilityScope.trap({
+            try self.resolvedPackagesStore.load()
+        }) else {
+            return nil
+        }
 
         // Ensure we don't have any error at this point.
         guard !observabilityScope.errorsReported else {
@@ -109,6 +114,7 @@ extension Workspace {
         updateConstraints += try graphRoot.constraints(self.enabledTraitsMap)
 
         let resolvedPackages: ResolvedPackagesStore.ResolvedPackages
+        let skipUpdateForResolvedPackages = !packages.isEmpty
         if packages.isEmpty {
             // No input packages so we have to do a full update. Set resolved packages map to empty.
             resolvedPackages = [:]
@@ -122,18 +128,72 @@ extension Workspace {
                 }
         }
 
-        // Resolve the dependencies.
-        let resolver = try self.createResolver(resolvedPackages: resolvedPackages, observabilityScope: observabilityScope)
-        self.activeResolver = resolver
+        let updateResults: [DependencyResolverBinding]
+        if skipUpdateForResolvedPackages && !self.configuration.skipDependenciesUpdates {
+            let localProvider = ResolverPrecomputationProvider(
+                root: graphRoot,
+                dependencyManifests: currentManifests,
+                currentToolsVersion: self.currentToolsVersion,
+                allowedLocalPackageIdentities: Set(resolvedPackages.keys),
+                fallbackProvider: self.packageContainerProvider
+            )
+            let resolver = try self.createResolver(
+                provider: localProvider,
+                resolvedPackages: resolvedPackages,
+                skipUpdateForResolvedPackages: true,
+                observabilityScope: observabilityScope
+            )
+            self.activeResolver = resolver
 
-        let updateResults = await self.resolveDependencies(
-            resolver: resolver,
-            constraints: updateConstraints,
-            observabilityScope: observabilityScope
-        )
+            let initialResult = await self.solveDependencies(
+                resolver: resolver,
+                constraints: updateConstraints
+            )
 
-        // Reset the active resolver.
-        self.activeResolver = nil
+            // Reset the active resolver.
+            self.activeResolver = nil
+
+            guard !observabilityScope.errorsReported else {
+                return nil
+            }
+
+            switch initialResult {
+            case .success(let bindings):
+                updateResults = bindings
+            case .failure:
+                observabilityScope.emit(
+                    debug: "partial update could not be resolved using pinned dependency metadata alone; retrying with refreshed package containers"
+                )
+
+                let retryResolver = try self.createResolver(
+                    resolvedPackages: resolvedPackages,
+                    observabilityScope: observabilityScope
+                )
+                self.activeResolver = retryResolver
+                updateResults = await self.resolveDependencies(
+                    resolver: retryResolver,
+                    constraints: updateConstraints,
+                    observabilityScope: observabilityScope
+                )
+                self.activeResolver = nil
+            }
+        } else {
+            // Resolve the dependencies.
+            let resolver = try self.createResolver(
+                resolvedPackages: resolvedPackages,
+                observabilityScope: observabilityScope
+            )
+            self.activeResolver = resolver
+
+            updateResults = await self.resolveDependencies(
+                resolver: resolver,
+                constraints: updateConstraints,
+                observabilityScope: observabilityScope
+            )
+
+            // Reset the active resolver.
+            self.activeResolver = nil
+        }
 
         guard !observabilityScope.errorsReported else {
             return nil
@@ -1155,11 +1215,15 @@ extension Workspace {
 
     /// Creates resolver for the workspace.
     fileprivate func createResolver(
+        provider: PackageContainerProvider? = nil,
         resolvedPackages: ResolvedPackagesStore.ResolvedPackages,
+        skipUpdateForResolvedPackages: Bool = false,
         observabilityScope: ObservabilityScope
     ) throws -> PubGrubDependencyResolver {
         var delegate: DependencyResolverDelegate
-        let observabilityDelegate = ObservabilityDependencyResolverDelegate(observabilityScope: observabilityScope)
+        let observabilityDelegate = ObservabilityDependencyResolverDelegate(
+            observabilityScope: observabilityScope
+        )
         if let workspaceDelegate = self.delegate {
             delegate = MultiplexResolverDelegate([
                 observabilityDelegate,
@@ -1170,13 +1234,24 @@ extension Workspace {
         }
 
         return PubGrubDependencyResolver(
-            provider: packageContainerProvider,
+            provider: provider ?? packageContainerProvider,
             resolvedPackages: resolvedPackages,
             skipDependenciesUpdates: self.configuration.skipDependenciesUpdates,
+            skipUpdateForResolvedPackages: skipUpdateForResolvedPackages,
             prefetchBasedOnResolvedFile: self.configuration.prefetchBasedOnResolvedFile,
             observabilityScope: observabilityScope,
             delegate: delegate
         )
+    }
+
+    fileprivate func solveDependencies(
+        resolver: PubGrubDependencyResolver,
+        constraints: [PackageContainerConstraint]
+    ) async -> Result<[DependencyResolverBinding], Error> {
+        os_signpost(.begin, name: SignpostName.pubgrub)
+        let result = await resolver.solve(constraints: constraints)
+        os_signpost(.end, name: SignpostName.pubgrub)
+        return result
     }
 
     /// Runs the dependency resolver based on constraints provided and returns the results.
@@ -1185,9 +1260,10 @@ extension Workspace {
         constraints: [PackageContainerConstraint],
         observabilityScope: ObservabilityScope
     ) async -> [DependencyResolverBinding] {
-        os_signpost(.begin, name: SignpostName.pubgrub)
-        let result = await resolver.solve(constraints: constraints)
-        os_signpost(.end, name: SignpostName.pubgrub)
+        let result = await self.solveDependencies(
+            resolver: resolver,
+            constraints: constraints
+        )
 
         // Take an action based on the result.
         switch result {

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -145,12 +145,10 @@ extension Workspace {
             )
             self.activeResolver = resolver
 
-            let initialResult = await self.solveDependencies(
-                resolver: resolver,
-                constraints: updateConstraints
-            )
+            os_signpost(.begin, name: SignpostName.pubgrub)
+            let initialResult = await resolver.solve(constraints: updateConstraints)
+            os_signpost(.end, name: SignpostName.pubgrub)
 
-            // Reset the active resolver.
             self.activeResolver = nil
 
             guard !observabilityScope.errorsReported else {
@@ -160,7 +158,7 @@ extension Workspace {
             switch initialResult {
             case .success(let bindings):
                 updateResults = bindings
-            case .failure:
+            case .failure(let error) where Self.canRetryPartialUpdateWithRefreshedContainers(error):
                 observabilityScope.emit(
                     debug: "partial update could not be resolved using pinned dependency metadata alone; retrying with refreshed package containers"
                 )
@@ -176,6 +174,9 @@ extension Workspace {
                     observabilityScope: observabilityScope
                 )
                 self.activeResolver = nil
+            case .failure(let error):
+                observabilityScope.emit(error)
+                return nil
             }
         } else {
             // Resolve the dependencies.
@@ -1244,26 +1245,15 @@ extension Workspace {
         )
     }
 
-    fileprivate func solveDependencies(
-        resolver: PubGrubDependencyResolver,
-        constraints: [PackageContainerConstraint]
-    ) async -> Result<[DependencyResolverBinding], Error> {
-        os_signpost(.begin, name: SignpostName.pubgrub)
-        let result = await resolver.solve(constraints: constraints)
-        os_signpost(.end, name: SignpostName.pubgrub)
-        return result
-    }
-
     /// Runs the dependency resolver based on constraints provided and returns the results.
     fileprivate func resolveDependencies(
         resolver: PubGrubDependencyResolver,
         constraints: [PackageContainerConstraint],
         observabilityScope: ObservabilityScope
     ) async -> [DependencyResolverBinding] {
-        let result = await self.solveDependencies(
-            resolver: resolver,
-            constraints: constraints
-        )
+        os_signpost(.begin, name: SignpostName.pubgrub)
+        let result = await resolver.solve(constraints: constraints)
+        os_signpost(.end, name: SignpostName.pubgrub)
 
         // Take an action based on the result.
         switch result {
@@ -1273,6 +1263,14 @@ extension Workspace {
             observabilityScope.emit(error)
             return []
         }
+    }
+
+    // Only retry partial-update failures caused by the local-precomputation shortcut
+    // itself (missing or mismatched local manifests). Other errors — manifest parsing,
+    // registry, tools-version, PubGrub unresolvable — will fail again with refreshed
+    // containers, so they are surfaced directly.
+    private static func canRetryPartialUpdateWithRefreshedContainers(_ error: Error) -> Bool {
+        error is ResolverPrecomputationError
     }
 
     /// Create the cache directories.

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -1734,6 +1734,70 @@ final class PubGrubTests: XCTestCase {
             ]
         )
     }
+
+    func testPubGrubPackageContainerCanTrustPinnedVersion() async throws {
+        final class FailingVersionEnumerationContainer: PackageContainer {
+            enum UnexpectedCall: Error {
+                case versionEnumeration
+            }
+
+            let package: PackageReference
+            let shouldInvalidatePinnedVersions = true
+
+            init(package: PackageReference) {
+                self.package = package
+            }
+
+            func isToolsVersionCompatible(at version: Version) async -> Bool { true }
+            func toolsVersion(for version: Version) async throws -> ToolsVersion { .current }
+            func toolsVersionsAppropriateVersionsDescending() async throws -> [Version] {
+                throw UnexpectedCall.versionEnumeration
+            }
+            func versionsAscending() async throws -> [Version] {
+                throw UnexpectedCall.versionEnumeration
+            }
+            func getDependencies(
+                at version: Version,
+                productFilter: ProductFilter,
+                _ enabledTraits: EnabledTraits = ["default"]
+            ) async throws -> [PackageContainerConstraint] {
+                []
+            }
+            func getDependencies(
+                at revision: String,
+                productFilter: ProductFilter,
+                _ enabledTraits: EnabledTraits = ["default"]
+            ) async throws -> [PackageContainerConstraint] {
+                []
+            }
+            func getUnversionedDependencies(
+                productFilter: ProductFilter,
+                _ enabledTraits: EnabledTraits = ["default"]
+            ) async throws -> [PackageContainerConstraint] {
+                []
+            }
+            func loadPackageReference(at boundVersion: BoundVersion) async throws -> PackageReference { self.package }
+        }
+
+        let path = AbsolutePath("/Package")
+        let package = PackageReference.localSourceControl(identity: .init(path: path), path: path)
+        let pinnedVersion = Version(1, 2, 3)
+        let container = PubGrubPackageContainer(
+            underlying: FailingVersionEnumerationContainer(package: package),
+            resolvedPackages: [
+                package.identity: .init(
+                    packageRef: package,
+                    state: .version(pinnedVersion, revision: nil)
+                )
+            ],
+            trustPinnedVersions: true
+        )
+        let term = Term("package@1.2.3")
+
+        let version = try await container.getBestAvailableVersion(for: term)
+
+        XCTAssertEqual(version, pinnedVersion)
+    }
 }
 
 final class PubGrubTestsBasicGraphs: XCTestCase {

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -1787,7 +1787,8 @@ final class PubGrubTests: XCTestCase {
             resolvedPackages: [
                 package.identity: .init(
                     packageRef: package,
-                    state: .version(pinnedVersion, revision: nil)
+                    state: .version(pinnedVersion, revision: nil),
+                    originalScmUrl: nil
                 )
             ],
             trustPinnedVersions: true

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1826,6 +1826,7 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
+        workspace.delegate.clear()
 
         // Run partial updates.
         //
@@ -1838,8 +1839,13 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
+        XCTAssertEqual(
+            workspace.delegate.events.filter { $0.hasPrefix("updating repo:") },
+            ["updating repo: /tmp/ws/pkgs/Bar"]
+        )
 
         // Try to update just Foo. This should update Foo but not Bar.
+        workspace.delegate.clear()
         try await workspace.checkUpdate(roots: ["Root"], packages: ["Foo"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -1847,8 +1853,13 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.5.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
         }
+        XCTAssertEqual(
+            workspace.delegate.events.filter { $0.hasPrefix("updating repo:") },
+            ["updating repo: /tmp/ws/pkgs/Foo"]
+        )
 
         // Run full update.
+        workspace.delegate.clear()
         try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
             XCTAssertNoDiagnostics(diagnostics)
         }
@@ -1856,6 +1867,13 @@ final class WorkspaceTests: XCTestCase {
             result.check(dependency: "foo", at: .checkout(.version("1.5.0")))
             result.check(dependency: "bar", at: .checkout(.version("1.2.0")))
         }
+        XCTAssertEqual(
+            Set(workspace.delegate.events.filter { $0.hasPrefix("updating repo:") }),
+            Set([
+                "updating repo: /tmp/ws/pkgs/Foo",
+                "updating repo: /tmp/ws/pkgs/Bar",
+            ])
+        )
     }
 
     func testCleanAndReset() async throws {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -1841,7 +1841,7 @@ final class WorkspaceTests: XCTestCase {
         }
         XCTAssertEqual(
             workspace.delegate.events.filter { $0.hasPrefix("updating repo:") },
-            ["updating repo: /tmp/ws/pkgs/Bar"]
+            ["updating repo: \(sandbox.appending(components: "pkgs", "Bar"))"]
         )
 
         // Try to update just Foo. This should update Foo but not Bar.
@@ -1855,7 +1855,7 @@ final class WorkspaceTests: XCTestCase {
         }
         XCTAssertEqual(
             workspace.delegate.events.filter { $0.hasPrefix("updating repo:") },
-            ["updating repo: /tmp/ws/pkgs/Foo"]
+            ["updating repo: \(sandbox.appending(components: "pkgs", "Foo"))"]
         )
 
         // Run full update.
@@ -1870,8 +1870,8 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertEqual(
             Set(workspace.delegate.events.filter { $0.hasPrefix("updating repo:") }),
             Set([
-                "updating repo: /tmp/ws/pkgs/Foo",
-                "updating repo: /tmp/ws/pkgs/Bar",
+                "updating repo: \(sandbox.appending(components: "pkgs", "Foo"))",
+                "updating repo: \(sandbox.appending(components: "pkgs", "Bar"))",
             ])
         )
     }


### PR DESCRIPTION
## Summary
- avoid eagerly updating every resolved dependency during `swift package update <package>`
- add a partial-update fast path that reuses local manifest metadata for pinned non-target packages and falls back to the full resolver path if needed
- trust pinned versions for those non-target packages so PubGrub can skip expensive version enumeration work

**Note**: Running `swiftformat` (on the files I touched, swiftformat version = 0.60.1) produces a larger diff than I expected. Happy to run it, or leave the manual formatting.

## Testing
- swift test --filter WorkspaceTests/testPartialUpdate
- swift test --filter PubGrubTests/testPubGrubPackageContainerCanTrustPinnedVersion
- swift build --product swift-package

## Benchmark
On an internal project with 35 dependencies:
- before: `~/Code/swift-package-manager/.build/debug/swift-package update MYPACKAGE` took `1:21.55`
- after: the same command took `4.456s`
- after the change, only `MYPACKAGE` is refreshed; the rest of the graph resolves from pinned/local metadata at near-zero cost