### PR TITLE
Extended manifest parsing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -348,7 +348,16 @@ let package = Package(
                 "Basics",
                 "PackageModel",
                 "SourceControl",
-            ],
+            ] + swiftSyntaxDependencies(
+                [
+                    "SwiftDiagnostics",
+                    "SwiftIfConfig",
+                    "SwiftOperators",
+                    "SwiftParser",
+                    "SwiftParserDiagnostics",
+                    "SwiftSyntax",
+                ]
+            ),
             exclude: ["CMakeLists.txt", "README.md"],
             swiftSettings: commonExperimentalFeatures
         ),

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 add_compile_definitions(USE_IMPL_ONLY_IMPORTS)
 
+# The CMake build does not support the parsing manifest loader due to
+# the bootstrap process intermingling host runtimes with the built
+# runtimes.
+add_compile_definitions(DISABLE_PARSING_MANIFEST_LOADER)
+
 add_subdirectory(_AsyncFileSystem)
 add_subdirectory(Basics)
 add_subdirectory(BinarySymbols)

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -71,6 +71,9 @@ public struct GlobalOptions: ParsableArguments {
 
     @OptionGroup(title: "Trait Options")
     public var traits: TraitOptions
+
+    @OptionGroup(title: "Manifest Options")
+    public var manifest: ManifestOptions
 }
 
 public struct LocationOptions: ParsableArguments {
@@ -874,6 +877,36 @@ public struct SBOMOptions: ParsableArguments {
             return !["false", "0", "no"].contains(lowercased)
         }
         return false
+    }
+}
+
+public struct ManifestOptions: ParsableArguments {
+    public init() {}
+
+    @Option(
+        name: .customLong("experimental-manifest-processing-mode"),
+        help: "Specifies how manifest files are processed"
+    )
+    public var manifestProcessingMode: ManifestProcessingMode = .onlyExecuted
+
+    @Flag(
+        name: .customLong("experimental-show-manifest-parser-limitations"),
+        help: "Show any manifest parser limitations uncovered in the manifest file"
+    )
+    public var showManifestParserLimitations: Bool = false
+
+    public enum ManifestProcessingMode: String, ExpressibleByArgument {
+        case onlyParsed = "only-parsed"
+        case onlyExecuted = "only-executed"
+        case crosscheck = "crosscheck"
+        case parsedWithFallback = "parsed-with-fallback"
+
+        public static var allValueDescriptions: [String: String] {
+            ["only-parsed" : "Use the built-in manifest parser",
+             "only-executed" : "Build and execute the manifest",
+             "parsed-with-fallback": "Use the built-in manifest parser. If it encounters limitations, fall back to building and executing the manifest.",
+             "crosscheck" : "Use both the built-in manifest parser and also execute the manifest, cross-checking the results"]
+        }
     }
 }
 

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -848,7 +848,7 @@ public final class SwiftCommandState {
         return rootManifests.values.map { $0.toolsVersion }.min()
     }
 
-    func getManifestLoader() throws -> ManifestLoader {
+    func getManifestLoader() throws -> any ManifestLoaderProtocol {
         try self._manifestLoader.get()
     }
 
@@ -1113,7 +1113,16 @@ public final class SwiftCommandState {
         )
     })
 
-    private lazy var _manifestLoader: Result<ManifestLoader, Swift.Error> = Result(catching: {
+    private func createParsingManifestLoader() throws -> ParsingManifestLoader {
+        return try ParsingManifestLoader(
+            toolchain: self.getHostToolchain(),
+            pruneDependencies: self.options.resolver.pruneDependencies,
+            extraManifestFlags: self.options.build.manifestFlags,
+            environment: nil
+        )
+    }
+
+    private func createExecutingManifestLoader() throws -> ManifestLoader {
         let cachePath: AbsolutePath? = switch (
             self.options.caching.shouldDisableManifestCaching,
             self.options.caching.manifestCachingMode
@@ -1143,6 +1152,21 @@ public final class SwiftCommandState {
             importRestrictions: .none,
             pruneDependencies: self.options.resolver.pruneDependencies
         )
+    }
+
+    private lazy var _manifestLoader: Result<any ManifestLoaderProtocol, Swift.Error> = Result(
+        catching: {
+            switch self.options.manifest.manifestProcessingMode {
+            case .onlyParsed: try createParsingManifestLoader()
+            case .onlyExecuted: try createExecutingManifestLoader()
+            case .crosscheck, .parsedWithFallback:
+                ChainedParsingManifestLoader(
+                    parsingLoader: try createParsingManifestLoader(),
+                    executingLoader: try createExecutingManifestLoader(),
+                    showLimitations: self.options.manifest.showManifestParserLimitations,
+                    crosscheck: self.options.manifest.manifestProcessingMode == .crosscheck
+                )
+        }
     })
 
     /// An enum indicating the execution status of run commands.

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1113,6 +1113,7 @@ public final class SwiftCommandState {
         )
     })
 
+    #if !DISABLE_PARSING_MANIFEST_LOADER
     private func createParsingManifestLoader() throws -> ParsingManifestLoader {
         return try ParsingManifestLoader(
             toolchain: self.getHostToolchain(),
@@ -1121,6 +1122,7 @@ public final class SwiftCommandState {
             environment: nil
         )
     }
+    #endif
 
     private func createExecutingManifestLoader() throws -> ManifestLoader {
         let cachePath: AbsolutePath? = switch (
@@ -1157,15 +1159,28 @@ public final class SwiftCommandState {
     private lazy var _manifestLoader: Result<any ManifestLoaderProtocol, Swift.Error> = Result(
         catching: {
             switch self.options.manifest.manifestProcessingMode {
-            case .onlyParsed: try createParsingManifestLoader()
-            case .onlyExecuted: try createExecutingManifestLoader()
+            case .onlyParsed:
+                #if !DISABLE_PARSING_MANIFEST_LOADER
+                return try createParsingManifestLoader()
+                #else
+                fatalError("swiftpm was built without support for the parsed manifest loader")
+                #endif
+
             case .crosscheck, .parsedWithFallback:
-                ChainedParsingManifestLoader(
+                #if !DISABLE_PARSING_MANIFEST_LOADER
+                return ChainedParsingManifestLoader(
                     parsingLoader: try createParsingManifestLoader(),
                     executingLoader: try createExecutingManifestLoader(),
                     showLimitations: self.options.manifest.showManifestParserLimitations,
                     crosscheck: self.options.manifest.manifestProcessingMode == .crosscheck
                 )
+                #else
+                // Silently fall back to the executing manifest loader.
+                fallthrough
+                #endif
+
+            case .onlyExecuted:
+                return try createExecutingManifestLoader()
         }
     })
 

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -21,12 +21,28 @@ add_library(PackageLoading
   RegistryReleaseMetadataSerialization.swift
   Target+PkgConfig.swift
   TargetSourcesBuilder.swift
-  ToolsVersionParser.swift)
+  ToolsVersionParser.swift
+
+  ManifestParsing/BuildConfiguration+HostToolchain.swift
+  ManifestParsing/ChainedParsingManifestLoader.swift
+  ManifestParsing/ManifestParseLimitation.swift
+  ManifestParsing/ManifestParserError.swift
+  ManifestParsing/ParsingManifestLoader.swift
+)
+
 target_link_libraries(PackageLoading PUBLIC
   TSCBasic
   Basics
   PackageModel
-  TSCUtility)
+  TSCUtility
+
+  SwiftSyntax::SwiftDiagnostics
+  SwiftSyntax::SwiftIfConfig
+  SwiftSyntax::SwiftOperators
+  SwiftSyntax::SwiftParser
+  SwiftSyntax::SwiftParserDiagnostics
+  SwiftSyntax::SwiftSyntax
+)
 target_link_libraries(PackageLoading PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 target_link_libraries(PackageLoading PRIVATE

--- a/Sources/PackageLoading/CMakeLists.txt
+++ b/Sources/PackageLoading/CMakeLists.txt
@@ -21,28 +21,12 @@ add_library(PackageLoading
   RegistryReleaseMetadataSerialization.swift
   Target+PkgConfig.swift
   TargetSourcesBuilder.swift
-  ToolsVersionParser.swift
-
-  ManifestParsing/BuildConfiguration+HostToolchain.swift
-  ManifestParsing/ChainedParsingManifestLoader.swift
-  ManifestParsing/ManifestParseLimitation.swift
-  ManifestParsing/ManifestParserError.swift
-  ManifestParsing/ParsingManifestLoader.swift
-)
-
+  ToolsVersionParser.swift)
 target_link_libraries(PackageLoading PUBLIC
   TSCBasic
   Basics
   PackageModel
-  TSCUtility
-
-  SwiftSyntax::SwiftDiagnostics
-  SwiftSyntax::SwiftIfConfig
-  SwiftSyntax::SwiftOperators
-  SwiftSyntax::SwiftParser
-  SwiftSyntax::SwiftParserDiagnostics
-  SwiftSyntax::SwiftSyntax
-)
+  TSCUtility)
 target_link_libraries(PackageLoading PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 target_link_libraries(PackageLoading PRIVATE

--- a/Sources/PackageLoading/ManifestParsing/BuildConfiguration+HostToolchain.swift
+++ b/Sources/PackageLoading/ManifestParsing/BuildConfiguration+HostToolchain.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !DISABLE_PARSING_MANIFEST_LOADER
 import Basics
 import SwiftIfConfig
 import TSCUtility
@@ -39,3 +40,5 @@ extension StaticBuildConfiguration {
         return try decoder.decode(StaticBuildConfiguration.self, from: outputData)
     }
 }
+#endif
+

--- a/Sources/PackageLoading/ManifestParsing/BuildConfiguration+HostToolchain.swift
+++ b/Sources/PackageLoading/ManifestParsing/BuildConfiguration+HostToolchain.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import SwiftIfConfig
+import TSCUtility
+import Foundation
+
+extension StaticBuildConfiguration {
+    public static func getHostConfiguration(
+        usingSwiftCompiler swiftCompiler: AbsolutePath,
+        extraManifestFlags: [String],
+    ) throws -> StaticBuildConfiguration {
+        // Call the compiler to get the static build configuration JSON.
+        let compilerOutput: String
+        do {
+            let args = [swiftCompiler.pathString, "-frontend", "-print-static-build-config"] + extraManifestFlags
+            let result = try AsyncProcess.popen(arguments: args)
+            compilerOutput = try result.utf8Output()
+        } catch {
+            throw InternalError("Failed to get target info (\(error.interpolationDescription))")
+        }
+
+        // Parse the compiler's JSON output.
+        guard let outputData = compilerOutput.data(using: .utf8) else {
+            throw InternalError("Failed to get data from compiler output for static build configuration: \(compilerOutput)")
+        }
+
+        let decoder = JSONDecoder()
+        return try decoder.decode(StaticBuildConfiguration.self, from: outputData)
+    }
+}

--- a/Sources/PackageLoading/ManifestParsing/ChainedParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ChainedParsingManifestLoader.swift
@@ -1,0 +1,230 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Dispatch
+import Foundation
+import PackageModel
+import SourceControl
+
+public import SwiftDiagnostics
+import SwiftParser
+import SwiftParserDiagnostics
+import SwiftSyntax
+
+import struct TSCBasic.ByteString
+
+import struct TSCUtility.Version
+
+/// Manifest loader that chains together a parsing manifest loader (which
+/// parses the manifest source directly) and an another manifest loader
+/// (e.g., that executes the manifest). It can use the parsing manifest
+/// loader when that succeeds, or cross-check the results of the parsing
+/// manifest loader against the other manifest loader to verify that they
+/// produce the same results.
+public final class ChainedParsingManifestLoader: ManifestLoaderProtocol {
+    let parsingLoader: ParsingManifestLoader
+    let executingLoader: any ManifestLoaderProtocol
+
+    /// Whether to show the limitations that prevent us from using the
+    /// results of the parsing loader.
+    let showLimitations: Bool
+
+    /// Whether to cross-check the results of the two loaders. Otherwise,
+    /// the results will be taken from the parsing loader if it succeeds,
+    /// and the executing loader otherwise.
+    let crosscheck: Bool
+
+    public init(
+        parsingLoader: ParsingManifestLoader,
+        executingLoader: any ManifestLoaderProtocol,
+        showLimitations: Bool,
+        crosscheck: Bool
+    ) {
+        self.parsingLoader = parsingLoader
+        self.executingLoader = executingLoader
+        self.showLimitations = showLimitations
+        self.crosscheck = crosscheck
+    }
+
+    public func load(
+        manifestPath: AbsolutePath,
+        manifestToolsVersion: ToolsVersion,
+        packageIdentity: PackageIdentity,
+        packageKind: PackageReference.Kind,
+        packageLocation: String,
+        packageVersion: (version: Version?, revision: String?)?,
+        identityResolver: IdentityResolver,
+        dependencyMapper: DependencyMapper,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        delegateQueue: DispatchQueue
+    ) async throws -> Manifest {
+        if crosscheck {
+            // When cross-checking, we're doing timings. Pre-load the file
+            // to warm the filesystem cache rather than charging it to
+            // a particular loader.
+            let manifestContents: ByteString
+            do {
+                manifestContents = try fileSystem.readFileContents(manifestPath)
+            } catch {
+                throw ManifestParserError.inaccessibleManifest(path: manifestPath, reason: String(describing: error))
+            }
+            _ = manifestContents
+        }
+
+        // Parse the manifest directly with the parsing loader.
+        let parsedManifest: Manifest?
+        let parsingStartTime = DispatchTime.now()
+        let parsingEndTime: DispatchTime
+        do {
+            let manifest = try parsingLoader.load(
+                manifestPath: manifestPath,
+                manifestToolsVersion: manifestToolsVersion,
+                packageIdentity: packageIdentity,
+                packageKind: packageKind,
+                packageLocation: packageLocation,
+                packageVersion: packageVersion,
+                identityResolver: identityResolver,
+                dependencyMapper: dependencyMapper,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                delegateQueue: delegateQueue
+            )
+
+            // We successfully parsed the manifest. If we aren't
+            // cross-checking the results, we're done.
+            if !crosscheck {
+                return manifest
+            }
+
+            parsedManifest = manifest
+            parsingEndTime = DispatchTime.now()
+        } catch {
+            guard case .limitations(let limitations) = error else {
+                throw error
+            }
+
+            // We hit a limitation of the parsed approach, which can either
+            // be a missing feature or something executable in the manifest.
+            parsingEndTime = DispatchTime.now()
+
+            if showLimitations {
+                print("Manifest parser encountered \(limitations.count) limitations that prevent its use for '\(manifestPath.pathString)'")
+
+                let formatter = DiagnosticsFormatter()
+                let filename = manifestPath.pathString
+                let locationConverter = SourceLocationConverter(
+                    fileName: filename,
+                    tree: limitations[0].syntax.root
+                )
+                for limitation in limitations {
+                    let diagLoc = locationConverter.location(
+                        for: limitation.syntax.position
+                    )
+                    let prefix = "\(filename):\(diagLoc.line):\(diagLoc.column):"
+                    let message = formatter.formattedMessage(limitation)
+
+                    let source = formatter.annotatedSource(
+                        tree: limitation.syntax.root,
+                        diags: [limitation.asDiagnostic()]
+                    )
+
+                    print(
+                        "\(prefix) \(message)\n\(source)"
+                    )
+                }
+            }
+            parsedManifest = nil
+        }
+
+        // Use the executing loader to process the manifest.
+        let executingStartTime = DispatchTime.now()
+        let executedManifest = try await executingLoader.load(
+            manifestPath: manifestPath,
+            manifestToolsVersion: manifestToolsVersion,
+            packageIdentity: packageIdentity,
+            packageKind: packageKind,
+            packageLocation: packageLocation,
+            packageVersion: packageVersion,
+            identityResolver: identityResolver,
+            dependencyMapper: dependencyMapper,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope,
+            delegateQueue: delegateQueue
+        )
+        let executingEndTime = DispatchTime.now()
+
+        let parsingDuration = parsingStartTime.distance(to: parsingEndTime)
+        let executingDuration = executingStartTime.distance(to: executingEndTime)
+
+        // If we have a parsed manifest, it means that we want to
+        // cross-check the results. Do so now.
+        if let parsedManifest {
+            precondition(crosscheck)
+
+            let parsedJSON = try parsedManifest.toJSON()
+            let executedJSON = try executedManifest.toJSON()
+            guard parsedJSON == executedJSON else {
+                print("""
+                    Manifest loading cross-check failed for '\(manifestPath.pathString)':
+                      - Parsing took \(parsingDuration)
+                      - Executing took \(executingDuration)
+                    """
+                )
+                throw ChainedParsingError.manifestMismatch(
+                    manifestPath: manifestPath.pathString,
+                    parsed: parsedJSON,
+                    executed: executedJSON
+                )
+            }
+
+            print("""
+                Manifest loading cross-check succeeded for '\(manifestPath.pathString)':
+                  - Parsing took \(parsingDuration)
+                  - Executing took \(executingDuration)
+                """
+            )
+            return parsedManifest
+        } else {
+            print("""
+                Manifest loading encountered limitations for '\(manifestPath.pathString)':
+                  - Parsing took \(parsingDuration)
+                  - Executing took \(executingDuration)
+                """
+            )
+        }
+
+        return executedManifest
+    }
+
+    public func resetCache(observabilityScope: Basics.ObservabilityScope) async {
+        await parsingLoader.resetCache(observabilityScope: observabilityScope)
+        await executingLoader.resetCache(observabilityScope: observabilityScope)
+    }
+
+    public func purgeCache(observabilityScope: Basics.ObservabilityScope) async {
+        await parsingLoader.purgeCache(observabilityScope: observabilityScope)
+        await executingLoader.purgeCache(observabilityScope: observabilityScope)
+    }
+
+    enum ChainedParsingError: Error, CustomStringConvertible {
+        case manifestMismatch(manifestPath: String, parsed: String, executed: String)
+
+        var description: String {
+            switch self {
+            case .manifestMismatch(manifestPath: let manifestPath, parsed: let parsed, executed: let expected):
+                "The manifest produced by parsing '\(manifestPath)' does not match the one produced by executing: \(parsed) != \(expected)"
+            }
+        }
+    }
+}

--- a/Sources/PackageLoading/ManifestParsing/ChainedParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ChainedParsingManifestLoader.swift
@@ -17,7 +17,7 @@ import Foundation
 import PackageModel
 import SourceControl
 
-public import SwiftDiagnostics
+import SwiftDiagnostics
 import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax

--- a/Sources/PackageLoading/ManifestParsing/ChainedParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ChainedParsingManifestLoader.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !DISABLE_PARSING_MANIFEST_LOADER
 import Basics
 import Dispatch
 import Foundation
@@ -228,3 +229,4 @@ public final class ChainedParsingManifestLoader: ManifestLoaderProtocol {
         }
     }
 }
+#endif

--- a/Sources/PackageLoading/ManifestParsing/ManifestParseLimitation.swift
+++ b/Sources/PackageLoading/ManifestParsing/ManifestParseLimitation.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !DISABLE_PARSING_MANIFEST_LOADER
 import SwiftDiagnostics
 import SwiftSyntax
 
@@ -134,3 +135,4 @@ extension ManifestParseLimitation: DiagnosticMessage {
         )
     }
 }
+#endif

--- a/Sources/PackageLoading/ManifestParsing/ManifestParseLimitation.swift
+++ b/Sources/PackageLoading/ManifestParsing/ManifestParseLimitation.swift
@@ -45,6 +45,10 @@ public enum ManifestParseLimitation {
 
     /// Unhandled operator-precedence issue.
     case operatorPrecedence(Syntax)
+
+    /// A diagnostic produced while evaluating `#if` conditions (e.g.,
+    /// `canImport` checks that the static configuration cannot evaluate).
+    case ifConfigDiagnostic(SyntaxDiagnostic)
 }
 
 extension ManifestParseLimitation: CustomStringConvertible {
@@ -75,6 +79,8 @@ extension ManifestParseLimitation {
             return Syntax(expr)
         case .operatorPrecedence(let node):
             return Syntax(node)
+        case .ifConfigDiagnostic(let diagnostic):
+            return Syntax(diagnostic.node)
         }
     }
 
@@ -106,6 +112,8 @@ extension ManifestParseLimitation: DiagnosticMessage {
             return "Invalid Swift language version '\(value)'; expected format is major[.minor[.patch]]"
         case .operatorPrecedence(_):
             return "Unhandled operator precedence issue"
+        case .ifConfigDiagnostic(let diagnostic):
+            return diagnostic.message
         }
     }
 
@@ -119,6 +127,7 @@ extension ManifestParseLimitation: DiagnosticMessage {
         case .unsupportedArgument: "unsupported-argument"
         case .invalidSwiftLanguageVersion: "invalid-swift-language-version"
         case .operatorPrecedence: "unhandled-operator-precedence"
+        case .ifConfigDiagnostic: "ifconfig-diagnostic"
         }
 
         return MessageID(domain: "manifest-parse-limitation", id: id)

--- a/Sources/PackageLoading/ManifestParsing/ManifestParseLimitation.swift
+++ b/Sources/PackageLoading/ManifestParsing/ManifestParseLimitation.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+
+/// A description of a limitation of the manifest parser, such as an
+/// unrecognized syntax node or some kind of dynamic expression that the
+/// manifest parser does not understand.
+///
+/// Every limitation will have a corresponding syntax node and can be
+/// treated as a `DiagnosticMessage` so that it can be shown to the user.
+public enum ManifestParseLimitation {
+    /// An unexpected syntax node of any kind.
+    case unexpectedSyntax(Syntax)
+
+    /// An import declaration that refers to an unknown module.
+    case unknownImportModule(ImportDeclSyntax, moduleName: String)
+
+    /// An import declaration that uses unsupported declaration syntax.
+    case unsupportedImportForm(ImportDeclSyntax)
+
+    /// A variable declaration that doesn't follow the straightforward
+    /// "let x = y" format we support.
+    case unsupportedVariableForm(VariableDeclSyntax)
+
+    /// An expression that has an unknown expression.
+    case unsupportedExpression(ExprSyntax, expected: String)
+
+    /// A call argument that is unknown/unsupported.
+    case unsupportedArgument(LabeledExprSyntax, callee: String)
+
+    /// An invalid Swift language version value.
+    case invalidSwiftLanguageVersion(ExprSyntax, value: String)
+
+    /// Unhandled operator-precedence issue.
+    case operatorPrecedence(Syntax)
+}
+
+extension ManifestParseLimitation: CustomStringConvertible {
+    public var description: String {
+        let formatter = DiagnosticsFormatter()
+        return formatter.formattedMessage(self) + "\n" + formatter.annotatedSource(tree: syntax.root, diags: [asDiagnostic()])
+    }
+}
+
+/// MARK: Diagnostics
+extension ManifestParseLimitation {
+    /// The syntax node this limitation describes.
+    var syntax: Syntax {
+        switch self {
+        case .unexpectedSyntax(let node):
+            return node
+        case .unknownImportModule(let decl, _):
+            return Syntax(decl)
+        case .unsupportedImportForm(let decl):
+            return Syntax(decl)
+        case .unsupportedVariableForm(let decl):
+            return Syntax(decl)
+        case .unsupportedExpression(let expr, _):
+            return Syntax(expr)
+        case .unsupportedArgument(let arg, callee: _):
+            return Syntax(arg)
+        case .invalidSwiftLanguageVersion(let expr, _):
+            return Syntax(expr)
+        case .operatorPrecedence(let node):
+            return Syntax(node)
+        }
+    }
+
+    /// Produce a diagnostic describing this limitation.
+    func asDiagnostic() -> Diagnostic {
+        Diagnostic(node: syntax, message: self)
+    }
+}
+
+extension ManifestParseLimitation: DiagnosticMessage {
+    public var message: String {
+        switch self {
+        case .unexpectedSyntax(let node):
+            return "Unsupported syntax '\(node.kind)' in package manifest"
+        case .unknownImportModule(_, moduleName: let name):
+            return "Import of unknown module named '\(name)'"
+        case .unsupportedImportForm:
+            return "Unsupported import syntax"
+        case .unsupportedVariableForm:
+            return "Variables can only have the form 'let <name> = <expression>'"
+        case .unsupportedExpression(_, expected: let expected):
+            return "Unhandled expression in \(expected)"
+        case .unsupportedArgument(let arg, callee: let callee):
+            if let label = arg.label?.identifier {
+                return "Unhandled argument '\(label.name)' in call to '\(callee)"
+            }
+            return "Unhandled argument in call to '\(callee)'"
+        case .invalidSwiftLanguageVersion(_, value: let value):
+            return "Invalid Swift language version '\(value)'; expected format is major[.minor[.patch]]"
+        case .operatorPrecedence(_):
+            return "Unhandled operator precedence issue"
+        }
+    }
+
+    public var diagnosticID: MessageID {
+        let id = switch self {
+        case .unexpectedSyntax: "unexpected-syntax"
+        case .unknownImportModule: "unknown-import-module"
+        case .unsupportedImportForm: "unsupported-import-form"
+        case .unsupportedVariableForm: "unsupported-variable-form"
+        case .unsupportedExpression: "unsupported-expression"
+        case .unsupportedArgument: "unsupported-argument"
+        case .invalidSwiftLanguageVersion: "invalid-swift-language-version"
+        case .operatorPrecedence: "unhandled-operator-precedence"
+        }
+
+        return MessageID(domain: "manifest-parse-limitation", id: id)
+    }
+
+    public var severity: DiagnosticSeverity {
+        .error
+    }
+
+    public var category: DiagnosticCategory? {
+        DiagnosticCategory(
+            name: "PackageManifest",
+            documentationURL: nil
+        )
+    }
+}

--- a/Sources/PackageLoading/ManifestParsing/ManifestParserError.swift
+++ b/Sources/PackageLoading/ManifestParsing/ManifestParserError.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import SwiftDiagnostics
+
+/// An error that can be produced when parsing a manifest directly.
+public enum ManifestParserError: Error {
+    /// The manifest parser encountered known limitations and cannot produce
+    /// a complete manifest.
+    case limitations([ManifestParseLimitation])
+
+    /// The parser encountered syntactic errors when parsing the manifest.
+    case syntaxErrors([SwiftDiagnostics.Diagnostic])
+
+    /// The manifest file could not be loaded.
+    case inaccessibleManifest(path: AbsolutePath, reason: String)
+
+    /// The manifest file is missing a package name.
+    case missingPackageName
+}
+
+extension ManifestParserError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .limitations(let limitations):
+            return "Manifest parser encountered limitations\n" + limitations.map(\.description).joined(separator: "\n")
+        case .syntaxErrors:
+            return "Syntax errors in manifest"
+        case .inaccessibleManifest(path: let path, reason: let reason):
+            return "Could not read package manifest at \(path): \(reason)"
+        case .missingPackageName:
+            return "Could not find the package name"
+        }
+    }
+}
+
+extension ManifestParserError: LocalizedError {
+    public var errorDescription: String? {
+        description
+    }
+}

--- a/Sources/PackageLoading/ManifestParsing/ManifestParserError.swift
+++ b/Sources/PackageLoading/ManifestParsing/ManifestParserError.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !DISABLE_PARSING_MANIFEST_LOADER
 import Basics
 import Foundation
 import SwiftDiagnostics
@@ -50,3 +51,4 @@ extension ManifestParserError: LocalizedError {
         description
     }
 }
+#endif

--- a/Sources/PackageLoading/ManifestParsing/ManifestParserError.swift
+++ b/Sources/PackageLoading/ManifestParsing/ManifestParserError.swift
@@ -13,6 +13,7 @@
 #if !DISABLE_PARSING_MANIFEST_LOADER
 import Basics
 import Foundation
+import PackageModel
 import SwiftDiagnostics
 
 /// An error that can be produced when parsing a manifest directly.
@@ -29,6 +30,9 @@ public enum ManifestParserError: Error {
 
     /// The manifest file is missing a package name.
     case missingPackageName
+
+    /// Unhandled Swift language mode.
+    case unknownLanguageMode(SwiftLanguageVersion)
 }
 
 extension ManifestParserError: CustomStringConvertible {
@@ -42,6 +46,8 @@ extension ManifestParserError: CustomStringConvertible {
             return "Could not read package manifest at \(path): \(reason)"
         case .missingPackageName:
             return "Could not find the package name"
+        case .unknownLanguageMode(let version):
+            return "Could not handle language mode \(version)"
         }
     }
 }

--- a/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
@@ -45,19 +45,22 @@ public typealias SyntaxDiagnostic = SwiftDiagnostics.Diagnostic
 /// than continue to manifest parsing.
 public final class ParsingManifestLoader: ManifestLoaderProtocol {
     let pruneDependencies: Bool
-    let config: StaticBuildConfiguration
+
+    /// Build configurations indexed by language mode.
+    let configurations: [SwiftLanguageVersion: StaticBuildConfiguration]
+
     let environment: [String: String]?
 
     /// Initialize the manifest loader with the given static build
     /// configuration, which will be used to evaluate `#if` conditions in
     /// the manifest.
     public init(
-        configuration: StaticBuildConfiguration,
+        configurations: [SwiftLanguageVersion: StaticBuildConfiguration],
         pruneDependencies: Bool = false,
         environment: [String: String]?
     ) {
         self.pruneDependencies = pruneDependencies
-        self.config = configuration
+        self.configurations = configurations
         self.environment = environment
     }
 
@@ -69,11 +72,17 @@ public final class ParsingManifestLoader: ManifestLoaderProtocol {
         extraManifestFlags: [String],
         environment: [String: String]?
     ) throws {
-        self.init(
-            configuration: try StaticBuildConfiguration.getHostConfiguration(
+        var configurations: [SwiftLanguageVersion: StaticBuildConfiguration] = [:]
+        for version in SwiftLanguageVersion.supportedSwiftLanguageVersions {
+            let config = try StaticBuildConfiguration.getHostConfiguration(
                 usingSwiftCompiler: toolchain.swiftCompilerPathForManifests,
-                extraManifestFlags: extraManifestFlags
-            ),
+                extraManifestFlags: extraManifestFlags + ["-swift-version", version.rawValue]
+            )
+            configurations[version] = config
+        }
+
+        self.init(
+            configurations: configurations,
             pruneDependencies: pruneDependencies,
             environment: environment
         )
@@ -196,10 +205,9 @@ public final class ParsingManifestLoader: ManifestLoaderProtocol {
         // from the compiler reflects its default language mode, but the
         // manifest is compiled with the language version implied by its
         // tools version (e.g., tools version 6.0 → Swift 6 mode).
-        var config = self.config
         let toolsLanguageVersion = manifestToolsVersion.swiftLanguageVersion
-        if let parsedVersion = VersionTuple(parsing: toolsLanguageVersion.rawValue) {
-            config.languageMode = parsedVersion
+        guard let config = configurations[toolsLanguageVersion] else {
+            throw .unknownLanguageMode(toolsLanguageVersion)
         }
 
         // Parse the source file.

--- a/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
@@ -1,0 +1,3290 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Dispatch
+import Foundation
+import PackageModel
+import SourceControl
+
+public import SwiftDiagnostics
+import SwiftIfConfig
+import SwiftOperators
+import SwiftParser
+import SwiftParserDiagnostics
+import SwiftSyntax
+
+import struct TSCBasic.ByteString
+
+import struct TSCUtility.Version
+
+public typealias SyntaxDiagnostic = SwiftDiagnostics.Diagnostic
+
+/// Manifest loader that operates by using SwiftSyntax to parse the manifest
+/// file directly rather than executing it.
+///
+/// This manifest loader takes a conservative approach of rejecting anything
+/// in the manifest file that it doesn't understand, recording a set of
+/// "limitations" along the way. The presence of limitations after parsing
+/// means that SwiftPM will have to execute the manifest, but is not
+/// necessarily an error.
+///
+/// This manifest loader can also produce errors that would prevent
+/// manifest execution from succeeding, for example syntax errors in the
+/// manifest. The client can choose to report these errors directly rather
+/// than continue to manifest parsing.
+public final class ParsingManifestLoader: ManifestLoaderProtocol {
+    let pruneDependencies: Bool
+    let config: StaticBuildConfiguration
+    let environment: [String: String]?
+
+    /// Initialize the manifest loader with the given static build
+    /// configuration, which will be used to evaluate `#if` conditions in
+    /// the manifest.
+    public init(
+        configuration: StaticBuildConfiguration,
+        pruneDependencies: Bool = false,
+        environment: [String: String]?
+    ) {
+        self.pruneDependencies = pruneDependencies
+        self.config = configuration
+        self.environment = environment
+    }
+
+    /// Initialize the manifest loader using the given host toolchain.
+    /// The toolchain will be used to derive the static build configuration.
+    public convenience init(
+        toolchain: UserToolchain,
+        pruneDependencies: Bool = false,
+        extraManifestFlags: [String],
+        environment: [String: String]?
+    ) throws {
+        self.init(
+            configuration: try StaticBuildConfiguration.getHostConfiguration(
+                usingSwiftCompiler: toolchain.swiftCompilerPathForManifests,
+                extraManifestFlags: extraManifestFlags
+            ),
+            pruneDependencies: pruneDependencies,
+            environment: environment
+        )
+    }
+
+    public func resetCache(observabilityScope: Basics.ObservabilityScope) async {
+        // No caching, so there is nothing to do.
+    }
+    
+    public func purgeCache(observabilityScope: Basics.ObservabilityScope) async {
+        // No caching, so there is nothing to do.
+    }
+    
+    /// Load the manifest for the package at `path`.
+    ///
+    /// - Parameters:
+    ///   - manifestPath: The root path of the package.
+    ///   - manifestToolsVersion: The version of the tools the manifest supports.
+    ///   - packageIdentity: the identity of the package
+    ///   - packageKind: The kind of package the manifest is from.
+    ///   - packageLocation: The location the package the manifest was loaded from.
+    ///   - packageVersion: Optional. The version and revision of the package.
+    ///   - identityResolver: A helper to resolve identities based on configuration
+    ///   - dependencyMapper: A helper to map dependencies.
+    ///   - fileSystem: File system to load from.
+    ///   - observabilityScope: Observability scope to emit diagnostics.
+    ///   - callbackQueue: The dispatch queue to perform completion handler on.
+    ///   - completion: The completion handler .
+    public func load(
+        manifestPath: AbsolutePath,
+        manifestToolsVersion: ToolsVersion,
+        packageIdentity: PackageIdentity,
+        packageKind: PackageReference.Kind,
+        packageLocation: String,
+        packageVersion: (version: Version?, revision: String?)?,
+        identityResolver: IdentityResolver,
+        dependencyMapper: DependencyMapper,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        delegateQueue: DispatchQueue
+    ) throws(ManifestParserError) -> Manifest {
+        let manifestContents: ByteString
+        do {
+            manifestContents = try fileSystem.readFileContents(manifestPath)
+        } catch {
+            throw ManifestParserError.inaccessibleManifest(path: manifestPath, reason: String(describing: error))
+        }
+
+        return try parse(
+            manifestPath: manifestPath,
+            manifestContents: manifestContents,
+            manifestToolsVersion: manifestToolsVersion,
+            packageIdentity: packageIdentity,
+            packageKind: packageKind,
+            packageLocation: packageLocation,
+            packageVersion: packageVersion,
+            identityResolver: identityResolver,
+            dependencyMapper: dependencyMapper,
+            fileSystem: fileSystem,
+            observabilityScope: observabilityScope,
+            delegateQueue: delegateQueue
+        )
+    }
+
+    /// Parse a package manifest, without compiling and executing it.
+    public func parse(
+        manifestPath: AbsolutePath,
+        manifestContents: ByteString,
+        manifestToolsVersion: ToolsVersion,
+        packageIdentity: PackageIdentity,
+        packageKind: PackageReference.Kind,
+        packageLocation: String,
+        packageVersion: (version: Version?, revision: String?)?,
+        identityResolver: IdentityResolver,
+        dependencyMapper: DependencyMapper,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        delegateQueue: DispatchQueue
+    ) throws(ManifestParserError) -> Manifest {
+        try manifestContents.contents.withUnsafeBufferPointer { manifestBytes throws(ManifestParserError) in
+            try parse(
+                manifestPath: manifestPath,
+                manifestContents: manifestBytes,
+                manifestToolsVersion: manifestToolsVersion,
+                packageIdentity: packageIdentity,
+                packageKind: packageKind,
+                packageLocation: packageLocation,
+                packageVersion: packageVersion,
+                identityResolver: identityResolver,
+                dependencyMapper: dependencyMapper,
+                fileSystem: fileSystem,
+                observabilityScope: observabilityScope,
+                delegateQueue: delegateQueue
+            )
+        }
+    }
+
+    private func parse(
+        manifestPath: AbsolutePath,
+        manifestContents: UnsafeBufferPointer<UInt8>,
+        manifestToolsVersion: ToolsVersion,
+        packageIdentity: PackageIdentity,
+        packageKind: PackageReference.Kind,
+        packageLocation: String,
+        packageVersion: (version: Version?, revision: String?)?,
+        identityResolver: IdentityResolver,
+        dependencyMapper: DependencyMapper,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        delegateQueue: DispatchQueue
+    ) throws(ManifestParserError) -> Manifest {
+
+        let contextModel = StaticContextModel(
+            packageDirectory: manifestPath.parentDirectory.pathString,
+            environment: environment ?? ProcessInfo.processInfo.environment
+        )
+        
+        // Parse the source file.
+        var sourceFile: SourceFileSyntax = Parser.parse(source: manifestContents)
+
+        // Fold all operators in the source file so we can evaluate
+        // expressions.
+        var operatorLimitations: [ManifestParseLimitation] = []
+        sourceFile = OperatorTable.standardOperators.foldAll(sourceFile) { error in
+            operatorLimitations.append(.operatorPrecedence(error.asDiagnostic.node))
+        }.cast(SourceFileSyntax.self)
+
+        if !operatorLimitations.isEmpty {
+            throw .limitations(operatorLimitations)
+        }
+
+        // Check for syntax errors that would prevent us from going further.
+        let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: sourceFile)
+        if !diagnostics.isEmpty {
+            // Filter out diagnostics in unparsed regions.
+            let configured = sourceFile.configuredRegions(in: config)
+            let relevantDiagnostics = diagnostics.filter { diag in
+                switch configured.isActive(diag.node) {
+                case .active, .inactive:
+                    true
+
+                case .unparsed:
+                    false
+                }
+            }
+
+            if !relevantDiagnostics.isEmpty {
+                throw .syntaxErrors(relevantDiagnostics)
+            }
+        }
+
+        // Walk the source file to parse
+        let visitor = ManifestParseVisitor(
+            manifestPath: manifestPath,
+            configuration: config,
+            dependencyMapper: dependencyMapper,
+            fileSystem: fileSystem,
+            contextModel: contextModel,
+            defaultPackageAccess: manifestToolsVersion >= .v5_9
+        )
+        visitor.walk(sourceFile)
+
+        // If we hit any of the limitations of the manifest parser, bail out
+        // now.
+        if !visitor.limitations.isEmpty {
+            throw .limitations(visitor.limitations)
+        }
+
+        /// We need to found a package name to continue.
+        guard let packageName = visitor.packageName else {
+            throw .missingPackageName
+        }
+
+        // Convert legacy system library packages to the current target-based
+        // model, mirroring the same logic in ManifestLoader.load().
+        //
+        // An old-style system library package has no explicit targets or
+        // products in the manifest, but has a `module.modulemap` file at the
+        // package root. In that case we synthesize a system library target and
+        // an automatic library product that wraps it, carrying over the
+        // package-level pkgConfig and providers.
+        var products = visitor.products
+        var targets = visitor.targets
+        if products.isEmpty, targets.isEmpty,
+            fileSystem.isFile(manifestPath.parentDirectory.appending(component: moduleMapFilename)) {
+            // These initializers only throw for invalid argument combinations.
+            // The arguments below are always valid (matching what ManifestLoader
+            // synthesizes for legacy system library packages), so force-try is safe.
+            products.append(try! ProductDescription(
+                name: packageName,
+                type: .library(.automatic),
+                targets: [packageName])
+            )
+            targets.append(try! TargetDescription(
+                name: packageName,
+                path: "",
+                type: .system,
+                packageAccess: false,
+                pkgConfig: visitor.pkgConfig,
+                providers: visitor.providers
+            ))
+        }
+
+        return Manifest(
+            displayName: packageName,
+            packageIdentity: packageIdentity,
+            path: manifestPath,
+            packageKind: packageKind,
+            packageLocation: packageLocation,
+            defaultLocalization: visitor.defaultLocalization,
+            platforms: visitor.platforms,
+            version: packageVersion?.version,
+            revision: packageVersion?.revision,
+            toolsVersion: manifestToolsVersion,
+            pkgConfig: visitor.pkgConfig,
+            providers: visitor.providers,
+            cLanguageStandard: visitor.cLanguageStandard,
+            cxxLanguageStandard: visitor.cxxLanguageStandard,
+            swiftLanguageVersions: visitor.swiftLanguageVersions,
+            dependencies: visitor.dependencies,
+            products: products,
+            targets: targets,
+            traits: Set(visitor.traits),
+            pruneDependencies: self.pruneDependencies
+        )
+    }
+}
+
+/// Syntax visitor that processes the parsed manifest.
+class ManifestParseVisitor: ActiveSyntaxAnyVisitor {
+    /// Limitations encountered while processing the manifest.
+    var limitations: [ManifestParseLimitation] = []
+
+    /// The path to the manifest file (used for resolving relative paths)
+    let manifestPath: AbsolutePath
+    
+    /// Dependency mapper for handling path resolution and mirrors
+    let dependencyMapper: DependencyMapper
+    
+    /// File system for path operations
+    let fileSystem: FileSystem
+    
+    /// Context model for Context API support (packageDirectory, gitInformation, environment)
+    let contextModel: StaticContextModel
+
+    /// Package name
+    var packageName: String?
+
+    /// The default localization for resources.
+    var defaultLocalization: String?
+
+    /// Platforms.
+    var platforms: [PlatformDescription] = []
+
+    /// Targets
+    var targets: [TargetDescription] = []
+
+    var pkgConfig: String?
+
+    /// Swift language versions.
+    var swiftLanguageVersions: [SwiftLanguageVersion]?
+
+    /// Package dependencies.
+    ///
+    var dependencies: [PackageDependency] = []
+
+    /// System package providers.
+    var providers: [SystemPackageProviderDescription]?
+
+    /// Products.
+    var products: [ProductDescription] = []
+
+    /// Traits.
+    var traits: [TraitDescription] = []
+
+    /// C++ language standard.
+    var cxxLanguageStandard: String?
+
+    /// C language standard.
+    var cLanguageStandard: String?
+
+    var defaultPackageAccess: Bool
+
+    init(
+        manifestPath: AbsolutePath,
+        configuration: StaticBuildConfiguration,
+        dependencyMapper: DependencyMapper,
+        fileSystem: FileSystem,
+        contextModel: StaticContextModel,
+        defaultPackageAccess: Bool
+    ) {
+        self.manifestPath = manifestPath
+        self.dependencyMapper = dependencyMapper
+        self.fileSystem = fileSystem
+        self.contextModel = contextModel
+        self.defaultPackageAccess = defaultPackageAccess
+        super.init(viewMode: .fixedUp, configuration: configuration)
+    }
+
+    override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+        // Any node not specifically handled is considered a limitation.
+        limitations.append(.unexpectedSyntax(node))
+
+        return .skipChildren
+    }
+
+    override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
+        if node.tokenKind == .endOfFile {
+            return .skipChildren
+        }
+
+        return visitAny(Syntax(node))
+    }
+    /// Process global variable declarations to find the "package" declaration.
+    override func visit(_ varNode: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        // Dig out the name and initializer.
+        guard let (_, initializer) = varNode.asSingleInitializedVariable() else {
+            limitations.append(.unsupportedVariableForm(varNode))
+            return .skipChildren
+        }
+
+        // Check whether we know this call or not.
+        guard let (knownCall, arguments) = initializer.asKnownCall() else {
+            limitations.append(
+                .unsupportedExpression(
+                    initializer,
+                    expected: "top-level variable initializer"
+                )
+            )
+            return .skipChildren
+        }
+
+        // Handle any top-level known calls here.
+        switch knownCall {
+        case .package:
+            handlePackageDeclaration(initializer: initializer, arguments: arguments)
+        }
+
+        return .skipChildren
+    }
+
+
+    /// Check whether import declarations match known modules. Otherwise, we
+    /// can't reason about what the manifest is doing.
+    override func visit(_ importNode: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+        // Match import declaration with a single path component.
+        guard importNode.attributes.isEmpty, importNode.modifiers.isEmpty,
+              let pathComponent = importNode.path.first,
+              importNode.path.count == 1,
+              let moduleName = pathComponent.name.identifier
+        else {
+            limitations.append(.unsupportedImportForm(importNode))
+            return .skipChildren
+        }
+
+        // Check for module names we understand.
+        switch moduleName.name {
+        case "PackageDescription", "Foundation", "CompilerPluginSupport":
+            // Okay
+            break
+
+        default:
+            // Module name we don't know anything about.
+            limitations.append(
+                .unknownImportModule(importNode, moduleName: moduleName.name)
+            )
+        }
+
+        return .skipChildren
+    }
+
+    // Nodes we trivially step into.
+    override func visit(_: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+        .visitChildren
+    }
+
+    override func visit(_: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
+        .visitChildren
+    }
+
+    override func visit(_: CodeBlockItemSyntax) -> SyntaxVisitorContinueKind {
+        .visitChildren
+    }
+}
+
+/// MARK: Declaration handling
+extension ManifestParseVisitor {
+    func handlePackageDeclaration(
+        initializer: ExprSyntax,
+        arguments: LabeledExprListSyntax
+    ) {
+        for argument in arguments {
+            if argument.label?.text == "name" {
+                guard let name = argument.expression.asStringLiteralValue(in: contextModel) else {
+                    limitations.append(
+                        .unsupportedExpression(
+                            argument.expression,
+                            expected: "string literal"
+                        )
+                    )
+
+                    continue
+                }
+
+                // Record the package name.
+                self.packageName = name
+                continue
+            }
+            
+            if argument.label?.text == "dependencies" {
+                guard let dependenciesArray = argument.expression.as(ArrayExprSyntax.self) else {
+                    limitations.append(
+                        .unsupportedExpression(
+                            argument.expression,
+                            expected: "array of package dependencies"
+                        )
+                    )
+                    continue
+                }
+                
+                for dependencyElement in dependenciesArray.elements {
+                    if let dependency = parsePackageDependency(dependencyElement.expression, manifestPath: manifestPath) {
+                        self.dependencies.append(dependency)
+                    }
+                }
+                continue
+            }
+
+            // Accept both swiftLanguageVersions (deprecated) and swiftLanguageModes (6.0+)
+            if argument.label?.text == "swiftLanguageVersions" || argument.label?.text == "swiftLanguageModes" {
+                // Try new-style syntax first (e.g., [.v3, .v4, .version("5")])
+                if let versions = argument.expression.asSwiftLanguageVersionArray() {
+                    self.swiftLanguageVersions = versions
+                    continue
+                }
+
+                // Fall back to old-style integer array syntax (e.g., [3, 4])
+                guard let intVersions = argument.expression.asIntegerArray() else {
+                    limitations.append(
+                        .unsupportedExpression(
+                            argument.expression,
+                            expected: "array of Swift language versions"
+                        )
+                    )
+                    continue
+                }
+
+                // Convert integers to SwiftLanguageVersion with validation
+                // Note: Even if the array is empty, we set it to an empty array (not nil)
+                // to distinguish from the case where swiftLanguageVersions wasn't specified
+                var validatedVersions: [SwiftLanguageVersion] = []
+                var hasValidationError = false
+                for (index, version) in intVersions.enumerated() {
+                    let versionString = "\(version)"
+                    guard let swiftVersion = SwiftLanguageVersion(string: versionString) else {
+                        hasValidationError = true
+                        // Get the actual syntax element for better error reporting
+                        if let arrayExpr = argument.expression.as(ArrayExprSyntax.self),
+                           index < arrayExpr.elements.count {
+                            let element = arrayExpr.elements[arrayExpr.elements.index(arrayExpr.elements.startIndex, offsetBy: index)]
+                            limitations.append(.invalidSwiftLanguageVersion(element.expression, value: versionString))
+                        } else {
+                            limitations.append(.invalidSwiftLanguageVersion(argument.expression, value: versionString))
+                        }
+                        continue
+                    }
+                    validatedVersions.append(swiftVersion)
+                }
+
+                // Only set if we successfully validated all versions
+                if !hasValidationError {
+                    self.swiftLanguageVersions = validatedVersions
+                }
+                continue
+            }
+            
+            if argument.label?.text == "pkgConfig" {
+                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                    self.pkgConfig = value
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "pkgConfig string"))
+                }
+                continue
+            }
+            
+            if argument.label?.text == "providers" {
+                guard let providersArray = argument.expression.as(ArrayExprSyntax.self) else {
+                    limitations.append(
+                        .unsupportedExpression(
+                            argument.expression,
+                            expected: "array of providers"
+                        )
+                    )
+                    continue
+                }
+                
+                var parsedProviders: [SystemPackageProviderDescription] = []
+                for providerElement in providersArray.elements {
+                    if let provider = parseSystemPackageProvider(providerElement.expression) {
+                        parsedProviders.append(provider)
+                    }
+                }
+                self.providers = parsedProviders.isEmpty ? nil : parsedProviders
+                continue
+            }
+            
+            if argument.label?.text == "products" {
+                guard let productsArray = argument.expression.as(ArrayExprSyntax.self) else {
+                    limitations.append(
+                        .unsupportedExpression(
+                            argument.expression,
+                            expected: "array of products"
+                        )
+                    )
+                    continue
+                }
+                
+                for productElement in productsArray.elements {
+                    if let product = parseProduct(productElement.expression) {
+                        self.products.append(product)
+                    }
+                }
+                continue
+            }
+            
+            if argument.label?.text == "cLanguageStandard" {
+                if let standard = parseCLanguageStandard(argument.expression) {
+                    self.cLanguageStandard = standard
+                }
+                continue
+            }
+            
+            if argument.label?.text == "cxxLanguageStandard" {
+                if let standard = parseCxxLanguageStandard(argument.expression) {
+                    self.cxxLanguageStandard = standard
+                }
+                continue
+            }
+            
+            if argument.label?.text == "platforms" {
+                guard let platformsArray = argument.expression.as(ArrayExprSyntax.self) else {
+                    limitations.append(
+                        .unsupportedExpression(
+                            argument.expression,
+                            expected: "array of platforms"
+                        )
+                    )
+                    continue
+                }
+                
+                var parsedPlatforms: [PlatformDescription] = []
+                for platformElement in platformsArray.elements {
+                    if let platform = parsePlatform(platformElement.expression) {
+                        parsedPlatforms.append(platform)
+                    }
+                }
+                self.platforms = parsedPlatforms
+                continue
+            }
+            
+            if argument.label?.text == "defaultLocalization" {
+                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                    self.defaultLocalization = value
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "default localization language tag"))
+                }
+                continue
+            }
+            
+            if argument.label?.text == "targets" {
+                guard let targetsArray = argument.expression.as(ArrayExprSyntax.self) else {
+                    limitations.append(
+                        .unsupportedExpression(
+                            argument.expression,
+                            expected: "array of targets"
+                        )
+                    )
+                    continue
+                }
+                
+                // Parse each target in the array
+                for targetElement in targetsArray.elements {
+                    if let target = parseTarget(targetElement.expression) {
+                        self.targets.append(target)
+                    }
+                }
+                continue
+            }
+            
+            if argument.label?.text == "traits" {
+                guard let traitsArray = argument.expression.as(ArrayExprSyntax.self) else {
+                    limitations.append(
+                        .unsupportedExpression(
+                            argument.expression,
+                            expected: "array of traits"
+                        )
+                    )
+                    continue
+                }
+                
+                var parsedTraits: [TraitDescription] = []
+                for traitElement in traitsArray.elements {
+                    if let trait = parseTrait(traitElement.expression) {
+                        parsedTraits.append(trait)
+                    }
+                }
+                self.traits = parsedTraits
+                continue
+            }
+
+            // Unhandled argument.
+            limitations.append(.unsupportedArgument(argument, callee: "Package"))
+        }
+    }
+    
+    /// Parse a target declaration like .target(name: "foo", dependencies: [...])
+    private func parseTarget(_ expr: ExprSyntax) -> TargetDescription? {
+        guard let functionCall = expr.as(FunctionCallExprSyntax.self),
+              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil, // Leading dot syntax
+              let methodName = memberAccess.declName.baseName.identifier?.name else {
+            limitations.append(.unsupportedExpression(expr, expected: "target declaration"))
+            return nil
+        }
+        
+        // Determine target type from method name
+        let targetType: TargetDescription.TargetKind
+        switch methodName {
+        case "target":
+            targetType = .regular
+        case "testTarget":
+            targetType = .test
+        case "executableTarget":
+            targetType = .executable
+        case "systemLibrary":
+            targetType = .system
+        case "binaryTarget":
+            targetType = .binary
+        case "plugin":
+            targetType = .plugin
+        case "macro":
+            targetType = .macro
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known target type"))
+            return nil
+        }
+        
+        // Parse target arguments
+        var name: String?
+        var dependencies: [TargetDescription.Dependency] = []
+        var path: String? = nil
+        var url: String? = nil
+        var checksum: String? = nil
+        var exclude: [String] = []
+        var sources: [String]? = nil
+        var resources: [TargetDescription.Resource] = []
+        var publicHeadersPath: String? = nil
+        var pkgConfig: String? = nil
+        var providers: [SystemPackageProviderDescription]? = nil
+        var pluginCapability: TargetDescription.PluginCapability? = nil
+        var settings: [TargetBuildSettingDescription.Setting] = []
+        var pluginUsages: [TargetDescription.PluginUsage]? = nil
+        // Binary and system library targets always have packageAccess: false;
+        // neither exposes package-access symbols and the PackageDescription API
+        // does not accept a packageAccess parameter for binaryTarget(…) or
+        // systemLibrary(…).
+        var packageAccess: Bool = (targetType == .binary || targetType == .system) ? false : defaultPackageAccess
+
+        for argument in functionCall.arguments {
+            let label = argument.label?.text
+            
+            if label == "name" {
+                name = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "dependencies" {
+                if let deps = argument.expression.parseArrayElements(parseTargetDependency) {
+                    dependencies.append(contentsOf: deps)
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of target dependencies"))
+                }
+            } else if label == "path" {
+                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                    path = value
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "path string"))
+                }
+            } else if label == "url" {
+                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                    url = value
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "url string"))
+                }
+            } else if label == "checksum" {
+                if let value = argument.expression.asStringLiteralValue() {
+                    checksum = value
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "checksum string"))
+                }
+            } else if label == "exclude" {
+                if let value = argument.expression.asStringArray(in: contextModel) {
+                    exclude = value
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of excluded paths"))
+                }
+            } else if label == "sources" {
+                if let parsed = argument.expression.asStringArray(in: contextModel) {
+                    sources = parsed
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of source file paths"))
+                }
+            } else if label == "publicHeadersPath" {
+                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                    publicHeadersPath = value
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "publicHeadersPath string"))
+                }
+            } else if label == "pkgConfig" {
+                if let value = argument.expression.asStringLiteralValue() {
+                    pkgConfig = value
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "pkgConfig string"))
+                }
+            } else if label == "providers" {
+                if let providersArray = argument.expression.as(ArrayExprSyntax.self) {
+                    var parsedProviders: [SystemPackageProviderDescription] = []
+                    for providerElement in providersArray.elements {
+                        if let provider = parseSystemPackageProvider(providerElement.expression) {
+                            parsedProviders.append(provider)
+                        }
+                    }
+                    providers = parsedProviders.isEmpty ? nil : parsedProviders
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of system package providers"))
+                }
+            } else if label == "resources" {
+                if let parsed = argument.expression.parseArrayElements(parseResource) {
+                    resources.append(contentsOf: parsed)
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of resources"))
+                }
+            } else if label == "capability" {
+                pluginCapability = parsePluginCapability(argument.expression)
+            } else if label == "cSettings" {
+                if let parsed = argument.expression.parseArrayElements({ parseBuildSetting($0, tool: .c) }) {
+                    settings.append(contentsOf: parsed)
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of C build settings"))
+                }
+            } else if label == "cxxSettings" {
+                if let parsed = argument.expression.parseArrayElements({ parseBuildSetting($0, tool: .cxx) }) {
+                    settings.append(contentsOf: parsed)
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of C++ build settings"))
+                }
+            } else if label == "swiftSettings" {
+                if let parsed = argument.expression.parseArrayElements({ parseBuildSetting($0, tool: .swift) }) {
+                    settings.append(contentsOf: parsed)
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of Swift build settings"))
+                }
+            } else if label == "linkerSettings" {
+                if let parsed = argument.expression.parseArrayElements({ parseBuildSetting($0, tool: .linker) }) {
+                    settings.append(contentsOf: parsed)
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of linker settings"))
+                }
+            } else if label == "plugins" {
+                if let parsed = argument.expression.parseArrayElements(parsePluginUsage) {
+                    pluginUsages = parsed
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of plugin usages"))
+                }
+            } else if label == "packageAccess" {
+                if let boolValue = argument.expression.asBooleanLiteralValue() {
+                    packageAccess = boolValue
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "boolean literal for packageAccess"))
+                }
+            } else {
+                limitations.append(.unsupportedArgument(argument, callee: methodName))
+            }
+        }
+        
+        guard let targetName = name else {
+            limitations.append(.unsupportedExpression(expr, expected: "target with name"))
+            return nil
+        }
+        
+        do {
+            return try TargetDescription(
+                name: targetName,
+                dependencies: dependencies,
+                path: path,
+                url: url,
+                exclude: exclude,
+                sources: sources,
+                resources: resources,
+                publicHeadersPath: publicHeadersPath,
+                type: targetType,
+                packageAccess: packageAccess,
+                pkgConfig: pkgConfig,
+                providers: providers,
+                pluginCapability: pluginCapability,
+                settings: settings,
+                checksum: checksum,
+                pluginUsages: pluginUsages
+            )
+        } catch {
+            // If TargetDescription initialization fails (e.g., invalid property combinations),
+            // treat it as a limitation
+            limitations.append(.unsupportedExpression(expr, expected: "valid target configuration"))
+            return nil
+        }
+    }
+    
+    /// Parse a target dependency like "dep1", .target(name: "dep2"), or .product(name: "dep3", package: "Pkg")
+    private func parseTargetDependency(_ expr: ExprSyntax) -> TargetDescription.Dependency? {
+        // Case 1: String literal dependency (e.g., "dep1")
+        if let depName = expr.asStringLiteralValue(in: contextModel) {
+            return .byName(name: depName, condition: nil)
+        }
+        
+        // Case 2: .target(name: ...) or .product(name: ..., package: ...)
+        guard let (methodName, arguments) = expr.asMemberAccessCall() else {
+            limitations.append(.unsupportedExpression(expr, expected: "target dependency"))
+            return nil
+        }
+        
+        if methodName == "target" {
+            // Parse .target(name: "...", condition: ...)
+            var name: String?
+            var condition: PackageConditionDescription?
+            
+            for argument in arguments {
+                let label = argument.label?.text
+                if label == "name" {
+                    name = argument.expression.asStringLiteralValue(in: contextModel)
+                } else if label == "condition" {
+                    condition = parsePackageCondition(argument.expression)
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "target"))
+                }
+            }
+
+            if let targetName = name {
+                return .target(name: targetName, condition: condition)
+            }
+            limitations.append(.unsupportedExpression(expr, expected: ".target with name"))
+            return nil
+        } else if methodName == "product" {
+            // Parse .product(name: "...", package: "...", moduleAliases: [...], condition: ...)
+            var name: String?
+            var package: String?
+            var moduleAliases: [String: String]?
+            var condition: PackageConditionDescription?
+            
+            for argument in arguments {
+                let label = argument.label?.text
+                if label == "name" {
+                    name = argument.expression.asStringLiteralValue(in: contextModel)
+                } else if label == "package" {
+                    package = argument.expression.asStringLiteralValue(in: contextModel)
+                } else if label == "moduleAliases" {
+                    moduleAliases = parseModuleAliases(argument.expression)
+                } else if label == "condition" {
+                    condition = parsePackageCondition(argument.expression)
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "product"))
+                }
+            }
+
+            if let productName = name {
+                return .product(name: productName, package: package, moduleAliases: moduleAliases, condition: condition)
+            }
+            limitations.append(.unsupportedExpression(expr, expected: ".product with name"))
+            return nil
+        } else if methodName == "byName" {
+            // Parse .byName(name: "...", condition: ...)
+            var name: String?
+            var condition: PackageConditionDescription?
+            
+            for argument in arguments {
+                let label = argument.label?.text
+                if label == "name" {
+                    name = argument.expression.asStringLiteralValue(in: contextModel)
+                } else if label == "condition" {
+                    condition = parsePackageCondition(argument.expression)
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "byName"))
+                }
+            }
+
+            if let depName = name {
+                return .byName(name: depName, condition: condition)
+            }
+            limitations.append(.unsupportedExpression(expr, expected: ".byName with name"))
+            return nil
+        } else {
+            limitations.append(.unsupportedExpression(expr, expected: ".target or .product dependency"))
+            return nil
+        }
+    }
+    
+    /// Parse a package condition like .when(platforms: [.macOS, .linux])
+    private func parsePackageCondition(_ expr: ExprSyntax) -> PackageConditionDescription? {
+        guard let (methodName, arguments) = expr.asMemberAccessCall(),
+              methodName == "when" else {
+            limitations.append(.unsupportedExpression(expr, expected: "package condition"))
+            return nil
+        }
+        
+        var platformNames: [String] = []
+        var hasPlatforms = false
+        var config: String?
+        var traits: [String]?
+
+        for argument in arguments {
+            let label = argument.label?.text
+            
+            if label == "platforms" {
+                hasPlatforms = true
+                guard let arrayExpr = argument.expression.as(ArrayExprSyntax.self) else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of platform conditions"))
+                    continue
+                }
+                for element in arrayExpr.elements {
+                    if let name = element.expression.asPlatformConditionName() {
+                        platformNames.append(name.lowercased())
+                    } else {
+                        limitations.append(.unsupportedExpression(element.expression, expected: "known platform"))
+                    }
+                }
+            } else if label == "configuration" {
+                if let value = argument.expression.asEnumMember() {
+                    config = value
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "build configuration"))
+                }
+            } else if label == "traits" {
+                if let parsed = argument.expression.asStringArray(in: contextModel) {
+                    traits = parsed
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of trait names"))
+                }
+            } else {
+                limitations.append(.unsupportedArgument(argument, callee: "when"))
+            }
+        }
+
+        // If platforms is explicitly empty and no other conditions, return nil (no condition)
+        if hasPlatforms && platformNames.isEmpty && config == nil && traits == nil {
+            return nil
+        }
+        
+        // At least one non-empty condition must be specified
+        if !platformNames.isEmpty || config != nil || traits != nil {
+            return PackageConditionDescription(platformNames: platformNames, config: config, traits: traits.map { Set($0)})
+        }
+        
+        limitations.append(.unsupportedExpression(expr, expected: "package condition with platforms, configuration, or traits"))
+        return nil
+    }
+    
+    /// Parse module aliases dictionary like ["OriginalName": "AliasName", ...]
+    private func parseModuleAliases(_ expr: ExprSyntax) -> [String: String]? {
+        guard let dictExpr = expr.as(DictionaryExprSyntax.self) else {
+            limitations.append(.unsupportedExpression(expr, expected: "dictionary for module aliases"))
+            return nil
+        }
+        
+        var aliases: [String: String] = [:]
+        
+        // Check if it's a dictionary with elements
+        switch dictExpr.content {
+        case .colon:
+            // Empty dictionary [:]
+            return nil
+        case .elements(let elements):
+            // Dictionary with key-value pairs
+            for element in elements {
+                if let keyString = element.key.asStringLiteralValue(in: contextModel),
+                   let valueString = element.value.asStringLiteralValue(in: contextModel) {
+                    aliases[keyString] = valueString
+                } else {
+                    limitations.append(.unsupportedExpression(element.key, expected: "string literal module alias key and value"))
+                }
+            }
+        }
+        
+        return aliases.isEmpty ? nil : aliases
+    }
+    
+    /// Parse a build setting like .headerSearchPath("path"), .define("NAME"), .linkedLibrary("lib"), etc.
+    private func parseBuildSetting(_ expr: ExprSyntax, tool: TargetBuildSettingDescription.Tool) -> TargetBuildSettingDescription.Setting? {
+        guard let functionCall = expr.as(FunctionCallExprSyntax.self),
+              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil,
+              let methodName = memberAccess.declName.baseName.identifier?.name else {
+            limitations.append(.unsupportedExpression(expr, expected: "build setting"))
+            return nil
+        }
+        
+        var kind: TargetBuildSettingDescription.Kind?
+        var condition: PackageConditionDescription?
+        var conditionArgumentIndex: Int?
+
+        // Parse the kind based on method name
+        switch methodName {
+        case "headerSearchPath":
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil, let path = argument.expression.asStringLiteralValue(in: contextModel) {
+                        kind = .headerSearchPath(path)
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "headerSearchPath"))
+                }
+            }
+        case "define":
+            // .define("NAME") or .define("NAME", to: "VALUE")
+            var name: String?
+            var value: String?
+            
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if let str = argument.expression.asStringLiteralValue(in: contextModel) {
+                        name = str
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "to" {
+                    value = argument.expression.asStringLiteralValue(in: contextModel)
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "define"))
+                }
+            }
+            
+            if let defineName = name {
+                if let defineValue = value {
+                    kind = .define("\(defineName)=\(defineValue)")
+                } else {
+                    kind = .define(defineName)
+                }
+            }
+        case "linkedLibrary":
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil, let library = argument.expression.asStringLiteralValue(in: contextModel) {
+                        kind = .linkedLibrary(library)
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "linkedLibrary"))
+                }
+            }
+        case "linkedFramework":
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil, let framework = argument.expression.asStringLiteralValue(in: contextModel) {
+                        kind = .linkedFramework(framework)
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "linkedFramework"))
+                }
+            }
+        case "unsafeFlags":
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil, let flagsArray = argument.expression.as(ArrayExprSyntax.self) {
+                        var flags: [String] = []
+                        for flagElement in flagsArray.elements {
+                            if let flag = flagElement.expression.asStringLiteralValue(in: contextModel) {
+                                flags.append(flag)
+                            } else {
+                                limitations.append(.unsupportedExpression(flagElement.expression, expected: "string literal in unsafeFlags"))
+                            }
+                        }
+                        kind = .unsafeFlags(flags)
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "unsafeFlags"))
+                }
+            }
+        case "enableUpcomingFeature":
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil, let feature = argument.expression.asStringLiteralValue(in: contextModel) {
+                        kind = .enableUpcomingFeature(feature)
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "enableUpcomingFeature"))
+                }
+            }
+        case "enableExperimentalFeature":
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil, let feature = argument.expression.asStringLiteralValue(in: contextModel) {
+                        kind = .enableExperimentalFeature(feature)
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "enableExperimentalFeature"))
+                }
+            }
+        case "interoperabilityMode":
+            // .interoperabilityMode(.C) or .interoperabilityMode(.Cxx)
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil,
+                       let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
+                       memberAccess.base == nil,
+                       let modeName = memberAccess.declName.baseName.identifier?.name {
+                        switch modeName {
+                        case "C":
+                            kind = .interoperabilityMode(.C)
+                        case "Cxx":
+                            kind = .interoperabilityMode(.Cxx)
+                        default:
+                            limitations.append(.unsupportedExpression(argument.expression, expected: "known interoperability mode"))
+                        }
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "interoperabilityMode"))
+                }
+            }
+        case "strictMemorySafety":
+            kind = .strictMemorySafety
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil || label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "strictMemorySafety"))
+                }
+            }
+        case "swiftLanguageMode", "swiftLanguageVersion":
+            // .swiftLanguageMode(.v5) or .swiftLanguageMode(.version("6"))
+            // Also supports deprecated .swiftLanguageVersion() for backward compatibility
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil, let version = parseSwiftLanguageVersion(argument.expression) {
+                        kind = .swiftLanguageMode(version)
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: methodName))
+                }
+            }
+        case "treatAllWarnings":
+            // .treatAllWarnings(.warning) or .treatAllWarnings(.error)
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil || label == "as" {
+                    if let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
+                       memberAccess.base == nil,
+                       let levelName = memberAccess.declName.baseName.identifier?.name {
+                        switch levelName {
+                        case "warning":
+                            kind = .treatAllWarnings(.warning)
+                        case "error":
+                            kind = .treatAllWarnings(.error)
+                        default:
+                            limitations.append(.unsupportedExpression(argument.expression, expected: "warning level (.warning or .error)"))
+                        }
+                    } else if label == nil {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "treatAllWarnings"))
+                }
+            }
+        case "treatWarning":
+            // .treatWarning("deprecated", as: .error)
+            var warningName: String?
+            var level: TargetBuildSettingDescription.WarningLevel?
+            
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if let str = argument.expression.asStringLiteralValue(in: contextModel) {
+                        warningName = str
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "as" {
+                    if let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
+                       memberAccess.base == nil,
+                       let levelName = memberAccess.declName.baseName.identifier?.name {
+                        switch levelName {
+                        case "warning":
+                            level = .warning
+                        case "error":
+                            level = .error
+                        default:
+                            break
+                        }
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "treatWarning"))
+                }
+            }
+            
+            if let warning = warningName, let warningLevel = level {
+                kind = .treatWarning(warning, warningLevel)
+            }
+        case "enableWarning":
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil, let warning = argument.expression.asStringLiteralValue(in: contextModel) {
+                        kind = .enableWarning(warning)
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "enableWarning"))
+                }
+            }
+        case "disableWarning":
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil, let warning = argument.expression.asStringLiteralValue(in: contextModel) {
+                        kind = .disableWarning(warning)
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "disableWarning"))
+                }
+            }
+        case "defaultIsolation":
+            // .defaultIsolation(MainActor.self) → .MainActor isolation
+            // .defaultIsolation(nil)            → nonisolated (compiler default)
+            for (index, argument) in functionCall.arguments.enumerated() {
+                let label = argument.label?.text
+                if label == nil {
+                    if kind == nil {
+                        if argument.expression.is(NilLiteralExprSyntax.self) {
+                            kind = .defaultIsolation(.nonisolated)
+                        } else if let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
+                                  let base = memberAccess.base?.as(DeclReferenceExprSyntax.self),
+                                  base.baseName.text == "MainActor",
+                                  memberAccess.declName.baseName.text == "self" {
+                            kind = .defaultIsolation(.MainActor)
+                        } else {
+                            conditionArgumentIndex = index
+                        }
+                    } else {
+                        conditionArgumentIndex = index
+                    }
+                } else if label == "condition" {
+                    conditionArgumentIndex = index
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "defaultIsolation"))
+                }
+            }
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known build setting type"))
+            return nil
+        }
+        
+        // Parse condition if present. The condition parameter is unlabeled in the
+        // PackageDescription API (e.g., .define("C", .when(platforms: [.linux]))),
+        // though some manifests may also use the explicit label "condition:".
+        // Each case above sets conditionArgumentIndex when it identifies the
+        // condition argument.
+        if let conditionIndex = conditionArgumentIndex {
+            let conditionArg = functionCall.arguments[
+                functionCall.arguments.index(functionCall.arguments.startIndex, offsetBy: conditionIndex)
+            ]
+            if let parsedCondition = parsePackageCondition(conditionArg.expression) {
+                condition = parsedCondition
+            }
+        }
+        
+        guard let settingKind = kind else {
+            limitations.append(.unsupportedExpression(expr, expected: "valid build setting"))
+            return nil
+        }
+        
+        return TargetBuildSettingDescription.Setting(tool: tool, kind: settingKind, condition: condition)
+    }
+    
+    /// Parse a Swift language version like .v5, .v6, or .version("5")
+    private func parseSwiftLanguageVersion(_ expr: ExprSyntax?) -> SwiftLanguageVersion? {
+        guard let expr = expr else { return nil }
+        
+        // Case 1: Member access like .v5, .v6
+        if let memberAccess = expr.as(MemberAccessExprSyntax.self),
+           memberAccess.base == nil,
+           let versionName = memberAccess.declName.baseName.identifier?.name {
+            let versionString: String
+            switch versionName {
+            case "v3": versionString = "3"
+            case "v4": versionString = "4"
+            case "v4_2": versionString = "4.2"
+            case "v5": versionString = "5"
+            case "v6": versionString = "6"
+            default: return nil
+            }
+            return SwiftLanguageVersion(string: versionString)
+        }
+        
+        // Case 2: Function call like .version("5")
+        if let functionCall = expr.as(FunctionCallExprSyntax.self),
+           let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+           memberAccess.base == nil,
+           let methodName = memberAccess.declName.baseName.identifier?.name,
+           methodName == "version",
+           let firstArg = functionCall.arguments.first,
+           firstArg.label == nil,
+           let versionString = firstArg.expression.asStringLiteralValue() {
+            return SwiftLanguageVersion(string: versionString)
+        }
+        
+        return nil
+    }
+    
+    /// Parse a system package provider like .brew(["openssl"]) or .apt(["openssl", "libssl-dev"])
+    private func parseSystemPackageProvider(_ expr: ExprSyntax) -> SystemPackageProviderDescription? {
+        guard let functionCall = expr.as(FunctionCallExprSyntax.self),
+              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil, // Leading dot syntax
+              let methodName = memberAccess.declName.baseName.identifier?.name else {
+            limitations.append(.unsupportedExpression(expr, expected: "system package provider"))
+            return nil
+        }
+        
+        // Parse arguments
+        var packages: [String] = []
+        for argument in functionCall.arguments {
+            let label = argument.label?.text
+            if label == nil {
+                if let arrayExpr = argument.expression.as(ArrayExprSyntax.self) {
+                    for element in arrayExpr.elements {
+                        if let packageName = element.expression.asStringLiteralValue(in: contextModel) {
+                            packages.append(packageName)
+                        } else {
+                            limitations.append(.unsupportedExpression(element.expression, expected: "string literal package name"))
+                        }
+                    }
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of package names"))
+                }
+            } else {
+                limitations.append(.unsupportedArgument(argument, callee: methodName))
+            }
+        }
+        
+        switch methodName {
+        case "brew":
+            return .brew(packages)
+        case "apt":
+            return .apt(packages)
+        case "yum":
+            return .yum(packages)
+        case "nuget":
+            return .nuget(packages)
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known provider type"))
+            return nil
+        }
+    }
+    
+    /// Parse a resource declaration like .copy("foo.txt") or .process("bar.txt", localization: .default)
+    private func parseResource(_ expr: ExprSyntax) -> TargetDescription.Resource? {
+        guard let (methodName, arguments) = expr.asMemberAccessCall() else {
+            limitations.append(.unsupportedExpression(expr, expected: "resource declaration"))
+            return nil
+        }
+        
+        // Parse the path argument (first unlabeled argument)
+        guard let firstArg = arguments.first,
+              firstArg.label == nil,
+              let path = firstArg.expression.asStringLiteralValue(in: contextModel) else {
+            limitations.append(.unsupportedExpression(expr, expected: "resource with path"))
+            return nil
+        }
+        
+        // Determine the rule based on method name
+        let rule: TargetDescription.Resource.Rule
+        switch methodName {
+        case "copy":
+            for argument in arguments.dropFirst() {
+                limitations.append(.unsupportedArgument(argument, callee: methodName))
+            }
+            rule = .copy
+        case "process":
+            // Check for localization argument
+            var localization: TargetDescription.Resource.Localization? = nil
+            for argument in arguments.dropFirst() {
+                if argument.label?.text == "localization" {
+                    guard let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
+                          memberAccess.base == nil,
+                          let localizationName = memberAccess.declName.baseName.identifier?.name else {
+                        limitations.append(.unsupportedExpression(argument.expression, expected: "known localization type"))
+                        return nil
+                    }
+                    switch localizationName {
+                    case "default":
+                        localization = .default
+                    case "base":
+                        localization = .base
+                    default:
+                        limitations.append(.unsupportedExpression(argument.expression, expected: "known localization type"))
+                        return nil
+                    }
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: methodName))
+                }
+            }
+            rule = .process(localization: localization)
+        case "embedInCode":
+            for argument in arguments.dropFirst() {
+                limitations.append(.unsupportedArgument(argument, callee: methodName))
+            }
+            rule = .embedInCode
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known resource type"))
+            return nil
+        }
+        
+        return TargetDescription.Resource(rule: rule, path: (try? RelativePath(validating: path))?.pathString ?? path)
+    }
+    
+    /// Parse a plugin capability like .buildTool() or .command(intent: .custom(verb: "foo", description: "bar"))
+    private func parsePluginCapability(_ expr: ExprSyntax) -> TargetDescription.PluginCapability? {
+        guard let (methodName, arguments) = expr.asMemberAccessCall() else {
+            limitations.append(.unsupportedExpression(expr, expected: "plugin capability"))
+            return nil
+        }
+        
+        switch methodName {
+        case "buildTool":
+            for argument in arguments {
+                limitations.append(.unsupportedArgument(argument, callee: "buildTool"))
+            }
+            return .buildTool
+        case "command":
+            // Parse .command(intent: ..., permissions: [...])
+            var intent: TargetDescription.PluginCommandIntent?
+            var permissions: [TargetDescription.PluginPermission] = []
+            
+            for argument in arguments {
+                let label = argument.label?.text
+                if label == "intent" {
+                    intent = parsePluginCommandIntent(argument.expression)
+                } else if label == "permissions" {
+                    permissions = argument.expression.parseArrayElements(parsePluginPermission) ?? []
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "command"))
+                }
+            }
+            
+            if let commandIntent = intent {
+                return .command(intent: commandIntent, permissions: permissions)
+            } else {
+                limitations.append(.unsupportedExpression(expr, expected: "command capability with intent"))
+                return nil
+            }
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known plugin capability type"))
+            return nil
+        }
+    }
+    
+    /// Parse a plugin command intent like .documentationGeneration or .custom(verb: "foo", description: "bar")
+    private func parsePluginCommandIntent(_ expr: ExprSyntax) -> TargetDescription.PluginCommandIntent? {
+        // Handle .documentationGeneration or .sourceCodeFormatting (without parens)
+        if let intentName = expr.asEnumMember() {
+            switch intentName {
+            case "documentationGeneration":
+                return .documentationGeneration
+            case "sourceCodeFormatting":
+                return .sourceCodeFormatting
+            default:
+                break
+            }
+        }
+        
+        // Handle .documentationGeneration(), .sourceCodeFormatting(), or .custom(verb:description:) (with parens)
+        if let (methodName, arguments) = expr.asMemberAccessCall() {
+            switch methodName {
+            case "documentationGeneration":
+                return .documentationGeneration
+            case "sourceCodeFormatting":
+                return .sourceCodeFormatting
+            case "custom":
+                var verb: String?
+                var description: String?
+                
+                for argument in arguments {
+                    let label = argument.label?.text
+                    if label == "verb" {
+                        verb = argument.expression.asStringLiteralValue(in: contextModel)
+                    } else if label == "description" {
+                        description = argument.expression.asStringLiteralValue(in: contextModel)
+                    } else {
+                        limitations.append(.unsupportedArgument(argument, callee: "custom"))
+                    }
+                }
+                
+                if let v = verb, let d = description {
+                    return .custom(verb: v, description: d)
+                }
+            default:
+                break
+            }
+        }
+        
+        limitations.append(.unsupportedExpression(expr, expected: "plugin command intent"))
+        return nil
+    }
+    
+    /// Parse a plugin permission like .writeToPackageDirectory(reason: "...")
+    private func parsePluginPermission(_ expr: ExprSyntax) -> TargetDescription.PluginPermission? {
+        guard let (methodName, arguments) = expr.asMemberAccessCall() else {
+            limitations.append(.unsupportedExpression(expr, expected: "plugin permission"))
+            return nil
+        }
+        
+        switch methodName {
+        case "writeToPackageDirectory":
+            for argument in arguments {
+                if argument.label?.text == "reason",
+                   let reason = argument.expression.asStringLiteralValue(in: contextModel) {
+                    return .writeToPackageDirectory(reason: reason)
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "writeToPackageDirectory"))
+                }
+            }
+            limitations.append(.unsupportedExpression(expr, expected: "writeToPackageDirectory with reason"))
+            return nil
+        case "allowNetworkConnections":
+            // Parse .allowNetworkConnections(scope: ..., reason: "...")
+            var scope: TargetDescription.PluginNetworkPermissionScope?
+            var reason: String?
+            
+            for argument in arguments {
+                let label = argument.label?.text
+                if label == "scope" {
+                    scope = parsePluginNetworkPermissionScope(argument.expression)
+                } else if label == "reason" {
+                    reason = argument.expression.asStringLiteralValue(in: contextModel)
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "allowNetworkConnections"))
+                }
+            }
+            
+            if let s = scope, let r = reason {
+                return .allowNetworkConnections(scope: s, reason: r)
+            } else {
+                limitations.append(.unsupportedExpression(expr, expected: "allowNetworkConnections with scope and reason"))
+                return nil
+            }
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known plugin permission type"))
+            return nil
+        }
+    }
+    
+    /// Parse a plugin network permission scope like .none, .local(ports: [8080]), .all(ports: []), .docker, .unixDomainSocket
+    private func parsePluginNetworkPermissionScope(_ expr: ExprSyntax) -> TargetDescription.PluginNetworkPermissionScope? {
+        // Simple cases: .none, .docker, .unixDomainSocket
+        if let memberAccess = expr.as(MemberAccessExprSyntax.self),
+           memberAccess.base == nil,
+           let scopeName = memberAccess.declName.baseName.identifier?.name {
+            switch scopeName {
+            case "none":
+                return TargetDescription.PluginNetworkPermissionScope.none
+            case "docker":
+                return .docker
+            case "unixDomainSocket":
+                return .unixDomainSocket
+            default:
+                break
+            }
+        }
+        
+        // Cases with ports: .local(ports: [...]), .all(ports: [...])
+        if let functionCall = expr.as(FunctionCallExprSyntax.self),
+           let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+           memberAccess.base == nil,
+           let scopeName = memberAccess.declName.baseName.identifier?.name {
+            var ports: [Int] = []
+            
+            for argument in functionCall.arguments {
+                if argument.label?.text == "ports",
+                   let portsArray = argument.expression.as(ArrayExprSyntax.self) {
+                    for portElement in portsArray.elements {
+                        if let intLiteral = portElement.expression.as(IntegerLiteralExprSyntax.self),
+                           let port = Int(intLiteral.literal.text) {
+                            ports.append(port)
+                        }
+                    }
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: scopeName))
+                }
+            }
+            
+            switch scopeName {
+            case "local":
+                return .local(ports: ports)
+            case "all":
+                return .all(ports: ports)
+            default:
+                limitations.append(.unsupportedExpression(expr, expected: "known network permission scope"))
+                return nil
+            }
+        }
+        
+        limitations.append(.unsupportedExpression(expr, expected: "plugin network permission scope"))
+        return nil
+    }
+    
+    /// Parse a plugin usage like "PluginName", .plugin(name: "MyPlugin"), or .plugin(name: "MyPlugin", package: "MyPackage")
+    private func parsePluginUsage(_ expr: ExprSyntax) -> TargetDescription.PluginUsage? {
+        // Case 1: String literal (e.g., "PluginName" - refers to plugin in same package)
+        if let pluginName = expr.asStringLiteralValue(in: contextModel) {
+            return .plugin(name: pluginName, package: nil)
+        }
+        
+        // Case 2: .plugin(name: "...", package: "...") or .plugin(name: "...")
+        guard let functionCall = expr.as(FunctionCallExprSyntax.self),
+              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil, // Leading dot syntax
+              memberAccess.declName.baseName.text == "plugin" else {
+            limitations.append(.unsupportedExpression(expr, expected: "plugin usage declaration"))
+            return nil
+        }
+        
+        var name: String?
+        var package: String?
+        
+        for argument in functionCall.arguments {
+            let label = argument.label?.text
+            if label == "name" {
+                name = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "package" {
+                package = argument.expression.asStringLiteralValue(in: contextModel)
+            } else {
+                limitations.append(.unsupportedArgument(argument, callee: "plugin"))
+            }
+        }
+        
+        guard let pluginName = name else {
+            limitations.append(.unsupportedExpression(expr, expected: "plugin usage with name"))
+            return nil
+        }
+        
+        return .plugin(name: pluginName, package: package)
+    }
+    
+    /// Parse a product declaration like .executable(name: "tool", targets: ["tool"])
+    private func parseProduct(_ expr: ExprSyntax) -> ProductDescription? {
+        guard let (methodName, arguments) = expr.asMemberAccessCall() else {
+            limitations.append(.unsupportedExpression(expr, expected: "product declaration"))
+            return nil
+        }
+
+        // Parse product arguments
+        var name: String?
+        var targets: [String] = []
+        var productType: ProductType?
+        var settings: [ProductSetting] = []
+
+        #if ENABLE_APPLE_PRODUCT_TYPES
+        // For iOSApplication products, we collect settings from individual parameters
+        var bundleIdentifier: String?
+        var teamIdentifier: String?
+        var displayVersion: String?
+        var bundleVersion: String?
+        var appIcon: ProductSetting.IOSAppInfo.AppIcon?
+        var accentColor: ProductSetting.IOSAppInfo.AccentColor?
+        var supportedDeviceFamilies: [ProductSetting.IOSAppInfo.DeviceFamily] = []
+        var supportedInterfaceOrientations: [ProductSetting.IOSAppInfo.InterfaceOrientation] = []
+        var capabilities: [ProductSetting.IOSAppInfo.Capability] = []
+        var appCategory: ProductSetting.IOSAppInfo.AppCategory?
+        var additionalInfoPlistContentFilePath: String?
+        #endif
+
+        for argument in arguments {
+            let label = argument.label?.text
+
+            if label == "name" {
+                name = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "targets" {
+                targets = argument.expression.asStringArray(in: contextModel) ?? []
+            } else if label == "type" {
+                // Parse library type like .dynamic or .static
+                if let typeName = argument.expression.asEnumMember() {
+                    switch typeName {
+                    case "dynamic":
+                        productType = .library(.dynamic)
+                    case "static":
+                        productType = .library(.static)
+                    default:
+                        limitations.append(.unsupportedExpression(argument.expression, expected: "known library type"))
+                    }
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "known library type"))
+                }
+            } else {
+                // For Apple product types, additional labels are handled below.
+                // On non-Apple builds any unrecognized label is a limitation.
+                #if ENABLE_APPLE_PRODUCT_TYPES
+                if label == "bundleIdentifier" {
+                    bundleIdentifier = argument.expression.asStringLiteralValue(in: contextModel)
+                } else if label == "teamIdentifier" {
+                    teamIdentifier = argument.expression.asStringLiteralValue(in: contextModel)
+                } else if label == "displayVersion" {
+                    displayVersion = argument.expression.asStringLiteralValue(in: contextModel)
+                } else if label == "bundleVersion" {
+                    bundleVersion = argument.expression.asStringLiteralValue(in: contextModel)
+                } else if label == "appIcon" {
+                    appIcon = parseAppIcon(argument.expression)
+                } else if label == "accentColor" {
+                    accentColor = parseAccentColor(argument.expression)
+                } else if label == "supportedDeviceFamilies" {
+                    supportedDeviceFamilies = parseDeviceFamilies(argument.expression)
+                } else if label == "supportedInterfaceOrientations" {
+                    supportedInterfaceOrientations = parseInterfaceOrientations(argument.expression)
+                } else if label == "capabilities" {
+                    capabilities = parseCapabilities(argument.expression)
+                } else if label == "appCategory" {
+                    appCategory = parseAppCategory(argument.expression)
+                } else if label == "additionalInfoPlistContentFilePath" {
+                    additionalInfoPlistContentFilePath = argument.expression.asStringLiteralValue(in: contextModel)
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: methodName))
+                }
+                #else
+                limitations.append(.unsupportedArgument(argument, callee: methodName))
+                #endif
+            }
+        }
+        
+        guard let productName = name else {
+            limitations.append(.unsupportedExpression(expr, expected: "product with name"))
+            return nil
+        }
+        
+        // Determine product type from method name if not explicitly set
+        let finalProductType: ProductType
+        switch methodName {
+        case "executable":
+            finalProductType = .executable
+        case "library":
+            finalProductType = productType ?? .library(.automatic)
+        case "plugin":
+            finalProductType = .plugin
+        #if ENABLE_APPLE_PRODUCT_TYPES
+        case "iOSApplication":
+            finalProductType = .executable
+            
+            // Build product settings from parsed iOS app configuration
+            if let bundleIdentifier = bundleIdentifier {
+                settings.append(.bundleIdentifier(bundleIdentifier))
+            }
+            if let teamIdentifier = teamIdentifier {
+                settings.append(.teamIdentifier(teamIdentifier))
+            }
+            if let displayVersion = displayVersion {
+                settings.append(.displayVersion(displayVersion))
+            }
+            if let bundleVersion = bundleVersion {
+                settings.append(.bundleVersion(bundleVersion))
+            }
+            
+            // Create IOSAppInfo setting if we have any iOS-specific configuration
+            let appInfo = ProductSetting.IOSAppInfo(
+                appIcon: appIcon,
+                accentColor: accentColor,
+                supportedDeviceFamilies: supportedDeviceFamilies,
+                supportedInterfaceOrientations: supportedInterfaceOrientations,
+                capabilities: capabilities,
+                appCategory: appCategory,
+                additionalInfoPlistContentFilePath: additionalInfoPlistContentFilePath
+            )
+            settings.append(.iOSAppInfo(appInfo))
+        #endif
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known product type"))
+            return nil
+        }
+        
+        do {
+            return try ProductDescription(
+                name: productName,
+                type: finalProductType,
+                targets: targets,
+                settings: settings
+            )
+        } catch {
+            limitations.append(.unsupportedExpression(expr, expected: "valid product configuration"))
+            return nil
+        }
+    }
+    
+    /// Parse C language standard like .iso9899_199409
+    private func parseCLanguageStandard(_ expr: ExprSyntax) -> String? {
+        guard let standardName = expr.asEnumMember() else {
+            limitations.append(.unsupportedExpression(expr, expected: "C language standard"))
+            return nil
+        }
+        
+        // Map enum case names (as written in Package.swift) to their string representations.
+        // These must stay in sync with Serialization.CLanguageStandard in
+        // PackageDescriptionSerialization.swift.
+        switch standardName {
+        case "c89": return "c89"
+        case "c90": return "c90"
+        case "iso9899_1990": return "iso9899:1990"
+        case "iso9899_199409": return "iso9899:199409"
+        case "gnu89": return "gnu89"
+        case "gnu90": return "gnu90"
+        case "c99": return "c99"
+        case "iso9899_1999": return "iso9899:1999"
+        case "gnu99": return "gnu99"
+        case "c11": return "c11"
+        case "iso9899_2011": return "iso9899:2011"
+        case "gnu11": return "gnu11"
+        case "c17": return "c17"
+        case "c18": return "c18"
+        case "iso9899_2017": return "iso9899:2017"
+        case "iso9899_2018": return "iso9899:2018"
+        case "gnu17": return "gnu17"
+        case "gnu18": return "gnu18"
+        case "c2x": return "c2x"
+        case "gnu2x": return "gnu2x"
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known C language standard"))
+            return nil
+        }
+    }
+    
+    /// Parse C++ language standard like .gnucxx14
+    private func parseCxxLanguageStandard(_ expr: ExprSyntax) -> String? {
+        guard let standardName = expr.asEnumMember() else {
+            limitations.append(.unsupportedExpression(expr, expected: "C++ language standard"))
+            return nil
+        }
+        
+        // Map enum case names (as written in Package.swift) to their string representations.
+        // These must stay in sync with Serialization.CXXLanguageStandard in
+        // PackageDescriptionSerialization.swift.
+        switch standardName {
+        case "cxx98": return "c++98"
+        case "cxx03": return "c++03"
+        case "gnucxx98": return "gnu++98"
+        case "gnucxx03": return "gnu++03"
+        case "cxx11": return "c++11"
+        case "gnucxx11": return "gnu++11"
+        case "cxx14": return "c++14"
+        case "gnucxx14": return "gnu++14"
+        case "cxx17": return "c++17"
+        case "cxx1z": return "c++1z"
+        case "gnucxx17": return "gnu++17"
+        case "gnucxx1z": return "gnu++1z"
+        case "cxx20": return "c++20"
+        case "gnucxx20": return "gnu++20"
+        case "cxx2b": return "c++2b"
+        case "gnucxx2b": return "gnu++2b"
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known C++ language standard"))
+            return nil
+        }
+    }
+    
+    #if ENABLE_APPLE_PRODUCT_TYPES
+    /// Parse an app icon like .asset("icon") or .placeholder(.appIcon)
+    private func parseAppIcon(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.AppIcon? {
+        guard let (methodName, arguments) = expr.asMemberAccessCall() else {
+            limitations.append(.unsupportedExpression(expr, expected: "app icon"))
+            return nil
+        }
+        
+        switch methodName {
+        case "asset":
+            if let name = arguments.first?.expression.asStringLiteralValue(in: contextModel) {
+                for argument in arguments.dropFirst() {
+                    limitations.append(.unsupportedArgument(argument, callee: "asset"))
+                }
+                return .asset(name: name)
+            }
+        case "placeholder":
+            if let iconArg = arguments.first?.expression,
+               let iconName = iconArg.asEnumMember() {
+                for argument in arguments.dropFirst() {
+                    limitations.append(.unsupportedArgument(argument, callee: "placeholder"))
+                }
+                return .placeholder(icon: .init(rawValue: iconName))
+            }
+        default:
+            break
+        }
+        
+        limitations.append(.unsupportedExpression(expr, expected: "valid app icon"))
+        return nil
+    }
+    
+    /// Parse an accent color like .asset("color") or .presetColor(.blue)
+    private func parseAccentColor(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.AccentColor? {
+        guard let (methodName, arguments) = expr.asMemberAccessCall() else {
+            limitations.append(.unsupportedExpression(expr, expected: "accent color"))
+            return nil
+        }
+        
+        switch methodName {
+        case "asset":
+            if let name = arguments.first?.expression.asStringLiteralValue(in: contextModel) {
+                for argument in arguments.dropFirst() {
+                    limitations.append(.unsupportedArgument(argument, callee: "asset"))
+                }
+                return .asset(name: name)
+            }
+        case "presetColor":
+            if let colorArg = arguments.first?.expression,
+               let colorName = colorArg.asEnumMember() {
+                for argument in arguments.dropFirst() {
+                    limitations.append(.unsupportedArgument(argument, callee: "presetColor"))
+                }
+                return .presetColor(presetColor: .init(rawValue: colorName))
+            }
+        default:
+            break
+        }
+        
+        limitations.append(.unsupportedExpression(expr, expected: "valid accent color"))
+        return nil
+    }
+    
+    /// Parse device families like [.pad, .phone, .mac]
+    private func parseDeviceFamilies(_ expr: ExprSyntax) -> [ProductSetting.IOSAppInfo.DeviceFamily] {
+        guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
+            limitations.append(.unsupportedExpression(expr, expected: "device family array"))
+            return []
+        }
+        
+        var families: [ProductSetting.IOSAppInfo.DeviceFamily] = []
+        for element in arrayExpr.elements {
+            if let familyName = element.expression.asEnumMember(),
+               let family = ProductSetting.IOSAppInfo.DeviceFamily(rawValue: familyName) {
+                families.append(family)
+            }
+        }
+        return families
+    }
+    
+    /// Parse interface orientations like [.portrait, .landscapeRight(.when(deviceFamilies: [.mac]))]
+    private func parseInterfaceOrientations(_ expr: ExprSyntax) -> [ProductSetting.IOSAppInfo.InterfaceOrientation] {
+        guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
+            limitations.append(.unsupportedExpression(expr, expected: "interface orientation array"))
+            return []
+        }
+        
+        var orientations: [ProductSetting.IOSAppInfo.InterfaceOrientation] = []
+        for element in arrayExpr.elements {
+            if let orientation = parseInterfaceOrientation(element.expression) {
+                orientations.append(orientation)
+            }
+        }
+        return orientations
+    }
+    
+    /// Parse a single interface orientation like .portrait or .landscapeRight(.when(deviceFamilies: [.mac]))
+    private func parseInterfaceOrientation(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.InterfaceOrientation? {
+        // Handle simple case: .portrait (no condition)
+        if let orientationName = expr.asEnumMember() {
+            switch orientationName {
+            case "portrait":
+                return .portrait(condition: nil)
+            case "portraitUpsideDown":
+                return .portraitUpsideDown(condition: nil)
+            case "landscapeRight":
+                return .landscapeRight(condition: nil)
+            case "landscapeLeft":
+                return .landscapeLeft(condition: nil)
+            default:
+                break
+            }
+        }
+        
+        // Handle conditional case: .portrait(.when(deviceFamilies: [.mac]))
+        guard let functionCall = expr.as(FunctionCallExprSyntax.self),
+              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil,
+              let orientationName = memberAccess.declName.baseName.identifier?.name else {
+            limitations.append(.unsupportedExpression(expr, expected: "interface orientation"))
+            return nil
+        }
+        
+        var condition: ProductSetting.IOSAppInfo.DeviceFamilyCondition?
+        if let conditionArg = functionCall.arguments.first?.expression {
+            condition = parseDeviceFamilyCondition(conditionArg)
+        }
+        for argument in functionCall.arguments.dropFirst() {
+            limitations.append(.unsupportedArgument(argument, callee: orientationName))
+        }
+        
+        switch orientationName {
+        case "portrait":
+            return .portrait(condition: condition)
+        case "portraitUpsideDown":
+            return .portraitUpsideDown(condition: condition)
+        case "landscapeRight":
+            return .landscapeRight(condition: condition)
+        case "landscapeLeft":
+            return .landscapeLeft(condition: condition)
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "valid interface orientation"))
+            return nil
+        }
+    }
+    
+    /// Parse a device family condition like .when(deviceFamilies: [.mac])
+    private func parseDeviceFamilyCondition(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.DeviceFamilyCondition? {
+        guard let (methodName, arguments) = expr.asMemberAccessCall(),
+              methodName == "when" else {
+            limitations.append(.unsupportedExpression(expr, expected: "device family condition"))
+            return nil
+        }
+        
+        for argument in arguments {
+            if argument.label?.text == "deviceFamilies" {
+                let families = parseDeviceFamilies(argument.expression)
+                return ProductSetting.IOSAppInfo.DeviceFamilyCondition(deviceFamilies: families)
+            }
+        }
+        
+        return nil
+    }
+    
+    /// Parse capabilities like [.camera(purposeString: "..."), .microphone(purposeString: "...")]
+    private func parseCapabilities(_ expr: ExprSyntax) -> [ProductSetting.IOSAppInfo.Capability] {
+        guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
+            limitations.append(.unsupportedExpression(expr, expected: "capability array"))
+            return []
+        }
+        
+        var capabilities: [ProductSetting.IOSAppInfo.Capability] = []
+        for element in arrayExpr.elements {
+            if let capability = parseCapability(element.expression) {
+                capabilities.append(capability)
+            }
+        }
+        return capabilities
+    }
+    
+    /// Parse a single capability
+    private func parseCapability(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.Capability? {
+        guard let (purpose, arguments) = expr.asMemberAccessCall() else {
+            limitations.append(.unsupportedExpression(expr, expected: "capability"))
+            return nil
+        }
+        
+        var purposeString: String?
+        var bonjourServiceTypes: [String]?
+        var condition: ProductSetting.IOSAppInfo.DeviceFamilyCondition?
+        
+        for argument in arguments {
+            let label = argument.label?.text
+            
+            if label == "purposeString" {
+                purposeString = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "bonjourServiceTypes" {
+                bonjourServiceTypes = argument.expression.asStringArray(in: contextModel)
+            } else if label == nil {
+                // Unlabeled argument could be a condition
+                if let cond = parseDeviceFamilyCondition(argument.expression) {
+                    condition = cond
+                }
+            }
+        }
+        
+        return ProductSetting.IOSAppInfo.Capability(
+            purpose: purpose,
+            purposeString: purposeString,
+            bonjourServiceTypes: bonjourServiceTypes,
+            condition: condition
+        )
+    }
+    
+    /// Parse an app category like .developerTools
+    private func parseAppCategory(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.AppCategory? {
+        guard let categoryName = expr.asEnumMember() else {
+            limitations.append(.unsupportedExpression(expr, expected: "app category"))
+            return nil
+        }
+        
+        // Map the enum name to the raw value format
+        let rawValue: String
+        switch categoryName {
+        case "business":
+            rawValue = "public.app-category.business"
+        case "developerTools":
+            rawValue = "public.app-category.developer-tools"
+        case "education":
+            rawValue = "public.app-category.education"
+        case "entertainment":
+            rawValue = "public.app-category.entertainment"
+        case "finance":
+            rawValue = "public.app-category.finance"
+        case "games":
+            rawValue = "public.app-category.games"
+        case "healthAndFitness":
+            rawValue = "public.app-category.healthcare-fitness"
+        case "lifestyle":
+            rawValue = "public.app-category.lifestyle"
+        case "medical":
+            rawValue = "public.app-category.medical"
+        case "music":
+            rawValue = "public.app-category.music"
+        case "news":
+            rawValue = "public.app-category.news"
+        case "photography":
+            rawValue = "public.app-category.photography"
+        case "productivity":
+            rawValue = "public.app-category.productivity"
+        case "reference":
+            rawValue = "public.app-category.reference"
+        case "socialNetworking":
+            rawValue = "public.app-category.social-networking"
+        case "sports":
+            rawValue = "public.app-category.sports"
+        case "travel":
+            rawValue = "public.app-category.travel"
+        case "utilities":
+            rawValue = "public.app-category.utilities"
+        case "weather":
+            rawValue = "public.app-category.weather"
+        case "graphics_design":
+            rawValue = "public.app-category.graphics-design"
+        default:
+            rawValue = categoryName
+        }
+        
+        return ProductSetting.IOSAppInfo.AppCategory(rawValue: rawValue)
+    }
+    #endif
+    
+    /// Parse a package dependency like `.package(url: "/foo", from: "1.0.0")` or `.package(url: "/foo", branch: "main")`
+    private func parsePackageDependency(_ expr: ExprSyntax, manifestPath: AbsolutePath) -> PackageDependency? {
+        // Expect a function call like .package(url: "/foo", from: "1.0.0")
+        guard let functionCall = expr.as(FunctionCallExprSyntax.self),
+              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil, // Leading dot syntax
+              let methodName = memberAccess.declName.baseName.identifier?.name,
+              methodName == "package" else {
+            limitations.append(.unsupportedExpression(expr, expected: "package dependency declaration"))
+            return nil
+        }
+        
+        var name: String?
+        var url: String?
+        var path: String?  // Filesystem path
+        var id: String?  // Registry package ID
+        var requirement: PackageDependency.SourceControl.Requirement?
+        var registryRequirement: PackageDependency.Registry.Requirement?
+        var traits: [PackageDependency.Trait]?
+
+        // Parse arguments
+        for argument in functionCall.arguments {
+            let label = argument.label?.text
+
+            if label == "name" {
+                name = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "id" {
+                id = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "url" {
+                url = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "path" {
+                path = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "traits" {
+                traits = parseDependencyTraits(argument.expression)
+            } else if label == "from" {
+                if let versionString = argument.expression.asStringLiteralValue(),
+                   let version = Version(versionString) {
+                    if id != nil {
+                        // Registry dependency
+                        registryRequirement = .range(.upToNextMajor(from: version))
+                    } else {
+                        // Source control dependency
+                        requirement = .range(.upToNextMajor(from: version))
+                    }
+                }
+            } else if label == "branch" {
+                if let branch = argument.expression.asStringLiteralValue(in: contextModel) {
+                    requirement = .branch(branch)
+                }
+            } else if label == "revision" {
+                if let revision = argument.expression.asStringLiteralValue(in: contextModel) {
+                    requirement = .revision(revision)
+                }
+            } else if label == "exact" {
+                if let versionString = argument.expression.asStringLiteralValue(),
+                   let version = Version(versionString) {
+                    if id != nil {
+                        // Registry dependency
+                        registryRequirement = .exact(version)
+                    } else {
+                        // Source control dependency
+                        requirement = .exact(version)
+                    }
+                }
+            } else if label == nil {
+                // Unlabeled argument could be:
+                // 1. A requirement like .upToNextMajor(from: "1.0.0")
+                // 2. A range operator expression like "1.0.0"..<"2.0.0"
+                
+                // Check for range operators - handle InfixOperatorExprSyntax (after sequence folding)
+                if let infixExpr = argument.expression.as(InfixOperatorExprSyntax.self),
+                   let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self) {
+                    let opText = op.operator.text.trimmingCharacters(in: .whitespaces)
+
+                    if opText == "..<" || opText == "..." {
+                        // Parse the left and right operands as version strings
+                        if let lowerString = infixExpr.leftOperand.asStringLiteralValue(),
+                           let lowerVersion = Version(lowerString),
+                           let upperString = infixExpr.rightOperand.asStringLiteralValue(),
+                           let upperVersion = Version(upperString) {
+
+                            if opText == "..." {
+                                // Closed range - convert to half-open range
+                                let upperNext = Version(
+                                    upperVersion.major,
+                                    upperVersion.minor,
+                                    upperVersion.patch + 1,
+                                    prereleaseIdentifiers: upperVersion.prereleaseIdentifiers,
+                                    buildMetadataIdentifiers: upperVersion.buildMetadataIdentifiers
+                                )
+                                if id != nil {
+                                    registryRequirement = .range(lowerVersion..<upperNext)
+                                } else {
+                                    requirement = .range(lowerVersion..<upperNext)
+                                }
+                            } else {
+                                // Half-open range
+                                if id != nil {
+                                    registryRequirement = .range(lowerVersion..<upperVersion)
+                                } else {
+                                    requirement = .range(lowerVersion..<upperVersion)
+                                }
+                            }
+                        } else {
+                            limitations.append(.unsupportedExpression(argument.expression, expected: "version range with string literal bounds"))
+                        }
+                    } else {
+                        limitations.append(.unsupportedExpression(argument.expression, expected: "version range operator (..<  or ...)"))
+                    }
+                } else if let rangeExpr = argument.expression.as(SequenceExprSyntax.self) {
+                    // Fallback: Check for range operators in SequenceExprSyntax (for older syntax trees)
+                    // Look for range operators like ..< or ...
+                    var lowerBound: Version?
+                    var upperBound: Version?
+                    var isClosedRange = false
+
+                    for element in rangeExpr.elements {
+                        if let stringLiteral = element.asStringLiteralValue(),
+                           let version = Version(stringLiteral) {
+                            if lowerBound == nil {
+                                lowerBound = version
+                            } else {
+                                upperBound = version
+                            }
+                        } else if let binaryOp = element.as(BinaryOperatorExprSyntax.self) {
+                            let opText = binaryOp.operator.text.trimmingCharacters(in: .whitespaces)
+                            if opText == "..." {
+                                isClosedRange = true
+                            }
+                        } else {
+                            // Check if this element is just the operator token
+                            let elementText = element.description.trimmingCharacters(in: .whitespaces)
+                            if elementText == "..." {
+                                isClosedRange = true
+                            }
+                        }
+                    }
+
+                    if let lower = lowerBound, let upper = upperBound {
+                        if isClosedRange {
+                            // Convert closed range to open range by using next patch version
+                            let upperNext = Version(
+                                upper.major,
+                                upper.minor,
+                                upper.patch + 1,
+                                prereleaseIdentifiers: upper.prereleaseIdentifiers,
+                                buildMetadataIdentifiers: upper.buildMetadataIdentifiers
+                            )
+                            if id != nil {
+                                registryRequirement = .range(lower..<upperNext)
+                            } else {
+                                requirement = .range(lower..<upperNext)
+                            }
+                        } else {
+                            if id != nil {
+                                registryRequirement = .range(lower..<upper)
+                            } else {
+                                requirement = .range(lower..<upper)
+                            }
+                        }
+                    } else {
+                        limitations.append(.unsupportedExpression(argument.expression, expected: "version range with two bounds"))
+                    }
+                } else if let reqExpr = argument.expression.as(FunctionCallExprSyntax.self),
+                   let reqMemberAccess = reqExpr.calledExpression.as(MemberAccessExprSyntax.self),
+                   reqMemberAccess.base == nil,
+                   let reqName = reqMemberAccess.declName.baseName.identifier?.name {
+
+                    switch reqName {
+                    case "upToNextMajor":
+                        if let fromArg = reqExpr.arguments.first(where: { $0.label?.text == "from" }),
+                           let versionString = fromArg.expression.asStringLiteralValue(),
+                           let version = Version(versionString) {
+                            if id != nil {
+                                registryRequirement = .range(.upToNextMajor(from: version))
+                            } else {
+                                requirement = .range(.upToNextMajor(from: version))
+                            }
+                        }
+                    case "upToNextMinor":
+                        if let fromArg = reqExpr.arguments.first(where: { $0.label?.text == "from" }),
+                           let versionString = fromArg.expression.asStringLiteralValue(),
+                           let version = Version(versionString) {
+                            if id != nil {
+                                registryRequirement = .range(.upToNextMinor(from: version))
+                            } else {
+                                requirement = .range(.upToNextMinor(from: version))
+                            }
+                        }
+                    case "exact":
+                        if let versionString = reqExpr.arguments.first?.expression.asStringLiteralValue(),
+                           let version = Version(versionString) {
+                            if id != nil {
+                                registryRequirement = .exact(version)
+                            } else {
+                                requirement = .exact(version)
+                            }
+                        }
+                    case "branch":
+                        if let branch = reqExpr.arguments.first?.expression.asStringLiteralValue() {
+                            requirement = .branch(branch)
+                        }
+                    case "revision":
+                        if let revision = reqExpr.arguments.first?.expression.asStringLiteralValue() {
+                            requirement = .revision(revision)
+                        }
+                    default:
+                        limitations.append(.unsupportedExpression(argument.expression, expected: "package dependency requirement"))
+                    }
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "package dependency requirement"))
+                }
+            } else {
+                limitations.append(.unsupportedArgument(argument, callee: "package"))
+            }
+        }
+
+        // Handle filesystem dependencies (no version control)
+        if let fsPath = path {
+            let mappableDep = MappablePackageDependency(
+                parentPackagePath: manifestPath.parentDirectory,
+                kind: .fileSystem(name: name, path: fsPath),
+                productFilter: .everything,
+                traits: Set(traits ?? [.init(name: "default")])
+            )
+            
+            do {
+                return try dependencyMapper.mappedDependency(mappableDep, fileSystem: fileSystem)
+            } catch {
+                limitations.append(.unsupportedExpression(expr, expected: "valid filesystem path: \(error)"))
+                return nil
+            }
+        }
+
+        // Handle registry dependencies
+        if let packageID = id {
+            guard let regReq = registryRequirement else {
+                limitations.append(.unsupportedExpression(expr, expected: "registry dependency with requirement"))
+                return nil
+            }
+
+            let identity = PackageIdentity.plain(packageID)
+            return .registry(
+                identity: identity,
+                requirement: regReq,
+                productFilter: .everything,
+                traits: Set(traits ?? [.init(name: "default")])
+            )
+        }
+
+        guard let url = url, let requirement = requirement else {
+            limitations.append(.unsupportedExpression(expr, expected: "package dependency with url and requirement"))
+            return nil
+        }
+        
+        // Use the dependency mapper for source control dependencies
+        let mappableDep = MappablePackageDependency(
+            parentPackagePath: manifestPath.parentDirectory,
+            kind: .sourceControl(name: name, location: url, requirement: requirement),
+            productFilter: .everything,
+            traits: Set(traits ?? [.init(name: "default")])
+        )
+        
+        do {
+            return try dependencyMapper.mappedDependency(mappableDep, fileSystem: fileSystem)
+        } catch {
+            limitations.append(.unsupportedExpression(expr, expected: "valid source control dependency: \(error)"))
+            return nil
+        }
+    }
+    
+    /// Parse a platform description like `.macOS("10.13.option1.option2")` or `.iOS(.v12)`
+    private func parsePlatform(_ expr: ExprSyntax) -> PlatformDescription? {
+        // Expect a function call like .macOS("10.13")
+        guard let (platformName, arguments) = expr.asMemberAccessCall() else {
+            limitations.append(.unsupportedExpression(expr, expected: "platform declaration"))
+            return nil
+        }
+        
+        // Map platform names (as written in Package.swift) to their canonical form.
+        // These must stay in sync with the static properties on Platform in
+        // PackageModel/Platform.swift.
+        let canonicalName: String
+        switch platformName {
+        case "macOS": canonicalName = "macos"
+        case "iOS": canonicalName = "ios"
+        case "tvOS": canonicalName = "tvos"
+        case "watchOS": canonicalName = "watchos"
+        case "visionOS": canonicalName = "visionos"
+        case "macCatalyst": canonicalName = "maccatalyst"
+        case "driverKit": canonicalName = "driverkit"
+        case "linux": canonicalName = "linux"
+        case "windows": canonicalName = "windows"
+        case "android": canonicalName = "android"
+        case "wasi": canonicalName = "wasi"
+        case "openbsd": canonicalName = "openbsd"
+        case "freebsd": canonicalName = "freebsd"
+
+        case "custom":
+            // .custom("platformName", versionString: "1.0")
+            var customName: String?
+            var versionString: String?
+            for argument in arguments {
+                let label = argument.label?.text
+                if label == nil {
+                    customName = argument.expression.asStringLiteralValue()
+                } else if label == "versionString" {
+                    versionString = argument.expression.asStringLiteralValue()
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "custom"))
+                }
+            }
+            guard let name = customName, let version = versionString else {
+                limitations.append(.unsupportedExpression(expr, expected: "custom platform with name and versionString"))
+                return nil
+            }
+            return PlatformDescription(name: name, version: version, options: [])
+
+        default:
+            limitations.append(.unsupportedExpression(expr, expected: "known platform"))
+            return nil
+        }
+        
+        // Get the version argument and check for unexpected extra arguments
+        guard let firstArg = arguments.first else {
+            limitations.append(.unsupportedExpression(expr, expected: "platform with version"))
+            return nil
+        }
+        
+        for argument in arguments.dropFirst() {
+            limitations.append(.unsupportedArgument(argument, callee: platformName))
+        }
+
+        var version: String
+        var options: [String] = []
+        
+        // Check if it's a string literal like "10.13.option1.option2"
+        if let versionString = firstArg.expression.asStringLiteralValue() {
+            // Parse version and options from the string
+            let components = versionString.split(separator: ".")
+            if components.isEmpty {
+                limitations.append(.unsupportedExpression(expr, expected: "valid version string"))
+                return nil
+            }
+            
+            // Find where version numbers end and options begin
+            var versionComponents: [Substring] = []
+            var optionComponents: [String] = []
+            var inOptions = false
+            
+            for component in components {
+                if !inOptions && component.allSatisfy({ $0.isNumber }) {
+                    versionComponents.append(component)
+                } else {
+                    inOptions = true
+                    optionComponents.append(String(component))
+                }
+            }
+            
+            version = versionComponents.joined(separator: ".")
+            options = optionComponents
+        }
+        // Check if it's a member access like .v10_13
+        else if let memberAccess = firstArg.expression.as(MemberAccessExprSyntax.self),
+                memberAccess.base == nil,
+                let versionName = memberAccess.declName.baseName.identifier?.name {
+            // Parse version from names like "v10_13" or "v12"
+            if versionName.hasPrefix("v") {
+                let versionPart = String(versionName.dropFirst()) // Remove "v"
+                // Replace underscores with dots
+                version = versionPart.replacingOccurrences(of: "_", with: ".")
+                
+                // Normalize version to have at least major.minor (e.g., "12" -> "12.0")
+                if !version.contains(".") {
+                    version = version + ".0"
+                }
+            } else {
+                limitations.append(.unsupportedExpression(expr, expected: "version in format .vX_Y"))
+                return nil
+            }
+        }
+        else {
+            limitations.append(.unsupportedExpression(expr, expected: "string literal or version constant"))
+            return nil
+        }
+        
+        return PlatformDescription(name: canonicalName, version: version, options: options)
+    }
+    
+    /// Parse a trait declaration like "Trait1", Trait(name: "Trait2", description: "..."), or .trait(name: "Trait3", enabledTraits: [...])
+    private func parseTrait(_ expr: ExprSyntax) -> TraitDescription? {
+        // Case 1: String literal "TraitName"
+        if let traitName = expr.asStringLiteralValue(in: contextModel) {
+            return TraitDescription(name: traitName)
+        }
+        
+        // Case 2: Trait(name: "...", description: "...", enabledTraits: [...]) or .trait(...) or .default(...)
+        guard let functionCall = expr.as(FunctionCallExprSyntax.self) else {
+            limitations.append(.unsupportedExpression(expr, expected: "trait declaration"))
+            return nil
+        }
+        
+        // Check if it's Trait(...), .trait(...), or .default(...)
+        let methodName: String?
+        if let identifierExpr = functionCall.calledExpression.as(DeclReferenceExprSyntax.self),
+           identifierExpr.baseName.text == "Trait" {
+            methodName = "trait"
+        } else if let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+                  memberAccess.base == nil {
+            methodName = memberAccess.declName.baseName.text
+        } else {
+            methodName = nil
+        }
+        
+        guard let method = methodName, (method == "trait" || method == "default") else {
+            limitations.append(.unsupportedExpression(expr, expected: "Trait(...), .trait(...), or .default(...)"))
+            return nil
+        }
+        
+        // Handle .default(enabledTraits: [...])
+        if method == "default" {
+            var enabledTraits: [String] = []
+
+            for argument in functionCall.arguments {
+                if argument.label?.text == "enabledTraits" {
+                    if let parsed = argument.expression.asStringArray(in: contextModel) {
+                        enabledTraits = parsed
+                    } else {
+                        limitations.append(.unsupportedExpression(argument.expression, expected: "array of enabled trait names"))
+                    }
+                } else {
+                    limitations.append(.unsupportedArgument(argument, callee: "default"))
+                }
+            }
+
+            return TraitDescription(
+                name: "default",
+                description: "The default traits of this package.",
+                enabledTraits: Set(enabledTraits)
+            )
+        }
+
+        // Handle .trait(...) or Trait(...)
+        var name: String?
+        var description: String?
+        var enabledTraits: [String] = []
+
+        for argument in functionCall.arguments {
+            let label = argument.label?.text
+            if label == "name" {
+                name = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "description" {
+                description = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "enabledTraits" {
+                if let parsed = argument.expression.asStringArray(in: contextModel) {
+                    enabledTraits = parsed
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of enabled trait names"))
+                }
+            } else {
+                limitations.append(.unsupportedArgument(argument, callee: "trait"))
+            }
+        }
+        
+        guard let traitName = name else {
+            limitations.append(.unsupportedExpression(expr, expected: "trait with name"))
+            return nil
+        }
+        
+        return TraitDescription(name: traitName, description: description, enabledTraits: Set(enabledTraits))
+    }
+    
+    /// Parse dependency traits array like ["FooTrait1", .trait(name: "FooTrait2", condition: ...), .defaults]
+    private func parseDependencyTraits(_ expr: ExprSyntax) -> [PackageDependency.Trait]? {
+        guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
+            limitations.append(.unsupportedExpression(expr, expected: "array of dependency traits"))
+            return nil
+        }
+        
+        var traits: [PackageDependency.Trait] = []
+        
+        for traitElement in arrayExpr.elements {
+            if let trait = parseDependencyTrait(traitElement.expression) {
+                traits.append(trait)
+            }
+        }
+        
+        return traits.isEmpty ? nil : traits
+    }
+    
+    /// Parse a single dependency trait like "FooTrait1", .trait(name: "...", condition: ...), or .defaults
+    private func parseDependencyTrait(_ expr: ExprSyntax) -> PackageDependency.Trait? {
+        // Case 1: String literal "TraitName"
+        if let traitName = expr.asStringLiteralValue(in: contextModel) {
+            return PackageDependency.Trait(name: traitName)
+        }
+        
+        // Case 2: .defaults
+        if let memberAccess = expr.as(MemberAccessExprSyntax.self),
+           memberAccess.base == nil,
+           memberAccess.declName.baseName.text == "defaults" {
+            return PackageDependency.Trait(name: "default")
+        }
+        
+        // Case 3: .trait(name: "...", condition: ...) or Package.Dependency.Trait(name: "...", condition: ...)
+        guard let functionCall = expr.as(FunctionCallExprSyntax.self) else {
+            limitations.append(.unsupportedExpression(expr, expected: "dependency trait declaration"))
+            return nil
+        }
+        
+        // Check if it's .trait(...) or Package.Dependency.Trait(...)
+        let isValidCall: Bool
+        if let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+           memberAccess.base == nil,
+           memberAccess.declName.baseName.text == "trait" {
+            isValidCall = true
+        } else if let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+                  let baseAccess = memberAccess.base?.as(MemberAccessExprSyntax.self),
+                  memberAccess.declName.baseName.text == "Trait" {
+            // Package.Dependency.Trait(...)
+            isValidCall = true
+            _ = baseAccess
+        } else {
+            isValidCall = false
+        }
+        
+        guard isValidCall else {
+            limitations.append(.unsupportedExpression(expr, expected: ".trait(...) or Package.Dependency.Trait(...)"))
+            return nil
+        }
+        
+        var name: String?
+        var condition: PackageDependency.Trait.Condition?
+        
+        for argument in functionCall.arguments {
+            let label = argument.label?.text
+            if label == "name" {
+                name = argument.expression.asStringLiteralValue(in: contextModel)
+            } else if label == "condition" {
+                condition = parseDependencyTraitCondition(argument.expression)
+            } else {
+                limitations.append(.unsupportedArgument(argument, callee: "trait"))
+            }
+        }
+        
+        guard let traitName = name else {
+            limitations.append(.unsupportedExpression(expr, expected: "dependency trait with name"))
+            return nil
+        }
+        
+        return PackageDependency.Trait(name: traitName, condition: condition)
+    }
+    
+    /// Parse a dependency trait condition like .when(traits: ["Trait1"])
+    private func parseDependencyTraitCondition(_ expr: ExprSyntax) -> PackageDependency.Trait.Condition? {
+        guard let (methodName, arguments) = expr.asMemberAccessCall(),
+              methodName == "when" else {
+            limitations.append(.unsupportedExpression(expr, expected: "trait condition"))
+            return nil
+        }
+        
+        var traits: [String]?
+        
+        for argument in arguments {
+            if argument.label?.text == "traits" {
+                if let parsed = argument.expression.asStringArray(in: contextModel) {
+                    traits = parsed
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of trait names"))
+                }
+            } else {
+                limitations.append(.unsupportedArgument(argument, callee: "when"))
+            }
+        }
+        
+        return PackageDependency.Trait.Condition(traits: traits.map { Set($0) })
+    }
+}
+
+/// MARK: Parsing helpers
+extension VariableDeclSyntax {
+    /// Match the form 'let x = y', and return the identifier for 'x' and the
+    /// expression for 'y'.
+    func asSingleInitializedVariable() -> (Identifier, ExprSyntax)? {
+        // No attributes, no modifiers, and a single "let" binding with an
+        // identifier and an initializer.
+        guard attributes.isEmpty, modifiers.isEmpty,
+              (bindingSpecifier.tokenKind == .keyword(.let) ||
+               bindingSpecifier.tokenKind == .keyword(.var)),
+              let binding = bindings.first, bindings.count == 1,
+              let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?
+                .identifier.identifier,
+              let initializer = binding.initializer else {
+            return nil
+        }
+
+        return (identifier, initializer.value)
+    }
+}
+
+/// Describes the kinds of calls that we recognize.
+fileprivate enum KnownCallType {
+    /// Package(...) initializer
+    case package
+
+    /// Match the name in a direct call such as "Package(...)".
+    init?(directCallTo name: String) {
+        switch name {
+        case "Package": self = .package
+        default: return nil
+        }
+    }
+}
+
+extension ExprSyntax {
+    /// Try to treat the given expression as a known call, extracting out the
+    /// arguments to the call.
+    fileprivate func asKnownCall() -> (KnownCallType, LabeledExprListSyntax)? {
+        guard let functionCall = self.as(FunctionCallExprSyntax.self) else {
+            return nil
+        }
+
+        // Look for known calls.
+        let knownCallType: KnownCallType
+        let callee = functionCall.calledExpression
+        if let calleeRef = callee.as(DeclReferenceExprSyntax.self),
+           let identifier = calleeRef.baseName.identifier,
+           calleeRef.argumentNames == nil,
+           let knownCall = KnownCallType(directCallTo: identifier.name)
+        {
+            knownCallType = knownCall
+        } else {
+            return nil
+        }
+
+        return (knownCallType, functionCall.arguments)
+    }
+
+    /// Extract the string literal value from the expression, if it is one.
+    fileprivate func asStringLiteralValue() -> String? {
+        guard let stringLiteral = self.as(StringLiteralExprSyntax.self) else {
+            return nil
+        }
+
+        return stringLiteral.representedLiteralValue
+    }
+
+    /// Evaluate a string literal that may contain Context interpolations, or a direct Context expression.
+    /// Returns the evaluated string, or nil if it cannot be evaluated.
+    fileprivate func asStringLiteralValue(in contextModel: StaticContextModel) -> String? {
+        // First, try to evaluate as a direct Context expression (e.g., Context.packageDirectory)
+        if let value = self.evaluateContextExpression(contextModel: contextModel) {
+            return value
+        }
+
+        // Otherwise, try to parse as a string literal
+        guard let stringLiteral = self.as(StringLiteralExprSyntax.self) else {
+            return nil
+        }
+
+        // Simple case: no interpolation — use representedLiteralValue to correctly handle
+        // escape sequences (e.g. \" in a C preprocessor define value becomes ").
+        if let value = stringLiteral.representedLiteralValue {
+            return value
+        }
+
+        // Complex case: handle interpolations with Context values
+        var result = ""
+        for segment in stringLiteral.segments {
+            switch segment {
+            case .stringSegment(let contents):
+                result += contents.content.text
+
+            case .expressionSegment(let exprSegment):
+                // Try to evaluate the interpolated expression
+                if let value = exprSegment.expressions.first?.expression.evaluateContextExpression(contextModel: contextModel) {
+                    result += value
+                } else {
+                    // Cannot evaluate this interpolation
+                    return nil
+                }
+            }
+        }
+
+        return result
+    }
+    
+    /// Evaluate a Context expression like Context.gitInformation?.currentTag or Context.environment["KEY"]
+    /// Returns the string representation of the value, or nil if it cannot be evaluated.
+    fileprivate func evaluateContextExpression(contextModel: StaticContextModel) -> String? {
+        var expr: ExprSyntax = self
+        var nilCoalescingDefault: String? = nil
+
+        // Handle nil-coalescing operator (??)
+        if let infixExpr = expr.as(InfixOperatorExprSyntax.self),
+           let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self),
+           op.operator.text.trimmingCharacters(in: .whitespaces) == "??" {
+            // Get the default value from the right side
+            if let rightValue = infixExpr.rightOperand.asStringLiteralValue() {
+                nilCoalescingDefault = rightValue
+            }
+            // Continue evaluating the left side
+            expr = infixExpr.leftOperand
+        }
+        
+        // Handle boolean comparison (== true)
+        if let infixExpr = expr.as(InfixOperatorExprSyntax.self),
+           let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self),
+           op.operator.text.trimmingCharacters(in: .whitespaces) == "==" {
+            // Check if right side is 'true'
+            if let boolLit = infixExpr.rightOperand.as(BooleanLiteralExprSyntax.self),
+               boolLit.literal.tokenKind == .keyword(.true) {
+                expr = infixExpr.leftOperand
+            }
+        }
+        
+        // Check for subscript access (e.g., Context.environment["KEY"])
+        if let subscriptExpr = expr.as(SubscriptCallExprSyntax.self) {
+            // Parse the base expression (e.g., Context.environment)
+            var baseParts: [String] = []
+            var currentExpr = subscriptExpr.calledExpression
+            
+            // Walk through the member access chain
+            while true {
+                if let memberAccess = currentExpr.as(MemberAccessExprSyntax.self) {
+                    baseParts.insert(memberAccess.declName.baseName.text, at: 0)
+                    if let base = memberAccess.base {
+                        currentExpr = base
+                    } else {
+                        break
+                    }
+                } else if let declRef = currentExpr.as(DeclReferenceExprSyntax.self) {
+                    baseParts.insert(declRef.baseName.text, at: 0)
+                    break
+                } else {
+                    return nil
+                }
+            }
+            
+            // Check if it's Context.environment
+            if baseParts.count == 2 && baseParts[0] == "Context" && baseParts[1] == "environment" {
+                // Get the subscript key
+                if let firstArg = subscriptExpr.arguments.first,
+                   let keyString = firstArg.expression.asStringLiteralValue() {
+                    // Look up the environment variable
+                    if let value = contextModel.environment[keyString] {
+                        return value
+                    } else {
+                        return nilCoalescingDefault
+                    }
+                }
+            }
+            
+            return nil
+        }
+        
+        // Now parse the member access chain
+        // Expected patterns:
+        // - Context.packageDirectory
+        // - Context.gitInformation?.currentTag
+        // - Context.gitInformation?.currentCommit
+        // - Context.gitInformation?.hasUncommittedChanges
+        
+        // Extract all parts of the member access chain
+        var parts: [String] = []
+        var currentExpr = expr
+        
+        // Walk backwards through the member access chain
+        while true {
+            if let sequence = currentExpr.as(SequenceExprSyntax.self) {
+                // A sequence expression can contain optional chaining
+                // For "Context.gitInformation?.currentTag", this will be a sequence
+                // We need to extract the meaningful parts
+                
+                // For optional chaining, the sequence contains: base, postfixOperator(?), member access
+                // Let's try to parse it differently - just take the first element if it's what we need
+                if let firstElement = sequence.elements.first {
+                    currentExpr = firstElement
+                    continue
+                } else {
+                    return nil
+                }
+            } else if let memberAccess = currentExpr.as(MemberAccessExprSyntax.self) {
+                // Add the member name
+                parts.insert(memberAccess.declName.baseName.text, at: 0)
+                
+                if let base = memberAccess.base {
+                    currentExpr = base
+                } else {
+                    // No more base, we're done
+                    break
+                }
+            } else if let optChain = currentExpr.as(OptionalChainingExprSyntax.self) {
+                // Skip the optional chaining wrapper and continue
+                currentExpr = optChain.expression
+            } else if let postfixUnary = currentExpr.as(PostfixUnaryExprSyntax.self) {
+                // This handles the ? in optional chaining
+                currentExpr = postfixUnary.expression
+            } else if let declRef = currentExpr.as(DeclReferenceExprSyntax.self) {
+                // This is the base identifier (e.g., "Context")
+                parts.insert(declRef.baseName.text, at: 0)
+                break
+            } else {
+                // Unknown expression structure
+                return nil
+            }
+        }
+        
+        // Now evaluate based on the parts
+        guard parts.count >= 2 && parts[0] == "Context" else {
+            return nil
+        }
+        
+        switch parts[1] {
+        case "packageDirectory":
+            return contextModel.packageDirectory
+            
+        case "gitInformation":
+            guard parts.count >= 3 else {
+                return nil
+            }
+            guard let gitInfo = contextModel.gitInformation else {
+                return nilCoalescingDefault
+            }
+            
+            switch parts[2] {
+            case "currentTag":
+                if let tag = gitInfo.currentTag {
+                    return tag
+                } else {
+                    return nilCoalescingDefault ?? ""
+                }
+                
+            case "currentCommit":
+                return gitInfo.currentCommit
+                
+            case "hasUncommittedChanges":
+                let value = gitInfo.hasUncommittedChanges
+                return value ? "true" : "false"
+                
+            default:
+                return nil
+            }
+            
+        default:
+            return nil
+        }
+    }
+
+    /// Extract the boolean literal value from the expression, if it is one.
+    fileprivate func asBooleanLiteralValue() -> Bool? {
+        guard let boolLiteral = self.as(BooleanLiteralExprSyntax.self) else {
+            return nil
+        }
+
+        return boolLiteral.literal.tokenKind == .keyword(.true)
+    }
+
+    /// Extract an array of integer values from the expression, if it is one.
+    fileprivate func asIntegerArray() -> [Int]? {
+        guard let arrayExpr = self.as(ArrayExprSyntax.self) else {
+            return nil
+        }
+
+        var result: [Int] = []
+        for element in arrayExpr.elements {
+            guard let intLiteral = element.expression.as(IntegerLiteralExprSyntax.self),
+                  let value = Int(intLiteral.literal.text) else {
+                return nil
+            }
+            result.append(value)
+        }
+
+        return result
+    }
+    
+    /// Extract an array of Swift language versions from the expression.
+    /// Supports both old-style integers [3, 4] and new-style member references [.v3, .v4, .version("5")].
+    fileprivate func asSwiftLanguageVersionArray() -> [SwiftLanguageVersion]? {
+        guard let arrayExpr = self.as(ArrayExprSyntax.self) else {
+            return nil
+        }
+        
+        var result: [SwiftLanguageVersion] = []
+        for element in arrayExpr.elements {
+            let expr = element.expression
+            
+            // Try to parse as member access (e.g., .v3, .v4, .v4_2)
+            if let memberAccess = expr.as(MemberAccessExprSyntax.self),
+               memberAccess.base == nil,  // Leading dot syntax
+               let memberName = memberAccess.declName.baseName.identifier?.name {
+                // Map member names to version strings
+                let versionString: String
+                switch memberName {
+                case "v3": versionString = "3"
+                case "v4": versionString = "4"
+                case "v4_2": versionString = "4.2"
+                case "v5": versionString = "5"
+                case "v6": versionString = "6"
+                default:
+                    return nil  // Unknown version member
+                }
+                
+                guard let version = SwiftLanguageVersion(string: versionString) else {
+                    return nil
+                }
+                result.append(version)
+                continue
+            }
+            
+            // Try to parse as function call (e.g., .version("5"))
+            if let functionCall = expr.as(FunctionCallExprSyntax.self),
+               let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+               memberAccess.base == nil,  // Leading dot syntax
+               let methodName = memberAccess.declName.baseName.identifier?.name,
+               methodName == "version",
+               let firstArg = functionCall.arguments.first,
+               firstArg.label == nil,
+               let versionString = firstArg.expression.asStringLiteralValue() {
+                guard let version = SwiftLanguageVersion(string: versionString) else {
+                    return nil
+                }
+                result.append(version)
+                continue
+            }
+            
+            // Unable to parse this element
+            return nil
+        }
+        
+        return result
+    }
+
+    /// Extract a member access function call (e.g., `.target(name: "foo")`)
+    /// Returns the method name and arguments if successful.
+    fileprivate func asMemberAccessCall() -> (methodName: String, arguments: LabeledExprListSyntax)? {
+        guard let functionCall = self.as(FunctionCallExprSyntax.self),
+              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil,  // Leading dot syntax
+              let methodName = memberAccess.declName.baseName.identifier?.name else {
+            return nil
+        }
+        return (methodName, functionCall.arguments)
+    }
+
+    /// Parse array elements using a transform function.
+    /// Returns array of successfully transformed elements, or nil if expression is not an array.
+    fileprivate func parseArrayElements<T>(_ transform: (ExprSyntax) -> T?) -> [T]? {
+        guard let arrayExpr = self.as(ArrayExprSyntax.self) else {
+            return nil
+        }
+
+        var result: [T] = []
+        for element in arrayExpr.elements {
+            if let value = transform(element.expression) {
+                result.append(value)
+            }
+        }
+        return result
+    }
+
+    /// Parse an array of string literals.
+    fileprivate func asStringArray(in contextModel: StaticContextModel) -> [String]? {
+        return parseArrayElements {
+            $0.asStringLiteralValue(in: contextModel)
+        }
+    }
+
+    /// Parse an enum member access (e.g., `.static`, `.dynamic`).
+    /// Returns the member name if it's a simple member access with no base.
+    fileprivate func asEnumMember() -> String? {
+        guard let memberAccess = self.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil,  // Leading dot syntax
+              let memberName = memberAccess.declName.baseName.identifier?.name else {
+            return nil
+        }
+        return memberName
+    }
+
+    /// Parse a platform name as used in a `.when(platforms: [...])` condition.
+    /// Handles both plain enum members (e.g. `.linux`) and custom platforms
+    /// (e.g. `.custom("freebsd")`).
+    fileprivate func asPlatformConditionName() -> String? {
+        if let name = self.asEnumMember() {
+            return name
+        }
+
+        // Handle .custom("platformName")
+        guard let functionCall = self.as(FunctionCallExprSyntax.self),
+              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil,
+              memberAccess.declName.baseName.identifier?.name == "custom",
+              let firstArg = functionCall.arguments.first,
+              firstArg.label == nil,
+              let customName = firstArg.expression.asStringLiteralValue() else {
+            return nil
+        }
+        return customName
+    }
+}
+
+/// A version of ContextModel that stores everything directly, rather than
+/// falling back to the current process's environment.
+class StaticContextModel {
+    let packageDirectory : String
+    var environment: [String : String]
+
+    init(packageDirectory: String, environment: [String : String]) {
+        self.packageDirectory = packageDirectory
+        self.environment = environment
+    }
+
+    lazy var gitInformation: ContextModel.GitInformation? = {
+        do {
+            let repo = GitRepository(path: try AbsolutePath(validating: packageDirectory))
+            return ContextModel.GitInformation(
+                currentTag: repo.getCurrentTag(),
+                currentCommit: try repo.getCurrentRevision().identifier,
+                hasUncommittedChanges: repo.hasUncommittedChanges()
+            )
+        } catch {
+            // Ignore errors getting git info
+            return nil
+        }
+    }()
+}

--- a/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
@@ -487,6 +487,123 @@ class ManifestParseVisitor: ActiveSyntaxAnyVisitor {
     override func visit(_: CodeBlockItemSyntax) -> SyntaxVisitorContinueKind {
         .visitChildren
     }
+
+    /// Handle top-level function calls like `package.dependencies.append(...)` or
+    /// `package.targets.append(contentsOf: [...])`.
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        // Match package.<property>.append(...) or package.<property>.append(contentsOf: ...)
+        guard let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self),
+              let methodName = memberAccess.declName.baseName.identifier?.name,
+              (methodName == "append"),
+              let propertyAccess = memberAccess.base?.as(MemberAccessExprSyntax.self),
+              let propertyName = propertyAccess.declName.baseName.identifier?.name,
+              let baseRef = propertyAccess.base?.as(DeclReferenceExprSyntax.self),
+              baseRef.baseName.text == "package" else {
+            return visitAny(Syntax(node))
+        }
+
+        guard let firstArg = node.arguments.first else {
+            return visitAny(Syntax(node))
+        }
+
+        if firstArg.label?.text == "contentsOf" {
+            // package.<property>.append(contentsOf: [...])
+            appendToPackageProperty(propertyName, arrayExpr: firstArg.expression)
+        } else if firstArg.label == nil {
+            // package.<property>.append(<element>)
+            appendToPackageProperty(propertyName, elementExpr: firstArg.expression)
+        } else {
+            return visitAny(Syntax(node))
+        }
+
+        return .skipChildren
+    }
+
+    /// Handle top-level `package.<property> += [...]` expressions.
+    override func visit(_ node: InfixOperatorExprSyntax) -> SyntaxVisitorContinueKind {
+        // Match package.<property> += <array>
+        guard let op = node.operator.as(BinaryOperatorExprSyntax.self),
+              op.operator.text.trimmingCharacters(in: .whitespaces) == "+=",
+              let propertyAccess = node.leftOperand.as(MemberAccessExprSyntax.self),
+              let propertyName = propertyAccess.declName.baseName.identifier?.name,
+              let baseRef = propertyAccess.base?.as(DeclReferenceExprSyntax.self),
+              baseRef.baseName.text == "package" else {
+            return visitAny(Syntax(node))
+        }
+
+        appendToPackageProperty(propertyName, arrayExpr: node.rightOperand)
+        return .skipChildren
+    }
+
+    /// Append a single element to a package property by name.
+    private func appendToPackageProperty(_ propertyName: String, elementExpr: ExprSyntax) {
+        switch propertyName {
+        case "dependencies":
+            var dep: PackageDependency?
+            resolve(elementExpr, description: "package dependency", into: &dep) { expr throws(ResolutionError) in
+                try self.parsePackageDependency(expr)
+            }
+            if let dep { self.dependencies = (self.dependencies ?? []) + [dep] }
+        case "targets":
+            var target: TargetDescription?
+            resolve(elementExpr, description: "target", into: &target)
+            if let target { self.targets = (self.targets ?? []) + [target] }
+        case "products":
+            var product: ProductDescription?
+            resolve(elementExpr, description: "product", into: &product)
+            if let product { self.products = (self.products ?? []) + [product] }
+        case "platforms":
+            var platform: PlatformDescription?
+            resolve(elementExpr, description: "platform", into: &platform)
+            if let platform { self.platforms = (self.platforms ?? []) + [platform] }
+        case "providers":
+            var provider: SystemPackageProviderDescription?
+            resolve(elementExpr, description: "system package provider", into: &provider)
+            if let provider { self.providers = (self.providers ?? []) + [provider] }
+        case "traits":
+            var trait: TraitDescription?
+            resolve(elementExpr, description: "trait", into: &trait)
+            if let trait { self.traits = (self.traits ?? []) + [trait] }
+        default:
+            limitations.append(.unsupportedExpression(elementExpr, expected: "known package property"))
+        }
+    }
+
+    /// Append an array expression to a package property by name.
+    private func appendToPackageProperty(_ propertyName: String, arrayExpr: ExprSyntax) {
+        switch propertyName {
+        case "dependencies":
+            var newDeps: [PackageDependency]?
+            resolve(arrayExpr, description: "array of package dependencies", into: &newDeps) { expr throws(ResolutionError) in
+                try self.resolveArray(expr) { expr throws(ResolutionError) in
+                    try self.parsePackageDependency(expr)
+                }
+            }
+            if let newDeps { self.dependencies = (self.dependencies ?? []) + newDeps }
+        case "targets":
+            var newTargets: [TargetDescription]?
+            resolve(arrayExpr, description: "array of targets", into: &newTargets)
+            if let newTargets { self.targets = (self.targets ?? []) + newTargets }
+        case "products":
+            var newProducts: [ProductDescription]?
+            resolve(arrayExpr, description: "array of products", into: &newProducts)
+            if let newProducts { self.products = (self.products ?? []) + newProducts }
+        case "platforms":
+            var newPlatforms: [PlatformDescription]?
+            resolve(arrayExpr, description: "array of platforms", into: &newPlatforms)
+            if let newPlatforms { self.platforms = (self.platforms ?? []) + newPlatforms }
+        case "providers":
+            var newProviders: [SystemPackageProviderDescription]?
+            resolve(arrayExpr, description: "array of system package providers", into: &newProviders)
+            if let newProviders { self.providers = (self.providers ?? []) + newProviders }
+        case "traits":
+            var newTraits: [TraitDescription]?
+            resolve(arrayExpr, description: "array of traits", into: &newTraits)
+            if let newTraits { self.traits = (self.traits ?? []) + newTraits }
+        default:
+            limitations.append(.unsupportedExpression(arrayExpr, expected: "known package property"))
+        }
+    }
 }
 
 /// MARK: Handling arrays and variable resolution

--- a/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
@@ -236,6 +236,18 @@ public final class ParsingManifestLoader: ManifestLoaderProtocol {
         )
         visitor.walk(sourceFile)
 
+        // If the visitor produced any diagnostics while evaluating #if
+        // conditions (e.g., canImport checks that StaticBuildConfiguration
+        // cannot evaluate), treat them as limitations so we fall back to the
+        // executing manifest loader.
+        if !visitor.diagnostics.isEmpty {
+            visitor.limitations.append(
+                contentsOf: visitor.diagnostics.map {
+                    .ifConfigDiagnostic($0)
+                }
+            )
+        }
+
         // If we hit any of the limitations of the manifest parser, bail out
         // now.
         if !visitor.limitations.isEmpty {

--- a/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
@@ -1421,6 +1421,9 @@ extension ManifestParseVisitor {
                     }
                 } else if label == "to" {
                     value = resolveStringLiteral(argument.expression)
+                    if value == nil {
+                        limitations.append(.unsupportedExpression(argument.expression, expected: "'to' value of 'define'"))
+                    }
                 } else if label == "condition" {
                     conditionArgumentIndex = index
                 } else {

--- a/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !DISABLE_PARSING_MANIFEST_LOADER
 import Basics
 import Dispatch
 import Foundation
@@ -3288,3 +3289,4 @@ class StaticContextModel {
         }
     }()
 }
+#endif

--- a/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
@@ -190,7 +190,18 @@ public final class ParsingManifestLoader: ManifestLoaderProtocol {
             packageDirectory: manifestPath.parentDirectory.pathString,
             environment: environment ?? ProcessInfo.processInfo.environment
         )
-        
+
+        // Adjust the language mode in the build configuration to match
+        // the manifest's tools version. The static build configuration
+        // from the compiler reflects its default language mode, but the
+        // manifest is compiled with the language version implied by its
+        // tools version (e.g., tools version 6.0 → Swift 6 mode).
+        var config = self.config
+        let toolsLanguageVersion = manifestToolsVersion.swiftLanguageVersion
+        if let parsedVersion = VersionTuple(parsing: toolsLanguageVersion.rawValue) {
+            config.languageMode = parsedVersion
+        }
+
         // Parse the source file.
         var sourceFile: SourceFileSyntax = Parser.parse(source: manifestContents)
 

--- a/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
@@ -357,6 +357,10 @@ class ManifestParseVisitor: ActiveSyntaxAnyVisitor {
 
     var defaultPackageAccess: Bool
 
+    /// Storage for global variables defined in the manifest
+    /// Maps variable names to their expression syntax nodes for lazy evaluation
+    private var globalVariables: [String: ExprSyntax] = [:]
+
     init(
         manifestPath: AbsolutePath,
         configuration: StaticBuildConfiguration,
@@ -387,34 +391,30 @@ class ManifestParseVisitor: ActiveSyntaxAnyVisitor {
 
         return visitAny(Syntax(node))
     }
-    /// Process global variable declarations to find the "package" declaration.
+
+    /// Process global variable declarations to find the "package" declaration or global variables.
     override func visit(_ varNode: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
         // Dig out the name and initializer.
-        guard let (_, initializer) = varNode.asSingleInitializedVariable() else {
+        guard let (varName, initializer) = varNode.asSingleInitializedVariable() else {
             limitations.append(.unsupportedVariableForm(varNode))
             return .skipChildren
         }
 
         // Check whether we know this call or not.
-        guard let (knownCall, arguments) = initializer.asKnownCall() else {
-            limitations.append(
-                .unsupportedExpression(
-                    initializer,
-                    expected: "top-level variable initializer"
-                )
-            )
+        if let (knownCall, arguments) = initializer.asKnownCall() {
+            // Handle any top-level known calls here.
+            switch knownCall {
+            case .package:
+                handlePackageDeclaration(initializer: initializer, arguments: arguments)
+            }
             return .skipChildren
         }
 
-        // Handle any top-level known calls here.
-        switch knownCall {
-        case .package:
-            handlePackageDeclaration(initializer: initializer, arguments: arguments)
-        }
-
+        // Store the expression for this global variable
+        // We'll parse it on-demand when it's referenced
+        globalVariables[varName.name] = initializer
         return .skipChildren
     }
-
 
     /// Check whether import declarations match known modules. Otherwise, we
     /// can't reason about what the manifest is doing.
@@ -459,6 +459,340 @@ class ManifestParseVisitor: ActiveSyntaxAnyVisitor {
     }
 }
 
+/// MARK: Handling arrays and variable resolution
+extension ManifestParseVisitor {
+    /// Resolve a string literal expression with support for global variable references and interpolations
+    /// - Parameters:
+    ///   - expr: The expression to parse (could be a string literal, variable reference, or Context expression)
+    /// - Returns: The resolved string value, or nil if it cannot be resolved
+    private func resolveStringLiteral(_ expr: ExprSyntax) -> String? {
+        // Case 1: Variable reference - resolve and recurse
+        if let varRef = expr.as(DeclReferenceExprSyntax.self),
+           let varName = varRef.baseName.identifier?.name,
+           let value = globalVariables[varName] {
+            // Recursively resolve the variable's value
+            return resolveStringLiteral(value)
+        }
+        
+        // Case 2: Direct Context expression (e.g., Context.packageDirectory)
+        if let value = evaluateContextExpression(expr) {
+            return value
+        }
+        
+        // Case 3: String literal (possibly with interpolations)
+        guard let stringLiteral = expr.as(StringLiteralExprSyntax.self) else {
+            return nil
+        }
+
+        // Simple case: no interpolation — use representedLiteralValue to correctly handle
+        // escape sequences (e.g. \" in a C preprocessor define value becomes ").
+        if let value = stringLiteral.representedLiteralValue {
+            return value
+        }
+
+        // Complex case: handle interpolations with Context values and global variables
+        var result = ""
+        for segment in stringLiteral.segments {
+            switch segment {
+            case .stringSegment(let contents):
+                // For string segments.
+                result += contents.content.text
+
+            case .expressionSegment(let exprSegment):
+                // Try to evaluate the interpolated expression
+                guard let interpolatedExpr = exprSegment.expressions.first?.expression, exprSegment.expressions.count == 1 else {
+                    return nil
+                }
+                
+                // Recursively resolve the interpolated expression
+                // This allows variable references, Context expressions, etc.
+                if let value = resolveStringLiteral(interpolatedExpr) {
+                    result += value
+                } else {
+                    // Cannot evaluate this interpolation
+                    return nil
+                }
+            }
+        }
+
+        return result
+    }
+    
+    /// Evaluate a Context expression like Context.gitInformation?.currentTag or Context.environment["KEY"]
+    /// Returns the string representation of the value, or nil if it cannot be evaluated.
+    private func evaluateContextExpression(_ expr: ExprSyntax) -> String? {
+        var currentExpr: ExprSyntax = expr
+        var nilCoalescingDefault: String? = nil
+
+        // Handle nil-coalescing operator (??)
+        if let infixExpr = currentExpr.as(InfixOperatorExprSyntax.self),
+           let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self),
+           op.operator.text.trimmingCharacters(in: .whitespaces) == "??" {
+            // Get the default value from the right side
+            if let rightValue = resolveStringLiteral(infixExpr.rightOperand) {
+                nilCoalescingDefault = rightValue
+            }
+            // Continue evaluating the left side
+            currentExpr = infixExpr.leftOperand
+        }
+        
+        // Handle boolean comparison (== true)
+        if let infixExpr = currentExpr.as(InfixOperatorExprSyntax.self),
+           let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self),
+           op.operator.text.trimmingCharacters(in: .whitespaces) == "==" {
+            // Check if right side is 'true'
+            if let boolLit = infixExpr.rightOperand.as(BooleanLiteralExprSyntax.self),
+               boolLit.literal.tokenKind == .keyword(.true) {
+                currentExpr = infixExpr.leftOperand
+            }
+        }
+        
+        // Check for subscript access (e.g., Context.environment["KEY"])
+        if let subscriptExpr = currentExpr.as(SubscriptCallExprSyntax.self) {
+            // Parse the base expression (e.g., Context.environment)
+            var baseParts: [String] = []
+            var baseExpr = subscriptExpr.calledExpression
+            
+            // Walk through the member access chain
+            while true {
+                if let memberAccess = baseExpr.as(MemberAccessExprSyntax.self) {
+                    baseParts.insert(memberAccess.declName.baseName.text, at: 0)
+                    if let base = memberAccess.base {
+                        baseExpr = base
+                    } else {
+                        break
+                    }
+                } else if let declRef = baseExpr.as(DeclReferenceExprSyntax.self) {
+                    baseParts.insert(declRef.baseName.text, at: 0)
+                    break
+                } else {
+                    return nil
+                }
+            }
+            
+            // Check if it's Context.environment
+            if baseParts.count == 2 && baseParts[0] == "Context" && baseParts[1] == "environment" {
+                // Get the subscript key
+                if let firstArg = subscriptExpr.arguments.first,
+                   let keyString = resolveStringLiteral(firstArg.expression) {
+                    // Look up the environment variable
+                    if let value = contextModel.environment[keyString] {
+                        return value
+                    } else {
+                        return nilCoalescingDefault
+                    }
+                }
+            }
+            
+            return nil
+        }
+        
+        // Now parse the member access chain
+        // Expected patterns:
+        // - Context.packageDirectory
+        // - Context.gitInformation?.currentTag
+        // - Context.gitInformation?.currentCommit
+        // - Context.gitInformation?.hasUncommittedChanges
+        
+        // Extract all parts of the member access chain
+        var parts: [String] = []
+        
+        // Walk backwards through the member access chain
+        while true {
+            if let memberAccess = currentExpr.as(MemberAccessExprSyntax.self) {
+                // Add the member name
+                parts.insert(memberAccess.declName.baseName.text, at: 0)
+                
+                if let base = memberAccess.base {
+                    currentExpr = base
+                } else {
+                    // No more base, we're done
+                    break
+                }
+            } else if let optChain = currentExpr.as(OptionalChainingExprSyntax.self) {
+                // Skip the optional chaining wrapper and continue
+                currentExpr = optChain.expression
+            } else if let postfixUnary = currentExpr.as(PostfixOperatorExprSyntax.self) {
+                // This handles the ? in optional chaining
+                currentExpr = postfixUnary.expression
+            } else if let declRef = currentExpr.as(DeclReferenceExprSyntax.self) {
+                // This is the base identifier (e.g., "Context")
+                parts.insert(declRef.baseName.text, at: 0)
+                break
+            } else {
+                // Unknown expression structure
+                return nil
+            }
+        }
+        
+        // Now evaluate based on the parts
+        guard parts.count >= 2 && parts[0] == "Context" else {
+            return nil
+        }
+        
+        switch parts[1] {
+        case "packageDirectory":
+            return contextModel.packageDirectory
+            
+        case "gitInformation":
+            guard parts.count >= 3 else {
+                return nil
+            }
+            guard let gitInfo = contextModel.gitInformation else {
+                return nilCoalescingDefault
+            }
+            
+            switch parts[2] {
+            case "currentTag":
+                if let tag = gitInfo.currentTag {
+                    return tag
+                } else {
+                    return nilCoalescingDefault ?? ""
+                }
+                
+            case "currentCommit":
+                return gitInfo.currentCommit
+                
+            case "hasUncommittedChanges":
+                let value = gitInfo.hasUncommittedChanges
+                return value ? "true" : "false"
+                
+            default:
+                return nil
+            }
+            
+        default:
+            return nil
+        }
+    }
+    
+    /// Resolve a string array expression with support for global variable references and concatenation
+    /// - Parameters:
+    ///   - expr: The expression to parse (could be an array literal, variable reference, or concatenation)
+    ///   - expectedDescription: Description of what's expected for error messages
+    /// - Returns: The resolved array of strings, or nil if it cannot be resolved
+    private func resolveStringArray(_ expr: ExprSyntax, expectedDescription: String) -> [String]? {
+        return resolveArray(
+            expr,
+            expectedDescription: expectedDescription
+        ) { element in
+            resolveStringLiteral(element)
+        }
+    }
+    
+    /// Parse an array expression with full support for variable resolution, concatenation, and element parsing
+    /// - Parameters:
+    ///   - expr: The expression to parse (could be an array literal, variable reference, or array concatenation)
+    ///   - originalExpr: The original unresolved expression (used for error reporting)
+    ///   - expectedDescription: Description of what's expected for error messages
+    ///   - elementParser: Closure that parses individual array elements
+    /// - Returns: Array of parsed elements, or nil if parsing failed
+    ///
+    /// This function recursively handles:
+    /// - Variable references (e.g., `myArray`)
+    /// - Array concatenation (e.g., `array1 + array2`)
+    /// - Nested combinations (e.g., `var1 + var2 + [.item3]`)
+    private func resolveArray<T>(
+        _ expr: ExprSyntax,
+        originalExpr: ExprSyntax? = nil,
+        expectedDescription: String,
+        elementParser: (ExprSyntax) -> T?
+    ) -> [T]? {
+        // Case 1: Variable reference - resolve and recurse
+        if let varRef = expr.as(DeclReferenceExprSyntax.self),
+           let varName = varRef.baseName.identifier?.name,
+           let value = globalVariables[varName] {
+            // Recursively resolve and parse the variable's value
+            return resolveArray(
+                value,
+                originalExpr: originalExpr,
+                expectedDescription: expectedDescription,
+                elementParser: elementParser
+            )
+        }
+        
+        // Case 2: Binary expression (array concatenation with +)
+        if let infixExpr = expr.as(InfixOperatorExprSyntax.self),
+           let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self),
+           op.operator.text.trimmingCharacters(in: .whitespaces) == "+" {
+            
+            // Recursively resolve and parse both operands
+            guard let leftElements = resolveArray(
+                infixExpr.leftOperand,
+                originalExpr: originalExpr,
+                expectedDescription: expectedDescription,
+                elementParser: elementParser
+            ) else {
+                return nil
+            }
+            
+            guard let rightElements = resolveArray(
+                infixExpr.rightOperand,
+                originalExpr: originalExpr,
+                expectedDescription: expectedDescription,
+                elementParser: elementParser
+            ) else {
+                return nil
+            }
+            
+            // Combine the parsed elements from both sides
+            return leftElements + rightElements
+        }
+        
+        // Case 3: Array literal - parse its elements directly
+        guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
+            limitations.append(
+                .unsupportedExpression(
+                    originalExpr ?? expr,
+                    expected: expectedDescription
+                )
+            )
+            return nil
+        }
+        
+        // Parse each element in the array
+        var results: [T] = []
+        for element in arrayExpr.elements {
+            var elementExpr = element.expression
+            if let varRef = element.expression.as(DeclReferenceExprSyntax.self),
+               let varName = varRef.baseName.identifier?.name,
+               let value = globalVariables[varName] {
+                elementExpr = value
+            }
+
+            if let parsed = elementParser(elementExpr) {
+                results.append(parsed)
+            }
+        }
+        
+        return results
+    }
+    
+    /// Parse a platform name as used in a `.when(platforms: [...])` condition.
+    /// Handles both plain enum members (e.g. `.linux`) and custom platforms
+    /// (e.g. `.custom("freebsd")`).
+    /// - Parameters:
+    ///   - expr: The expression to parse
+    /// - Returns: The platform name, or nil if it cannot be parsed
+    private func parsePlatformConditionName(_ expr: ExprSyntax) -> String? {
+        if let name = expr.asEnumMember() {
+            return name
+        }
+
+        // Handle .custom("platformName")
+        guard let functionCall = expr.as(FunctionCallExprSyntax.self),
+              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+              memberAccess.base == nil,
+              memberAccess.declName.baseName.identifier?.name == "custom",
+              let firstArg = functionCall.arguments.first,
+              firstArg.label == nil else {
+            return nil
+        }
+        
+        return resolveStringLiteral(firstArg.expression)
+    }
+}
+
 /// MARK: Declaration handling
 extension ManifestParseVisitor {
     func handlePackageDeclaration(
@@ -467,37 +801,28 @@ extension ManifestParseVisitor {
     ) {
         for argument in arguments {
             if argument.label?.text == "name" {
-                guard let name = argument.expression.asStringLiteralValue(in: contextModel) else {
+                if let name = resolveStringLiteral(argument.expression) {
+                    // Record the package name.
+                    self.packageName = name
+                } else {
                     limitations.append(
                         .unsupportedExpression(
                             argument.expression,
-                            expected: "string literal"
+                            expected: "string literal or reference to global variable"
                         )
                     )
-
-                    continue
                 }
-
-                // Record the package name.
-                self.packageName = name
                 continue
             }
             
             if argument.label?.text == "dependencies" {
-                guard let dependenciesArray = argument.expression.as(ArrayExprSyntax.self) else {
-                    limitations.append(
-                        .unsupportedExpression(
-                            argument.expression,
-                            expected: "array of package dependencies"
-                        )
-                    )
-                    continue
-                }
-                
-                for dependencyElement in dependenciesArray.elements {
-                    if let dependency = parsePackageDependency(dependencyElement.expression, manifestPath: manifestPath) {
-                        self.dependencies.append(dependency)
-                    }
+                if let deps = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of package dependencies or reference to global variable"
+                ) { expr in
+                    parsePackageDependency(expr, manifestPath: manifestPath)
+                } {
+                    self.dependencies.append(contentsOf: deps)
                 }
                 continue
             }
@@ -551,50 +876,32 @@ extension ManifestParseVisitor {
             }
             
             if argument.label?.text == "pkgConfig" {
-                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                if let value = resolveStringLiteral(argument.expression) {
                     self.pkgConfig = value
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "pkgConfig string"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "pkgConfig string or reference to global variable"))
                 }
                 continue
             }
             
             if argument.label?.text == "providers" {
-                guard let providersArray = argument.expression.as(ArrayExprSyntax.self) else {
-                    limitations.append(
-                        .unsupportedExpression(
-                            argument.expression,
-                            expected: "array of providers"
-                        )
-                    )
-                    continue
+                if let parsedProviders = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of providers",
+                    elementParser: parseSystemPackageProvider
+                ) {
+                    self.providers = parsedProviders.isEmpty ? nil : parsedProviders
                 }
-                
-                var parsedProviders: [SystemPackageProviderDescription] = []
-                for providerElement in providersArray.elements {
-                    if let provider = parseSystemPackageProvider(providerElement.expression) {
-                        parsedProviders.append(provider)
-                    }
-                }
-                self.providers = parsedProviders.isEmpty ? nil : parsedProviders
                 continue
             }
             
             if argument.label?.text == "products" {
-                guard let productsArray = argument.expression.as(ArrayExprSyntax.self) else {
-                    limitations.append(
-                        .unsupportedExpression(
-                            argument.expression,
-                            expected: "array of products"
-                        )
-                    )
-                    continue
-                }
-                
-                for productElement in productsArray.elements {
-                    if let product = parseProduct(productElement.expression) {
-                        self.products.append(product)
-                    }
+                if let prods = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of products or reference to global variable",
+                    elementParser: parseProduct
+                ) {
+                    self.products.append(contentsOf: prods)
                 }
                 continue
             }
@@ -614,73 +921,44 @@ extension ManifestParseVisitor {
             }
             
             if argument.label?.text == "platforms" {
-                guard let platformsArray = argument.expression.as(ArrayExprSyntax.self) else {
-                    limitations.append(
-                        .unsupportedExpression(
-                            argument.expression,
-                            expected: "array of platforms"
-                        )
-                    )
-                    continue
+                if let plats = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of platforms or reference to global variable",
+                    elementParser: parsePlatform
+                ) {
+                    self.platforms = plats
                 }
-                
-                var parsedPlatforms: [PlatformDescription] = []
-                for platformElement in platformsArray.elements {
-                    if let platform = parsePlatform(platformElement.expression) {
-                        parsedPlatforms.append(platform)
-                    }
-                }
-                self.platforms = parsedPlatforms
                 continue
             }
             
             if argument.label?.text == "defaultLocalization" {
-                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                if let value = resolveStringLiteral(argument.expression) {
                     self.defaultLocalization = value
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "default localization language tag"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "default localization language tag or reference to global variable"))
                 }
                 continue
             }
             
             if argument.label?.text == "targets" {
-                guard let targetsArray = argument.expression.as(ArrayExprSyntax.self) else {
-                    limitations.append(
-                        .unsupportedExpression(
-                            argument.expression,
-                            expected: "array of targets"
-                        )
-                    )
-                    continue
-                }
-                
-                // Parse each target in the array
-                for targetElement in targetsArray.elements {
-                    if let target = parseTarget(targetElement.expression) {
-                        self.targets.append(target)
-                    }
+                if let tgts = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of targets or reference to global variable",
+                    elementParser: parseTarget
+                ) {
+                    self.targets.append(contentsOf: tgts)
                 }
                 continue
             }
             
             if argument.label?.text == "traits" {
-                guard let traitsArray = argument.expression.as(ArrayExprSyntax.self) else {
-                    limitations.append(
-                        .unsupportedExpression(
-                            argument.expression,
-                            expected: "array of traits"
-                        )
-                    )
-                    continue
+                if let trts = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of traits or reference to global variable",
+                    elementParser: parseTrait
+                ) {
+                    self.traits = trts
                 }
-                
-                var parsedTraits: [TraitDescription] = []
-                for traitElement in traitsArray.elements {
-                    if let trait = parseTrait(traitElement.expression) {
-                        parsedTraits.append(trait)
-                    }
-                }
-                self.traits = parsedTraits
                 continue
             }
 
@@ -746,104 +1024,126 @@ extension ManifestParseVisitor {
             let label = argument.label?.text
             
             if label == "name" {
-                name = argument.expression.asStringLiteralValue(in: contextModel)
+                name = resolveStringLiteral(argument.expression)
             } else if label == "dependencies" {
-                if let deps = argument.expression.parseArrayElements(parseTargetDependency) {
+                if let deps = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of target dependencies or reference to global variable",
+                    elementParser: parseTargetDependency
+                ) {
                     dependencies.append(contentsOf: deps)
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of target dependencies"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of target dependencies or reference to global variable"))
                 }
             } else if label == "path" {
-                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                if let value = resolveStringLiteral(argument.expression) {
                     path = value
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "path string"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "path string or reference to global variable"))
                 }
             } else if label == "url" {
-                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                if let value = resolveStringLiteral(argument.expression) {
                     url = value
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "url string"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "url string or reference to global variable"))
                 }
             } else if label == "checksum" {
-                if let value = argument.expression.asStringLiteralValue() {
+                if let value = resolveStringLiteral(argument.expression) {
                     checksum = value
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "checksum string"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "checksum string or reference to global variable"))
                 }
             } else if label == "exclude" {
-                if let value = argument.expression.asStringArray(in: contextModel) {
+                if let value = resolveStringArray(argument.expression, expectedDescription: "array of excluded paths or reference to global variable") {
                     exclude = value
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of excluded paths"))
                 }
             } else if label == "sources" {
-                if let parsed = argument.expression.asStringArray(in: contextModel) {
+                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of source file paths or reference to global variable") {
                     sources = parsed
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of source file paths"))
                 }
             } else if label == "publicHeadersPath" {
-                if let value = argument.expression.asStringLiteralValue(in: contextModel) {
+                if let value = resolveStringLiteral(argument.expression) {
                     publicHeadersPath = value
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "publicHeadersPath string"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "publicHeadersPath string or reference to global variable"))
                 }
             } else if label == "pkgConfig" {
-                if let value = argument.expression.asStringLiteralValue() {
+                if let value = resolveStringLiteral(argument.expression) {
                     pkgConfig = value
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "pkgConfig string"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "pkgConfig string or reference to global variable"))
                 }
             } else if label == "providers" {
-                if let providersArray = argument.expression.as(ArrayExprSyntax.self) {
-                    var parsedProviders: [SystemPackageProviderDescription] = []
-                    for providerElement in providersArray.elements {
-                        if let provider = parseSystemPackageProvider(providerElement.expression) {
-                            parsedProviders.append(provider)
-                        }
-                    }
+                if let parsedProviders = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of system package providers or reference to global variable",
+                    elementParser: parseSystemPackageProvider
+                ) {
                     providers = parsedProviders.isEmpty ? nil : parsedProviders
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of system package providers"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of system package providers or reference to global variable"))
                 }
             } else if label == "resources" {
-                if let parsed = argument.expression.parseArrayElements(parseResource) {
+                if let parsed = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of resources or reference to global variable",
+                    elementParser: parseResource
+                ) {
                     resources.append(contentsOf: parsed)
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of resources"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of resources or reference to global variable"))
                 }
             } else if label == "capability" {
                 pluginCapability = parsePluginCapability(argument.expression)
             } else if label == "cSettings" {
-                if let parsed = argument.expression.parseArrayElements({ parseBuildSetting($0, tool: .c) }) {
+                if let parsed = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of C build settings or reference to global variable",
+                    elementParser: { parseBuildSetting($0, tool: .c) }
+                ) {
                     settings.append(contentsOf: parsed)
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of C build settings"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of C build settings or reference to global variable"))
                 }
             } else if label == "cxxSettings" {
-                if let parsed = argument.expression.parseArrayElements({ parseBuildSetting($0, tool: .cxx) }) {
+                if let parsed = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of C++ build settings or reference to global variable",
+                    elementParser: { parseBuildSetting($0, tool: .cxx) }
+                ) {
                     settings.append(contentsOf: parsed)
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of C++ build settings"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of C++ build settings or reference to global variable"))
                 }
             } else if label == "swiftSettings" {
-                if let parsed = argument.expression.parseArrayElements({ parseBuildSetting($0, tool: .swift) }) {
+                if let parsed = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of Swift build settings or reference to global variable",
+                    elementParser: { parseBuildSetting($0, tool: .swift) }
+                ) {
                     settings.append(contentsOf: parsed)
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of Swift build settings"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of Swift build settings or reference to global variable"))
                 }
             } else if label == "linkerSettings" {
-                if let parsed = argument.expression.parseArrayElements({ parseBuildSetting($0, tool: .linker) }) {
+                if let parsed = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of linker settings or reference to global variable",
+                    elementParser: { parseBuildSetting($0, tool: .linker) }
+                ) {
                     settings.append(contentsOf: parsed)
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of linker settings"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of linker settings or reference to global variable"))
                 }
             } else if label == "plugins" {
-                if let parsed = argument.expression.parseArrayElements(parsePluginUsage) {
+                if let parsed = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of plugin usages or reference to global variable",
+                    elementParser: parsePluginUsage
+                ) {
                     pluginUsages = parsed
                 } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of plugin usages"))
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of plugin usages or reference to global variable"))
                 }
             } else if label == "packageAccess" {
                 if let boolValue = argument.expression.asBooleanLiteralValue() {
@@ -890,8 +1190,8 @@ extension ManifestParseVisitor {
     
     /// Parse a target dependency like "dep1", .target(name: "dep2"), or .product(name: "dep3", package: "Pkg")
     private func parseTargetDependency(_ expr: ExprSyntax) -> TargetDescription.Dependency? {
-        // Case 1: String literal dependency (e.g., "dep1")
-        if let depName = expr.asStringLiteralValue(in: contextModel) {
+        // Case 1: String literal dependency (e.g., "dep1") or variable reference
+        if let depName = resolveStringLiteral(expr) {
             return .byName(name: depName, condition: nil)
         }
         
@@ -909,7 +1209,7 @@ extension ManifestParseVisitor {
             for argument in arguments {
                 let label = argument.label?.text
                 if label == "name" {
-                    name = argument.expression.asStringLiteralValue(in: contextModel)
+                    name = resolveStringLiteral(argument.expression)
                 } else if label == "condition" {
                     condition = parsePackageCondition(argument.expression)
                 } else {
@@ -932,9 +1232,9 @@ extension ManifestParseVisitor {
             for argument in arguments {
                 let label = argument.label?.text
                 if label == "name" {
-                    name = argument.expression.asStringLiteralValue(in: contextModel)
+                    name = resolveStringLiteral(argument.expression)
                 } else if label == "package" {
-                    package = argument.expression.asStringLiteralValue(in: contextModel)
+                    package = resolveStringLiteral(argument.expression)
                 } else if label == "moduleAliases" {
                     moduleAliases = parseModuleAliases(argument.expression)
                 } else if label == "condition" {
@@ -957,7 +1257,7 @@ extension ManifestParseVisitor {
             for argument in arguments {
                 let label = argument.label?.text
                 if label == "name" {
-                    name = argument.expression.asStringLiteralValue(in: contextModel)
+                    name = resolveStringLiteral(argument.expression)
                 } else if label == "condition" {
                     condition = parsePackageCondition(argument.expression)
                 } else {
@@ -994,16 +1294,16 @@ extension ManifestParseVisitor {
             
             if label == "platforms" {
                 hasPlatforms = true
-                guard let arrayExpr = argument.expression.as(ArrayExprSyntax.self) else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of platform conditions"))
+                if let platforms = resolveArray(
+                    argument.expression,
+                    expectedDescription: "array of platform conditions or reference to global variable"
+                ) { expr -> String? in
+                    parsePlatformConditionName(expr)
+                } {
+                    platformNames = platforms.map { $0.lowercased() }
+                } else {
+                    // resolveArray already added the limitation
                     continue
-                }
-                for element in arrayExpr.elements {
-                    if let name = element.expression.asPlatformConditionName() {
-                        platformNames.append(name.lowercased())
-                    } else {
-                        limitations.append(.unsupportedExpression(element.expression, expected: "known platform"))
-                    }
                 }
             } else if label == "configuration" {
                 if let value = argument.expression.asEnumMember() {
@@ -1012,10 +1312,8 @@ extension ManifestParseVisitor {
                     limitations.append(.unsupportedExpression(argument.expression, expected: "build configuration"))
                 }
             } else if label == "traits" {
-                if let parsed = argument.expression.asStringArray(in: contextModel) {
+                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of trait names or reference to global variable") {
                     traits = parsed
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of trait names"))
                 }
             } else {
                 limitations.append(.unsupportedArgument(argument, callee: "when"))
@@ -1053,11 +1351,11 @@ extension ManifestParseVisitor {
         case .elements(let elements):
             // Dictionary with key-value pairs
             for element in elements {
-                if let keyString = element.key.asStringLiteralValue(in: contextModel),
-                   let valueString = element.value.asStringLiteralValue(in: contextModel) {
+                if let keyString = resolveStringLiteral(element.key),
+                   let valueString = resolveStringLiteral(element.value) {
                     aliases[keyString] = valueString
                 } else {
-                    limitations.append(.unsupportedExpression(element.key, expected: "string literal module alias key and value"))
+                    limitations.append(.unsupportedExpression(element.key, expected: "string literal module alias key and value or reference to global variable"))
                 }
             }
         }
@@ -1085,7 +1383,7 @@ extension ManifestParseVisitor {
             for (index, argument) in functionCall.arguments.enumerated() {
                 let label = argument.label?.text
                 if label == nil {
-                    if kind == nil, let path = argument.expression.asStringLiteralValue(in: contextModel) {
+                    if kind == nil, let path = resolveStringLiteral(argument.expression) {
                         kind = .headerSearchPath(path)
                     } else {
                         conditionArgumentIndex = index
@@ -1104,13 +1402,13 @@ extension ManifestParseVisitor {
             for (index, argument) in functionCall.arguments.enumerated() {
                 let label = argument.label?.text
                 if label == nil {
-                    if let str = argument.expression.asStringLiteralValue(in: contextModel) {
+                    if let str = resolveStringLiteral(argument.expression) {
                         name = str
                     } else {
                         conditionArgumentIndex = index
                     }
                 } else if label == "to" {
-                    value = argument.expression.asStringLiteralValue(in: contextModel)
+                    value = resolveStringLiteral(argument.expression)
                 } else if label == "condition" {
                     conditionArgumentIndex = index
                 } else {
@@ -1129,7 +1427,7 @@ extension ManifestParseVisitor {
             for (index, argument) in functionCall.arguments.enumerated() {
                 let label = argument.label?.text
                 if label == nil {
-                    if kind == nil, let library = argument.expression.asStringLiteralValue(in: contextModel) {
+                    if kind == nil, let library = resolveStringLiteral(argument.expression) {
                         kind = .linkedLibrary(library)
                     } else {
                         conditionArgumentIndex = index
@@ -1144,7 +1442,7 @@ extension ManifestParseVisitor {
             for (index, argument) in functionCall.arguments.enumerated() {
                 let label = argument.label?.text
                 if label == nil {
-                    if kind == nil, let framework = argument.expression.asStringLiteralValue(in: contextModel) {
+                    if kind == nil, let framework = resolveStringLiteral(argument.expression) {
                         kind = .linkedFramework(framework)
                     } else {
                         conditionArgumentIndex = index
@@ -1162,10 +1460,10 @@ extension ManifestParseVisitor {
                     if kind == nil, let flagsArray = argument.expression.as(ArrayExprSyntax.self) {
                         var flags: [String] = []
                         for flagElement in flagsArray.elements {
-                            if let flag = flagElement.expression.asStringLiteralValue(in: contextModel) {
+                            if let flag = resolveStringLiteral(flagElement.expression) {
                                 flags.append(flag)
                             } else {
-                                limitations.append(.unsupportedExpression(flagElement.expression, expected: "string literal in unsafeFlags"))
+                                limitations.append(.unsupportedExpression(flagElement.expression, expected: "string literal in unsafeFlags or reference to global variable"))
                             }
                         }
                         kind = .unsafeFlags(flags)
@@ -1182,7 +1480,7 @@ extension ManifestParseVisitor {
             for (index, argument) in functionCall.arguments.enumerated() {
                 let label = argument.label?.text
                 if label == nil {
-                    if kind == nil, let feature = argument.expression.asStringLiteralValue(in: contextModel) {
+                    if kind == nil, let feature = resolveStringLiteral(argument.expression) {
                         kind = .enableUpcomingFeature(feature)
                     } else {
                         conditionArgumentIndex = index
@@ -1197,7 +1495,7 @@ extension ManifestParseVisitor {
             for (index, argument) in functionCall.arguments.enumerated() {
                 let label = argument.label?.text
                 if label == nil {
-                    if kind == nil, let feature = argument.expression.asStringLiteralValue(in: contextModel) {
+                    if kind == nil, let feature = resolveStringLiteral(argument.expression) {
                         kind = .enableExperimentalFeature(feature)
                     } else {
                         conditionArgumentIndex = index
@@ -1294,7 +1592,7 @@ extension ManifestParseVisitor {
             for (index, argument) in functionCall.arguments.enumerated() {
                 let label = argument.label?.text
                 if label == nil {
-                    if let str = argument.expression.asStringLiteralValue(in: contextModel) {
+                    if let str = resolveStringLiteral(argument.expression) {
                         warningName = str
                     } else {
                         conditionArgumentIndex = index
@@ -1326,7 +1624,7 @@ extension ManifestParseVisitor {
             for (index, argument) in functionCall.arguments.enumerated() {
                 let label = argument.label?.text
                 if label == nil {
-                    if kind == nil, let warning = argument.expression.asStringLiteralValue(in: contextModel) {
+                    if kind == nil, let warning = resolveStringLiteral(argument.expression) {
                         kind = .enableWarning(warning)
                     } else {
                         conditionArgumentIndex = index
@@ -1341,7 +1639,7 @@ extension ManifestParseVisitor {
             for (index, argument) in functionCall.arguments.enumerated() {
                 let label = argument.label?.text
                 if label == nil {
-                    if kind == nil, let warning = argument.expression.asStringLiteralValue(in: contextModel) {
+                    if kind == nil, let warning = resolveStringLiteral(argument.expression) {
                         kind = .disableWarning(warning)
                     } else {
                         conditionArgumentIndex = index
@@ -1457,10 +1755,10 @@ extension ManifestParseVisitor {
             if label == nil {
                 if let arrayExpr = argument.expression.as(ArrayExprSyntax.self) {
                     for element in arrayExpr.elements {
-                        if let packageName = element.expression.asStringLiteralValue(in: contextModel) {
+                        if let packageName = resolveStringLiteral(element.expression) {
                             packages.append(packageName)
                         } else {
-                            limitations.append(.unsupportedExpression(element.expression, expected: "string literal package name"))
+                            limitations.append(.unsupportedExpression(element.expression, expected: "string literal package name or reference to global variable"))
                         }
                     }
                 } else {
@@ -1496,8 +1794,8 @@ extension ManifestParseVisitor {
         // Parse the path argument (first unlabeled argument)
         guard let firstArg = arguments.first,
               firstArg.label == nil,
-              let path = firstArg.expression.asStringLiteralValue(in: contextModel) else {
-            limitations.append(.unsupportedExpression(expr, expected: "resource with path"))
+              let path = resolveStringLiteral(firstArg.expression) else {
+            limitations.append(.unsupportedExpression(expr, expected: "resource with path or reference to global variable"))
             return nil
         }
         
@@ -1570,7 +1868,11 @@ extension ManifestParseVisitor {
                 if label == "intent" {
                     intent = parsePluginCommandIntent(argument.expression)
                 } else if label == "permissions" {
-                    permissions = argument.expression.parseArrayElements(parsePluginPermission) ?? []
+                    permissions = resolveArray(
+                        argument.expression,
+                        expectedDescription: "array of plugin permissions or reference to global variable",
+                        elementParser: parsePluginPermission
+                    ) ?? []
                 } else {
                     limitations.append(.unsupportedArgument(argument, callee: "command"))
                 }
@@ -1616,9 +1918,9 @@ extension ManifestParseVisitor {
                 for argument in arguments {
                     let label = argument.label?.text
                     if label == "verb" {
-                        verb = argument.expression.asStringLiteralValue(in: contextModel)
+                        verb = resolveStringLiteral(argument.expression)
                     } else if label == "description" {
-                        description = argument.expression.asStringLiteralValue(in: contextModel)
+                        description = resolveStringLiteral(argument.expression)
                     } else {
                         limitations.append(.unsupportedArgument(argument, callee: "custom"))
                     }
@@ -1647,7 +1949,7 @@ extension ManifestParseVisitor {
         case "writeToPackageDirectory":
             for argument in arguments {
                 if argument.label?.text == "reason",
-                   let reason = argument.expression.asStringLiteralValue(in: contextModel) {
+                   let reason = resolveStringLiteral(argument.expression) {
                     return .writeToPackageDirectory(reason: reason)
                 } else {
                     limitations.append(.unsupportedArgument(argument, callee: "writeToPackageDirectory"))
@@ -1665,7 +1967,7 @@ extension ManifestParseVisitor {
                 if label == "scope" {
                     scope = parsePluginNetworkPermissionScope(argument.expression)
                 } else if label == "reason" {
-                    reason = argument.expression.asStringLiteralValue(in: contextModel)
+                    reason = resolveStringLiteral(argument.expression)
                 } else {
                     limitations.append(.unsupportedArgument(argument, callee: "allowNetworkConnections"))
                 }
@@ -1739,8 +2041,8 @@ extension ManifestParseVisitor {
     
     /// Parse a plugin usage like "PluginName", .plugin(name: "MyPlugin"), or .plugin(name: "MyPlugin", package: "MyPackage")
     private func parsePluginUsage(_ expr: ExprSyntax) -> TargetDescription.PluginUsage? {
-        // Case 1: String literal (e.g., "PluginName" - refers to plugin in same package)
-        if let pluginName = expr.asStringLiteralValue(in: contextModel) {
+        // Case 1: String literal (e.g., "PluginName" - refers to plugin in same package) or variable reference
+        if let pluginName = resolveStringLiteral(expr) {
             return .plugin(name: pluginName, package: nil)
         }
         
@@ -1759,9 +2061,9 @@ extension ManifestParseVisitor {
         for argument in functionCall.arguments {
             let label = argument.label?.text
             if label == "name" {
-                name = argument.expression.asStringLiteralValue(in: contextModel)
+                name = resolveStringLiteral(argument.expression)
             } else if label == "package" {
-                package = argument.expression.asStringLiteralValue(in: contextModel)
+                package = resolveStringLiteral(argument.expression)
             } else {
                 limitations.append(.unsupportedArgument(argument, callee: "plugin"))
             }
@@ -1807,9 +2109,11 @@ extension ManifestParseVisitor {
             let label = argument.label?.text
 
             if label == "name" {
-                name = argument.expression.asStringLiteralValue(in: contextModel)
+                name = resolveStringLiteral(argument.expression)
             } else if label == "targets" {
-                targets = argument.expression.asStringArray(in: contextModel) ?? []
+                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of target names or reference to global variable") {
+                    targets = parsed
+                }
             } else if label == "type" {
                 // Parse library type like .dynamic or .static
                 if let typeName = argument.expression.asEnumMember() {
@@ -1829,13 +2133,13 @@ extension ManifestParseVisitor {
                 // On non-Apple builds any unrecognized label is a limitation.
                 #if ENABLE_APPLE_PRODUCT_TYPES
                 if label == "bundleIdentifier" {
-                    bundleIdentifier = argument.expression.asStringLiteralValue(in: contextModel)
+                    bundleIdentifier = resolveStringLiteral(argument.expression)
                 } else if label == "teamIdentifier" {
-                    teamIdentifier = argument.expression.asStringLiteralValue(in: contextModel)
+                    teamIdentifier = resolveStringLiteral(argument.expression)
                 } else if label == "displayVersion" {
-                    displayVersion = argument.expression.asStringLiteralValue(in: contextModel)
+                    displayVersion = resolveStringLiteral(argument.expression)
                 } else if label == "bundleVersion" {
-                    bundleVersion = argument.expression.asStringLiteralValue(in: contextModel)
+                    bundleVersion = resolveStringLiteral(argument.expression)
                 } else if label == "appIcon" {
                     appIcon = parseAppIcon(argument.expression)
                 } else if label == "accentColor" {
@@ -1849,7 +2153,7 @@ extension ManifestParseVisitor {
                 } else if label == "appCategory" {
                     appCategory = parseAppCategory(argument.expression)
                 } else if label == "additionalInfoPlistContentFilePath" {
-                    additionalInfoPlistContentFilePath = argument.expression.asStringLiteralValue(in: contextModel)
+                    additionalInfoPlistContentFilePath = resolveStringLiteral(argument.expression)
                 } else {
                     limitations.append(.unsupportedArgument(argument, callee: methodName))
                 }
@@ -2001,7 +2305,8 @@ extension ManifestParseVisitor {
         
         switch methodName {
         case "asset":
-            if let name = arguments.first?.expression.asStringLiteralValue(in: contextModel) {
+            if let firstExpr = arguments.first?.expression,
+               let name = resolveStringLiteral(firstExpr) {
                 for argument in arguments.dropFirst() {
                     limitations.append(.unsupportedArgument(argument, callee: "asset"))
                 }
@@ -2032,7 +2337,8 @@ extension ManifestParseVisitor {
         
         switch methodName {
         case "asset":
-            if let name = arguments.first?.expression.asStringLiteralValue(in: contextModel) {
+            if let firstExpr = arguments.first?.expression,
+               let name = resolveStringLiteral(firstExpr) {
                 for argument in arguments.dropFirst() {
                     limitations.append(.unsupportedArgument(argument, callee: "asset"))
                 }
@@ -2186,9 +2492,9 @@ extension ManifestParseVisitor {
             let label = argument.label?.text
             
             if label == "purposeString" {
-                purposeString = argument.expression.asStringLiteralValue(in: contextModel)
+                purposeString = resolveStringLiteral(argument.expression)
             } else if label == "bonjourServiceTypes" {
-                bonjourServiceTypes = argument.expression.asStringArray(in: contextModel)
+                bonjourServiceTypes = resolveStringArray(argument.expression, expectedDescription: "array of Bonjour service types or reference to global variable")
             } else if label == nil {
                 // Unlabeled argument could be a condition
                 if let cond = parseDeviceFamilyCondition(argument.expression) {
@@ -2288,13 +2594,13 @@ extension ManifestParseVisitor {
             let label = argument.label?.text
 
             if label == "name" {
-                name = argument.expression.asStringLiteralValue(in: contextModel)
+                name = resolveStringLiteral(argument.expression)
             } else if label == "id" {
-                id = argument.expression.asStringLiteralValue(in: contextModel)
+                id = resolveStringLiteral(argument.expression)
             } else if label == "url" {
-                url = argument.expression.asStringLiteralValue(in: contextModel)
+                url = resolveStringLiteral(argument.expression)
             } else if label == "path" {
-                path = argument.expression.asStringLiteralValue(in: contextModel)
+                path = resolveStringLiteral(argument.expression)
             } else if label == "traits" {
                 traits = parseDependencyTraits(argument.expression)
             } else if label == "from" {
@@ -2309,11 +2615,11 @@ extension ManifestParseVisitor {
                     }
                 }
             } else if label == "branch" {
-                if let branch = argument.expression.asStringLiteralValue(in: contextModel) {
+                if let branch = resolveStringLiteral(argument.expression) {
                     requirement = .branch(branch)
                 }
             } else if label == "revision" {
-                if let revision = argument.expression.asStringLiteralValue(in: contextModel) {
+                if let revision = resolveStringLiteral(argument.expression) {
                     requirement = .revision(revision)
                 }
             } else if label == "exact" {
@@ -2371,60 +2677,6 @@ extension ManifestParseVisitor {
                         }
                     } else {
                         limitations.append(.unsupportedExpression(argument.expression, expected: "version range operator (..<  or ...)"))
-                    }
-                } else if let rangeExpr = argument.expression.as(SequenceExprSyntax.self) {
-                    // Fallback: Check for range operators in SequenceExprSyntax (for older syntax trees)
-                    // Look for range operators like ..< or ...
-                    var lowerBound: Version?
-                    var upperBound: Version?
-                    var isClosedRange = false
-
-                    for element in rangeExpr.elements {
-                        if let stringLiteral = element.asStringLiteralValue(),
-                           let version = Version(stringLiteral) {
-                            if lowerBound == nil {
-                                lowerBound = version
-                            } else {
-                                upperBound = version
-                            }
-                        } else if let binaryOp = element.as(BinaryOperatorExprSyntax.self) {
-                            let opText = binaryOp.operator.text.trimmingCharacters(in: .whitespaces)
-                            if opText == "..." {
-                                isClosedRange = true
-                            }
-                        } else {
-                            // Check if this element is just the operator token
-                            let elementText = element.description.trimmingCharacters(in: .whitespaces)
-                            if elementText == "..." {
-                                isClosedRange = true
-                            }
-                        }
-                    }
-
-                    if let lower = lowerBound, let upper = upperBound {
-                        if isClosedRange {
-                            // Convert closed range to open range by using next patch version
-                            let upperNext = Version(
-                                upper.major,
-                                upper.minor,
-                                upper.patch + 1,
-                                prereleaseIdentifiers: upper.prereleaseIdentifiers,
-                                buildMetadataIdentifiers: upper.buildMetadataIdentifiers
-                            )
-                            if id != nil {
-                                registryRequirement = .range(lower..<upperNext)
-                            } else {
-                                requirement = .range(lower..<upperNext)
-                            }
-                        } else {
-                            if id != nil {
-                                registryRequirement = .range(lower..<upper)
-                            } else {
-                                requirement = .range(lower..<upper)
-                            }
-                        }
-                    } else {
-                        limitations.append(.unsupportedExpression(argument.expression, expected: "version range with two bounds"))
                     }
                 } else if let reqExpr = argument.expression.as(FunctionCallExprSyntax.self),
                    let reqMemberAccess = reqExpr.calledExpression.as(MemberAccessExprSyntax.self),
@@ -2568,9 +2820,9 @@ extension ManifestParseVisitor {
             for argument in arguments {
                 let label = argument.label?.text
                 if label == nil {
-                    customName = argument.expression.asStringLiteralValue()
+                    customName = resolveStringLiteral(argument.expression)
                 } else if label == "versionString" {
-                    versionString = argument.expression.asStringLiteralValue()
+                    versionString = resolveStringLiteral(argument.expression)
                 } else {
                     limitations.append(.unsupportedArgument(argument, callee: "custom"))
                 }
@@ -2600,7 +2852,7 @@ extension ManifestParseVisitor {
         var options: [String] = []
         
         // Check if it's a string literal like "10.13.option1.option2"
-        if let versionString = firstArg.expression.asStringLiteralValue() {
+        if let versionString = resolveStringLiteral(firstArg.expression) {
             // Parse version and options from the string
             let components = versionString.split(separator: ".")
             if components.isEmpty {
@@ -2654,8 +2906,8 @@ extension ManifestParseVisitor {
     
     /// Parse a trait declaration like "Trait1", Trait(name: "Trait2", description: "..."), or .trait(name: "Trait3", enabledTraits: [...])
     private func parseTrait(_ expr: ExprSyntax) -> TraitDescription? {
-        // Case 1: String literal "TraitName"
-        if let traitName = expr.asStringLiteralValue(in: contextModel) {
+        // Case 1: String literal "TraitName" or variable reference
+        if let traitName = resolveStringLiteral(expr) {
             return TraitDescription(name: traitName)
         }
         
@@ -2688,10 +2940,8 @@ extension ManifestParseVisitor {
 
             for argument in functionCall.arguments {
                 if argument.label?.text == "enabledTraits" {
-                    if let parsed = argument.expression.asStringArray(in: contextModel) {
+                    if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of enabled trait names or reference to global variable") {
                         enabledTraits = parsed
-                    } else {
-                        limitations.append(.unsupportedExpression(argument.expression, expected: "array of enabled trait names"))
                     }
                 } else {
                     limitations.append(.unsupportedArgument(argument, callee: "default"))
@@ -2713,14 +2963,12 @@ extension ManifestParseVisitor {
         for argument in functionCall.arguments {
             let label = argument.label?.text
             if label == "name" {
-                name = argument.expression.asStringLiteralValue(in: contextModel)
+                name = resolveStringLiteral(argument.expression)
             } else if label == "description" {
-                description = argument.expression.asStringLiteralValue(in: contextModel)
+                description = resolveStringLiteral(argument.expression)
             } else if label == "enabledTraits" {
-                if let parsed = argument.expression.asStringArray(in: contextModel) {
+                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of enabled trait names or reference to global variable") {
                     enabledTraits = parsed
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of enabled trait names"))
                 }
             } else {
                 limitations.append(.unsupportedArgument(argument, callee: "trait"))
@@ -2737,26 +2985,17 @@ extension ManifestParseVisitor {
     
     /// Parse dependency traits array like ["FooTrait1", .trait(name: "FooTrait2", condition: ...), .defaults]
     private func parseDependencyTraits(_ expr: ExprSyntax) -> [PackageDependency.Trait]? {
-        guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
-            limitations.append(.unsupportedExpression(expr, expected: "array of dependency traits"))
-            return nil
-        }
-        
-        var traits: [PackageDependency.Trait] = []
-        
-        for traitElement in arrayExpr.elements {
-            if let trait = parseDependencyTrait(traitElement.expression) {
-                traits.append(trait)
-            }
-        }
-        
-        return traits.isEmpty ? nil : traits
+        return resolveArray(
+            expr,
+            expectedDescription: "array of dependency traits or reference to global variable",
+            elementParser: parseDependencyTrait
+        )
     }
     
     /// Parse a single dependency trait like "FooTrait1", .trait(name: "...", condition: ...), or .defaults
     private func parseDependencyTrait(_ expr: ExprSyntax) -> PackageDependency.Trait? {
-        // Case 1: String literal "TraitName"
-        if let traitName = expr.asStringLiteralValue(in: contextModel) {
+        // Case 1: String literal "TraitName" or variable reference
+        if let traitName = resolveStringLiteral(expr) {
             return PackageDependency.Trait(name: traitName)
         }
         
@@ -2800,7 +3039,7 @@ extension ManifestParseVisitor {
         for argument in functionCall.arguments {
             let label = argument.label?.text
             if label == "name" {
-                name = argument.expression.asStringLiteralValue(in: contextModel)
+                name = resolveStringLiteral(argument.expression)
             } else if label == "condition" {
                 condition = parseDependencyTraitCondition(argument.expression)
             } else {
@@ -2828,10 +3067,8 @@ extension ManifestParseVisitor {
         
         for argument in arguments {
             if argument.label?.text == "traits" {
-                if let parsed = argument.expression.asStringArray(in: contextModel) {
+                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of trait names or reference to global variable") {
                     traits = parsed
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of trait names"))
                 }
             } else {
                 limitations.append(.unsupportedArgument(argument, callee: "when"))
@@ -2908,208 +3145,6 @@ extension ExprSyntax {
         }
 
         return stringLiteral.representedLiteralValue
-    }
-
-    /// Evaluate a string literal that may contain Context interpolations, or a direct Context expression.
-    /// Returns the evaluated string, or nil if it cannot be evaluated.
-    fileprivate func asStringLiteralValue(in contextModel: StaticContextModel) -> String? {
-        // First, try to evaluate as a direct Context expression (e.g., Context.packageDirectory)
-        if let value = self.evaluateContextExpression(contextModel: contextModel) {
-            return value
-        }
-
-        // Otherwise, try to parse as a string literal
-        guard let stringLiteral = self.as(StringLiteralExprSyntax.self) else {
-            return nil
-        }
-
-        // Simple case: no interpolation — use representedLiteralValue to correctly handle
-        // escape sequences (e.g. \" in a C preprocessor define value becomes ").
-        if let value = stringLiteral.representedLiteralValue {
-            return value
-        }
-
-        // Complex case: handle interpolations with Context values
-        var result = ""
-        for segment in stringLiteral.segments {
-            switch segment {
-            case .stringSegment(let contents):
-                result += contents.content.text
-
-            case .expressionSegment(let exprSegment):
-                // Try to evaluate the interpolated expression
-                if let value = exprSegment.expressions.first?.expression.evaluateContextExpression(contextModel: contextModel) {
-                    result += value
-                } else {
-                    // Cannot evaluate this interpolation
-                    return nil
-                }
-            }
-        }
-
-        return result
-    }
-    
-    /// Evaluate a Context expression like Context.gitInformation?.currentTag or Context.environment["KEY"]
-    /// Returns the string representation of the value, or nil if it cannot be evaluated.
-    fileprivate func evaluateContextExpression(contextModel: StaticContextModel) -> String? {
-        var expr: ExprSyntax = self
-        var nilCoalescingDefault: String? = nil
-
-        // Handle nil-coalescing operator (??)
-        if let infixExpr = expr.as(InfixOperatorExprSyntax.self),
-           let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self),
-           op.operator.text.trimmingCharacters(in: .whitespaces) == "??" {
-            // Get the default value from the right side
-            if let rightValue = infixExpr.rightOperand.asStringLiteralValue() {
-                nilCoalescingDefault = rightValue
-            }
-            // Continue evaluating the left side
-            expr = infixExpr.leftOperand
-        }
-        
-        // Handle boolean comparison (== true)
-        if let infixExpr = expr.as(InfixOperatorExprSyntax.self),
-           let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self),
-           op.operator.text.trimmingCharacters(in: .whitespaces) == "==" {
-            // Check if right side is 'true'
-            if let boolLit = infixExpr.rightOperand.as(BooleanLiteralExprSyntax.self),
-               boolLit.literal.tokenKind == .keyword(.true) {
-                expr = infixExpr.leftOperand
-            }
-        }
-        
-        // Check for subscript access (e.g., Context.environment["KEY"])
-        if let subscriptExpr = expr.as(SubscriptCallExprSyntax.self) {
-            // Parse the base expression (e.g., Context.environment)
-            var baseParts: [String] = []
-            var currentExpr = subscriptExpr.calledExpression
-            
-            // Walk through the member access chain
-            while true {
-                if let memberAccess = currentExpr.as(MemberAccessExprSyntax.self) {
-                    baseParts.insert(memberAccess.declName.baseName.text, at: 0)
-                    if let base = memberAccess.base {
-                        currentExpr = base
-                    } else {
-                        break
-                    }
-                } else if let declRef = currentExpr.as(DeclReferenceExprSyntax.self) {
-                    baseParts.insert(declRef.baseName.text, at: 0)
-                    break
-                } else {
-                    return nil
-                }
-            }
-            
-            // Check if it's Context.environment
-            if baseParts.count == 2 && baseParts[0] == "Context" && baseParts[1] == "environment" {
-                // Get the subscript key
-                if let firstArg = subscriptExpr.arguments.first,
-                   let keyString = firstArg.expression.asStringLiteralValue() {
-                    // Look up the environment variable
-                    if let value = contextModel.environment[keyString] {
-                        return value
-                    } else {
-                        return nilCoalescingDefault
-                    }
-                }
-            }
-            
-            return nil
-        }
-        
-        // Now parse the member access chain
-        // Expected patterns:
-        // - Context.packageDirectory
-        // - Context.gitInformation?.currentTag
-        // - Context.gitInformation?.currentCommit
-        // - Context.gitInformation?.hasUncommittedChanges
-        
-        // Extract all parts of the member access chain
-        var parts: [String] = []
-        var currentExpr = expr
-        
-        // Walk backwards through the member access chain
-        while true {
-            if let sequence = currentExpr.as(SequenceExprSyntax.self) {
-                // A sequence expression can contain optional chaining
-                // For "Context.gitInformation?.currentTag", this will be a sequence
-                // We need to extract the meaningful parts
-                
-                // For optional chaining, the sequence contains: base, postfixOperator(?), member access
-                // Let's try to parse it differently - just take the first element if it's what we need
-                if let firstElement = sequence.elements.first {
-                    currentExpr = firstElement
-                    continue
-                } else {
-                    return nil
-                }
-            } else if let memberAccess = currentExpr.as(MemberAccessExprSyntax.self) {
-                // Add the member name
-                parts.insert(memberAccess.declName.baseName.text, at: 0)
-                
-                if let base = memberAccess.base {
-                    currentExpr = base
-                } else {
-                    // No more base, we're done
-                    break
-                }
-            } else if let optChain = currentExpr.as(OptionalChainingExprSyntax.self) {
-                // Skip the optional chaining wrapper and continue
-                currentExpr = optChain.expression
-            } else if let postfixUnary = currentExpr.as(PostfixUnaryExprSyntax.self) {
-                // This handles the ? in optional chaining
-                currentExpr = postfixUnary.expression
-            } else if let declRef = currentExpr.as(DeclReferenceExprSyntax.self) {
-                // This is the base identifier (e.g., "Context")
-                parts.insert(declRef.baseName.text, at: 0)
-                break
-            } else {
-                // Unknown expression structure
-                return nil
-            }
-        }
-        
-        // Now evaluate based on the parts
-        guard parts.count >= 2 && parts[0] == "Context" else {
-            return nil
-        }
-        
-        switch parts[1] {
-        case "packageDirectory":
-            return contextModel.packageDirectory
-            
-        case "gitInformation":
-            guard parts.count >= 3 else {
-                return nil
-            }
-            guard let gitInfo = contextModel.gitInformation else {
-                return nilCoalescingDefault
-            }
-            
-            switch parts[2] {
-            case "currentTag":
-                if let tag = gitInfo.currentTag {
-                    return tag
-                } else {
-                    return nilCoalescingDefault ?? ""
-                }
-                
-            case "currentCommit":
-                return gitInfo.currentCommit
-                
-            case "hasUncommittedChanges":
-                let value = gitInfo.hasUncommittedChanges
-                return value ? "true" : "false"
-                
-            default:
-                return nil
-            }
-            
-        default:
-            return nil
-        }
     }
 
     /// Extract the boolean literal value from the expression, if it is one.
@@ -3208,29 +3243,6 @@ extension ExprSyntax {
         return (methodName, functionCall.arguments)
     }
 
-    /// Parse array elements using a transform function.
-    /// Returns array of successfully transformed elements, or nil if expression is not an array.
-    fileprivate func parseArrayElements<T>(_ transform: (ExprSyntax) -> T?) -> [T]? {
-        guard let arrayExpr = self.as(ArrayExprSyntax.self) else {
-            return nil
-        }
-
-        var result: [T] = []
-        for element in arrayExpr.elements {
-            if let value = transform(element.expression) {
-                result.append(value)
-            }
-        }
-        return result
-    }
-
-    /// Parse an array of string literals.
-    fileprivate func asStringArray(in contextModel: StaticContextModel) -> [String]? {
-        return parseArrayElements {
-            $0.asStringLiteralValue(in: contextModel)
-        }
-    }
-
     /// Parse an enum member access (e.g., `.static`, `.dynamic`).
     /// Returns the member name if it's a simple member access with no base.
     fileprivate func asEnumMember() -> String? {
@@ -3240,27 +3252,6 @@ extension ExprSyntax {
             return nil
         }
         return memberName
-    }
-
-    /// Parse a platform name as used in a `.when(platforms: [...])` condition.
-    /// Handles both plain enum members (e.g. `.linux`) and custom platforms
-    /// (e.g. `.custom("freebsd")`).
-    fileprivate func asPlatformConditionName() -> String? {
-        if let name = self.asEnumMember() {
-            return name
-        }
-
-        // Handle .custom("platformName")
-        guard let functionCall = self.as(FunctionCallExprSyntax.self),
-              let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
-              memberAccess.base == nil,
-              memberAccess.declName.baseName.identifier?.name == "custom",
-              let firstArg = functionCall.arguments.first,
-              firstArg.label == nil,
-              let customName = firstArg.expression.asStringLiteralValue() else {
-            return nil
-        }
-        return customName
     }
 }
 

--- a/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestParsing/ParsingManifestLoader.swift
@@ -278,8 +278,8 @@ public final class ParsingManifestLoader: ManifestLoaderProtocol {
         // package root. In that case we synthesize a system library target and
         // an automatic library product that wraps it, carrying over the
         // package-level pkgConfig and providers.
-        var products = visitor.products
-        var targets = visitor.targets
+        var products = visitor.products ?? []
+        var targets = visitor.targets ?? []
         if products.isEmpty, targets.isEmpty,
             fileSystem.isFile(manifestPath.parentDirectory.appending(component: moduleMapFilename)) {
             // These initializers only throw for invalid argument combinations.
@@ -307,7 +307,7 @@ public final class ParsingManifestLoader: ManifestLoaderProtocol {
             packageKind: packageKind,
             packageLocation: packageLocation,
             defaultLocalization: visitor.defaultLocalization,
-            platforms: visitor.platforms,
+            platforms: visitor.platforms ?? [],
             version: packageVersion?.version,
             revision: packageVersion?.revision,
             toolsVersion: manifestToolsVersion,
@@ -316,10 +316,10 @@ public final class ParsingManifestLoader: ManifestLoaderProtocol {
             cLanguageStandard: visitor.cLanguageStandard,
             cxxLanguageStandard: visitor.cxxLanguageStandard,
             swiftLanguageVersions: visitor.swiftLanguageVersions,
-            dependencies: visitor.dependencies,
+            dependencies: visitor.dependencies ?? [],
             products: products,
             targets: targets,
-            traits: Set(visitor.traits),
+            traits: Set(visitor.traits ?? []),
             pruneDependencies: self.pruneDependencies
         )
     }
@@ -349,10 +349,10 @@ class ManifestParseVisitor: ActiveSyntaxAnyVisitor {
     var defaultLocalization: String?
 
     /// Platforms.
-    var platforms: [PlatformDescription] = []
+    var platforms: [PlatformDescription]?
 
     /// Targets
-    var targets: [TargetDescription] = []
+    var targets: [TargetDescription]?
 
     var pkgConfig: String?
 
@@ -360,17 +360,16 @@ class ManifestParseVisitor: ActiveSyntaxAnyVisitor {
     var swiftLanguageVersions: [SwiftLanguageVersion]?
 
     /// Package dependencies.
-    ///
-    var dependencies: [PackageDependency] = []
+    var dependencies: [PackageDependency]?
 
     /// System package providers.
     var providers: [SystemPackageProviderDescription]?
 
     /// Products.
-    var products: [ProductDescription] = []
+    var products: [ProductDescription]?
 
     /// Traits.
-    var traits: [TraitDescription] = []
+    var traits: [TraitDescription]?
 
     /// C++ language standard.
     var cxxLanguageStandard: String?
@@ -484,66 +483,138 @@ class ManifestParseVisitor: ActiveSyntaxAnyVisitor {
 
 /// MARK: Handling arrays and variable resolution
 extension ManifestParseVisitor {
+    /// An error that can occur when resolving an expression to a value.
+    enum ResolutionError: Error {
+        case unhandledExpression(ExprSyntax)
+        case missingValue(ExprSyntax, description: String)
+
+        var nearestExpr: ExprSyntax {
+            switch self {
+            case .unhandledExpression(let expr):
+                return expr
+            case .missingValue(let expr, description: _):
+                return expr
+            }
+        }
+    }
+
+    /// Attempt to resolve the given expression using the given matching function,
+    /// writing the resulting value into `result` if it succeeds and recording
+    /// a limitation if it fails.
+    ///
+    /// \returns true on success, false (and records a limitation) on failure
+    @discardableResult
+    private func resolve<T>(_ expr: ExprSyntax, description: String, into result: inout T?, matcher: (ExprSyntax) throws(ResolutionError) -> T) -> Bool {
+        do {
+            result = try matcher(expr)
+            return true
+        } catch {
+            limitations.append(.unsupportedExpression(error.nearestExpr, expected: description))
+        }
+        return false
+    }
+
+    /// Atempt to resolve the given expression for an arbitrary type that conforms
+    /// to ParsingResolvable. The result is written into result on success, and a
+    /// limitation is reported on failure.
+    @discardableResult
+    private func resolve<T: ParsingResolvable>(_ expr: ExprSyntax, description: String, into result: inout T?) -> Bool {
+        resolve(expr, description: description, into: &result) { expr throws(ResolutionError) in
+            try T.resolve(expr, in: self)
+        }
+    }
+
+    /// Attempt to resolve the given expression using the given matching function,
+    /// where the matcher may return nil to indicate no value (as opposed to an error).
+    /// The result is written into `result` if non-nil; a limitation is recorded on error.
+    @discardableResult
+    private func resolve<T>(_ expr: ExprSyntax, description: String, into result: inout T?, matcher: (ExprSyntax) throws(ResolutionError) -> T?) -> Bool {
+        do {
+            result = try matcher(expr)
+            return true
+        } catch {
+            limitations.append(.unsupportedExpression(error.nearestExpr, expected: description))
+        }
+        return false
+    }
+
+    /// Attempt to resolve the given expression as an array and append to the given array.
+    /// Records a limitation if resolution fails.
+    ///
+    /// \returns true on success, false (and records a limitation) on failure
+    @discardableResult
+    private func resolve<T>(_ expr: ExprSyntax, description: String, appendingInto result: inout [T], matcher: (ExprSyntax) throws(ResolutionError) -> T) -> Bool {
+        var temp: [T]?
+        let ok = resolve(expr, description: description, into: &temp) { expr throws(ResolutionError) in
+            try resolveArray(expr, elementParser: matcher)
+        }
+        if let temp { result.append(contentsOf: temp) }
+        return ok
+    }
+
+    /// Attempt to resolve the given expression as an array and append to the given array.
+    /// Records a limitation if resolution fails.
+    ///
+    /// \returns true on success, false (and records a limitation) on failure
+    @discardableResult
+    private func resolve<T: ParsingResolvable>(_ expr: ExprSyntax, description: String, appendingInto result: inout [T]) -> Bool {
+        return resolve(expr, description: description, appendingInto: &result) { expr throws(ResolutionError) in
+            try T.resolve(expr, in: self)
+        }
+    }
+
     /// Resolve a string literal expression with support for global variable references and interpolations
     /// - Parameters:
     ///   - expr: The expression to parse (could be a string literal, variable reference, or Context expression)
-    /// - Returns: The resolved string value, or nil if it cannot be resolved
-    private func resolveStringLiteral(_ expr: ExprSyntax) -> String? {
-        // Case 1: Variable reference - resolve and recurse
+    /// - Returns: The resolved string value
+    /// - Throws: ResolutionError with the narrowest expression that could not be handled, on failure.
+    fileprivate func resolveStringLiteral(_ expr: ExprSyntax) throws(ResolutionError) -> String {
+        // Case 1: String literal (possibly with interpolations)
+        if let stringLiteral = expr.as(StringLiteralExprSyntax.self) {
+            // Simple case: no interpolation — use representedLiteralValue to correctly handle
+            // escape sequences (e.g. \" in a C preprocessor define value becomes ").
+            if let value = stringLiteral.representedLiteralValue {
+                return value
+            }
+
+            // Complex case: handle interpolations with Context values and global variables
+            var result = ""
+            for segment in stringLiteral.segments {
+                switch segment {
+                case .stringSegment(let contents):
+                    // For string segments.
+                    result += contents.content.text
+
+                case .expressionSegment(let exprSegment):
+                    // Try to evaluate the interpolated expression
+                    guard let interpolatedExpr = exprSegment.expressions.first?.expression, exprSegment.expressions.count == 1 else {
+                        throw .unhandledExpression(expr)
+                    }
+
+                    // Recursively resolve the interpolated expression
+                    // This allows variable references, Context expressions, etc.
+                    result += try resolveStringLiteral(interpolatedExpr)
+                }
+            }
+
+            return result
+        }
+
+        // Case 2: Variable reference - resolve and recurse
         if let varRef = expr.as(DeclReferenceExprSyntax.self),
            let varName = varRef.baseName.identifier?.name,
            let value = globalVariables[varName] {
             // Recursively resolve the variable's value
-            return resolveStringLiteral(value)
+            return try resolveStringLiteral(value)
         }
         
-        // Case 2: Direct Context expression (e.g., Context.packageDirectory)
-        if let value = evaluateContextExpression(expr) {
-            return value
-        }
-        
-        // Case 3: String literal (possibly with interpolations)
-        guard let stringLiteral = expr.as(StringLiteralExprSyntax.self) else {
-            return nil
-        }
-
-        // Simple case: no interpolation — use representedLiteralValue to correctly handle
-        // escape sequences (e.g. \" in a C preprocessor define value becomes ").
-        if let value = stringLiteral.representedLiteralValue {
-            return value
-        }
-
-        // Complex case: handle interpolations with Context values and global variables
-        var result = ""
-        for segment in stringLiteral.segments {
-            switch segment {
-            case .stringSegment(let contents):
-                // For string segments.
-                result += contents.content.text
-
-            case .expressionSegment(let exprSegment):
-                // Try to evaluate the interpolated expression
-                guard let interpolatedExpr = exprSegment.expressions.first?.expression, exprSegment.expressions.count == 1 else {
-                    return nil
-                }
-                
-                // Recursively resolve the interpolated expression
-                // This allows variable references, Context expressions, etc.
-                if let value = resolveStringLiteral(interpolatedExpr) {
-                    result += value
-                } else {
-                    // Cannot evaluate this interpolation
-                    return nil
-                }
-            }
-        }
-
-        return result
+        // Case 3: Direct Context expression (e.g., Context.packageDirectory)
+        return try evaluateContextExpression(expr)
     }
-    
+
     /// Evaluate a Context expression like Context.gitInformation?.currentTag or Context.environment["KEY"]
-    /// Returns the string representation of the value, or nil if it cannot be evaluated.
-    private func evaluateContextExpression(_ expr: ExprSyntax) -> String? {
+    /// Returns the string representation of the value, or throws an error if something cannot be evaluated.
+    private func evaluateContextExpression(_ expr: ExprSyntax) throws(ResolutionError) -> String {
         var currentExpr: ExprSyntax = expr
         var nilCoalescingDefault: String? = nil
 
@@ -552,9 +623,8 @@ extension ManifestParseVisitor {
            let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self),
            op.operator.text.trimmingCharacters(in: .whitespaces) == "??" {
             // Get the default value from the right side
-            if let rightValue = resolveStringLiteral(infixExpr.rightOperand) {
-                nilCoalescingDefault = rightValue
-            }
+            nilCoalescingDefault = try resolveStringLiteral(infixExpr.rightOperand)
+
             // Continue evaluating the left side
             currentExpr = infixExpr.leftOperand
         }
@@ -567,6 +637,8 @@ extension ManifestParseVisitor {
             if let boolLit = infixExpr.rightOperand.as(BooleanLiteralExprSyntax.self),
                boolLit.literal.tokenKind == .keyword(.true) {
                 currentExpr = infixExpr.leftOperand
+            } else {
+                throw .unhandledExpression(infixExpr.rightOperand)
             }
         }
         
@@ -589,25 +661,26 @@ extension ManifestParseVisitor {
                     baseParts.insert(declRef.baseName.text, at: 0)
                     break
                 } else {
-                    return nil
+                    throw .unhandledExpression(baseExpr)
                 }
             }
             
             // Check if it's Context.environment
             if baseParts.count == 2 && baseParts[0] == "Context" && baseParts[1] == "environment" {
                 // Get the subscript key
-                if let firstArg = subscriptExpr.arguments.first,
-                   let keyString = resolveStringLiteral(firstArg.expression) {
-                    // Look up the environment variable
+                if let firstArg = subscriptExpr.arguments.first {
+                   let keyString = try resolveStringLiteral(firstArg.expression)
                     if let value = contextModel.environment[keyString] {
                         return value
-                    } else {
+                    } else if let nilCoalescingDefault {
                         return nilCoalescingDefault
+                    } else {
+                        throw .unhandledExpression(firstArg.expression)
                     }
                 }
             }
             
-            return nil
+            throw .unhandledExpression(currentExpr)
         }
         
         // Now parse the member access chain
@@ -644,13 +717,13 @@ extension ManifestParseVisitor {
                 break
             } else {
                 // Unknown expression structure
-                return nil
+                throw .unhandledExpression(currentExpr)
             }
         }
         
         // Now evaluate based on the parts
         guard parts.count >= 2 && parts[0] == "Context" else {
-            return nil
+            throw .unhandledExpression(expr)
         }
         
         switch parts[1] {
@@ -659,20 +732,26 @@ extension ManifestParseVisitor {
             
         case "gitInformation":
             guard parts.count >= 3 else {
-                return nil
+                throw .unhandledExpression(expr)
             }
             guard let gitInfo = contextModel.gitInformation else {
-                return nilCoalescingDefault
+                if let nilCoalescingDefault {
+                    return nilCoalescingDefault
+                } else {
+                    throw .unhandledExpression(expr)
+                }
             }
             
             switch parts[2] {
             case "currentTag":
                 if let tag = gitInfo.currentTag {
                     return tag
+                } else if let nilCoalescingDefault {
+                    return nilCoalescingDefault
                 } else {
-                    return nilCoalescingDefault ?? ""
+                    throw .unhandledExpression(expr)
                 }
-                
+
             case "currentCommit":
                 return gitInfo.currentCommit
                 
@@ -681,55 +760,36 @@ extension ManifestParseVisitor {
                 return value ? "true" : "false"
                 
             default:
-                return nil
+                throw .unhandledExpression(expr)
             }
             
         default:
-            return nil
-        }
-    }
-    
-    /// Resolve a string array expression with support for global variable references and concatenation
-    /// - Parameters:
-    ///   - expr: The expression to parse (could be an array literal, variable reference, or concatenation)
-    ///   - expectedDescription: Description of what's expected for error messages
-    /// - Returns: The resolved array of strings, or nil if it cannot be resolved
-    private func resolveStringArray(_ expr: ExprSyntax, expectedDescription: String) -> [String]? {
-        return resolveArray(
-            expr,
-            expectedDescription: expectedDescription
-        ) { element in
-            resolveStringLiteral(element)
+            throw .unhandledExpression(expr)
         }
     }
     
     /// Parse an array expression with full support for variable resolution, concatenation, and element parsing
     /// - Parameters:
     ///   - expr: The expression to parse (could be an array literal, variable reference, or array concatenation)
-    ///   - originalExpr: The original unresolved expression (used for error reporting)
-    ///   - expectedDescription: Description of what's expected for error messages
     ///   - elementParser: Closure that parses individual array elements
-    /// - Returns: Array of parsed elements, or nil if parsing failed
+    /// - Returns: Array of parsed elements
+    /// - Throws: ResolutionError if something could not be parsed.
     ///
     /// This function recursively handles:
     /// - Variable references (e.g., `myArray`)
     /// - Array concatenation (e.g., `array1 + array2`)
     /// - Nested combinations (e.g., `var1 + var2 + [.item3]`)
-    private func resolveArray<T>(
+    fileprivate func resolveArray<T>(
         _ expr: ExprSyntax,
-        originalExpr: ExprSyntax? = nil,
-        expectedDescription: String,
-        elementParser: (ExprSyntax) -> T?
-    ) -> [T]? {
+        elementParser: (ExprSyntax) throws(ResolutionError) -> T
+    ) throws(ResolutionError) -> [T] {
         // Case 1: Variable reference - resolve and recurse
         if let varRef = expr.as(DeclReferenceExprSyntax.self),
            let varName = varRef.baseName.identifier?.name,
            let value = globalVariables[varName] {
             // Recursively resolve and parse the variable's value
-            return resolveArray(
+            return try resolveArray(
                 value,
-                originalExpr: originalExpr,
-                expectedDescription: expectedDescription,
                 elementParser: elementParser
             )
         }
@@ -740,23 +800,15 @@ extension ManifestParseVisitor {
            op.operator.text.trimmingCharacters(in: .whitespaces) == "+" {
             
             // Recursively resolve and parse both operands
-            guard let leftElements = resolveArray(
+            let leftElements = try resolveArray(
                 infixExpr.leftOperand,
-                originalExpr: originalExpr,
-                expectedDescription: expectedDescription,
                 elementParser: elementParser
-            ) else {
-                return nil
-            }
-            
-            guard let rightElements = resolveArray(
+            )
+
+            let rightElements = try resolveArray(
                 infixExpr.rightOperand,
-                originalExpr: originalExpr,
-                expectedDescription: expectedDescription,
                 elementParser: elementParser
-            ) else {
-                return nil
-            }
+            )
             
             // Combine the parsed elements from both sides
             return leftElements + rightElements
@@ -764,13 +816,7 @@ extension ManifestParseVisitor {
         
         // Case 3: Array literal - parse its elements directly
         guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
-            limitations.append(
-                .unsupportedExpression(
-                    originalExpr ?? expr,
-                    expected: expectedDescription
-                )
-            )
-            return nil
+            throw .unhandledExpression(expr)
         }
         
         // Parse each element in the array
@@ -783,21 +829,19 @@ extension ManifestParseVisitor {
                 elementExpr = value
             }
 
-            if let parsed = elementParser(elementExpr) {
-                results.append(parsed)
-            }
+            results.append(try elementParser(elementExpr))
         }
         
         return results
     }
-    
+
     /// Parse a platform name as used in a `.when(platforms: [...])` condition.
     /// Handles both plain enum members (e.g. `.linux`) and custom platforms
     /// (e.g. `.custom("freebsd")`).
     /// - Parameters:
     ///   - expr: The expression to parse
-    /// - Returns: The platform name, or nil if it cannot be parsed
-    private func parsePlatformConditionName(_ expr: ExprSyntax) -> String? {
+    /// - Returns: The platform name
+    private func parsePlatformConditionName(_ expr: ExprSyntax) throws (ResolutionError) -> String {
         if let name = expr.asEnumMember() {
             return name
         }
@@ -809,197 +853,118 @@ extension ManifestParseVisitor {
               memberAccess.declName.baseName.identifier?.name == "custom",
               let firstArg = functionCall.arguments.first,
               firstArg.label == nil else {
-            return nil
+            throw .unhandledExpression(expr)
         }
         
-        return resolveStringLiteral(firstArg.expression)
+        return try resolveStringLiteral(firstArg.expression)
     }
 }
 
 /// MARK: Declaration handling
 extension ManifestParseVisitor {
+    private func parseSwiftLanguageVersions(_ expr: ExprSyntax) throws(ResolutionError) -> [SwiftLanguageVersion] {
+        // Try new-style syntax first (e.g., [.v3, .v4, .version("5")])
+        if let versions = expr.asSwiftLanguageVersionArray() {
+            return versions
+        }
+
+        // Fall back to old-style integer array syntax (e.g., [3, 4])
+        guard let intVersions = expr.asIntegerArray() else {
+            throw .unhandledExpression(expr)
+        }
+
+        // Convert integers to SwiftLanguageVersion with validation
+        // Note: Even if the array is empty, we set it to an empty array (not nil)
+        // to distinguish from the case where swiftLanguageVersions wasn't specified
+        var validatedVersions: [SwiftLanguageVersion] = []
+        var hasValidationError = false
+        for (index, version) in intVersions.enumerated() {
+            let versionString = "\(version)"
+            guard let swiftVersion = SwiftLanguageVersion(string: versionString) else {
+                hasValidationError = true
+                // Get the actual syntax element for better error reporting
+                if let arrayExpr = expr.as(ArrayExprSyntax.self),
+                   index < arrayExpr.elements.count {
+                    let element = arrayExpr.elements[arrayExpr.elements.index(arrayExpr.elements.startIndex, offsetBy: index)]
+                    limitations.append(.invalidSwiftLanguageVersion(element.expression, value: versionString))
+                }
+                continue
+            }
+            validatedVersions.append(swiftVersion)
+        }
+
+        // Only set if we successfully validated all versions
+        if hasValidationError {
+            throw .unhandledExpression(expr)
+        }
+
+        return validatedVersions
+    }
+
     func handlePackageDeclaration(
         initializer: ExprSyntax,
         arguments: LabeledExprListSyntax
     ) {
         for argument in arguments {
-            if argument.label?.text == "name" {
-                if let name = resolveStringLiteral(argument.expression) {
-                    // Record the package name.
-                    self.packageName = name
-                } else {
-                    limitations.append(
-                        .unsupportedExpression(
-                            argument.expression,
-                            expected: "string literal or reference to global variable"
-                        )
-                    )
-                }
-                continue
-            }
-            
-            if argument.label?.text == "dependencies" {
-                if let deps = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of package dependencies or reference to global variable"
-                ) { expr in
-                    parsePackageDependency(expr, manifestPath: manifestPath)
-                } {
-                    self.dependencies.append(contentsOf: deps)
-                }
-                continue
-            }
+            switch argument.label?.text {
+            case "name":
+                resolve(argument.expression, description: "package name", into: &self.packageName)
+
+            case "dependencies":
+                resolve(argument.expression, description: "array of package dependencies", into: &self.dependencies)
 
             // Accept both swiftLanguageVersions (deprecated) and swiftLanguageModes (6.0+)
-            if argument.label?.text == "swiftLanguageVersions" || argument.label?.text == "swiftLanguageModes" {
-                // Try new-style syntax first (e.g., [.v3, .v4, .version("5")])
-                if let versions = argument.expression.asSwiftLanguageVersionArray() {
-                    self.swiftLanguageVersions = versions
-                    continue
+            case "swiftLanguageVersions", "swiftLanguageModes":
+                resolve(argument.expression, description: "swift language modes", into: &self.swiftLanguageVersions) { expr throws(ResolutionError) in
+                    try parseSwiftLanguageVersions(expr)
                 }
 
-                // Fall back to old-style integer array syntax (e.g., [3, 4])
-                guard let intVersions = argument.expression.asIntegerArray() else {
-                    limitations.append(
-                        .unsupportedExpression(
-                            argument.expression,
-                            expected: "array of Swift language versions"
-                        )
-                    )
-                    continue
+            case "pkgConfig":
+                resolve(argument.expression, description: "pkgConfig string", into: &self.pkgConfig)
+
+            case "providers":
+                resolve(argument.expression, description: "array of providers", into: &self.providers)
+
+            case "products":
+                resolve(argument.expression, description: "array of products", into: &self.products)
+
+            case "cLanguageStandard":
+                resolve(argument.expression, description: "C language standard", into: &self.cLanguageStandard) { expr throws(ResolutionError) in
+                    try parseCLanguageStandard(expr)
                 }
 
-                // Convert integers to SwiftLanguageVersion with validation
-                // Note: Even if the array is empty, we set it to an empty array (not nil)
-                // to distinguish from the case where swiftLanguageVersions wasn't specified
-                var validatedVersions: [SwiftLanguageVersion] = []
-                var hasValidationError = false
-                for (index, version) in intVersions.enumerated() {
-                    let versionString = "\(version)"
-                    guard let swiftVersion = SwiftLanguageVersion(string: versionString) else {
-                        hasValidationError = true
-                        // Get the actual syntax element for better error reporting
-                        if let arrayExpr = argument.expression.as(ArrayExprSyntax.self),
-                           index < arrayExpr.elements.count {
-                            let element = arrayExpr.elements[arrayExpr.elements.index(arrayExpr.elements.startIndex, offsetBy: index)]
-                            limitations.append(.invalidSwiftLanguageVersion(element.expression, value: versionString))
-                        } else {
-                            limitations.append(.invalidSwiftLanguageVersion(argument.expression, value: versionString))
-                        }
-                        continue
-                    }
-                    validatedVersions.append(swiftVersion)
+            case "cxxLanguageStandard":
+                resolve(argument.expression, description: "C++ language standard", into: &self.cxxLanguageStandard) { expr throws(ResolutionError) in
+                    try parseCxxLanguageStandard(expr)
                 }
 
-                // Only set if we successfully validated all versions
-                if !hasValidationError {
-                    self.swiftLanguageVersions = validatedVersions
-                }
-                continue
-            }
-            
-            if argument.label?.text == "pkgConfig" {
-                if let value = resolveStringLiteral(argument.expression) {
-                    self.pkgConfig = value
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "pkgConfig string or reference to global variable"))
-                }
-                continue
-            }
-            
-            if argument.label?.text == "providers" {
-                if let parsedProviders = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of providers",
-                    elementParser: parseSystemPackageProvider
-                ) {
-                    self.providers = parsedProviders.isEmpty ? nil : parsedProviders
-                }
-                continue
-            }
-            
-            if argument.label?.text == "products" {
-                if let prods = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of products or reference to global variable",
-                    elementParser: parseProduct
-                ) {
-                    self.products.append(contentsOf: prods)
-                }
-                continue
-            }
-            
-            if argument.label?.text == "cLanguageStandard" {
-                if let standard = parseCLanguageStandard(argument.expression) {
-                    self.cLanguageStandard = standard
-                }
-                continue
-            }
-            
-            if argument.label?.text == "cxxLanguageStandard" {
-                if let standard = parseCxxLanguageStandard(argument.expression) {
-                    self.cxxLanguageStandard = standard
-                }
-                continue
-            }
-            
-            if argument.label?.text == "platforms" {
-                if let plats = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of platforms or reference to global variable",
-                    elementParser: parsePlatform
-                ) {
-                    self.platforms = plats
-                }
-                continue
-            }
-            
-            if argument.label?.text == "defaultLocalization" {
-                if let value = resolveStringLiteral(argument.expression) {
-                    self.defaultLocalization = value
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "default localization language tag or reference to global variable"))
-                }
-                continue
-            }
-            
-            if argument.label?.text == "targets" {
-                if let tgts = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of targets or reference to global variable",
-                    elementParser: parseTarget
-                ) {
-                    self.targets.append(contentsOf: tgts)
-                }
-                continue
-            }
-            
-            if argument.label?.text == "traits" {
-                if let trts = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of traits or reference to global variable",
-                    elementParser: parseTrait
-                ) {
-                    self.traits = trts
-                }
-                continue
-            }
+            case "platforms":
+                resolve(argument.expression, description: "array of platforms", into: &self.platforms)
 
-            // Unhandled argument.
-            limitations.append(.unsupportedArgument(argument, callee: "Package"))
+            case "defaultLocalization":
+                resolve(argument.expression, description: "default localization language tag", into: &self.defaultLocalization)
+
+            case "targets":
+                resolve(argument.expression, description: "array of targets", into: &self.targets)
+
+            case "traits":
+                resolve(argument.expression, description: "array of traits", into: &self.traits)
+
+            default:
+                limitations.append(.unsupportedArgument(argument, callee: "Package"))
+            }
         }
     }
     
     /// Parse a target declaration like .target(name: "foo", dependencies: [...])
-    private func parseTarget(_ expr: ExprSyntax) -> TargetDescription? {
+    fileprivate func parseTarget(_ expr: ExprSyntax) throws(ResolutionError) -> TargetDescription {
         guard let functionCall = expr.as(FunctionCallExprSyntax.self),
               let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
               memberAccess.base == nil, // Leading dot syntax
               let methodName = memberAccess.declName.baseName.identifier?.name else {
-            limitations.append(.unsupportedExpression(expr, expected: "target declaration"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         // Determine target type from method name
         let targetType: TargetDescription.TargetKind
         switch methodName {
@@ -1018,19 +983,18 @@ extension ManifestParseVisitor {
         case "macro":
             targetType = .macro
         default:
-            limitations.append(.unsupportedExpression(expr, expected: "known target type"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         // Parse target arguments
-        var name: String?
-        var dependencies: [TargetDescription.Dependency] = []
+        var name: String? = nil
+        var dependencies: [TargetDescription.Dependency]? = nil
         var path: String? = nil
         var url: String? = nil
         var checksum: String? = nil
-        var exclude: [String] = []
+        var exclude: [String]? = nil
         var sources: [String]? = nil
-        var resources: [TargetDescription.Resource] = []
+        var resources: [TargetDescription.Resource]? = nil
         var publicHeadersPath: String? = nil
         var pkgConfig: String? = nil
         var providers: [SystemPackageProviderDescription]? = nil
@@ -1045,154 +1009,74 @@ extension ManifestParseVisitor {
 
         for argument in functionCall.arguments {
             let label = argument.label?.text
-            
-            if label == "name" {
-                name = resolveStringLiteral(argument.expression)
-            } else if label == "dependencies" {
-                if let deps = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of target dependencies or reference to global variable",
-                    elementParser: parseTargetDependency
-                ) {
-                    dependencies.append(contentsOf: deps)
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of target dependencies or reference to global variable"))
+
+            switch label {
+            case "name":
+                resolve(argument.expression, description: "target name", into: &name)
+            case "dependencies":
+                resolve(argument.expression, description: "array of target dependencies", into: &dependencies)
+            case "path":
+                resolve(argument.expression, description: "path string", into: &path)
+            case "url":
+                resolve(argument.expression, description: "url string", into: &url)
+            case "checksum":
+                resolve(argument.expression, description: "checksum string", into: &checksum)
+            case "exclude":
+                resolve(argument.expression, description: "array of excluded paths", into: &exclude)
+            case "sources":
+                resolve(argument.expression, description: "array of source file paths", into: &sources)
+            case "publicHeadersPath":
+                resolve(argument.expression, description: "publicHeadersPath string", into: &publicHeadersPath)
+            case "pkgConfig":
+                resolve(argument.expression, description: "pkgConfig string", into: &pkgConfig)
+            case "providers":
+                resolve(argument.expression, description: "array of system package providers", into: &providers)
+            case "resources":
+                resolve(argument.expression, description: "array of resources", into: &resources)
+            case "capability":
+                resolve(argument.expression, description: "plugin capability", into: &pluginCapability)
+            case "cSettings":
+                resolve(argument.expression, description: "array of C build settings", appendingInto: &settings) { expr throws(ResolutionError) in
+                    try parseBuildSetting(expr, tool: .c)
                 }
-            } else if label == "path" {
-                if let value = resolveStringLiteral(argument.expression) {
-                    path = value
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "path string or reference to global variable"))
+            case "cxxSettings":
+                resolve(argument.expression, description: "array of C++ build settings", appendingInto: &settings) { expr throws(ResolutionError) in
+                    try parseBuildSetting(expr, tool: .cxx)
                 }
-            } else if label == "url" {
-                if let value = resolveStringLiteral(argument.expression) {
-                    url = value
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "url string or reference to global variable"))
+            case "swiftSettings":
+                resolve(argument.expression, description: "array of Swift build settings", appendingInto: &settings) { expr throws(ResolutionError) in
+                    try parseBuildSetting(expr, tool: .swift)
                 }
-            } else if label == "checksum" {
-                if let value = resolveStringLiteral(argument.expression) {
-                    checksum = value
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "checksum string or reference to global variable"))
+            case "linkerSettings":
+                resolve(argument.expression, description: "array of linker settings", appendingInto: &settings) { expr throws(ResolutionError) in
+                    try parseBuildSetting(expr, tool: .linker)
                 }
-            } else if label == "exclude" {
-                if let value = resolveStringArray(argument.expression, expectedDescription: "array of excluded paths or reference to global variable") {
-                    exclude = value
-                }
-            } else if label == "sources" {
-                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of source file paths or reference to global variable") {
-                    sources = parsed
-                }
-            } else if label == "publicHeadersPath" {
-                if let value = resolveStringLiteral(argument.expression) {
-                    publicHeadersPath = value
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "publicHeadersPath string or reference to global variable"))
-                }
-            } else if label == "pkgConfig" {
-                if let value = resolveStringLiteral(argument.expression) {
-                    pkgConfig = value
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "pkgConfig string or reference to global variable"))
-                }
-            } else if label == "providers" {
-                if let parsedProviders = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of system package providers or reference to global variable",
-                    elementParser: parseSystemPackageProvider
-                ) {
-                    providers = parsedProviders.isEmpty ? nil : parsedProviders
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of system package providers or reference to global variable"))
-                }
-            } else if label == "resources" {
-                if let parsed = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of resources or reference to global variable",
-                    elementParser: parseResource
-                ) {
-                    resources.append(contentsOf: parsed)
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of resources or reference to global variable"))
-                }
-            } else if label == "capability" {
-                pluginCapability = parsePluginCapability(argument.expression)
-            } else if label == "cSettings" {
-                if let parsed = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of C build settings or reference to global variable",
-                    elementParser: { parseBuildSetting($0, tool: .c) }
-                ) {
-                    settings.append(contentsOf: parsed)
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of C build settings or reference to global variable"))
-                }
-            } else if label == "cxxSettings" {
-                if let parsed = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of C++ build settings or reference to global variable",
-                    elementParser: { parseBuildSetting($0, tool: .cxx) }
-                ) {
-                    settings.append(contentsOf: parsed)
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of C++ build settings or reference to global variable"))
-                }
-            } else if label == "swiftSettings" {
-                if let parsed = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of Swift build settings or reference to global variable",
-                    elementParser: { parseBuildSetting($0, tool: .swift) }
-                ) {
-                    settings.append(contentsOf: parsed)
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of Swift build settings or reference to global variable"))
-                }
-            } else if label == "linkerSettings" {
-                if let parsed = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of linker settings or reference to global variable",
-                    elementParser: { parseBuildSetting($0, tool: .linker) }
-                ) {
-                    settings.append(contentsOf: parsed)
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of linker settings or reference to global variable"))
-                }
-            } else if label == "plugins" {
-                if let parsed = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of plugin usages or reference to global variable",
-                    elementParser: parsePluginUsage
-                ) {
-                    pluginUsages = parsed
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of plugin usages or reference to global variable"))
-                }
-            } else if label == "packageAccess" {
+            case "plugins":
+                resolve(argument.expression, description: "array of plugin usages", into: &pluginUsages)
+            case "packageAccess":
                 if let boolValue = argument.expression.asBooleanLiteralValue() {
                     packageAccess = boolValue
                 } else {
                     limitations.append(.unsupportedExpression(argument.expression, expected: "boolean literal for packageAccess"))
                 }
-            } else {
+            default:
                 limitations.append(.unsupportedArgument(argument, callee: methodName))
             }
         }
-        
+
         guard let targetName = name else {
-            limitations.append(.unsupportedExpression(expr, expected: "target with name"))
-            return nil
+            throw .missingValue(expr, description: "target with name")
         }
-        
+
         do {
             return try TargetDescription(
                 name: targetName,
-                dependencies: dependencies,
+                dependencies: dependencies ?? [],
                 path: path,
                 url: url,
-                exclude: exclude,
+                exclude: exclude ?? [],
                 sources: sources,
-                resources: resources,
+                resources: resources ?? [],
                 publicHeadersPath: publicHeadersPath,
                 type: targetType,
                 packageAccess: packageAccess,
@@ -1207,213 +1091,195 @@ extension ManifestParseVisitor {
             // If TargetDescription initialization fails (e.g., invalid property combinations),
             // treat it as a limitation
             limitations.append(.unsupportedExpression(expr, expected: "valid target configuration"))
-            return nil
+            throw .unhandledExpression(expr)
         }
     }
     
     /// Parse a target dependency like "dep1", .target(name: "dep2"), or .product(name: "dep3", package: "Pkg")
-    private func parseTargetDependency(_ expr: ExprSyntax) -> TargetDescription.Dependency? {
-        // Case 1: String literal dependency (e.g., "dep1") or variable reference
-        if let depName = resolveStringLiteral(expr) {
+    fileprivate func parseTargetDependency(_ expr: ExprSyntax) throws(ResolutionError) -> TargetDescription.Dependency {
+        // If we don't have a member access call, it must be a string literal.
+        guard let (methodName, arguments) = expr.asMemberAccessCall() else {
+            // Case 1: String literal dependency (e.g., "dep1")
+            var depName: String?
+            resolve(expr, description: "target dependency name", into: &depName)
+            guard let depName else {
+                throw .unhandledExpression(expr)
+            }
             return .byName(name: depName, condition: nil)
         }
-        
+
         // Case 2: .target(name: ...) or .product(name: ..., package: ...)
-        guard let (methodName, arguments) = expr.asMemberAccessCall() else {
-            limitations.append(.unsupportedExpression(expr, expected: "target dependency"))
-            return nil
-        }
-        
-        if methodName == "target" {
+        switch methodName {
+        case "target":
             // Parse .target(name: "...", condition: ...)
             var name: String?
             var condition: PackageConditionDescription?
-            
+
             for argument in arguments {
                 let label = argument.label?.text
-                if label == "name" {
-                    name = resolveStringLiteral(argument.expression)
-                } else if label == "condition" {
-                    condition = parsePackageCondition(argument.expression)
-                } else {
+                switch label {
+                case "name":
+                    resolve(argument.expression, description: "target dependency name", into: &name)
+                case "condition":
+                    resolve(argument.expression, description: "target dependency condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "target"))
                 }
             }
 
-            if let targetName = name {
-                return .target(name: targetName, condition: condition)
+            guard let targetName = name else {
+                throw .missingValue(expr, description: ".target with name")
             }
-            limitations.append(.unsupportedExpression(expr, expected: ".target with name"))
-            return nil
-        } else if methodName == "product" {
+            return .target(name: targetName, condition: condition)
+
+        case "product":
             // Parse .product(name: "...", package: "...", moduleAliases: [...], condition: ...)
             var name: String?
             var package: String?
             var moduleAliases: [String: String]?
             var condition: PackageConditionDescription?
-            
+
             for argument in arguments {
                 let label = argument.label?.text
-                if label == "name" {
-                    name = resolveStringLiteral(argument.expression)
-                } else if label == "package" {
-                    package = resolveStringLiteral(argument.expression)
-                } else if label == "moduleAliases" {
-                    moduleAliases = parseModuleAliases(argument.expression)
-                } else if label == "condition" {
-                    condition = parsePackageCondition(argument.expression)
-                } else {
+                switch label {
+                case "name":
+                    resolve(argument.expression, description: "product dependency name", into: &name)
+                case "package":
+                    resolve(argument.expression, description: "product dependency package", into: &package)
+                case "moduleAliases":
+                    resolve(argument.expression, description: "module aliases", into: &moduleAliases) { expr throws(ResolutionError) in
+                        try parseModuleAliases(expr)
+                    }
+                case "condition":
+                    resolve(argument.expression, description: "product dependency condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "product"))
                 }
             }
 
-            if let productName = name {
-                return .product(name: productName, package: package, moduleAliases: moduleAliases, condition: condition)
+            guard let productName = name else {
+                throw .missingValue(expr, description: ".product with name")
             }
-            limitations.append(.unsupportedExpression(expr, expected: ".product with name"))
-            return nil
-        } else if methodName == "byName" {
+            return .product(name: productName, package: package, moduleAliases: moduleAliases, condition: condition)
+
+        case "byName":
             // Parse .byName(name: "...", condition: ...)
             var name: String?
             var condition: PackageConditionDescription?
-            
+
             for argument in arguments {
                 let label = argument.label?.text
-                if label == "name" {
-                    name = resolveStringLiteral(argument.expression)
-                } else if label == "condition" {
-                    condition = parsePackageCondition(argument.expression)
-                } else {
+                switch label {
+                case "name":
+                    resolve(argument.expression, description: "byName dependency name", into: &name)
+                case "condition":
+                    resolve(argument.expression, description: "byName dependency condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "byName"))
                 }
             }
 
-            if let depName = name {
-                return .byName(name: depName, condition: condition)
+            guard let depName = name else {
+                throw .missingValue(expr, description: ".byName with name")
             }
-            limitations.append(.unsupportedExpression(expr, expected: ".byName with name"))
-            return nil
-        } else {
-            limitations.append(.unsupportedExpression(expr, expected: ".target or .product dependency"))
-            return nil
+            return .byName(name: depName, condition: condition)
+
+        default:
+            throw .unhandledExpression(expr)
         }
     }
     
     /// Parse a package condition like .when(platforms: [.macOS, .linux])
-    private func parsePackageCondition(_ expr: ExprSyntax) -> PackageConditionDescription? {
+    fileprivate func parsePackageCondition(_ expr: ExprSyntax) throws(ResolutionError) -> PackageConditionDescription? {
         guard let (methodName, arguments) = expr.asMemberAccessCall(),
               methodName == "when" else {
-            limitations.append(.unsupportedExpression(expr, expected: "package condition"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         var platformNames: [String] = []
-        var hasPlatforms = false
         var config: String?
         var traits: [String]?
 
         for argument in arguments {
             let label = argument.label?.text
-            
-            if label == "platforms" {
-                hasPlatforms = true
-                if let platforms = resolveArray(
-                    argument.expression,
-                    expectedDescription: "array of platform conditions or reference to global variable"
-                ) { expr -> String? in
-                    parsePlatformConditionName(expr)
-                } {
-                    platformNames = platforms.map { $0.lowercased() }
-                } else {
-                    // resolveArray already added the limitation
-                    continue
+            switch label {
+            case "platforms":
+                resolve(argument.expression, description: "array of platform conditions", appendingInto: &platformNames) { expr throws(ResolutionError) in
+                    try parsePlatformConditionName(expr)
                 }
-            } else if label == "configuration" {
-                if let value = argument.expression.asEnumMember() {
-                    config = value
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "build configuration"))
+            case "configuration":
+                resolve(argument.expression, description: "build configuration", into: &config) { expr throws(ResolutionError) -> String in
+                    guard let member = expr.asEnumMember() else {
+                        throw .unhandledExpression(expr)
+                    }
+
+                    return member
                 }
-            } else if label == "traits" {
-                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of trait names or reference to global variable") {
-                    traits = parsed
-                }
-            } else {
+            case "traits":
+                resolve(argument.expression, description: "array of trait names", into: &traits)
+            default:
                 limitations.append(.unsupportedArgument(argument, callee: "when"))
             }
         }
 
-        // If platforms is explicitly empty and no other conditions, return nil (no condition)
-        if hasPlatforms && platformNames.isEmpty && config == nil && traits == nil {
+        // An empty condition (e.g., .when(platforms: [])) means no condition.
+        if config == nil && traits == nil && platformNames.isEmpty {
             return nil
         }
-        
-        // At least one non-empty condition must be specified
-        if !platformNames.isEmpty || config != nil || traits != nil {
-            return PackageConditionDescription(platformNames: platformNames, config: config, traits: traits.map { Set($0)})
-        }
-        
-        limitations.append(.unsupportedExpression(expr, expected: "package condition with platforms, configuration, or traits"))
-        return nil
+
+        return PackageConditionDescription(
+            platformNames: platformNames.map { $0.lowercased() },
+            config: config,
+            traits: traits.map { Set($0) }
+        )
     }
     
     /// Parse module aliases dictionary like ["OriginalName": "AliasName", ...]
-    private func parseModuleAliases(_ expr: ExprSyntax) -> [String: String]? {
+    private func parseModuleAliases(_ expr: ExprSyntax) throws(ResolutionError) -> [String: String] {
         guard let dictExpr = expr.as(DictionaryExprSyntax.self) else {
-            limitations.append(.unsupportedExpression(expr, expected: "dictionary for module aliases"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         var aliases: [String: String] = [:]
-        
+
         // Check if it's a dictionary with elements
         switch dictExpr.content {
         case .colon:
-            // Empty dictionary [:]
-            return nil
+            break
         case .elements(let elements):
             // Dictionary with key-value pairs
             for element in elements {
-                if let keyString = resolveStringLiteral(element.key),
-                   let valueString = resolveStringLiteral(element.value) {
-                    aliases[keyString] = valueString
-                } else {
-                    limitations.append(.unsupportedExpression(element.key, expected: "string literal module alias key and value or reference to global variable"))
-                }
+                let keyString = try resolveStringLiteral(element.key)
+                let valueString = try resolveStringLiteral(element.value)
+                aliases[keyString] = valueString
             }
         }
-        
-        return aliases.isEmpty ? nil : aliases
+
+        return aliases
     }
     
     /// Parse a build setting like .headerSearchPath("path"), .define("NAME"), .linkedLibrary("lib"), etc.
-    private func parseBuildSetting(_ expr: ExprSyntax, tool: TargetBuildSettingDescription.Tool) -> TargetBuildSettingDescription.Setting? {
+    fileprivate func parseBuildSetting(_ expr: ExprSyntax, tool: TargetBuildSettingDescription.Tool) throws(ResolutionError) -> TargetBuildSettingDescription.Setting {
         guard let functionCall = expr.as(FunctionCallExprSyntax.self),
               let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
               memberAccess.base == nil,
               let methodName = memberAccess.declName.baseName.identifier?.name else {
-            limitations.append(.unsupportedExpression(expr, expected: "build setting"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         var kind: TargetBuildSettingDescription.Kind?
         var condition: PackageConditionDescription?
-        var conditionArgumentIndex: Int?
 
         // Parse the kind based on method name
         switch methodName {
         case "headerSearchPath":
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil {
-                    if kind == nil, let path = resolveStringLiteral(argument.expression) {
-                        kind = .headerSearchPath(path)
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case nil where kind == nil:
+                    kind = .headerSearchPath(try resolveStringLiteral(argument.expression))
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "headerSearchPath"))
                 }
             }
@@ -1421,311 +1287,233 @@ extension ManifestParseVisitor {
             // .define("NAME") or .define("NAME", to: "VALUE")
             var name: String?
             var value: String?
-            
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil {
-                    if let str = resolveStringLiteral(argument.expression) {
-                        name = str
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "to" {
-                    value = resolveStringLiteral(argument.expression)
-                    if value == nil {
-                        limitations.append(.unsupportedExpression(argument.expression, expected: "'to' value of 'define'"))
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case nil where name == nil:
+                    resolve(argument.expression, description: "define", into: &name)
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                case "to":
+                    resolve(argument.expression, description: "'to' value of 'define'", into: &value)
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "define"))
                 }
             }
-            
-            if let defineName = name {
-                if let defineValue = value {
-                    kind = .define("\(defineName)=\(defineValue)")
+
+            if let name {
+                if let value {
+                    kind = .define("\(name)=\(value)")
                 } else {
-                    kind = .define(defineName)
+                    kind = .define(name)
                 }
             }
         case "linkedLibrary":
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil {
-                    if kind == nil, let library = resolveStringLiteral(argument.expression) {
-                        kind = .linkedLibrary(library)
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case nil where kind == nil:
+                    kind = .linkedLibrary(try resolveStringLiteral(argument.expression))
+
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "linkedLibrary"))
                 }
             }
         case "linkedFramework":
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil {
-                    if kind == nil, let framework = resolveStringLiteral(argument.expression) {
-                        kind = .linkedFramework(framework)
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case nil where kind == nil:
+                    kind = .linkedFramework(try resolveStringLiteral(argument.expression))
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "linkedFramework"))
                 }
             }
         case "unsafeFlags":
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil {
-                    if kind == nil, let flagsArray = argument.expression.as(ArrayExprSyntax.self) {
-                        var flags: [String] = []
-                        for flagElement in flagsArray.elements {
-                            if let flag = resolveStringLiteral(flagElement.expression) {
-                                flags.append(flag)
-                            } else {
-                                limitations.append(.unsupportedExpression(flagElement.expression, expected: "string literal in unsafeFlags or reference to global variable"))
-                            }
-                        }
-                        kind = .unsafeFlags(flags)
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case nil where kind == nil:
+                    kind = .unsafeFlags(try resolveArray(argument.expression) { expr throws(ResolutionError) in
+                        try resolveStringLiteral(expr)
+                    })
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "unsafeFlags"))
                 }
             }
         case "enableUpcomingFeature":
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil {
-                    if kind == nil, let feature = resolveStringLiteral(argument.expression) {
-                        kind = .enableUpcomingFeature(feature)
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case nil where kind == nil:
+                    kind = .enableUpcomingFeature(try resolveStringLiteral(argument.expression))
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "enableUpcomingFeature"))
                 }
             }
         case "enableExperimentalFeature":
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil {
-                    if kind == nil, let feature = resolveStringLiteral(argument.expression) {
-                        kind = .enableExperimentalFeature(feature)
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case nil where kind == nil:
+                    kind = .enableExperimentalFeature(try resolveStringLiteral(argument.expression))
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "enableExperimentalFeature"))
                 }
             }
         case "interoperabilityMode":
             // .interoperabilityMode(.C) or .interoperabilityMode(.Cxx)
-            for (index, argument) in functionCall.arguments.enumerated() {
+            for argument in functionCall.arguments {
                 let label = argument.label?.text
-                if label == nil {
-                    if kind == nil,
-                       let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
-                       memberAccess.base == nil,
-                       let modeName = memberAccess.declName.baseName.identifier?.name {
-                        switch modeName {
-                        case "C":
-                            kind = .interoperabilityMode(.C)
-                        case "Cxx":
-                            kind = .interoperabilityMode(.Cxx)
-                        default:
-                            limitations.append(.unsupportedExpression(argument.expression, expected: "known interoperability mode"))
-                        }
-                    } else {
-                        conditionArgumentIndex = index
+                switch label {
+                case nil where kind == nil:
+                    guard let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
+                          memberAccess.base == nil,
+                          let modeName = memberAccess.declName.baseName.identifier?.name else {
+                        limitations.append(.unsupportedArgument(argument, callee: "interoperabilityMode"))
+                        continue
                     }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+
+                    switch modeName {
+                    case "C":
+                        kind = .interoperabilityMode(.C)
+                    case "Cxx":
+                        kind = .interoperabilityMode(.Cxx)
+                    default:
+                        limitations.append(.unsupportedExpression(argument.expression, expected: "known interoperability mode"))
+                    }
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "interoperabilityMode"))
                 }
             }
         case "strictMemorySafety":
             kind = .strictMemorySafety
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil || label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "strictMemorySafety"))
                 }
             }
         case "swiftLanguageMode", "swiftLanguageVersion":
             // .swiftLanguageMode(.v5) or .swiftLanguageMode(.version("6"))
             // Also supports deprecated .swiftLanguageVersion() for backward compatibility
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil {
-                    if kind == nil, let version = parseSwiftLanguageVersion(argument.expression) {
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case nil where kind == nil:
+                    if let version = parseSwiftLanguageVersion(argument.expression) {
                         kind = .swiftLanguageMode(version)
                     } else {
-                        conditionArgumentIndex = index
+                        resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
                     }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: methodName))
                 }
             }
         case "treatAllWarnings":
             // .treatAllWarnings(.warning) or .treatAllWarnings(.error)
-            for (index, argument) in functionCall.arguments.enumerated() {
-                let label = argument.label?.text
-                if label == nil || label == "as" {
-                    if let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
-                       memberAccess.base == nil,
-                       let levelName = memberAccess.declName.baseName.identifier?.name {
-                        switch levelName {
-                        case "warning":
-                            kind = .treatAllWarnings(.warning)
-                        case "error":
-                            kind = .treatAllWarnings(.error)
-                        default:
-                            limitations.append(.unsupportedExpression(argument.expression, expected: "warning level (.warning or .error)"))
-                        }
-                    } else if label == nil {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+            var warningLevel: TargetBuildSettingDescription.WarningLevel?
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case "as":
+                    resolve(argument.expression, description: "warning level", into: &warningLevel)
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "treatAllWarnings"))
                 }
+            }
+            if let warningLevel {
+                kind = .treatAllWarnings(warningLevel)
             }
         case "treatWarning":
             // .treatWarning("deprecated", as: .error)
             var warningName: String?
             var level: TargetBuildSettingDescription.WarningLevel?
-            
-            for (index, argument) in functionCall.arguments.enumerated() {
+
+            for argument in functionCall.arguments {
                 let label = argument.label?.text
-                if label == nil {
-                    if let str = resolveStringLiteral(argument.expression) {
-                        warningName = str
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "as" {
-                    if let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
-                       memberAccess.base == nil,
-                       let levelName = memberAccess.declName.baseName.identifier?.name {
-                        switch levelName {
-                        case "warning":
-                            level = .warning
-                        case "error":
-                            level = .error
-                        default:
-                            break
-                        }
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+                switch label {
+                case nil where warningName == nil:
+                    resolve(argument.expression, description: "warning name", into: &warningName)
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                case "as":
+                    resolve(argument.expression, description: "warning level", into: &level)
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "treatWarning"))
                 }
             }
-            
+
             if let warning = warningName, let warningLevel = level {
                 kind = .treatWarning(warning, warningLevel)
             }
         case "enableWarning":
-            for (index, argument) in functionCall.arguments.enumerated() {
+            for argument in functionCall.arguments {
                 let label = argument.label?.text
-                if label == nil {
-                    if kind == nil, let warning = resolveStringLiteral(argument.expression) {
-                        kind = .enableWarning(warning)
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+                switch label {
+                case nil where kind == nil:
+                    kind = .enableWarning(try resolveStringLiteral(argument.expression))
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "enableWarning"))
                 }
             }
         case "disableWarning":
-            for (index, argument) in functionCall.arguments.enumerated() {
+            for argument in functionCall.arguments {
                 let label = argument.label?.text
-                if label == nil {
-                    if kind == nil, let warning = resolveStringLiteral(argument.expression) {
-                        kind = .disableWarning(warning)
-                    } else {
-                        conditionArgumentIndex = index
-                    }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+                switch label {
+                case nil where kind == nil:
+                    kind = .disableWarning(try resolveStringLiteral(argument.expression))
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "disableWarning"))
                 }
             }
         case "defaultIsolation":
             // .defaultIsolation(MainActor.self) → .MainActor isolation
             // .defaultIsolation(nil)            → nonisolated (compiler default)
-            for (index, argument) in functionCall.arguments.enumerated() {
+            for argument in functionCall.arguments {
                 let label = argument.label?.text
-                if label == nil {
-                    if kind == nil {
-                        if argument.expression.is(NilLiteralExprSyntax.self) {
-                            kind = .defaultIsolation(.nonisolated)
-                        } else if let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
-                                  let base = memberAccess.base?.as(DeclReferenceExprSyntax.self),
-                                  base.baseName.text == "MainActor",
-                                  memberAccess.declName.baseName.text == "self" {
-                            kind = .defaultIsolation(.MainActor)
-                        } else {
-                            conditionArgumentIndex = index
-                        }
+                switch label {
+                case nil where kind == nil && argument.expression.is(NilLiteralExprSyntax.self):
+                    kind = .defaultIsolation(.nonisolated)
+                case nil where kind == nil:
+                    if let memberAccess = argument.expression.as(MemberAccessExprSyntax.self),
+                       let base = memberAccess.base?.as(DeclReferenceExprSyntax.self),
+                       base.baseName.text == "MainActor",
+                       memberAccess.declName.baseName.text == "self" {
+                        kind = .defaultIsolation(.MainActor)
                     } else {
-                        conditionArgumentIndex = index
+                        limitations.append(.unsupportedArgument(argument, callee: "defaultIsolation"))
                     }
-                } else if label == "condition" {
-                    conditionArgumentIndex = index
-                } else {
+                case nil:
+                    resolve(argument.expression, description: "build setting condition", into: &condition) { expr throws(ResolutionError) in try parsePackageCondition(expr) }
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "defaultIsolation"))
                 }
             }
         default:
             limitations.append(.unsupportedExpression(expr, expected: "known build setting type"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
-        // Parse condition if present. The condition parameter is unlabeled in the
-        // PackageDescription API (e.g., .define("C", .when(platforms: [.linux]))),
-        // though some manifests may also use the explicit label "condition:".
-        // Each case above sets conditionArgumentIndex when it identifies the
-        // condition argument.
-        if let conditionIndex = conditionArgumentIndex {
-            let conditionArg = functionCall.arguments[
-                functionCall.arguments.index(functionCall.arguments.startIndex, offsetBy: conditionIndex)
-            ]
-            if let parsedCondition = parsePackageCondition(conditionArg.expression) {
-                condition = parsedCondition
-            }
-        }
-        
+
         guard let settingKind = kind else {
-            limitations.append(.unsupportedExpression(expr, expected: "valid build setting"))
-            return nil
+            throw .missingValue(expr, description: "valid build setting")
         }
-        
+
         return TargetBuildSettingDescription.Setting(tool: tool, kind: settingKind, condition: condition)
     }
     
@@ -1765,66 +1553,54 @@ extension ManifestParseVisitor {
     }
     
     /// Parse a system package provider like .brew(["openssl"]) or .apt(["openssl", "libssl-dev"])
-    private func parseSystemPackageProvider(_ expr: ExprSyntax) -> SystemPackageProviderDescription? {
+    fileprivate func parseSystemPackageProvider(_ expr: ExprSyntax) throws(ResolutionError) -> SystemPackageProviderDescription {
         guard let functionCall = expr.as(FunctionCallExprSyntax.self),
               let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
               memberAccess.base == nil, // Leading dot syntax
               let methodName = memberAccess.declName.baseName.identifier?.name else {
-            limitations.append(.unsupportedExpression(expr, expected: "system package provider"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         // Parse arguments
-        var packages: [String] = []
+        var packages: [String]?
         for argument in functionCall.arguments {
             let label = argument.label?.text
             if label == nil {
-                if let arrayExpr = argument.expression.as(ArrayExprSyntax.self) {
-                    for element in arrayExpr.elements {
-                        if let packageName = resolveStringLiteral(element.expression) {
-                            packages.append(packageName)
-                        } else {
-                            limitations.append(.unsupportedExpression(element.expression, expected: "string literal package name or reference to global variable"))
-                        }
-                    }
-                } else {
-                    limitations.append(.unsupportedExpression(argument.expression, expected: "array of package names"))
-                }
+                resolve(argument.expression, description: "array of package names", into: &packages)
             } else {
                 limitations.append(.unsupportedArgument(argument, callee: methodName))
             }
         }
-        
+
         switch methodName {
         case "brew":
-            return .brew(packages)
+            return .brew(packages ?? [])
         case "apt":
-            return .apt(packages)
+            return .apt(packages ?? [])
         case "yum":
-            return .yum(packages)
+            return .yum(packages ?? [])
         case "nuget":
-            return .nuget(packages)
+            return .nuget(packages ?? [])
+        case "pkg":
+            return .pkg(packages ?? [])
         default:
-            limitations.append(.unsupportedExpression(expr, expected: "known provider type"))
-            return nil
+            throw .unhandledExpression(expr)
         }
     }
     
     /// Parse a resource declaration like .copy("foo.txt") or .process("bar.txt", localization: .default)
-    private func parseResource(_ expr: ExprSyntax) -> TargetDescription.Resource? {
+    fileprivate func parseResource(_ expr: ExprSyntax) throws(ResolutionError) -> TargetDescription.Resource {
         guard let (methodName, arguments) = expr.asMemberAccessCall() else {
-            limitations.append(.unsupportedExpression(expr, expected: "resource declaration"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         // Parse the path argument (first unlabeled argument)
         guard let firstArg = arguments.first,
-              firstArg.label == nil,
-              let path = resolveStringLiteral(firstArg.expression) else {
-            limitations.append(.unsupportedExpression(expr, expected: "resource with path or reference to global variable"))
-            return nil
+              firstArg.label == nil else {
+            throw .missingValue(expr, description: "resource with path")
         }
-        
+        let path = try resolveStringLiteral(firstArg.expression)
+
         // Determine the rule based on method name
         let rule: TargetDescription.Resource.Rule
         switch methodName {
@@ -1842,7 +1618,7 @@ extension ManifestParseVisitor {
                           memberAccess.base == nil,
                           let localizationName = memberAccess.declName.baseName.identifier?.name else {
                         limitations.append(.unsupportedExpression(argument.expression, expected: "known localization type"))
-                        return nil
+                        throw .unhandledExpression(argument.expression)
                     }
                     switch localizationName {
                     case "default":
@@ -1851,7 +1627,7 @@ extension ManifestParseVisitor {
                         localization = .base
                     default:
                         limitations.append(.unsupportedExpression(argument.expression, expected: "known localization type"))
-                        return nil
+                        throw .unhandledExpression(argument.expression)
                     }
                 } else {
                     limitations.append(.unsupportedArgument(argument, callee: methodName))
@@ -1864,20 +1640,19 @@ extension ManifestParseVisitor {
             }
             rule = .embedInCode
         default:
-            limitations.append(.unsupportedExpression(expr, expected: "known resource type"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
-        return TargetDescription.Resource(rule: rule, path: (try? RelativePath(validating: path))?.pathString ?? path)
+
+        let normalizedPath = (try? RelativePath(validating: path))?.pathString ?? path
+        return TargetDescription.Resource(rule: rule, path: normalizedPath)
     }
     
     /// Parse a plugin capability like .buildTool() or .command(intent: .custom(verb: "foo", description: "bar"))
-    private func parsePluginCapability(_ expr: ExprSyntax) -> TargetDescription.PluginCapability? {
+    fileprivate func parsePluginCapability(_ expr: ExprSyntax) throws(ResolutionError) -> TargetDescription.PluginCapability {
         guard let (methodName, arguments) = expr.asMemberAccessCall() else {
-            limitations.append(.unsupportedExpression(expr, expected: "plugin capability"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         switch methodName {
         case "buildTool":
             for argument in arguments {
@@ -1888,36 +1663,29 @@ extension ManifestParseVisitor {
             // Parse .command(intent: ..., permissions: [...])
             var intent: TargetDescription.PluginCommandIntent?
             var permissions: [TargetDescription.PluginPermission] = []
-            
+
             for argument in arguments {
-                let label = argument.label?.text
-                if label == "intent" {
-                    intent = parsePluginCommandIntent(argument.expression)
-                } else if label == "permissions" {
-                    permissions = resolveArray(
-                        argument.expression,
-                        expectedDescription: "array of plugin permissions or reference to global variable",
-                        elementParser: parsePluginPermission
-                    ) ?? []
-                } else {
+                switch argument.label?.text {
+                case "intent":
+                    resolve(argument.expression, description: "plugin command intent", into: &intent)
+                case "permissions":
+                    resolve(argument.expression, description: "array of plugin permissions", appendingInto: &permissions)
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "command"))
                 }
             }
-            
-            if let commandIntent = intent {
-                return .command(intent: commandIntent, permissions: permissions)
-            } else {
-                limitations.append(.unsupportedExpression(expr, expected: "command capability with intent"))
-                return nil
+
+            guard let commandIntent = intent else {
+                throw .missingValue(expr, description: "command capability with intent")
             }
+            return .command(intent: commandIntent, permissions: permissions)
         default:
-            limitations.append(.unsupportedExpression(expr, expected: "known plugin capability type"))
-            return nil
+            throw .unhandledExpression(expr)
         }
     }
     
     /// Parse a plugin command intent like .documentationGeneration or .custom(verb: "foo", description: "bar")
-    private func parsePluginCommandIntent(_ expr: ExprSyntax) -> TargetDescription.PluginCommandIntent? {
+    fileprivate func parsePluginCommandIntent(_ expr: ExprSyntax) throws(ResolutionError) -> TargetDescription.PluginCommandIntent {
         // Handle .documentationGeneration or .sourceCodeFormatting (without parens)
         if let intentName = expr.asEnumMember() {
             switch intentName {
@@ -1929,90 +1697,84 @@ extension ManifestParseVisitor {
                 break
             }
         }
-        
+
         // Handle .documentationGeneration(), .sourceCodeFormatting(), or .custom(verb:description:) (with parens)
         if let (methodName, arguments) = expr.asMemberAccessCall() {
             switch methodName {
-            case "documentationGeneration":
-                return .documentationGeneration
-            case "sourceCodeFormatting":
-                return .sourceCodeFormatting
             case "custom":
                 var verb: String?
                 var description: String?
-                
+
                 for argument in arguments {
-                    let label = argument.label?.text
-                    if label == "verb" {
-                        verb = resolveStringLiteral(argument.expression)
-                    } else if label == "description" {
-                        description = resolveStringLiteral(argument.expression)
-                    } else {
+                    switch argument.label?.text {
+                    case "verb":
+                        resolve(argument.expression, description: "plugin command verb", into: &verb)
+                    case "description":
+                        resolve(argument.expression, description: "plugin command description", into: &description)
+                    default:
                         limitations.append(.unsupportedArgument(argument, callee: "custom"))
                     }
                 }
-                
-                if let v = verb, let d = description {
-                    return .custom(verb: v, description: d)
+
+                if let verb, let description {
+                    return .custom(verb: verb, description: description)
                 }
             default:
                 break
             }
         }
-        
-        limitations.append(.unsupportedExpression(expr, expected: "plugin command intent"))
-        return nil
+
+        throw .unhandledExpression(expr)
     }
     
     /// Parse a plugin permission like .writeToPackageDirectory(reason: "...")
-    private func parsePluginPermission(_ expr: ExprSyntax) -> TargetDescription.PluginPermission? {
+    fileprivate func parsePluginPermission(_ expr: ExprSyntax) throws(ResolutionError) -> TargetDescription.PluginPermission {
         guard let (methodName, arguments) = expr.asMemberAccessCall() else {
-            limitations.append(.unsupportedExpression(expr, expected: "plugin permission"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         switch methodName {
         case "writeToPackageDirectory":
+            var reason: String?
             for argument in arguments {
-                if argument.label?.text == "reason",
-                   let reason = resolveStringLiteral(argument.expression) {
-                    return .writeToPackageDirectory(reason: reason)
-                } else {
+                switch argument.label?.text {
+                case "reason":
+                    resolve(argument.expression, description: "writeToPackageDirectory reason", into: &reason)
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "writeToPackageDirectory"))
                 }
             }
-            limitations.append(.unsupportedExpression(expr, expected: "writeToPackageDirectory with reason"))
-            return nil
+            guard let reason else {
+                throw .missingValue(expr, description: "writeToPackageDirectory with reason")
+            }
+            return .writeToPackageDirectory(reason: reason)
         case "allowNetworkConnections":
             // Parse .allowNetworkConnections(scope: ..., reason: "...")
             var scope: TargetDescription.PluginNetworkPermissionScope?
             var reason: String?
-            
+
             for argument in arguments {
-                let label = argument.label?.text
-                if label == "scope" {
-                    scope = parsePluginNetworkPermissionScope(argument.expression)
-                } else if label == "reason" {
-                    reason = resolveStringLiteral(argument.expression)
-                } else {
+                switch argument.label?.text {
+                case "scope":
+                    resolve(argument.expression, description: "plugin network permission scope", into: &scope)
+                case "reason":
+                    resolve(argument.expression, description: "plugin permission reason", into: &reason)
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "allowNetworkConnections"))
                 }
             }
-            
-            if let s = scope, let r = reason {
-                return .allowNetworkConnections(scope: s, reason: r)
-            } else {
-                limitations.append(.unsupportedExpression(expr, expected: "allowNetworkConnections with scope and reason"))
-                return nil
+
+            guard let scope, let reason else {
+                throw .missingValue(expr, description: "allowNetworkConnections with scope and reason")
             }
+            return .allowNetworkConnections(scope: scope, reason: reason)
         default:
-            limitations.append(.unsupportedExpression(expr, expected: "known plugin permission type"))
-            return nil
+            throw .unhandledExpression(expr)
         }
     }
     
     /// Parse a plugin network permission scope like .none, .local(ports: [8080]), .all(ports: []), .docker, .unixDomainSocket
-    private func parsePluginNetworkPermissionScope(_ expr: ExprSyntax) -> TargetDescription.PluginNetworkPermissionScope? {
+    fileprivate func parsePluginNetworkPermissionScope(_ expr: ExprSyntax) throws(ResolutionError) -> TargetDescription.PluginNetworkPermissionScope {
         // Simple cases: .none, .docker, .unixDomainSocket
         if let memberAccess = expr.as(MemberAccessExprSyntax.self),
            memberAccess.base == nil,
@@ -2028,91 +1790,78 @@ extension ManifestParseVisitor {
                 break
             }
         }
-        
+
         // Cases with ports: .local(ports: [...]), .all(ports: [...])
         if let functionCall = expr.as(FunctionCallExprSyntax.self),
            let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
            memberAccess.base == nil,
            let scopeName = memberAccess.declName.baseName.identifier?.name {
             var ports: [Int] = []
-            
+
             for argument in functionCall.arguments {
                 if argument.label?.text == "ports",
-                   let portsArray = argument.expression.as(ArrayExprSyntax.self) {
-                    for portElement in portsArray.elements {
-                        if let intLiteral = portElement.expression.as(IntegerLiteralExprSyntax.self),
-                           let port = Int(intLiteral.literal.text) {
-                            ports.append(port)
-                        }
-                    }
+                   let portsArray = argument.expression.asIntegerArray() {
+                    ports = portsArray
                 } else {
                     limitations.append(.unsupportedArgument(argument, callee: scopeName))
                 }
             }
-            
+
             switch scopeName {
             case "local":
                 return .local(ports: ports)
             case "all":
                 return .all(ports: ports)
             default:
-                limitations.append(.unsupportedExpression(expr, expected: "known network permission scope"))
-                return nil
+                throw .unhandledExpression(expr)
             }
         }
-        
-        limitations.append(.unsupportedExpression(expr, expected: "plugin network permission scope"))
-        return nil
+
+        throw .unhandledExpression(expr)
     }
     
     /// Parse a plugin usage like "PluginName", .plugin(name: "MyPlugin"), or .plugin(name: "MyPlugin", package: "MyPackage")
-    private func parsePluginUsage(_ expr: ExprSyntax) -> TargetDescription.PluginUsage? {
-        // Case 1: String literal (e.g., "PluginName" - refers to plugin in same package) or variable reference
-        if let pluginName = resolveStringLiteral(expr) {
-            return .plugin(name: pluginName, package: nil)
-        }
-        
-        // Case 2: .plugin(name: "...", package: "...") or .plugin(name: "...")
-        guard let functionCall = expr.as(FunctionCallExprSyntax.self),
+    fileprivate func parsePluginUsage(_ expr: ExprSyntax) throws(ResolutionError) -> TargetDescription.PluginUsage {
+        // Case 1: .plugin(name: "...", package: "...") or .plugin(name: "...")
+        if let functionCall = expr.as(FunctionCallExprSyntax.self),
               let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
               memberAccess.base == nil, // Leading dot syntax
-              memberAccess.declName.baseName.text == "plugin" else {
-            limitations.append(.unsupportedExpression(expr, expected: "plugin usage declaration"))
-            return nil
-        }
-        
-        var name: String?
-        var package: String?
-        
-        for argument in functionCall.arguments {
-            let label = argument.label?.text
-            if label == "name" {
-                name = resolveStringLiteral(argument.expression)
-            } else if label == "package" {
-                package = resolveStringLiteral(argument.expression)
-            } else {
-                limitations.append(.unsupportedArgument(argument, callee: "plugin"))
+              memberAccess.declName.baseName.text == "plugin" {
+            var name: String?
+            var package: String?
+
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case "name":
+                    resolve(argument.expression, description: "plugin name", into: &name)
+                case "package":
+                    resolve(argument.expression, description: "plugin package", into: &package)
+                default:
+                    limitations.append(.unsupportedArgument(argument, callee: "plugin"))
+                }
             }
+
+            guard let pluginName = name else {
+                throw .missingValue(expr, description: "plugin usage with name")
+            }
+
+            return .plugin(name: pluginName, package: package)
         }
-        
-        guard let pluginName = name else {
-            limitations.append(.unsupportedExpression(expr, expected: "plugin usage with name"))
-            return nil
-        }
-        
-        return .plugin(name: pluginName, package: package)
+
+        // Case 2: String literal (e.g., "PluginName" - refers to plugin in same package)
+        let pluginName = try resolveStringLiteral(expr)
+        return .plugin(name: pluginName, package: nil)
     }
     
     /// Parse a product declaration like .executable(name: "tool", targets: ["tool"])
-    private func parseProduct(_ expr: ExprSyntax) -> ProductDescription? {
+    fileprivate func parseProduct(_ expr: ExprSyntax) throws(ResolutionError) -> ProductDescription {
         guard let (methodName, arguments) = expr.asMemberAccessCall() else {
-            limitations.append(.unsupportedExpression(expr, expected: "product declaration"))
-            return nil
+            throw .unhandledExpression(expr)
         }
 
         // Parse product arguments
         var name: String?
-        var targets: [String] = []
+        var targets: [String]?
         var productType: ProductType?
         var settings: [ProductSetting] = []
 
@@ -2134,13 +1883,14 @@ extension ManifestParseVisitor {
         for argument in arguments {
             let label = argument.label?.text
 
-            if label == "name" {
-                name = resolveStringLiteral(argument.expression)
-            } else if label == "targets" {
-                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of target names or reference to global variable") {
-                    targets = parsed
-                }
-            } else if label == "type" {
+            switch label {
+            case "name":
+                resolve(argument.expression, description: "product name", into: &name)
+
+            case "targets":
+                resolve(argument.expression, description: "product targets", into: &targets)
+
+            case "type":
                 // Parse library type like .dynamic or .static
                 if let typeName = argument.expression.asEnumMember() {
                     switch typeName {
@@ -2154,33 +1904,35 @@ extension ManifestParseVisitor {
                 } else {
                     limitations.append(.unsupportedExpression(argument.expression, expected: "known library type"))
                 }
-            } else {
+
+            default:
                 // For Apple product types, additional labels are handled below.
                 // On non-Apple builds any unrecognized label is a limitation.
                 #if ENABLE_APPLE_PRODUCT_TYPES
-                if label == "bundleIdentifier" {
-                    bundleIdentifier = resolveStringLiteral(argument.expression)
-                } else if label == "teamIdentifier" {
-                    teamIdentifier = resolveStringLiteral(argument.expression)
-                } else if label == "displayVersion" {
-                    displayVersion = resolveStringLiteral(argument.expression)
-                } else if label == "bundleVersion" {
-                    bundleVersion = resolveStringLiteral(argument.expression)
-                } else if label == "appIcon" {
-                    appIcon = parseAppIcon(argument.expression)
-                } else if label == "accentColor" {
-                    accentColor = parseAccentColor(argument.expression)
-                } else if label == "supportedDeviceFamilies" {
-                    supportedDeviceFamilies = parseDeviceFamilies(argument.expression)
-                } else if label == "supportedInterfaceOrientations" {
-                    supportedInterfaceOrientations = parseInterfaceOrientations(argument.expression)
-                } else if label == "capabilities" {
-                    capabilities = parseCapabilities(argument.expression)
-                } else if label == "appCategory" {
-                    appCategory = parseAppCategory(argument.expression)
-                } else if label == "additionalInfoPlistContentFilePath" {
-                    additionalInfoPlistContentFilePath = resolveStringLiteral(argument.expression)
-                } else {
+                switch label {
+                case "bundleIdentifier":
+                    resolve(argument.expression, description: "product bundle identifier", into: &bundleIdentifier)
+                case "teamIdentifier":
+                    resolve(argument.expression, description: "product team identifier", into: &teamIdentifier)
+                case "displayVersion":
+                    resolve(argument.expression, description: "product display version", into: &displayVersion)
+                case "bundleVersion":
+                    resolve(argument.expression, description: "product bundle version", into: &bundleVersion)
+                case "appIcon":
+                    resolve(argument.expression, description: "app icon", into: &appIcon)
+                case "accentColor":
+                    resolve(argument.expression, description: "accent color", into: &accentColor)
+                case "supportedDeviceFamilies":
+                    resolve(argument.expression, description: "supported device families", appendingInto: &supportedDeviceFamilies)
+                case "supportedInterfaceOrientations":
+                    resolve(argument.expression, description: "supported interface orientations", appendingInto: &supportedInterfaceOrientations)
+                case "capabilities":
+                    resolve(argument.expression, description: "capabilities", appendingInto: &capabilities)
+                case "appCategory":
+                    resolve(argument.expression, description: "app category", into: &appCategory)
+                case "additionalInfoPlistContentFilePath":
+                    resolve(argument.expression, description: "additional info plist path", into: &additionalInfoPlistContentFilePath)
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: methodName))
                 }
                 #else
@@ -2188,12 +1940,11 @@ extension ManifestParseVisitor {
                 #endif
             }
         }
-        
+
         guard let productName = name else {
-            limitations.append(.unsupportedExpression(expr, expected: "product with name"))
-            return nil
+            throw .missingValue(expr, description: "product with name")
         }
-        
+
         // Determine product type from method name if not explicitly set
         let finalProductType: ProductType
         switch methodName {
@@ -2206,7 +1957,7 @@ extension ManifestParseVisitor {
         #if ENABLE_APPLE_PRODUCT_TYPES
         case "iOSApplication":
             finalProductType = .executable
-            
+
             // Build product settings from parsed iOS app configuration
             if let bundleIdentifier = bundleIdentifier {
                 settings.append(.bundleIdentifier(bundleIdentifier))
@@ -2235,29 +1986,41 @@ extension ManifestParseVisitor {
         #endif
         default:
             limitations.append(.unsupportedExpression(expr, expected: "known product type"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         do {
             return try ProductDescription(
                 name: productName,
                 type: finalProductType,
-                targets: targets,
+                targets: targets ?? [],
                 settings: settings
             )
         } catch {
             limitations.append(.unsupportedExpression(expr, expected: "valid product configuration"))
-            return nil
+            throw .unhandledExpression(expr)
         }
     }
-    
-    /// Parse C language standard like .iso9899_199409
-    private func parseCLanguageStandard(_ expr: ExprSyntax) -> String? {
-        guard let standardName = expr.asEnumMember() else {
-            limitations.append(.unsupportedExpression(expr, expected: "C language standard"))
-            return nil
+
+    /// Parse a warning level like .warning or .error
+    fileprivate func parseWarningLevel(_ expr: ExprSyntax) throws(ResolutionError) -> TargetBuildSettingDescription.WarningLevel {
+        guard let name = expr.asEnumMember() else {
+            throw .unhandledExpression(expr)
         }
-        
+
+        switch name {
+        case "warning": return .warning
+        case "error": return .error
+        default: throw .unhandledExpression(expr)
+        }
+    }
+
+    /// Parse C language standard like .iso9899_199409
+    fileprivate func parseCLanguageStandard(_ expr: ExprSyntax) throws(ResolutionError) -> String {
+        guard let standardName = expr.asEnumMember() else {
+            throw .unhandledExpression(expr)
+        }
+
         // Map enum case names (as written in Package.swift) to their string representations.
         // These must stay in sync with Serialization.CLanguageStandard in
         // PackageDescriptionSerialization.swift.
@@ -2283,18 +2046,16 @@ extension ManifestParseVisitor {
         case "c2x": return "c2x"
         case "gnu2x": return "gnu2x"
         default:
-            limitations.append(.unsupportedExpression(expr, expected: "known C language standard"))
-            return nil
+            throw .unhandledExpression(expr)
         }
     }
     
     /// Parse C++ language standard like .gnucxx14
-    private func parseCxxLanguageStandard(_ expr: ExprSyntax) -> String? {
+    fileprivate func parseCxxLanguageStandard(_ expr: ExprSyntax) throws(ResolutionError) -> String {
         guard let standardName = expr.asEnumMember() else {
-            limitations.append(.unsupportedExpression(expr, expected: "C++ language standard"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         // Map enum case names (as written in Package.swift) to their string representations.
         // These must stay in sync with Serialization.CXXLanguageStandard in
         // PackageDescriptionSerialization.swift.
@@ -2316,111 +2077,82 @@ extension ManifestParseVisitor {
         case "cxx2b": return "c++2b"
         case "gnucxx2b": return "gnu++2b"
         default:
-            limitations.append(.unsupportedExpression(expr, expected: "known C++ language standard"))
-            return nil
+            throw .unhandledExpression(expr)
         }
     }
     
     #if ENABLE_APPLE_PRODUCT_TYPES
     /// Parse an app icon like .asset("icon") or .placeholder(.appIcon)
-    private func parseAppIcon(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.AppIcon? {
+    fileprivate func parseAppIcon(_ expr: ExprSyntax) throws(ResolutionError) -> ProductSetting.IOSAppInfo.AppIcon {
         guard let (methodName, arguments) = expr.asMemberAccessCall() else {
-            limitations.append(.unsupportedExpression(expr, expected: "app icon"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         switch methodName {
         case "asset":
-            if let firstExpr = arguments.first?.expression,
-               let name = resolveStringLiteral(firstExpr) {
-                for argument in arguments.dropFirst() {
-                    limitations.append(.unsupportedArgument(argument, callee: "asset"))
-                }
-                return .asset(name: name)
+            guard let firstExpr = arguments.first?.expression else {
+                throw .missingValue(expr, description: "app icon asset name")
             }
+            let name = try resolveStringLiteral(firstExpr)
+            for argument in arguments.dropFirst() {
+                limitations.append(.unsupportedArgument(argument, callee: "asset"))
+            }
+            return .asset(name: name)
         case "placeholder":
-            if let iconArg = arguments.first?.expression,
-               let iconName = iconArg.asEnumMember() {
-                for argument in arguments.dropFirst() {
-                    limitations.append(.unsupportedArgument(argument, callee: "placeholder"))
-                }
-                return .placeholder(icon: .init(rawValue: iconName))
+            guard let iconArg = arguments.first?.expression,
+                  let iconName = iconArg.asEnumMember() else {
+                throw .unhandledExpression(expr)
             }
+            for argument in arguments.dropFirst() {
+                limitations.append(.unsupportedArgument(argument, callee: "placeholder"))
+            }
+            return .placeholder(icon: .init(rawValue: iconName))
         default:
-            break
+            throw .unhandledExpression(expr)
         }
-        
-        limitations.append(.unsupportedExpression(expr, expected: "valid app icon"))
-        return nil
     }
-    
+
     /// Parse an accent color like .asset("color") or .presetColor(.blue)
-    private func parseAccentColor(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.AccentColor? {
+    fileprivate func parseAccentColor(_ expr: ExprSyntax) throws(ResolutionError) -> ProductSetting.IOSAppInfo.AccentColor {
         guard let (methodName, arguments) = expr.asMemberAccessCall() else {
-            limitations.append(.unsupportedExpression(expr, expected: "accent color"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         switch methodName {
         case "asset":
-            if let firstExpr = arguments.first?.expression,
-               let name = resolveStringLiteral(firstExpr) {
-                for argument in arguments.dropFirst() {
-                    limitations.append(.unsupportedArgument(argument, callee: "asset"))
-                }
-                return .asset(name: name)
+            guard let firstExpr = arguments.first?.expression else {
+                throw .missingValue(expr, description: "accent color asset name")
             }
+            let name = try resolveStringLiteral(firstExpr)
+            for argument in arguments.dropFirst() {
+                limitations.append(.unsupportedArgument(argument, callee: "asset"))
+            }
+            return .asset(name: name)
         case "presetColor":
-            if let colorArg = arguments.first?.expression,
-               let colorName = colorArg.asEnumMember() {
-                for argument in arguments.dropFirst() {
-                    limitations.append(.unsupportedArgument(argument, callee: "presetColor"))
-                }
-                return .presetColor(presetColor: .init(rawValue: colorName))
+            guard let colorArg = arguments.first?.expression,
+                  let colorName = colorArg.asEnumMember() else {
+                throw .unhandledExpression(expr)
             }
+            for argument in arguments.dropFirst() {
+                limitations.append(.unsupportedArgument(argument, callee: "presetColor"))
+            }
+            return .presetColor(presetColor: .init(rawValue: colorName))
         default:
-            break
+            throw .unhandledExpression(expr)
         }
-        
-        limitations.append(.unsupportedExpression(expr, expected: "valid accent color"))
-        return nil
     }
-    
-    /// Parse device families like [.pad, .phone, .mac]
-    private func parseDeviceFamilies(_ expr: ExprSyntax) -> [ProductSetting.IOSAppInfo.DeviceFamily] {
-        guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
-            limitations.append(.unsupportedExpression(expr, expected: "device family array"))
-            return []
+
+    /// Parse a device family like .pad, .phone, .mac
+    fileprivate func parseDeviceFamily(_ expr: ExprSyntax) throws(ResolutionError) -> ProductSetting.IOSAppInfo.DeviceFamily {
+        guard let familyName = expr.asEnumMember(),
+              let family = ProductSetting.IOSAppInfo.DeviceFamily(rawValue: familyName) else {
+            throw .unhandledExpression(expr)
         }
-        
-        var families: [ProductSetting.IOSAppInfo.DeviceFamily] = []
-        for element in arrayExpr.elements {
-            if let familyName = element.expression.asEnumMember(),
-               let family = ProductSetting.IOSAppInfo.DeviceFamily(rawValue: familyName) {
-                families.append(family)
-            }
-        }
-        return families
+        return family
     }
-    
-    /// Parse interface orientations like [.portrait, .landscapeRight(.when(deviceFamilies: [.mac]))]
-    private func parseInterfaceOrientations(_ expr: ExprSyntax) -> [ProductSetting.IOSAppInfo.InterfaceOrientation] {
-        guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
-            limitations.append(.unsupportedExpression(expr, expected: "interface orientation array"))
-            return []
-        }
-        
-        var orientations: [ProductSetting.IOSAppInfo.InterfaceOrientation] = []
-        for element in arrayExpr.elements {
-            if let orientation = parseInterfaceOrientation(element.expression) {
-                orientations.append(orientation)
-            }
-        }
-        return orientations
-    }
-    
+
     /// Parse a single interface orientation like .portrait or .landscapeRight(.when(deviceFamilies: [.mac]))
-    private func parseInterfaceOrientation(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.InterfaceOrientation? {
+    fileprivate func parseInterfaceOrientation(_ expr: ExprSyntax) throws(ResolutionError) -> ProductSetting.IOSAppInfo.InterfaceOrientation {
         // Handle simple case: .portrait (no condition)
         if let orientationName = expr.asEnumMember() {
             switch orientationName {
@@ -2433,27 +2165,26 @@ extension ManifestParseVisitor {
             case "landscapeLeft":
                 return .landscapeLeft(condition: nil)
             default:
-                break
+                throw .unhandledExpression(expr)
             }
         }
-        
+
         // Handle conditional case: .portrait(.when(deviceFamilies: [.mac]))
         guard let functionCall = expr.as(FunctionCallExprSyntax.self),
               let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
               memberAccess.base == nil,
               let orientationName = memberAccess.declName.baseName.identifier?.name else {
-            limitations.append(.unsupportedExpression(expr, expected: "interface orientation"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         var condition: ProductSetting.IOSAppInfo.DeviceFamilyCondition?
         if let conditionArg = functionCall.arguments.first?.expression {
-            condition = parseDeviceFamilyCondition(conditionArg)
+            resolve(conditionArg, description: "device family condition", into: &condition)
         }
         for argument in functionCall.arguments.dropFirst() {
             limitations.append(.unsupportedArgument(argument, callee: orientationName))
         }
-        
+
         switch orientationName {
         case "portrait":
             return .portrait(condition: condition)
@@ -2464,71 +2195,53 @@ extension ManifestParseVisitor {
         case "landscapeLeft":
             return .landscapeLeft(condition: condition)
         default:
-            limitations.append(.unsupportedExpression(expr, expected: "valid interface orientation"))
-            return nil
+            throw .unhandledExpression(expr)
         }
     }
-    
+
     /// Parse a device family condition like .when(deviceFamilies: [.mac])
-    private func parseDeviceFamilyCondition(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.DeviceFamilyCondition? {
+    fileprivate func parseDeviceFamilyCondition(_ expr: ExprSyntax) throws(ResolutionError) -> ProductSetting.IOSAppInfo.DeviceFamilyCondition {
         guard let (methodName, arguments) = expr.asMemberAccessCall(),
               methodName == "when" else {
-            limitations.append(.unsupportedExpression(expr, expected: "device family condition"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
+        var families: [ProductSetting.IOSAppInfo.DeviceFamily]?
         for argument in arguments {
-            if argument.label?.text == "deviceFamilies" {
-                let families = parseDeviceFamilies(argument.expression)
-                return ProductSetting.IOSAppInfo.DeviceFamilyCondition(deviceFamilies: families)
+            switch argument.label?.text {
+            case "deviceFamilies":
+                resolve(argument.expression, description: "device families", into: &families)
+            default:
+                limitations.append(.unsupportedArgument(argument, callee: "when"))
             }
         }
-        
-        return nil
+
+        return ProductSetting.IOSAppInfo.DeviceFamilyCondition(deviceFamilies: families ?? [])
     }
-    
-    /// Parse capabilities like [.camera(purposeString: "..."), .microphone(purposeString: "...")]
-    private func parseCapabilities(_ expr: ExprSyntax) -> [ProductSetting.IOSAppInfo.Capability] {
-        guard let arrayExpr = expr.as(ArrayExprSyntax.self) else {
-            limitations.append(.unsupportedExpression(expr, expected: "capability array"))
-            return []
-        }
-        
-        var capabilities: [ProductSetting.IOSAppInfo.Capability] = []
-        for element in arrayExpr.elements {
-            if let capability = parseCapability(element.expression) {
-                capabilities.append(capability)
-            }
-        }
-        return capabilities
-    }
-    
+
     /// Parse a single capability
-    private func parseCapability(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.Capability? {
+    fileprivate func parseCapability(_ expr: ExprSyntax) throws(ResolutionError) -> ProductSetting.IOSAppInfo.Capability {
         guard let (purpose, arguments) = expr.asMemberAccessCall() else {
-            limitations.append(.unsupportedExpression(expr, expected: "capability"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         var purposeString: String?
         var bonjourServiceTypes: [String]?
         var condition: ProductSetting.IOSAppInfo.DeviceFamilyCondition?
-        
+
         for argument in arguments {
-            let label = argument.label?.text
-            
-            if label == "purposeString" {
-                purposeString = resolveStringLiteral(argument.expression)
-            } else if label == "bonjourServiceTypes" {
-                bonjourServiceTypes = resolveStringArray(argument.expression, expectedDescription: "array of Bonjour service types or reference to global variable")
-            } else if label == nil {
-                // Unlabeled argument could be a condition
-                if let cond = parseDeviceFamilyCondition(argument.expression) {
-                    condition = cond
-                }
+            switch argument.label?.text {
+            case "purposeString":
+                resolve(argument.expression, description: "capability purpose string", into: &purposeString)
+            case "bonjourServiceTypes":
+                resolve(argument.expression, description: "array of Bonjour service types", into: &bonjourServiceTypes)
+            case nil:
+                resolve(argument.expression, description: "device family condition", into: &condition)
+            default:
+                limitations.append(.unsupportedArgument(argument, callee: purpose))
             }
         }
-        
+
         return ProductSetting.IOSAppInfo.Capability(
             purpose: purpose,
             purposeString: purposeString,
@@ -2536,14 +2249,13 @@ extension ManifestParseVisitor {
             condition: condition
         )
     }
-    
+
     /// Parse an app category like .developerTools
-    private func parseAppCategory(_ expr: ExprSyntax) -> ProductSetting.IOSAppInfo.AppCategory? {
+    fileprivate func parseAppCategory(_ expr: ExprSyntax) throws(ResolutionError) -> ProductSetting.IOSAppInfo.AppCategory {
         guard let categoryName = expr.asEnumMember() else {
-            limitations.append(.unsupportedExpression(expr, expected: "app category"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         // Map the enum name to the raw value format
         let rawValue: String
         switch categoryName {
@@ -2590,23 +2302,22 @@ extension ManifestParseVisitor {
         default:
             rawValue = categoryName
         }
-        
+
         return ProductSetting.IOSAppInfo.AppCategory(rawValue: rawValue)
     }
     #endif
     
     /// Parse a package dependency like `.package(url: "/foo", from: "1.0.0")` or `.package(url: "/foo", branch: "main")`
-    private func parsePackageDependency(_ expr: ExprSyntax, manifestPath: AbsolutePath) -> PackageDependency? {
+    fileprivate func parsePackageDependency(_ expr: ExprSyntax) throws(ResolutionError) -> PackageDependency {
         // Expect a function call like .package(url: "/foo", from: "1.0.0")
         guard let functionCall = expr.as(FunctionCallExprSyntax.self),
               let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
               memberAccess.base == nil, // Leading dot syntax
               let methodName = memberAccess.declName.baseName.identifier?.name,
               methodName == "package" else {
-            limitations.append(.unsupportedExpression(expr, expected: "package dependency declaration"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         var name: String?
         var url: String?
         var path: String?  // Filesystem path
@@ -2617,53 +2328,56 @@ extension ManifestParseVisitor {
 
         // Parse arguments
         for argument in functionCall.arguments {
-            let label = argument.label?.text
-
-            if label == "name" {
-                name = resolveStringLiteral(argument.expression)
-            } else if label == "id" {
-                id = resolveStringLiteral(argument.expression)
-            } else if label == "url" {
-                url = resolveStringLiteral(argument.expression)
-            } else if label == "path" {
-                path = resolveStringLiteral(argument.expression)
-            } else if label == "traits" {
-                traits = parseDependencyTraits(argument.expression)
-            } else if label == "from" {
+            switch argument.label?.text {
+            case "name":
+                resolve(argument.expression, description: "dependency name", into: &name)
+            case "id":
+                resolve(argument.expression, description: "dependency id", into: &id)
+            case "url":
+                resolve(argument.expression, description: "dependency url", into: &url)
+            case "path":
+                resolve(argument.expression, description: "dependency path", into: &path)
+            case "traits":
+                resolve(argument.expression, description: "array of dependency traits", into: &traits)
+            case "from":
                 if let versionString = argument.expression.asStringLiteralValue(),
                    let version = Version(versionString) {
                     if id != nil {
-                        // Registry dependency
                         registryRequirement = .range(.upToNextMajor(from: version))
                     } else {
-                        // Source control dependency
                         requirement = .range(.upToNextMajor(from: version))
                     }
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "version"))
                 }
-            } else if label == "branch" {
-                if let branch = resolveStringLiteral(argument.expression) {
-                    requirement = .branch(branch)
+            case "branch":
+                var branch: String?
+                resolve(argument.expression, description: "branch name", into: &branch)
+                if let branch {
+                    requirement = .branch(try resolveStringLiteral(argument.expression))
                 }
-            } else if label == "revision" {
-                if let revision = resolveStringLiteral(argument.expression) {
+            case "revision":
+                var revision: String?
+                resolve(argument.expression, description: "revision", into: &revision)
+                if let revision {
                     requirement = .revision(revision)
                 }
-            } else if label == "exact" {
+            case "exact":
                 if let versionString = argument.expression.asStringLiteralValue(),
                    let version = Version(versionString) {
                     if id != nil {
-                        // Registry dependency
                         registryRequirement = .exact(version)
                     } else {
-                        // Source control dependency
                         requirement = .exact(version)
                     }
+                } else {
+                    limitations.append(.unsupportedExpression(argument.expression, expected: "version"))
                 }
-            } else if label == nil {
+            case nil:
                 // Unlabeled argument could be:
                 // 1. A requirement like .upToNextMajor(from: "1.0.0")
                 // 2. A range operator expression like "1.0.0"..<"2.0.0"
-                
+
                 // Check for range operators - handle InfixOperatorExprSyntax (after sequence folding)
                 if let infixExpr = argument.expression.as(InfixOperatorExprSyntax.self),
                    let op = infixExpr.operator.as(BinaryOperatorExprSyntax.self) {
@@ -2719,6 +2433,8 @@ extension ManifestParseVisitor {
                             } else {
                                 requirement = .range(.upToNextMajor(from: version))
                             }
+                        } else {
+                            limitations.append(.unsupportedExpression(argument.expression, expected: "package dependency requirement"))
                         }
                     case "upToNextMinor":
                         if let fromArg = reqExpr.arguments.first(where: { $0.label?.text == "from" }),
@@ -2729,6 +2445,8 @@ extension ManifestParseVisitor {
                             } else {
                                 requirement = .range(.upToNextMinor(from: version))
                             }
+                        } else {
+                            limitations.append(.unsupportedExpression(argument.expression, expected: "package dependency requirement"))
                         }
                     case "exact":
                         if let versionString = reqExpr.arguments.first?.expression.asStringLiteralValue(),
@@ -2738,14 +2456,20 @@ extension ManifestParseVisitor {
                             } else {
                                 requirement = .exact(version)
                             }
+                        } else {
+                            limitations.append(.unsupportedExpression(argument.expression, expected: "package dependency requirement"))
                         }
                     case "branch":
                         if let branch = reqExpr.arguments.first?.expression.asStringLiteralValue() {
                             requirement = .branch(branch)
+                        } else {
+                            limitations.append(.unsupportedExpression(argument.expression, expected: "package dependency requirement"))
                         }
                     case "revision":
                         if let revision = reqExpr.arguments.first?.expression.asStringLiteralValue() {
                             requirement = .revision(revision)
+                        } else {
+                            limitations.append(.unsupportedExpression(argument.expression, expected: "package dependency requirement"))
                         }
                     default:
                         limitations.append(.unsupportedExpression(argument.expression, expected: "package dependency requirement"))
@@ -2753,7 +2477,7 @@ extension ManifestParseVisitor {
                 } else {
                     limitations.append(.unsupportedExpression(argument.expression, expected: "package dependency requirement"))
                 }
-            } else {
+            default:
                 limitations.append(.unsupportedArgument(argument, callee: "package"))
             }
         }
@@ -2766,20 +2490,19 @@ extension ManifestParseVisitor {
                 productFilter: .everything,
                 traits: Set(traits ?? [.init(name: "default")])
             )
-            
+
             do {
                 return try dependencyMapper.mappedDependency(mappableDep, fileSystem: fileSystem)
             } catch {
                 limitations.append(.unsupportedExpression(expr, expected: "valid filesystem path: \(error)"))
-                return nil
+                throw .unhandledExpression(expr)
             }
         }
 
         // Handle registry dependencies
         if let packageID = id {
             guard let regReq = registryRequirement else {
-                limitations.append(.unsupportedExpression(expr, expected: "registry dependency with requirement"))
-                return nil
+                throw .missingValue(expr, description: "registry dependency with requirement")
             }
 
             let identity = PackageIdentity.plain(packageID)
@@ -2791,11 +2514,10 @@ extension ManifestParseVisitor {
             )
         }
 
-        guard let url = url, let requirement = requirement else {
-            limitations.append(.unsupportedExpression(expr, expected: "package dependency with url and requirement"))
-            return nil
+        guard let url, let requirement else {
+            throw .missingValue(expr, description: "package dependency with url and requirement")
         }
-        
+
         // Use the dependency mapper for source control dependencies
         let mappableDep = MappablePackageDependency(
             parentPackagePath: manifestPath.parentDirectory,
@@ -2803,23 +2525,22 @@ extension ManifestParseVisitor {
             productFilter: .everything,
             traits: Set(traits ?? [.init(name: "default")])
         )
-        
+
         do {
             return try dependencyMapper.mappedDependency(mappableDep, fileSystem: fileSystem)
         } catch {
             limitations.append(.unsupportedExpression(expr, expected: "valid source control dependency: \(error)"))
-            return nil
+            throw .unhandledExpression(expr)
         }
     }
     
     /// Parse a platform description like `.macOS("10.13.option1.option2")` or `.iOS(.v12)`
-    private func parsePlatform(_ expr: ExprSyntax) -> PlatformDescription? {
+    fileprivate func parsePlatform(_ expr: ExprSyntax) throws(ResolutionError) -> PlatformDescription {
         // Expect a function call like .macOS("10.13")
         guard let (platformName, arguments) = expr.asMemberAccessCall() else {
-            limitations.append(.unsupportedExpression(expr, expected: "platform declaration"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         // Map platform names (as written in Package.swift) to their canonical form.
         // These must stay in sync with the static properties on Platform in
         // PackageModel/Platform.swift.
@@ -2844,53 +2565,67 @@ extension ManifestParseVisitor {
             var customName: String?
             var versionString: String?
             for argument in arguments {
-                let label = argument.label?.text
-                if label == nil {
-                    customName = resolveStringLiteral(argument.expression)
-                } else if label == "versionString" {
-                    versionString = resolveStringLiteral(argument.expression)
-                } else {
+                switch argument.label?.text {
+                case nil:
+                    resolve(argument.expression, description: "custom platform name", into: &customName)
+                case "versionString":
+                    resolve(argument.expression, description: "custom platform version", into: &versionString)
+                default:
                     limitations.append(.unsupportedArgument(argument, callee: "custom"))
                 }
             }
             guard let name = customName, let version = versionString else {
-                limitations.append(.unsupportedExpression(expr, expected: "custom platform with name and versionString"))
-                return nil
+                throw .missingValue(expr, description: "custom platform with name and versionString")
             }
             return PlatformDescription(name: name, version: version, options: [])
 
         default:
-            limitations.append(.unsupportedExpression(expr, expected: "known platform"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         // Get the version argument and check for unexpected extra arguments
         guard let firstArg = arguments.first else {
-            limitations.append(.unsupportedExpression(expr, expected: "platform with version"))
-            return nil
+            throw .missingValue(expr, description: "platform with version")
         }
-        
+
         for argument in arguments.dropFirst() {
             limitations.append(.unsupportedArgument(argument, callee: platformName))
         }
 
         var version: String
         var options: [String] = []
-        
-        // Check if it's a string literal like "10.13.option1.option2"
-        if let versionString = resolveStringLiteral(firstArg.expression) {
+
+        // Check if it's a member access like .v10_13
+        if let memberAccess = firstArg.expression.as(MemberAccessExprSyntax.self),
+                memberAccess.base == nil,
+                let versionName = memberAccess.declName.baseName.identifier?.name {
+            // Parse version from names like "v10_13" or "v12"
+            if versionName.hasPrefix("v") {
+                let versionPart = String(versionName.dropFirst()) // Remove "v"
+                // Replace underscores with dots
+                version = versionPart.replacingOccurrences(of: "_", with: ".")
+
+                // Normalize version to have at least major.minor (e.g., "12" -> "12.0")
+                if !version.contains(".") {
+                    version = version + ".0"
+                }
+            } else {
+                throw .unhandledExpression(firstArg.expression)
+            }
+        } else {
+            // Check if it's a string literal like "10.13.option1.option2"
+            let versionString = try resolveStringLiteral(firstArg.expression)
             // Parse version and options from the string
             let components = versionString.split(separator: ".")
             if components.isEmpty {
-                limitations.append(.unsupportedExpression(expr, expected: "valid version string"))
-                return nil
+                throw .missingValue(expr, description: "valid version string")
             }
-            
+
             // Find where version numbers end and options begin
             var versionComponents: [Substring] = []
             var optionComponents: [String] = []
             var inOptions = false
-            
+
             for component in components {
                 if !inOptions && component.allSatisfy({ $0.isNumber }) {
                     versionComponents.append(component)
@@ -2899,208 +2634,158 @@ extension ManifestParseVisitor {
                     optionComponents.append(String(component))
                 }
             }
-            
+
             version = versionComponents.joined(separator: ".")
             options = optionComponents
         }
-        // Check if it's a member access like .v10_13
-        else if let memberAccess = firstArg.expression.as(MemberAccessExprSyntax.self),
-                memberAccess.base == nil,
-                let versionName = memberAccess.declName.baseName.identifier?.name {
-            // Parse version from names like "v10_13" or "v12"
-            if versionName.hasPrefix("v") {
-                let versionPart = String(versionName.dropFirst()) // Remove "v"
-                // Replace underscores with dots
-                version = versionPart.replacingOccurrences(of: "_", with: ".")
-                
-                // Normalize version to have at least major.minor (e.g., "12" -> "12.0")
-                if !version.contains(".") {
-                    version = version + ".0"
-                }
-            } else {
-                limitations.append(.unsupportedExpression(expr, expected: "version in format .vX_Y"))
-                return nil
-            }
-        }
-        else {
-            limitations.append(.unsupportedExpression(expr, expected: "string literal or version constant"))
-            return nil
-        }
-        
+
         return PlatformDescription(name: canonicalName, version: version, options: options)
     }
     
     /// Parse a trait declaration like "Trait1", Trait(name: "Trait2", description: "..."), or .trait(name: "Trait3", enabledTraits: [...])
-    private func parseTrait(_ expr: ExprSyntax) -> TraitDescription? {
-        // Case 1: String literal "TraitName" or variable reference
-        if let traitName = resolveStringLiteral(expr) {
-            return TraitDescription(name: traitName)
-        }
-        
-        // Case 2: Trait(name: "...", description: "...", enabledTraits: [...]) or .trait(...) or .default(...)
-        guard let functionCall = expr.as(FunctionCallExprSyntax.self) else {
-            limitations.append(.unsupportedExpression(expr, expected: "trait declaration"))
-            return nil
-        }
-        
-        // Check if it's Trait(...), .trait(...), or .default(...)
-        let methodName: String?
-        if let identifierExpr = functionCall.calledExpression.as(DeclReferenceExprSyntax.self),
-           identifierExpr.baseName.text == "Trait" {
-            methodName = "trait"
-        } else if let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
-                  memberAccess.base == nil {
-            methodName = memberAccess.declName.baseName.text
-        } else {
-            methodName = nil
-        }
-        
-        guard let method = methodName, (method == "trait" || method == "default") else {
-            limitations.append(.unsupportedExpression(expr, expected: "Trait(...), .trait(...), or .default(...)"))
-            return nil
-        }
-        
-        // Handle .default(enabledTraits: [...])
-        if method == "default" {
-            var enabledTraits: [String] = []
+    fileprivate func parseTrait(_ expr: ExprSyntax) throws(ResolutionError) -> TraitDescription {
+        // Case 1: Trait(name: "...", description: "...", enabledTraits: [...]) or .trait(...) or .default(...)
+        if let functionCall = expr.as(FunctionCallExprSyntax.self) {
+            // Check if it's Trait(...), .trait(...), or .default(...)
+            let methodName: String?
+            if let identifierExpr = functionCall.calledExpression.as(DeclReferenceExprSyntax.self),
+               identifierExpr.baseName.text == "Trait" {
+                methodName = "trait"
+            } else if let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+                      memberAccess.base == nil {
+                methodName = memberAccess.declName.baseName.text
+            } else {
+                methodName = nil
+            }
+
+            guard let method = methodName, (method == "trait" || method == "default") else {
+                throw .unhandledExpression(expr)
+            }
+
+            // Handle .default(enabledTraits: [...])
+            if method == "default" {
+                var enabledTraits: [String]?
+
+                for argument in functionCall.arguments {
+                    if argument.label?.text == "enabledTraits" {
+                        resolve(argument.expression, description: "array of enabled trait names", into: &enabledTraits)
+                    } else {
+                        limitations.append(.unsupportedArgument(argument, callee: "default"))
+                    }
+                }
+
+                return TraitDescription(
+                    name: "default",
+                    description: "The default traits of this package.",
+                    enabledTraits: Set(enabledTraits ?? [])
+                )
+            }
+
+            // Handle .trait(...) or Trait(...)
+            var name: String?
+            var description: String?
+            var enabledTraits: [String]?
 
             for argument in functionCall.arguments {
-                if argument.label?.text == "enabledTraits" {
-                    if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of enabled trait names or reference to global variable") {
-                        enabledTraits = parsed
-                    }
+                let label = argument.label?.text
+                if label == "name" {
+                    resolve(argument.expression, description: "trait name", into: &name)
+                } else if label == "description" {
+                    resolve(argument.expression, description: "trait description", into: &description)
+                } else if label == "enabledTraits" {
+                    resolve(argument.expression, description: "array of enabled trait names", into: &enabledTraits)
                 } else {
-                    limitations.append(.unsupportedArgument(argument, callee: "default"))
+                    limitations.append(.unsupportedArgument(argument, callee: "trait"))
                 }
             }
 
-            return TraitDescription(
-                name: "default",
-                description: "The default traits of this package.",
-                enabledTraits: Set(enabledTraits)
-            )
-        }
-
-        // Handle .trait(...) or Trait(...)
-        var name: String?
-        var description: String?
-        var enabledTraits: [String] = []
-
-        for argument in functionCall.arguments {
-            let label = argument.label?.text
-            if label == "name" {
-                name = resolveStringLiteral(argument.expression)
-            } else if label == "description" {
-                description = resolveStringLiteral(argument.expression)
-            } else if label == "enabledTraits" {
-                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of enabled trait names or reference to global variable") {
-                    enabledTraits = parsed
-                }
-            } else {
-                limitations.append(.unsupportedArgument(argument, callee: "trait"))
+            guard let traitName = name else {
+                throw .missingValue(expr, description: "trait with name")
             }
+
+            return TraitDescription(name: traitName, description: description, enabledTraits: Set(enabledTraits ?? []))
         }
-        
-        guard let traitName = name else {
-            limitations.append(.unsupportedExpression(expr, expected: "trait with name"))
-            return nil
-        }
-        
-        return TraitDescription(name: traitName, description: description, enabledTraits: Set(enabledTraits))
+
+        // Case 2: String literal "TraitName"
+        let traitName = try resolveStringLiteral(expr)
+        return TraitDescription(name: traitName)
     }
-    
-    /// Parse dependency traits array like ["FooTrait1", .trait(name: "FooTrait2", condition: ...), .defaults]
-    private func parseDependencyTraits(_ expr: ExprSyntax) -> [PackageDependency.Trait]? {
-        return resolveArray(
-            expr,
-            expectedDescription: "array of dependency traits or reference to global variable",
-            elementParser: parseDependencyTrait
-        )
-    }
-    
+
     /// Parse a single dependency trait like "FooTrait1", .trait(name: "...", condition: ...), or .defaults
-    private func parseDependencyTrait(_ expr: ExprSyntax) -> PackageDependency.Trait? {
-        // Case 1: String literal "TraitName" or variable reference
-        if let traitName = resolveStringLiteral(expr) {
-            return PackageDependency.Trait(name: traitName)
-        }
-        
-        // Case 2: .defaults
+    fileprivate func parseDependencyTrait(_ expr: ExprSyntax) throws(ResolutionError) -> PackageDependency.Trait {
+        // Case 1: .defaults
         if let memberAccess = expr.as(MemberAccessExprSyntax.self),
            memberAccess.base == nil,
            memberAccess.declName.baseName.text == "defaults" {
             return PackageDependency.Trait(name: "default")
         }
-        
-        // Case 3: .trait(name: "...", condition: ...) or Package.Dependency.Trait(name: "...", condition: ...)
-        guard let functionCall = expr.as(FunctionCallExprSyntax.self) else {
-            limitations.append(.unsupportedExpression(expr, expected: "dependency trait declaration"))
-            return nil
-        }
-        
-        // Check if it's .trait(...) or Package.Dependency.Trait(...)
-        let isValidCall: Bool
-        if let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
-           memberAccess.base == nil,
-           memberAccess.declName.baseName.text == "trait" {
-            isValidCall = true
-        } else if let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
-                  let baseAccess = memberAccess.base?.as(MemberAccessExprSyntax.self),
-                  memberAccess.declName.baseName.text == "Trait" {
-            // Package.Dependency.Trait(...)
-            isValidCall = true
-            _ = baseAccess
-        } else {
-            isValidCall = false
-        }
-        
-        guard isValidCall else {
-            limitations.append(.unsupportedExpression(expr, expected: ".trait(...) or Package.Dependency.Trait(...)"))
-            return nil
-        }
-        
-        var name: String?
-        var condition: PackageDependency.Trait.Condition?
-        
-        for argument in functionCall.arguments {
-            let label = argument.label?.text
-            if label == "name" {
-                name = resolveStringLiteral(argument.expression)
-            } else if label == "condition" {
-                condition = parseDependencyTraitCondition(argument.expression)
+
+        // Case 2: .trait(name: "...", condition: ...) or Package.Dependency.Trait(name: "...", condition: ...)
+        if let functionCall = expr.as(FunctionCallExprSyntax.self) {
+            // Check if it's .trait(...) or Package.Dependency.Trait(...)
+            let isValidCall: Bool
+            if let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+               memberAccess.base == nil,
+               memberAccess.declName.baseName.text == "trait" {
+                isValidCall = true
+            } else if let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self),
+                      let baseAccess = memberAccess.base?.as(MemberAccessExprSyntax.self),
+                      memberAccess.declName.baseName.text == "Trait" {
+                // Package.Dependency.Trait(...)
+                isValidCall = true
+                _ = baseAccess
             } else {
-                limitations.append(.unsupportedArgument(argument, callee: "trait"))
+                isValidCall = false
             }
+
+            guard isValidCall else {
+                throw .unhandledExpression(expr)
+            }
+
+            var name: String?
+            var condition: PackageDependency.Trait.Condition?
+
+            for argument in functionCall.arguments {
+                switch argument.label?.text {
+                case "name":
+                    resolve(argument.expression, description: "dependency trait name", into: &name)
+                case "condition":
+                    resolve(argument.expression, description: "dependency trait condition", into: &condition)
+                default:
+                    limitations.append(.unsupportedArgument(argument, callee: "trait"))
+                }
+            }
+
+            guard let traitName = name else {
+                throw .missingValue(expr, description: "dependency trait with name")
+            }
+
+            return PackageDependency.Trait(name: traitName, condition: condition)
         }
-        
-        guard let traitName = name else {
-            limitations.append(.unsupportedExpression(expr, expected: "dependency trait with name"))
-            return nil
-        }
-        
-        return PackageDependency.Trait(name: traitName, condition: condition)
+
+        // Case 3: String literal "TraitName"
+        let traitName = try resolveStringLiteral(expr)
+        return PackageDependency.Trait(name: traitName)
     }
-    
+
     /// Parse a dependency trait condition like .when(traits: ["Trait1"])
-    private func parseDependencyTraitCondition(_ expr: ExprSyntax) -> PackageDependency.Trait.Condition? {
+    fileprivate func parseDependencyTraitCondition(_ expr: ExprSyntax) throws(ResolutionError) -> PackageDependency.Trait.Condition {
         guard let (methodName, arguments) = expr.asMemberAccessCall(),
               methodName == "when" else {
-            limitations.append(.unsupportedExpression(expr, expected: "trait condition"))
-            return nil
+            throw .unhandledExpression(expr)
         }
-        
+
         var traits: [String]?
-        
+
         for argument in arguments {
-            if argument.label?.text == "traits" {
-                if let parsed = resolveStringArray(argument.expression, expectedDescription: "array of trait names or reference to global variable") {
-                    traits = parsed
-                }
-            } else {
+            switch argument.label?.text {
+            case "traits":
+                resolve(argument.expression, description: "array of trait names", into: &traits)
+            default:
                 limitations.append(.unsupportedArgument(argument, callee: "when"))
             }
         }
-        
+
         return PackageDependency.Trait.Condition(traits: traits.map { Set($0) })
     }
 }
@@ -3306,4 +2991,167 @@ class StaticContextModel {
         }
     }()
 }
+
+// MARK: Resolution of types in a package manifest.
+
+fileprivate protocol ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws (ManifestParseVisitor.ResolutionError)-> Self
+}
+
+extension String: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> String {
+        try visitor.resolveStringLiteral(expr)
+    }
+}
+
+extension Array: ParsingResolvable where Element: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> [Element] {
+        try visitor.resolveArray(expr) { expr throws(ManifestParseVisitor.ResolutionError) in
+            try Element.resolve(expr, in: visitor)
+        }
+    }
+}
+
+extension ProductDescription: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> ProductDescription {
+        try visitor.parseProduct(expr)
+    }
+}
+
+extension TargetDescription: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TargetDescription {
+        try visitor.parseTarget(expr)
+    }
+}
+
+extension TargetDescription.Dependency: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TargetDescription.Dependency {
+        try visitor.parseTargetDependency(expr)
+    }
+}
+
+extension TargetDescription.Resource: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TargetDescription.Resource {
+        try visitor.parseResource(expr)
+    }
+}
+
+extension TargetDescription.PluginCapability: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TargetDescription.PluginCapability {
+        try visitor.parsePluginCapability(expr)
+    }
+}
+
+extension TargetDescription.PluginUsage: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TargetDescription.PluginUsage {
+        try visitor.parsePluginUsage(expr)
+    }
+}
+
+extension TargetDescription.PluginPermission: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TargetDescription.PluginPermission {
+        try visitor.parsePluginPermission(expr)
+    }
+}
+
+extension TargetDescription.PluginCommandIntent: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TargetDescription.PluginCommandIntent {
+        try visitor.parsePluginCommandIntent(expr)
+    }
+}
+
+extension TargetDescription.PluginNetworkPermissionScope: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TargetDescription.PluginNetworkPermissionScope {
+        try visitor.parsePluginNetworkPermissionScope(expr)
+    }
+}
+
+extension PlatformDescription: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> PlatformDescription {
+        try visitor.parsePlatform(expr)
+    }
+}
+
+extension TraitDescription: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TraitDescription {
+        try visitor.parseTrait(expr)
+    }
+}
+
+extension PackageDependency: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> PackageDependency {
+        try visitor.parsePackageDependency(expr)
+    }
+}
+
+extension PackageDependency.Trait: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> PackageDependency.Trait {
+        try visitor.parseDependencyTrait(expr)
+    }
+}
+
+extension PackageDependency.Trait.Condition: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> PackageDependency.Trait.Condition {
+        try visitor.parseDependencyTraitCondition(expr)
+    }
+}
+
+extension SystemPackageProviderDescription: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> SystemPackageProviderDescription {
+        try visitor.parseSystemPackageProvider(expr)
+    }
+}
+
+
+
+extension TargetBuildSettingDescription.WarningLevel: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> TargetBuildSettingDescription.WarningLevel {
+        try visitor.parseWarningLevel(expr)
+    }
+}
+
+#if ENABLE_APPLE_PRODUCT_TYPES
+extension ProductSetting.IOSAppInfo.AppIcon: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> ProductSetting.IOSAppInfo.AppIcon {
+        try visitor.parseAppIcon(expr)
+    }
+}
+
+extension ProductSetting.IOSAppInfo.AccentColor: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> ProductSetting.IOSAppInfo.AccentColor {
+        try visitor.parseAccentColor(expr)
+    }
+}
+
+extension ProductSetting.IOSAppInfo.DeviceFamily: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> ProductSetting.IOSAppInfo.DeviceFamily {
+        try visitor.parseDeviceFamily(expr)
+    }
+}
+
+extension ProductSetting.IOSAppInfo.InterfaceOrientation: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> ProductSetting.IOSAppInfo.InterfaceOrientation {
+        try visitor.parseInterfaceOrientation(expr)
+    }
+}
+
+extension ProductSetting.IOSAppInfo.DeviceFamilyCondition: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> ProductSetting.IOSAppInfo.DeviceFamilyCondition {
+        try visitor.parseDeviceFamilyCondition(expr)
+    }
+}
+
+extension ProductSetting.IOSAppInfo.Capability: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> ProductSetting.IOSAppInfo.Capability {
+        try visitor.parseCapability(expr)
+    }
+}
+
+extension ProductSetting.IOSAppInfo.AppCategory: ParsingResolvable {
+    static func resolve(_ expr: ExprSyntax, in visitor: ManifestParseVisitor) throws(ManifestParseVisitor.ResolutionError) -> ProductSetting.IOSAppInfo.AppCategory {
+        try visitor.parseAppCategory(expr)
+    }
+}
+#endif
+
 #endif

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -457,7 +457,7 @@ public struct EnabledTraits: Hashable {
     }
 
     public static func ==(_ lhs: EnabledTraits, _ rhs: EnabledTraits) -> Bool {
-        lhs._traits.names == rhs._traits.names
+        Set(lhs._traits.names) == Set(rhs._traits.names)
     }
 }
 

--- a/Sources/PackageModel/Manifest/Manifest.swift
+++ b/Sources/PackageModel/Manifest/Manifest.swift
@@ -668,4 +668,11 @@ extension Manifest: Encodable {
         try container.encode(self.platforms, forKey: .platforms)
         try container.encode(self.packageKind, forKey: .packageKind)
     }
+
+    public func toJSON() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [ .prettyPrinted, .sortedKeys ]
+        let data = try encoder.encode(self)
+        return String(data: data, encoding: .utf8)!
+    }
 }

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -205,9 +205,6 @@ fileprivate extension SourceCodeFragment {
                 traits.allSatisfy(\.isDefaultsCase)
 
             if !isDefault {
-                let traits = traits.sorted { a, b in
-                    PackageDependency.Trait.precedes(a, b)
-                }
                 params.append(
                     SourceCodeFragment(
                         key: "traits",
@@ -249,7 +246,7 @@ fileprivate extension SourceCodeFragment {
             params.append(
                 SourceCodeFragment(
                     key: "traits",
-                    subnodes: trait.sorted().map {
+                    subnodes: trait.map {
                         SourceCodeFragment(string: $0)
                     }
                 )
@@ -328,7 +325,7 @@ fileprivate extension SourceCodeFragment {
     init(from trait: TraitDescription) {
         let enabledTraitsNode = SourceCodeFragment(
             key: "enabledTraits",
-            subnodes: trait.enabledTraits.sorted().map {
+            subnodes: trait.enabledTraits.map {
                 SourceCodeFragment(string: $0)
             }
         )
@@ -529,7 +526,7 @@ fileprivate extension SourceCodeFragment {
         }
         if let traits = condition.traits {
             params.append(
-                SourceCodeFragment(key: "traits", subnodes: traits.sorted().map { trait in
+                SourceCodeFragment(key: "traits", subnodes: traits.map { trait in
                     SourceCodeFragment(string: trait)
                 })
             )

--- a/Sources/SwiftFixIt/SwiftFixIt.swift
+++ b/Sources/SwiftFixIt/SwiftFixIt.swift
@@ -384,7 +384,7 @@ private struct SourceFile {
 
         self.sourceLocationConverter = SwiftSyntax.SourceLocationConverter(
             fileName: path.pathString,
-            tree: self.syntax
+            tree: self.syntax.root
         )
     }
 

--- a/Sources/_InternalTestSupport/MockManifestLoader.swift
+++ b/Sources/_InternalTestSupport/MockManifestLoader.swift
@@ -75,7 +75,7 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
     public func purgeCache(observabilityScope: ObservabilityScope) async {}
 }
 
-extension ManifestLoader {
+extension ManifestLoaderProtocol {
     public func load(
         manifestPath: AbsolutePath,
         packageKind: PackageReference.Kind,

--- a/Sources/_InternalTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/_InternalTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -96,6 +96,15 @@ extension PackageDependency.SourceControl.Requirement {
     public static func upToNextMinor(from version: Version) -> Self {
         return .range(.upToNextMinor(from: version))
     }
+    public static func upToNextMajor(from versionString: String) -> Self {
+        return .range(.upToNextMajor(from: Version(stringLiteral: versionString)))
+    }
+    public static func upToNextMinor(from versionString: String) -> Self {
+        return .range(.upToNextMinor(from: Version(stringLiteral: versionString)))
+    }
+    public static func exact(_ versionString: String) -> Self {
+        return .exact(Version(stringLiteral: versionString))
+    }
 }
 
 extension PackageDependency.Registry.Requirement {

--- a/Tests/PackageLoadingTests/PDAppleProductLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDAppleProductLoadingTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -18,12 +18,16 @@ import _InternalTestSupport
 import PackageModel
 import PackageLoading
 
+enum AppleProductTestingError: Error {
+    case noManifest
+}
+
 class PackageDescriptionAppleProductLoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
         .v6_0 // TODO: confirm this value
     }
 
-    func testApplicationProducts() throws {
+    func testApplicationProducts() async throws {
       #if ENABLE_APPLE_PRODUCT_TYPES
         let content = """
             import PackageDescription
@@ -58,50 +62,60 @@ class PackageDescriptionAppleProductLoadingTests: PackageDescriptionLoadingTests
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, _) = try loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        // Check the targets.  We expect to have a single executable target.
-        XCTAssertEqual(manifest.targets.count, 1)
-        let mainTarget = manifest.targets[0]
-        XCTAssertEqual(mainTarget.type, .executable)
-        XCTAssertEqual(mainTarget.name, "Foo")
+            // Check the targets.  We expect to have a single executable target.
+            XCTAssertEqual(manifest.targets.count, 1)
+            let mainTarget = manifest.targets[0]
+            XCTAssertEqual(mainTarget.type, .executable)
+            XCTAssertEqual(mainTarget.name, "Foo")
 
-        // Check the products.  We expect to have a single executable product with iOS-specific settings.
-        XCTAssertEqual(manifest.products.count, 1)
-        let appProduct = manifest.products[0]
+            // Check the products.  We expect to have a single executable product with iOS-specific settings.
+            XCTAssertEqual(manifest.products.count, 1)
+            let appProduct = manifest.products[0]
 
-        // Check the core properties and basic settings of the application product.
-        XCTAssertEqual(appProduct.type, .executable)
-        XCTAssertEqual(appProduct.settings.count, 5)
-        XCTAssertTrue(appProduct.settings.contains(.bundleIdentifier("com.my.app")))
-        XCTAssertTrue(appProduct.settings.contains(.bundleVersion("1.4.2")))
+            // Check the core properties and basic settings of the application product.
+            XCTAssertEqual(appProduct.type, .executable)
+            XCTAssertEqual(appProduct.settings.count, 5)
+            XCTAssertTrue(appProduct.settings.contains(.bundleIdentifier("com.my.app")))
+            XCTAssertTrue(appProduct.settings.contains(.bundleVersion("1.4.2")))
 
-        // Find the "iOS Application Info" setting.
-        var appInfoSetting: ProductSetting.IOSAppInfo? = nil
-        for case let ProductSetting.iOSAppInfo(value) in appProduct.settings  {
-            appInfoSetting = .init(value)
+            // Find the "iOS Application Info" setting.
+            var appInfoSetting: ProductSetting.IOSAppInfo? = nil
+            for case let ProductSetting.iOSAppInfo(value) in appProduct.settings  {
+                appInfoSetting = .init(value)
+            }
+            guard let appInfoSetting = appInfoSetting else {
+                XCTFail("product has no .iOSAppInfo() setting")
+                throw AppleProductTestingError.noManifest
+            }
+
+            // Check the specific properties of the iOS Application Info.
+            XCTAssertEqual(appInfoSetting.appIcon, .asset(name: "icon"))
+            XCTAssertEqual(appInfoSetting.accentColor, .asset(name: "accentColor"))
+            XCTAssertEqual(appInfoSetting.supportedDeviceFamilies, [.pad, .mac])
+            XCTAssertEqual(appInfoSetting.supportedInterfaceOrientations, [
+                .portrait(condition: nil),
+                .portraitUpsideDown(condition: nil),
+                .landscapeRight(condition: .init(deviceFamilies: [.mac]))
+            ])
+            XCTAssertEqual(appInfoSetting.capabilities, [
+                .init(purpose: "camera", purposeString: "All the better to see you with…", condition: nil),
+                .init(purpose: "microphone", purposeString: "All the better to hear you with…", condition: .init(deviceFamilies: [.pad, .phone])),
+                .init(purpose: "localNetwork", purposeString: "Communication is key…", bonjourServiceTypes: ["_ipp._tcp"], condition: .init(deviceFamilies: [.mac]))
+            ])
+            XCTAssertEqual(appInfoSetting.appCategory?.rawValue, "public.app-category.developer-tools")
+            
+            return manifest
         }
-        guard let appInfoSetting = appInfoSetting else {
-            return XCTFail("product has no .iOSAppInfo() setting")
-        }
-
-        // Check the specific properties of the iOS Application Info.
-        XCTAssertEqual(appInfoSetting.appIcon, .asset(name: "icon"))
-        XCTAssertEqual(appInfoSetting.accentColor, .asset(name: "accentColor"))
-        XCTAssertEqual(appInfoSetting.supportedDeviceFamilies, [.pad, .mac])
-        XCTAssertEqual(appInfoSetting.supportedInterfaceOrientations, [
-            .portrait(condition: nil),
-            .portraitUpsideDown(condition: nil),
-            .landscapeRight(condition: .init(deviceFamilies: [.mac]))
-        ])
-        XCTAssertEqual(appInfoSetting.capabilities, [
-            .init(purpose: "camera", purposeString: "All the better to see you with…", condition: nil),
-            .init(purpose: "microphone", purposeString: "All the better to hear you with…", condition: .init(deviceFamilies: [.pad, .phone])),
-            .init(purpose: "localNetwork", purposeString: "Communication is key…", bonjourServiceTypes: ["_ipp._tcp"], condition: .init(deviceFamilies: [.mac]))
-        ])
-        XCTAssertEqual(appInfoSetting.appCategory?.rawValue, "public.app-category.developer-tools")
       #else
         throw XCTSkip("ENABLE_APPLE_PRODUCT_TYPES is not set")
       #endif

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -18,7 +18,22 @@ import XCTest
 
 class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
     lazy var manifestLoader = ManifestLoader(toolchain: try! UserToolchain.default, delegate: self)
+    lazy var parsingManifestLoader = try? ParsingManifestLoader(
+        toolchain: try! UserToolchain.default,
+        extraManifestFlags: [],
+        environment: self.environment
+    )
     var parsedManifest = ThreadSafeBox<AbsolutePath>(.root)
+
+    /// The array of manifest loaders to test with for complete coverage.
+    var testManifestLoaders: [(any ManifestLoaderProtocol)?] {
+        var result = [(any ManifestLoaderProtocol)?]()
+        if let parsingManifestLoader {
+            result.append(parsingManifestLoader)
+        }
+        result.append(/*default manifest loader*/nil)
+        return result
+    }
 
     func willLoad(packageIdentity: PackageModel.PackageIdentity, packageLocation: String, manifestPath: AbsolutePath) {
         // noop
@@ -56,11 +71,36 @@ class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
         fatalError("implement in subclass")
     }
 
+    var environment: [String: String]? { nil }
+
+    /// Run the given closure for each manifest loader, comparing the
+    /// resulting manifests to ensure that they match.
+    func forEachManifestLoader(
+        _ body: ((any ManifestLoaderProtocol)?) async throws -> Manifest,
+        file: StaticString = #file, line: UInt = #line
+    ) async rethrows {
+        var currentManifest: Manifest? = nil
+        for loader in self.testManifestLoaders {
+            let newManifest = try await body(loader)
+
+            if let currentManifest {
+                XCTAssertEqual(
+                    try currentManifest.toJSON(),
+                    try newManifest.toJSON(),
+                    file: file,
+                    line: line
+                )
+            } else {
+                currentManifest = newManifest
+            }
+        }
+    }
+
     func loadAndValidateManifest(
         _ content: String,
         toolsVersion: ToolsVersion? = nil,
         packageKind: PackageReference.Kind? = nil,
-        customManifestLoader: ManifestLoader? = nil,
+        customManifestLoader: (any ManifestLoaderProtocol)? = nil,
         observabilityScope: ObservabilityScope,
         file: StaticString = #file,
         line: UInt = #line
@@ -80,7 +120,7 @@ class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
         _ content: String,
         toolsVersion: ToolsVersion,
         packageKind: PackageReference.Kind,
-        manifestLoader: ManifestLoader,
+        manifestLoader: any ManifestLoaderProtocol,
         observabilityScope: ObservabilityScope,
         file: StaticString = #file,
         line: UInt = #line

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -29,15 +29,23 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.displayName, "Trivial")
-        XCTAssertEqual(manifest.toolsVersion, .v4)
-        XCTAssertEqual(manifest.targets, [])
-        XCTAssertEqual(manifest.dependencies, [])
+            XCTAssertEqual(manifest.displayName, "Trivial")
+            XCTAssertEqual(manifest.toolsVersion, .v4)
+            XCTAssertEqual(manifest.targets, [])
+            XCTAssertEqual(manifest.dependencies, [])
+
+            return manifest
+        }
     }
 
     func testTargetDependencies() async throws {
@@ -59,29 +67,37 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.displayName, "Trivial")
-        let foo = manifest.targetMap["foo"]!
-        XCTAssertEqual(foo.name, "foo")
-        XCTAssertFalse(foo.isTest)
+            XCTAssertEqual(manifest.displayName, "Trivial")
+            let foo = manifest.targetMap["foo"]!
+            XCTAssertEqual(foo.name, "foo")
+            XCTAssertFalse(foo.isTest)
 
-        let expectedDependencies: [TargetDescription.Dependency]
-        expectedDependencies = [
-            "dep1",
-            .target(name: "dep2"),
-            .product(name: "dep3", package: "Pkg"),
-            .product(name: "dep4"),
-        ]
-        XCTAssertEqual(foo.dependencies, expectedDependencies)
+            let expectedDependencies: [TargetDescription.Dependency]
+            expectedDependencies = [
+                "dep1",
+                .target(name: "dep2"),
+                .product(name: "dep3", package: "Pkg"),
+                .product(name: "dep4"),
+            ]
+            XCTAssertEqual(foo.dependencies, expectedDependencies)
 
-        let bar = manifest.targetMap["bar"]!
-        XCTAssertEqual(bar.name, "bar")
-        XCTAssertTrue(bar.isTest)
-        XCTAssertEqual(bar.dependencies, ["foo"])
+            let bar = manifest.targetMap["bar"]!
+            XCTAssertEqual(bar.name, "bar")
+            XCTAssertTrue(bar.isTest)
+            XCTAssertEqual(bar.dependencies, ["foo"])
+            
+            return manifest
+        }
     }
 
     func testCompatibleSwiftVersions() async throws {
@@ -93,11 +109,18 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                    swiftLanguageVersions: [3, 4]
                 )
                 """
-            let observability = ObservabilitySystem.makeForTesting()
-            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(validationDiagnostics)
-            XCTAssertEqual(manifest.swiftLanguageVersions?.map({$0.rawValue}), ["3", "4"])
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
+                XCTAssertEqual(manifest.swiftLanguageVersions?.map({$0.rawValue}), ["3", "4"])
+                return manifest
+            }
         }
 
         do {
@@ -108,11 +131,18 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                    swiftLanguageVersions: []
                 )
                 """
-            let observability = ObservabilitySystem.makeForTesting()
-            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(validationDiagnostics)
-            XCTAssertEqual(manifest.swiftLanguageVersions, [])
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
+                XCTAssertEqual(manifest.swiftLanguageVersions, [])
+                return manifest
+            }
         }
 
         do {
@@ -121,11 +151,18 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
                 let package = Package(
                    name: "Foo")
                 """
-            let observability = ObservabilitySystem.makeForTesting()
-            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(validationDiagnostics)
-            XCTAssertEqual(manifest.swiftLanguageVersions, nil)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
+                XCTAssertEqual(manifest.swiftLanguageVersions, nil)
+                return manifest
+            }
         }
     }
 
@@ -145,18 +182,26 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo2"], .localSourceControl(path: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo3"], .localSourceControl(path: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo4"], .localSourceControl(path: "/foo4", requirement: .exact("1.0.0")))
-        XCTAssertEqual(deps["foo5"], .localSourceControl(path: "/foo5", requirement: .branch("main")))
-        XCTAssertEqual(deps["foo6"], .localSourceControl(path: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["foo2"], .localSourceControl(path: "/foo2", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["foo3"], .localSourceControl(path: "/foo3", requirement: .upToNextMinor(from: "1.0.0")))
+            XCTAssertEqual(deps["foo4"], .localSourceControl(path: "/foo4", requirement: .exact("1.0.0")))
+            XCTAssertEqual(deps["foo5"], .localSourceControl(path: "/foo5", requirement: .branch("main")))
+            XCTAssertEqual(deps["foo6"], .localSourceControl(path: "/foo6", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            
+            return manifest
+        }
     }
 
     func testProducts() async throws {
@@ -176,27 +221,35 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
-        // Check tool.
-        let tool = products["tool"]!
-        XCTAssertEqual(tool.name, "tool")
-        XCTAssertEqual(tool.targets, ["tool"])
-        XCTAssertEqual(tool.type, .executable)
-        // Check Foo.
-        let foo = products["Foo"]!
-        XCTAssertEqual(foo.name, "Foo")
-        XCTAssertEqual(foo.type, .library(.automatic))
-        XCTAssertEqual(foo.targets, ["Foo"])
-        // Check FooDy.
-        let fooDy = products["FooDy"]!
-        XCTAssertEqual(fooDy.name, "FooDy")
-        XCTAssertEqual(fooDy.type, .library(.dynamic))
-        XCTAssertEqual(fooDy.targets, ["Foo"])
+            let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
+            // Check tool.
+            let tool = products["tool"]!
+            XCTAssertEqual(tool.name, "tool")
+            XCTAssertEqual(tool.targets, ["tool"])
+            XCTAssertEqual(tool.type, .executable)
+            // Check Foo.
+            let foo = products["Foo"]!
+            XCTAssertEqual(foo.name, "Foo")
+            XCTAssertEqual(foo.type, .library(.automatic))
+            XCTAssertEqual(foo.targets, ["Foo"])
+            // Check FooDy.
+            let fooDy = products["FooDy"]!
+            XCTAssertEqual(fooDy.name, "FooDy")
+            XCTAssertEqual(fooDy.type, .library(.dynamic))
+            XCTAssertEqual(fooDy.targets, ["Foo"])
+            
+            return manifest
+        }
     }
 
     func testSystemPackage() async throws {
@@ -212,17 +265,25 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.displayName, "Copenssl")
-        XCTAssertEqual(manifest.pkgConfig, "openssl")
-        XCTAssertEqual(manifest.providers, [
-            .brew(["openssl"]),
-            .apt(["openssl", "libssl-dev"]),
-        ])
+            XCTAssertEqual(manifest.displayName, "Copenssl")
+            XCTAssertEqual(manifest.pkgConfig, "openssl")
+            XCTAssertEqual(manifest.providers, [
+                .brew(["openssl"]),
+                .apt(["openssl", "libssl-dev"]),
+            ])
+            
+            return manifest
+        }
     }
 
     func testCTarget() async throws {
@@ -240,16 +301,24 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let foo = manifest.targetMap["Foo"]!
-        XCTAssertEqual(foo.publicHeadersPath, "inc")
+            let foo = manifest.targetMap["Foo"]!
+            XCTAssertEqual(foo.publicHeadersPath, "inc")
 
-        let bar = manifest.targetMap["Bar"]!
-        XCTAssertEqual(bar.publicHeadersPath, nil)
+            let bar = manifest.targetMap["Bar"]!
+            XCTAssertEqual(bar.publicHeadersPath, nil)
+            
+            return manifest
+        }
     }
 
     func testTargetProperties() async throws {
@@ -270,22 +339,30 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let foo = manifest.targetMap["Foo"]!
-        XCTAssertEqual(foo.publicHeadersPath, "inc")
-        XCTAssertEqual(foo.path, "foo/z")
-        XCTAssertEqual(foo.exclude, ["bar"])
-        XCTAssertEqual(foo.sources ?? [], ["bar.swift"])
+            let foo = manifest.targetMap["Foo"]!
+            XCTAssertEqual(foo.publicHeadersPath, "inc")
+            XCTAssertEqual(foo.path, "foo/z")
+            XCTAssertEqual(foo.exclude, ["bar"])
+            XCTAssertEqual(foo.sources ?? [], ["bar.swift"])
 
-        let bar = manifest.targetMap["Bar"]!
-        XCTAssertEqual(bar.publicHeadersPath, nil)
-        XCTAssertEqual(bar.path, nil)
-        XCTAssertEqual(bar.exclude, [])
-        XCTAssert(bar.sources == nil)
+            let bar = manifest.targetMap["Bar"]!
+            XCTAssertEqual(bar.publicHeadersPath, nil)
+            XCTAssertEqual(bar.path, nil)
+            XCTAssertEqual(bar.exclude, [])
+            XCTAssert(bar.sources == nil)
+            
+            return manifest
+        }
     }
 
     func testUnavailableAPIs() async throws {
@@ -326,14 +403,22 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             )
         """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.displayName, "testPackage")
-        XCTAssertEqual(manifest.cLanguageStandard, "iso9899:199409")
-        XCTAssertEqual(manifest.cxxLanguageStandard, "gnu++14")
+            XCTAssertEqual(manifest.displayName, "testPackage")
+            XCTAssertEqual(manifest.cLanguageStandard, "iso9899:199409")
+            XCTAssertEqual(manifest.cxxLanguageStandard, "gnu++14")
+            
+            return manifest
+        }
     }
 
     func testManifestWithWarnings() async throws {
@@ -440,4 +525,127 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
             result.check(diagnostic: "target 'B' referenced in product 'Product' could not be found; valid targets are: 'A'", severity: .error)
         }
     }
+
+    // Test the legacy system library package style: a package with pkgConfig
+    // (and optionally providers) at the Package level and a module.modulemap
+    // file on disk, but no explicit targets or products in the manifest. Both
+    // loaders must synthesize an equivalent system library target and product.
+    func testLegacySystemLibraryPackage() async throws {
+        let content = """
+            // swift-tools-version:4.0
+            import PackageDescription
+            let package = Package(
+                name: "CZLib",
+                pkgConfig: "zlib",
+                providers: [
+                    .brew(["zlib"]),
+                    .apt(["zlib1g-dev"]),
+                ]
+            )
+            """
+
+        for loader in self.testManifestLoaders {
+            let packagePath = AbsolutePath.root
+            let manifestPath = packagePath.appending(component: Manifest.filename)
+            let fileSystem = InMemoryFileSystem()
+            try fileSystem.writeFileContents(manifestPath, string: content)
+            // The presence of module.modulemap triggers the legacy system library path.
+            try fileSystem.writeFileContents(
+                packagePath.appending(component: "module.modulemap"),
+                string: "module CZLib { header \"zlib.h\" }"
+            )
+
+            let observability = ObservabilitySystem.makeForTesting()
+            let manifest = try await (loader ?? self.manifestLoader).load(
+                manifestPath: manifestPath,
+                packageKind: .fileSystem(packagePath),
+                toolsVersion: .v4,
+                fileSystem: fileSystem,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+
+            // The parser must synthesize a system library target and product.
+            XCTAssertEqual(manifest.targets.count, 1)
+            let target = try XCTUnwrap(manifest.targets.first)
+            XCTAssertEqual(target.name, "CZLib")
+            XCTAssertEqual(target.type, .system)
+            XCTAssertEqual(target.pkgConfig, "zlib")
+            XCTAssertEqual(target.providers, [.brew(["zlib"]), .apt(["zlib1g-dev"])])
+            XCTAssertEqual(target.packageAccess, false)
+
+            XCTAssertEqual(manifest.products.count, 1)
+            let product = try XCTUnwrap(manifest.products.first)
+            XCTAssertEqual(product.name, "CZLib")
+            XCTAssertEqual(product.type, .library(.automatic))
+            XCTAssertEqual(product.targets, ["CZLib"])
+
+            // Package-level pkgConfig/providers must still be present.
+            XCTAssertEqual(manifest.pkgConfig, "zlib")
+            XCTAssertEqual(manifest.providers, [.brew(["zlib"]), .apt(["zlib1g-dev"])])
+        }
+    }
+
+    // Without a module.modulemap on disk the manifest must NOT synthesize a
+    // system library target, even when pkgConfig is set at the package level.
+    func testLegacySystemLibraryPackageWithoutModuleMap() async throws {
+        let content = """
+            // swift-tools-version:4.0
+            import PackageDescription
+            let package = Package(
+                name: "CZLib",
+                pkgConfig: "zlib"
+            )
+            """
+
+        // No module.modulemap on disk — let loadAndValidateManifest create a
+        // minimal filesystem with only the manifest file.
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(
+            content,
+            customManifestLoader: self.parsingManifestLoader,
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        // No targets or products should be synthesized.
+        XCTAssertEqual(manifest.targets.count, 0)
+        XCTAssertEqual(manifest.products.count, 0)
+        XCTAssertEqual(manifest.pkgConfig, "zlib")
+    }
+
+    func testExplicitSourcesList() async throws {
+        // A target with an explicit sources list must be parsed identically by
+        // both the parsing loader and the executing loader.
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "CLib",
+                targets: [
+                    .target(
+                        name: "CLib",
+                        sources: ["src/foo.c", "src/bar.c", "src/baz.c"]
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets.count, 1)
+            let target = try XCTUnwrap(manifest.targets.first)
+            XCTAssertEqual(target.name, "CLib")
+            XCTAssertEqual(target.sources, ["src/foo.c", "src/bar.c", "src/baz.c"])
+
+            return manifest
+        }
+    }
 }
+

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -52,43 +52,51 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.displayName, "Trivial")
+            XCTAssertEqual(manifest.displayName, "Trivial")
 
-        // Check targets.
-        let foo = manifest.targetMap["foo"]!
-        XCTAssertEqual(foo.name, "foo")
-        XCTAssertFalse(foo.isTest)
-        XCTAssertEqual(foo.dependencies, ["dep1", .product(name: "product"), .target(name: "target")])
+            // Check targets.
+            let foo = manifest.targetMap["foo"]!
+            XCTAssertEqual(foo.name, "foo")
+            XCTAssertFalse(foo.isTest)
+            XCTAssertEqual(foo.dependencies, ["dep1", .product(name: "product"), .target(name: "target")])
 
-        let bar = manifest.targetMap["bar"]!
-        XCTAssertEqual(bar.name, "bar")
-        XCTAssertTrue(bar.isTest)
-        XCTAssertEqual(bar.dependencies, ["foo"])
+            let bar = manifest.targetMap["bar"]!
+            XCTAssertEqual(bar.name, "bar")
+            XCTAssertTrue(bar.isTest)
+            XCTAssertEqual(bar.dependencies, ["foo"])
 
-        // Check dependencies.
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            // Check dependencies.
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
-        // Check products.
-        let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
+            // Check products.
+            let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
 
-        let tool = products["tool"]!
-        XCTAssertEqual(tool.name, "tool")
-        XCTAssertEqual(tool.targets, ["tool"])
-        XCTAssertEqual(tool.type, .executable)
+            let tool = products["tool"]!
+            XCTAssertEqual(tool.name, "tool")
+            XCTAssertEqual(tool.targets, ["tool"])
+            XCTAssertEqual(tool.type, .executable)
 
-        let fooProduct = products["Foo"]!
-        XCTAssertEqual(fooProduct.name, "Foo")
-        XCTAssertEqual(fooProduct.type, .library(.automatic))
-        XCTAssertEqual(fooProduct.targets, ["foo"])
+            let fooProduct = products["Foo"]!
+            XCTAssertEqual(fooProduct.name, "Foo")
+            XCTAssertEqual(fooProduct.type, .library(.automatic))
+            XCTAssertEqual(fooProduct.targets, ["foo"])
+            
+            return manifest
+        }
     }
 
-    func testSwiftLanguageVersions() async throws {
+    func testSwiftLanguageVersionsDiagnostics() async throws {
         // Ensure integer values are not accepted.
         do {
             let content = """
@@ -114,7 +122,9 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 }
             }
         }
+    }
 
+    func testSwiftLanguageVersionsNew() async throws {
         // Check when Swift language versions is empty.
         do {
             let content = """
@@ -125,12 +135,20 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(validationDiagnostics)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
 
-            XCTAssertEqual(manifest.swiftLanguageVersions, [])
+                XCTAssertEqual(manifest.swiftLanguageVersions, [])
+                
+                return manifest
+            }
         }
 
         do {
@@ -142,17 +160,27 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(validationDiagnostics)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
 
-            XCTAssertEqual(
-                manifest.swiftLanguageVersions,
-                [.v3, .v4, .v4_2, SwiftLanguageVersion(string: "5")!]
-            )
+                XCTAssertEqual(
+                    manifest.swiftLanguageVersions,
+                    [.v3, .v4, .v4_2, SwiftLanguageVersion(string: "5")!]
+                )
+                
+                return manifest
+            }
         }
 
+        // The third test case checks that .v5 is unavailable in PackageDescription 4.2
+        // This only applies to the compilation-based manifest loader, not the parsing loader
         do {
             let content = """
                 import PackageDescription
@@ -163,7 +191,11 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 """
 
             let observability = ObservabilitySystem.makeForTesting()
-            await XCTAssertAsyncThrowsError(try await loadAndValidateManifest(content, observabilityScope: observability.topScope), "expected error") { error in
+            await XCTAssertAsyncThrowsError(try await loadAndValidateManifest(
+                content,
+                customManifestLoader: nil,
+                observabilityScope: observability.topScope
+            ), "expected error") { error in
                 if case ManifestParseError.invalidManifestFormat(let message, _, _) = error {
                     XCTAssertMatch(message, .contains("is unavailable"))
                     XCTAssertMatch(message, .contains("was introduced in PackageDescription 5"))
@@ -270,62 +302,70 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
-        XCTAssertEqual(deps["foo2"], .localSourceControl(path: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            XCTAssertEqual(deps["foo2"], .localSourceControl(path: "/foo2", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
 
-        if case .fileSystem(let dep) = deps["foo3"] {
-            XCTAssertEqual(dep.path, "/foo3")
-        } else {
-            XCTFail("expected to be local dependency")
-        }
+            if case .fileSystem(let dep) = deps["foo3"] {
+                XCTAssertEqual(dep.path, "/foo3")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-        if case .fileSystem(let dep) = deps["foo4"] {
-            XCTAssertEqual(dep.path, "/path/to/foo4")
-        } else {
-            XCTFail("expected to be local dependency")
-        }
+            if case .fileSystem(let dep) = deps["foo4"] {
+                XCTAssertEqual(dep.path, "/path/to/foo4")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-        XCTAssertEqual(deps["foo5"], .localSourceControl(path: "/foo5", requirement: .exact("1.2.3")))
-        XCTAssertEqual(deps["foo6"], .localSourceControl(path: "/foo6", requirement: .range("1.2.3"..<"2.0.0")))
-        XCTAssertEqual(deps["foo7"], .localSourceControl(path: "/foo7", requirement: .branch("main")))
-        XCTAssertEqual(deps["foo8"], .localSourceControl(path: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
-        XCTAssertEqual(deps["foo9"], .localSourceControl(path: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
+            XCTAssertEqual(deps["foo5"], .localSourceControl(path: "/foo5", requirement: .exact("1.2.3")))
+            XCTAssertEqual(deps["foo6"], .localSourceControl(path: "/foo6", requirement: .range("1.2.3"..<"2.0.0")))
+            XCTAssertEqual(deps["foo7"], .localSourceControl(path: "/foo7", requirement: .branch("main")))
+            XCTAssertEqual(deps["foo8"], .localSourceControl(path: "/foo8", requirement: .upToNextMinor(from: "1.3.4")))
+            XCTAssertEqual(deps["foo9"], .localSourceControl(path: "/foo9", requirement: .upToNextMajor(from: "1.3.4")))
 
-        let homeDir = "/home/user"
-        if case .fileSystem(let dep) = deps["foo10"] {
-            XCTAssertEqual(dep.path, try AbsolutePath(validating: "\(homeDir)/path/to/foo10"))
-        } else {
-            XCTFail("expected to be local dependency")
-        }
+            let homeDir = "/home/user"
+            if case .fileSystem(let dep) = deps["foo10"] {
+                XCTAssertEqual(dep.path, try AbsolutePath(validating: "\(homeDir)/path/to/foo10"))
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-        if case .fileSystem(let dep) = deps["~foo11"] {
-            XCTAssertEqual(dep.path, "/~foo11")
-        } else {
-            XCTFail("expected to be local dependency")
-        }
+            if case .fileSystem(let dep) = deps["~foo11"] {
+                XCTAssertEqual(dep.path, "/~foo11")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-        if case .fileSystem(let dep) = deps["foo12"] {
-            XCTAssertEqual(dep.path, try AbsolutePath(validating: "\(homeDir)/path/to/~/foo12"))
-        } else {
-            XCTFail("expected to be local dependency")
-        }
+            if case .fileSystem(let dep) = deps["foo12"] {
+                XCTAssertEqual(dep.path, try AbsolutePath(validating: "\(homeDir)/path/to/~/foo12"))
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-        if case .fileSystem(let dep) = deps["~"] {
-            XCTAssertEqual(dep.path, "/~")
-        } else {
-            XCTFail("expected to be local dependency")
-        }
+            if case .fileSystem(let dep) = deps["~"] {
+                XCTAssertEqual(dep.path, "/~")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
 
-        if case .fileSystem(let dep) = deps["foo13"] {
-            XCTAssertEqual(dep.path, "/path/to/foo13")
-        } else {
-            XCTFail("expected to be local dependency")
+            if case .fileSystem(let dep) = deps["foo13"] {
+                XCTAssertEqual(dep.path, "/path/to/foo13")
+            } else {
+                XCTFail("expected to be local dependency")
+            }
+            
+            return manifest
         }
     }
 
@@ -349,22 +389,30 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let foo = manifest.targetMap["foo"]!
-        XCTAssertEqual(foo.name, "foo")
-        XCTAssertFalse(foo.isTest)
-        XCTAssertEqual(foo.type, .regular)
-        XCTAssertEqual(foo.dependencies, ["bar"])
+            let foo = manifest.targetMap["foo"]!
+            XCTAssertEqual(foo.name, "foo")
+            XCTAssertFalse(foo.isTest)
+            XCTAssertEqual(foo.type, .regular)
+            XCTAssertEqual(foo.dependencies, ["bar"])
 
-        let bar = manifest.targetMap["bar"]!
-        XCTAssertEqual(bar.name, "bar")
-        XCTAssertEqual(bar.type, .system)
-        XCTAssertEqual(bar.pkgConfig, "libbar")
-        XCTAssertEqual(bar.providers, [.brew(["libgit"]), .apt(["a", "b"])])
+            let bar = manifest.targetMap["bar"]!
+            XCTAssertEqual(bar.name, "bar")
+            XCTAssertEqual(bar.type, .system)
+            XCTAssertEqual(bar.pkgConfig, "libbar")
+            XCTAssertEqual(bar.providers, [.brew(["libgit"]), .apt(["a", "b"])])
+
+            return manifest
+        }
     }
 
     /// Check that we load the manifest appropriate for the current version, if

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -48,40 +48,48 @@ final class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.displayName, "Trivial")
+            XCTAssertEqual(manifest.displayName, "Trivial")
 
-        // Check targets.
-        let foo = manifest.targetMap["foo"]!
-        XCTAssertEqual(foo.name, "foo")
-        XCTAssertFalse(foo.isTest)
-        XCTAssertEqual(foo.dependencies, ["dep1", .product(name: "product"), .target(name: "target")])
+            // Check targets.
+            let foo = manifest.targetMap["foo"]!
+            XCTAssertEqual(foo.name, "foo")
+            XCTAssertFalse(foo.isTest)
+            XCTAssertEqual(foo.dependencies, ["dep1", .product(name: "product"), .target(name: "target")])
 
-        let bar = manifest.targetMap["bar"]!
-        XCTAssertEqual(bar.name, "bar")
-        XCTAssertTrue(bar.isTest)
-        XCTAssertEqual(bar.dependencies, ["foo"])
+            let bar = manifest.targetMap["bar"]!
+            XCTAssertEqual(bar.name, "bar")
+            XCTAssertTrue(bar.isTest)
+            XCTAssertEqual(bar.dependencies, ["foo"])
 
-        // Check dependencies.
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
+            // Check dependencies.
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .localSourceControl(path: "/foo1", requirement: .upToNextMajor(from: "1.0.0")))
 
-        // Check products.
-        let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
+            // Check products.
+            let products = Dictionary(uniqueKeysWithValues: manifest.products.map{ ($0.name, $0) })
 
-        let tool = products["tool"]!
-        XCTAssertEqual(tool.name, "tool")
-        XCTAssertEqual(tool.targets, ["tool"])
-        XCTAssertEqual(tool.type, .executable)
+            let tool = products["tool"]!
+            XCTAssertEqual(tool.name, "tool")
+            XCTAssertEqual(tool.targets, ["tool"])
+            XCTAssertEqual(tool.type, .executable)
 
-        let fooProduct = products["Foo"]!
-        XCTAssertEqual(fooProduct.name, "Foo")
-        XCTAssertEqual(fooProduct.type, .library(.automatic))
-        XCTAssertEqual(fooProduct.targets, ["foo"])
+            let fooProduct = products["Foo"]!
+            XCTAssertEqual(fooProduct.name, "Foo")
+            XCTAssertEqual(fooProduct.type, .library(.automatic))
+            XCTAssertEqual(fooProduct.targets, ["foo"])
+            
+            return manifest
+        }
     }
 
     func testSwiftLanguageVersion() async throws {
@@ -94,12 +102,20 @@ final class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(validationDiagnostics)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
 
-            XCTAssertEqual(manifest.swiftLanguageVersions, [.v4, .v4_2, .v5])
+                XCTAssertEqual(manifest.swiftLanguageVersions, [.v4, .v4_2, .v5])
+                
+                return manifest
+            }
         }
 
         do {
@@ -154,16 +170,24 @@ final class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.platforms, [
-            PlatformDescription(name: "macos", version: "10.13", options: ["option1", "option2"]),
-            PlatformDescription(name: "ios", version: "12.2", options: ["option2"]),
-            PlatformDescription(name: "tvos", version: "12.3.4", options: ["option5", "option7", "option9"]),
-        ])
+            XCTAssertEqual(manifest.platforms, [
+                PlatformDescription(name: "macos", version: "10.13", options: ["option1", "option2"]),
+                PlatformDescription(name: "ios", version: "12.2", options: ["option2"]),
+                PlatformDescription(name: "tvos", version: "12.3.4", options: ["option5", "option7", "option9"]),
+            ])
+            
+            return manifest
+        }
     }
 
     func testPlatforms() async throws {
@@ -179,17 +203,25 @@ final class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(validationDiagnostics)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
 
-            XCTAssertEqual(manifest.platforms, [
-                PlatformDescription(name: "macos", version: "10.13"),
-                PlatformDescription(name: "ios", version: "12.2"),
-                PlatformDescription(name: "tvos", version: "12.0"),
-                PlatformDescription(name: "watchos", version: "3.0"),
-            ])
+                XCTAssertEqual(manifest.platforms, [
+                    PlatformDescription(name: "macos", version: "10.13"),
+                    PlatformDescription(name: "ios", version: "12.2"),
+                    PlatformDescription(name: "tvos", version: "12.0"),
+                    PlatformDescription(name: "watchos", version: "3.0"),
+                ])
+                
+                return manifest
+            }
         }
 
         // Test invalid custom versions.
@@ -340,25 +372,29 @@ final class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, customManifestLoader: loader, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let settings = manifest.targets[0].settings
+            let settings = manifest.targets[0].settings
 
-        XCTAssertEqual(settings[0], .init(tool: .c, kind: .headerSearchPath("path/to/foo")))
-        XCTAssertEqual(settings[1], .init(tool: .c, kind: .define("C"), condition: .init(platformNames: ["linux"])))
-        XCTAssertEqual(settings[2], .init(tool: .c, kind: .define("CC=4"), condition: .init(platformNames: ["linux"], config: "release")))
+            XCTAssertEqual(settings[0], .init(tool: .c, kind: .headerSearchPath("path/to/foo")))
+            XCTAssertEqual(settings[1], .init(tool: .c, kind: .define("C"), condition: .init(platformNames: ["linux"])))
+            XCTAssertEqual(settings[2], .init(tool: .c, kind: .define("CC=4"), condition: .init(platformNames: ["linux"], config: "release")))
 
-        XCTAssertEqual(settings[3], .init(tool: .cxx, kind: .headerSearchPath("path/to/bar")))
-        XCTAssertEqual(settings[4], .init(tool: .cxx, kind: .define("CXX")))
+            XCTAssertEqual(settings[3], .init(tool: .cxx, kind: .headerSearchPath("path/to/bar")))
+            XCTAssertEqual(settings[4], .init(tool: .cxx, kind: .define("CXX")))
 
-        XCTAssertEqual(settings[5], .init(tool: .swift, kind: .define("SWIFT"), condition: .init(config: "release")))
-        XCTAssertEqual(settings[6], .init(tool: .swift, kind: .define("SWIFT_DEBUG"), condition: .init(platformNames: ["watchos"], config: "debug")))
+            XCTAssertEqual(settings[5], .init(tool: .swift, kind: .define("SWIFT"), condition: .init(config: "release")))
+            XCTAssertEqual(settings[6], .init(tool: .swift, kind: .define("SWIFT_DEBUG"), condition: .init(platformNames: ["watchos"], config: "debug")))
 
-        XCTAssertEqual(settings[7], .init(tool: .linker, kind: .linkedLibrary("libz")))
-        XCTAssertEqual(settings[8], .init(tool: .linker, kind: .linkedFramework("CoreData"), condition: .init(platformNames: ["macos", "tvos"])))
+            XCTAssertEqual(settings[7], .init(tool: .linker, kind: .linkedLibrary("libz")))
+            XCTAssertEqual(settings[8], .init(tool: .linker, kind: .linkedFramework("CoreData"), condition: .init(platformNames: ["macos", "tvos"])))
+            
+            return manifest
+        }
     }
 
     func testSerializedDiagnostics() async throws {
@@ -484,9 +520,19 @@ final class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            _ = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
+                XCTAssertEqual(manifest.targets[0].settings, [])
+                
+                return manifest
+            }
         }
     }
 
@@ -519,21 +565,30 @@ final class PackageDescription5_0LoadingTests: PackageDescriptionLoadingTests {
         }
 
         do {
-            let observability = ObservabilitySystem.makeForTesting()
-            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, toolsVersion: .v5_2, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(validationDiagnostics)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    toolsVersion: .v5_2,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
 
-            XCTAssertEqual(manifest.displayName, "Foo")
+                XCTAssertEqual(manifest.displayName, "Foo")
 
-            // Check targets.
-            let foo = manifest.targetMap["foo"]!
-            XCTAssertEqual(foo.name, "foo")
-            XCTAssertFalse(foo.isTest)
-            XCTAssertEqual(foo.dependencies, [])
+                // Check targets.
+                let foo = manifest.targetMap["foo"]!
+                XCTAssertEqual(foo.name, "foo")
+                XCTAssertFalse(foo.isTest)
+                XCTAssertEqual(foo.dependencies, [])
 
-            let settings = foo.settings
-            XCTAssertEqual(settings[0], .init(tool: .c, kind: .define("LLVM_ON_WIN32"), condition: .init(platformNames: ["windows"])))
+                let settings = foo.settings
+                XCTAssertEqual(settings[0], .init(tool: .c, kind: .define("LLVM_ON_WIN32"), condition: .init(platformNames: ["windows"])))
+                
+                return manifest
+            }
         }
     }
 

--- a/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
@@ -84,21 +84,29 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.displayName, "Trivial")
-        XCTAssertEqual(manifest.dependencies[0].nameForModuleDependencyResolutionOnly, "Foo")
-        XCTAssertEqual(manifest.dependencies[1].nameForModuleDependencyResolutionOnly, "Foo2")
-        XCTAssertEqual(manifest.dependencies[2].nameForModuleDependencyResolutionOnly, "Foo3")
-        XCTAssertEqual(manifest.dependencies[3].nameForModuleDependencyResolutionOnly, "Foo4")
-        XCTAssertEqual(manifest.dependencies[4].nameForModuleDependencyResolutionOnly, "Foo5")
-        XCTAssertEqual(manifest.dependencies[5].nameForModuleDependencyResolutionOnly, "bar")
-        XCTAssertEqual(manifest.dependencies[6].nameForModuleDependencyResolutionOnly, "Bar2")
-        XCTAssertEqual(manifest.dependencies[7].nameForModuleDependencyResolutionOnly, "Baz")
-        XCTAssertEqual(manifest.dependencies[8].nameForModuleDependencyResolutionOnly, "swift")
+            XCTAssertEqual(manifest.displayName, "Trivial")
+            XCTAssertEqual(manifest.dependencies[0].nameForModuleDependencyResolutionOnly, "Foo")
+            XCTAssertEqual(manifest.dependencies[1].nameForModuleDependencyResolutionOnly, "Foo2")
+            XCTAssertEqual(manifest.dependencies[2].nameForModuleDependencyResolutionOnly, "Foo3")
+            XCTAssertEqual(manifest.dependencies[3].nameForModuleDependencyResolutionOnly, "Foo4")
+            XCTAssertEqual(manifest.dependencies[4].nameForModuleDependencyResolutionOnly, "Foo5")
+            XCTAssertEqual(manifest.dependencies[5].nameForModuleDependencyResolutionOnly, "bar")
+            XCTAssertEqual(manifest.dependencies[6].nameForModuleDependencyResolutionOnly, "Bar2")
+            XCTAssertEqual(manifest.dependencies[7].nameForModuleDependencyResolutionOnly, "Baz")
+            XCTAssertEqual(manifest.dependencies[8].nameForModuleDependencyResolutionOnly, "swift")
+            
+            return manifest
+        }
     }
 
     func testTargetDependencyProductInvalidPackage() async throws {
@@ -123,12 +131,19 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'foo' (from 'http://scm.com/org/foo'), 'bar' (from 'http://scm.com/org/bar')", severity: .error)
-                result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'foo' (from 'http://scm.com/org/foo'), 'bar' (from 'http://scm.com/org/bar')", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'foo' (from 'http://scm.com/org/foo'), 'bar' (from 'http://scm.com/org/bar')", severity: .error)
+                    result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'foo' (from 'http://scm.com/org/foo'), 'bar' (from 'http://scm.com/org/bar')", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -153,12 +168,19 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo' (from 'http://scm.com/org/foo'), 'Bar' (from 'http://scm.com/org/bar')", severity: .error)
-                result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'Foo' (from 'http://scm.com/org/foo'), 'Bar' (from 'http://scm.com/org/bar')", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo' (from 'http://scm.com/org/foo'), 'Bar' (from 'http://scm.com/org/bar')", severity: .error)
+                    result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'Foo' (from 'http://scm.com/org/foo'), 'Bar' (from 'http://scm.com/org/bar')", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -184,11 +206,19 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, packageKind: .root(.root), observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo' (from 'http://scm.com/org/foo1')", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    packageKind: .root(.root),
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.check(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo' (from 'http://scm.com/org/foo1')", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -214,14 +244,21 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                let fooPkg: AbsolutePath = "/foo"
-                let barPkg: AbsolutePath = "/bar"
-                result.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'foo' (at '\(fooPkg)'), 'bar' (at '\(barPkg)')", severity: .error)
-                result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'foo' (at '\(fooPkg)'), 'bar' (at '\(barPkg)')", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    let fooPkg: AbsolutePath = "/foo"
+                    let barPkg: AbsolutePath = "/bar"
+                    result.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'foo' (at '\(fooPkg)'), 'bar' (at '\(barPkg)')", severity: .error)
+                    result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'foo' (at '\(fooPkg)'), 'bar' (at '\(barPkg)')", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -246,14 +283,21 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                let foo1Pkg: AbsolutePath = "/foo1"
-                let bar1Pkg: AbsolutePath = "/bar1"
-                result.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo' (at '\(foo1Pkg)'), 'Bar' (at '\(bar1Pkg)')", severity: .error)
-                result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'Foo' (at '\(foo1Pkg)'), 'Bar' (at '\(bar1Pkg)')", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    let foo1Pkg: AbsolutePath = "/foo1"
+                    let bar1Pkg: AbsolutePath = "/bar1"
+                    result.checkUnordered(diagnostic: "unknown package 'foo1' in dependencies of target 'Target1'; valid packages are: 'Foo' (at '\(foo1Pkg)'), 'Bar' (at '\(bar1Pkg)')", severity: .error)
+                    result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'Foo' (at '\(foo1Pkg)'), 'Bar' (at '\(bar1Pkg)')", severity: .error)
+                }
+                return manifest
             }
         }
     }
@@ -279,19 +323,27 @@ final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let dependencies = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.nameForModuleDependencyResolutionOnly, $0) })
-        let dependencyFoobar = dependencies["Foobar"]!
-        let dependencyBarfoo = dependencies["Barfoo"]!
-        let targetFoo = manifest.targetMap["foo"]!
-        let targetBar = manifest.targetMap["bar"]!
-        XCTAssertEqual(manifest.packageDependency(referencedBy: targetFoo.dependencies[0]), dependencyFoobar)
-        XCTAssertEqual(manifest.packageDependency(referencedBy: targetFoo.dependencies[1]), dependencyBarfoo)
-        XCTAssertEqual(manifest.packageDependency(referencedBy: targetBar.dependencies[0]), nil)
+            let dependencies = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.nameForModuleDependencyResolutionOnly, $0) })
+            let dependencyFoobar = dependencies["Foobar"]!
+            let dependencyBarfoo = dependencies["Barfoo"]!
+            let targetFoo = manifest.targetMap["foo"]!
+            let targetBar = manifest.targetMap["bar"]!
+            XCTAssertEqual(manifest.packageDependency(referencedBy: targetFoo.dependencies[0]), dependencyFoobar)
+            XCTAssertEqual(manifest.packageDependency(referencedBy: targetFoo.dependencies[1]), dependencyBarfoo)
+            XCTAssertEqual(manifest.packageDependency(referencedBy: targetBar.dependencies[0]), nil)
+            
+            return manifest
+        }
     }
 
     func testResourcesUnavailable() async throws {

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -48,20 +48,67 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, customManifestLoader: loader, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let resources = manifest.targets[0].resources
-        XCTAssertEqual(resources[0], TargetDescription.Resource(rule: .copy, path: "foo.txt"))
-        XCTAssertEqual(resources[1], TargetDescription.Resource(rule: .process(localization: .none), path: "bar.txt"))
-        XCTAssertEqual(resources[2], TargetDescription.Resource(rule: .process(localization: .default), path: "biz.txt"))
-        XCTAssertEqual(resources[3], TargetDescription.Resource(rule: .process(localization: .base), path: "baz.txt"))
+            let resources = manifest.targets[0].resources
+            XCTAssertEqual(resources[0], TargetDescription.Resource(rule: .copy, path: "foo.txt"))
+            XCTAssertEqual(resources[1], TargetDescription.Resource(rule: .process(localization: .none), path: "bar.txt"))
+            XCTAssertEqual(resources[2], TargetDescription.Resource(rule: .process(localization: .default), path: "biz.txt"))
+            XCTAssertEqual(resources[3], TargetDescription.Resource(rule: .process(localization: .base), path: "baz.txt"))
 
-        let testResources = manifest.targets[1].resources
-        XCTAssertEqual(testResources[0], TargetDescription.Resource(rule: .process(localization: .none), path: "testfixture.txt"))
+            let testResources = manifest.targets[1].resources
+            XCTAssertEqual(testResources[0], TargetDescription.Resource(rule: .process(localization: .none), path: "testfixture.txt"))
+
+            return manifest
+        }
     }
+
+    func testResourcePathNormalization() async throws {
+        // Resource paths with trailing slashes must be normalized. The
+        // PackageDescription runtime routes paths through RelativePath before
+        // serializing them, so the executing loader always strips trailing
+        // slashes. The parsing loader must do the same.
+        let content = """
+            import PackageDescription
+            let package = Package(
+               name: "Foo",
+               targets: [
+                   .target(
+                       name: "Foo",
+                       resources: [
+                           .copy("Resources/"),
+                           .process("TestResources/"),
+                           .process("Localized/", localization: .base),
+                       ]
+                   ),
+               ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let resources = manifest.targets[0].resources
+            // Trailing slashes must be stripped from all path forms.
+            XCTAssertEqual(resources[0], TargetDescription.Resource(rule: .copy, path: "Resources"))
+            XCTAssertEqual(resources[1], TargetDescription.Resource(rule: .process(localization: .none), path: "TestResources"))
+            XCTAssertEqual(resources[2], TargetDescription.Resource(rule: .process(localization: .base), path: "Localized"))
+
+            return manifest
+        }
+    }
+
 
     func testBinaryTargetsTrivial() async throws {
         let content = """
@@ -87,61 +134,65 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, customManifestLoader: loader, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let targets = Dictionary(uniqueKeysWithValues: manifest.targets.map({ ($0.name, $0) }))
-        let foo1 = targets["Foo1"]!
-        let foo2 = targets["Foo2"]!
-        let foo3 = targets["Foo3"]
-        XCTAssertEqual(foo1, try? TargetDescription(
-            name: "Foo1",
-            dependencies: [],
-            path: "../Foo1.xcframework",
-            url: nil,
-            exclude: [],
-            sources: nil,
-            resources: [],
-            publicHeadersPath: nil,
-            type: .binary,
-            packageAccess: false,
-            pkgConfig: nil,
-            providers: nil,
-            settings: [],
-            checksum: nil))
-        XCTAssertEqual(foo2, try? TargetDescription(
-            name: "Foo2",
-            dependencies: [],
-            path: nil,
-            url: "https://foo.com/Foo2-1.0.0.zip",
-            exclude: [],
-            sources: nil,
-            resources: [],
-            publicHeadersPath: nil,
-            type: .binary,
-            packageAccess: false,
-            pkgConfig: nil,
-            providers: nil,
-            settings: [],
-            checksum: "839F9F30DC13C30795666DD8F6FB77DD0E097B83D06954073E34FE5154481F7A"))
-        XCTAssertEqual(foo3, try? TargetDescription(
-            name: "Foo3",
-            dependencies: [],
-            path: "./Foo3.zip",
-            url: nil,
-            exclude: [],
-            sources: nil,
-            resources: [],
-            publicHeadersPath: nil,
-            type: .binary,
-            packageAccess: false,
-            pkgConfig: nil,
-            providers: nil,
-            settings: [],
-            checksum: nil
-        ))
+            let targets = Dictionary(uniqueKeysWithValues: manifest.targets.map({ ($0.name, $0) }))
+            let foo1 = targets["Foo1"]!
+            let foo2 = targets["Foo2"]!
+            let foo3 = targets["Foo3"]
+            XCTAssertEqual(foo1, try? TargetDescription(
+                name: "Foo1",
+                dependencies: [],
+                path: "../Foo1.xcframework",
+                url: nil,
+                exclude: [],
+                sources: nil,
+                resources: [],
+                publicHeadersPath: nil,
+                type: .binary,
+                packageAccess: false,
+                pkgConfig: nil,
+                providers: nil,
+                settings: [],
+                checksum: nil))
+            XCTAssertEqual(foo2, try? TargetDescription(
+                name: "Foo2",
+                dependencies: [],
+                path: nil,
+                url: "https://foo.com/Foo2-1.0.0.zip",
+                exclude: [],
+                sources: nil,
+                resources: [],
+                publicHeadersPath: nil,
+                type: .binary,
+                packageAccess: false,
+                pkgConfig: nil,
+                providers: nil,
+                settings: [],
+                checksum: "839F9F30DC13C30795666DD8F6FB77DD0E097B83D06954073E34FE5154481F7A"))
+            XCTAssertEqual(foo3, try? TargetDescription(
+                name: "Foo3",
+                dependencies: [],
+                path: "./Foo3.zip",
+                url: nil,
+                exclude: [],
+                sources: nil,
+                resources: [],
+                publicHeadersPath: nil,
+                type: .binary,
+                packageAccess: false,
+                pkgConfig: nil,
+                providers: nil,
+                settings: [],
+                checksum: nil
+            ))
+            
+            return manifest
+        }
     }
 
     func testBinaryTargetsDisallowedProperties() async throws {
@@ -208,11 +259,18 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must be executable or automatic library products", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.check(diagnostic: "invalid type for binary product 'FooLibrary'; products referencing only binary targets must be executable or automatic library products", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -231,10 +289,17 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            XCTAssertNoDiagnostics(validationDiagnostics)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                XCTAssertNoDiagnostics(validationDiagnostics)
+                return manifest
+            }
         }
 
         do {
@@ -251,11 +316,18 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "invalid local path ' ' for binary target 'Foo', path expected to be relative to package root.", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.check(diagnostic: "invalid local path ' ' for binary target 'Foo', path expected to be relative to package root.", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -273,11 +345,18 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -295,11 +374,18 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'artifactbundle', 'xcframework', 'zip'", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'artifactbundle', 'xcframework', 'zip'", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -320,11 +406,18 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'artifactbundleindex', 'zip'", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'artifactbundleindex', 'zip'", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -342,11 +435,18 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'artifactbundle', 'xcframework', 'zip'", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'artifactbundle', 'xcframework', 'zip'", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -367,11 +467,18 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'artifactbundleindex', 'zip'", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.check(diagnostic: "unsupported extension for binary target 'Foo'; valid extensions are: 'artifactbundleindex', 'zip'", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -392,11 +499,18 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.check(diagnostic: "invalid URL scheme for binary target 'Foo'; valid schemes are: 'https'", severity: .error)
+                }
+                return manifest
             }
         }
 
@@ -471,16 +585,20 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, customManifestLoader: loader, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let dependencies = manifest.targets[0].dependencies
-        XCTAssertEqual(dependencies[0], .target(name: "Biz"))
-        XCTAssertEqual(dependencies[1], .target(name: "Bar", condition: .init(platformNames: ["linux"], config: nil)))
-        XCTAssertEqual(dependencies[2], .product(name: "Baz", package: "Baz", condition: .init(platformNames: ["macos"])))
-        XCTAssertEqual(dependencies[3], .byName(name: "Bar", condition: .init(platformNames: ["watchos", "ios"])))
+            let dependencies = manifest.targets[0].dependencies
+            XCTAssertEqual(dependencies[0], .target(name: "Biz"))
+            XCTAssertEqual(dependencies[1], .target(name: "Bar", condition: .init(platformNames: ["linux"], config: nil)))
+            XCTAssertEqual(dependencies[2], .product(name: "Baz", package: "Baz", condition: .init(platformNames: ["macos"])))
+            XCTAssertEqual(dependencies[3], .byName(name: "Bar", condition: .init(platformNames: ["watchos", "ios"])))
+            
+            return manifest
+        }
     }
 
     func testDefaultLocalization() async throws {
@@ -495,11 +613,19 @@ final class PackageDescription5_3LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
-        XCTAssertEqual(manifest.defaultLocalization, "fr")
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+            XCTAssertEqual(manifest.defaultLocalization, "fr")
+
+            return manifest
+        }
     }
 
     func testTargetPathsValidation() async throws {

--- a/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_4_LoadingTests.swift
@@ -34,12 +34,20 @@ class PackageDescription5_4LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.targets[0].type, .executable)
+            XCTAssertEqual(manifest.targets[0].type, .executable)
+            
+            return manifest
+        }
     }
 
     func testPluginsAreUnavailable() async throws {

--- a/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_5_LoadingTests.swift
@@ -34,14 +34,22 @@ class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo5"], .localSourceControl(path: "/foo5", requirement: .branch("main")))
-        XCTAssertEqual(deps["foo7"], .localSourceControl(path: "/foo7", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo5"], .localSourceControl(path: "/foo5", requirement: .branch("main")))
+            XCTAssertEqual(deps["foo7"], .localSourceControl(path: "/foo7", requirement: .revision("58e9de4e7b79e67c72a46e164158e3542e570ab6")))
+            
+            return manifest
+        }
     }
 
     func testPlatforms() async throws {
@@ -57,18 +65,26 @@ class PackageDescription5_5LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.platforms, [
-            PlatformDescription(name: "macos", version: "12.0"),
-            PlatformDescription(name: "ios", version: "15.0"),
-            PlatformDescription(name: "tvos", version: "15.0"),
-            PlatformDescription(name: "watchos", version: "8.0"),
-            PlatformDescription(name: "maccatalyst", version: "15.0"),
-            PlatformDescription(name: "driverkit", version: "21.0"),
-        ])
+            XCTAssertEqual(manifest.platforms, [
+                PlatformDescription(name: "macos", version: "12.0"),
+                PlatformDescription(name: "ios", version: "15.0"),
+                PlatformDescription(name: "tvos", version: "15.0"),
+                PlatformDescription(name: "watchos", version: "8.0"),
+                PlatformDescription(name: "maccatalyst", version: "15.0"),
+                PlatformDescription(name: "driverkit", version: "21.0"),
+            ])
+
+            return manifest
+        }
     }
 }

--- a/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_6_LoadingTests.swift
@@ -52,27 +52,35 @@ final class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertFalse(observability.diagnostics.hasErrors)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertFalse(observability.diagnostics.hasErrors)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["foo1"], .remoteSourceControl(identity: .plain("foo1"), deprecatedName: "foo1", url: "http://localhost/foo1", requirement: .range("1.1.1" ..< "2.0.0")))
-        XCTAssertEqual(deps["foo2"], .remoteSourceControl(identity: .plain("foo2"), url: "http://localhost/foo2", requirement: .range("1.1.1" ..< "2.0.0")))
-        XCTAssertEqual(deps["bar1"], .remoteSourceControl(identity: .plain("bar1"), deprecatedName: "bar1", url: "http://localhost/bar1", requirement: .range("1.1.1" ..< "2.0.0")))
-        XCTAssertEqual(deps["bar2"], .remoteSourceControl(identity: .plain("bar2"), url: "http://localhost/bar2", requirement: .range("1.1.1" ..< "2.0.0")))
-        XCTAssertEqual(deps["baz1"], .remoteSourceControl(identity: .plain("baz1"), deprecatedName: "baz1", url: "http://localhost/baz1", requirement: .range("1.1.1" ..< "1.2.0")))
-        XCTAssertEqual(deps["baz2"], .remoteSourceControl(identity: .plain("baz2"), url: "http://localhost/baz2", requirement: .range("1.1.1" ..< "1.2.0")))
-        XCTAssertEqual(deps["qux1"], .remoteSourceControl(identity: .plain("qux1"), deprecatedName: "qux1", url: "http://localhost/qux1", requirement: .exact("1.1.1")))
-        XCTAssertEqual(deps["qux2"], .remoteSourceControl(identity: .plain("qux2"), url: "http://localhost/qux2", requirement: .exact("1.1.1")))
-        XCTAssertEqual(deps["qux3"], .remoteSourceControl(identity: .plain("qux3"), url: "http://localhost/qux3", requirement: .exact("1.1.1")))
-        XCTAssertEqual(deps["quux1"], .remoteSourceControl(identity: .plain("quux1"), deprecatedName: "quux1", url: "http://localhost/quux1", requirement: .branch("main")))
-        XCTAssertEqual(deps["quux2"], .remoteSourceControl(identity: .plain("quux2"), url: "http://localhost/quux2", requirement: .branch("main")))
-        XCTAssertEqual(deps["quux3"], .remoteSourceControl(identity: .plain("quux3"), url: "http://localhost/quux3", requirement: .branch("main")))
-        XCTAssertEqual(deps["quuz1"], .remoteSourceControl(identity: .plain("quuz1"), deprecatedName: "quuz1", url: "http://localhost/quuz1", requirement: .revision("abcdefg")))
-        XCTAssertEqual(deps["quuz2"], .remoteSourceControl(identity: .plain("quuz2"), url: "http://localhost/quuz2", requirement: .revision("abcdefg")))
-        XCTAssertEqual(deps["quuz3"], .remoteSourceControl(identity: .plain("quuz3"), url: "http://localhost/quuz3", requirement: .revision("abcdefg")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["foo1"], .remoteSourceControl(identity: .plain("foo1"), deprecatedName: "foo1", url: "http://localhost/foo1", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["foo2"], .remoteSourceControl(identity: .plain("foo2"), url: "http://localhost/foo2", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["bar1"], .remoteSourceControl(identity: .plain("bar1"), deprecatedName: "bar1", url: "http://localhost/bar1", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["bar2"], .remoteSourceControl(identity: .plain("bar2"), url: "http://localhost/bar2", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["baz1"], .remoteSourceControl(identity: .plain("baz1"), deprecatedName: "baz1", url: "http://localhost/baz1", requirement: .range("1.1.1" ..< "1.2.0")))
+            XCTAssertEqual(deps["baz2"], .remoteSourceControl(identity: .plain("baz2"), url: "http://localhost/baz2", requirement: .range("1.1.1" ..< "1.2.0")))
+            XCTAssertEqual(deps["qux1"], .remoteSourceControl(identity: .plain("qux1"), deprecatedName: "qux1", url: "http://localhost/qux1", requirement: .exact("1.1.1")))
+            XCTAssertEqual(deps["qux2"], .remoteSourceControl(identity: .plain("qux2"), url: "http://localhost/qux2", requirement: .exact("1.1.1")))
+            XCTAssertEqual(deps["qux3"], .remoteSourceControl(identity: .plain("qux3"), url: "http://localhost/qux3", requirement: .exact("1.1.1")))
+            XCTAssertEqual(deps["quux1"], .remoteSourceControl(identity: .plain("quux1"), deprecatedName: "quux1", url: "http://localhost/quux1", requirement: .branch("main")))
+            XCTAssertEqual(deps["quux2"], .remoteSourceControl(identity: .plain("quux2"), url: "http://localhost/quux2", requirement: .branch("main")))
+            XCTAssertEqual(deps["quux3"], .remoteSourceControl(identity: .plain("quux3"), url: "http://localhost/quux3", requirement: .branch("main")))
+            XCTAssertEqual(deps["quuz1"], .remoteSourceControl(identity: .plain("quuz1"), deprecatedName: "quuz1", url: "http://localhost/quuz1", requirement: .revision("abcdefg")))
+            XCTAssertEqual(deps["quuz2"], .remoteSourceControl(identity: .plain("quuz2"), url: "http://localhost/quuz2", requirement: .revision("abcdefg")))
+            XCTAssertEqual(deps["quuz3"], .remoteSourceControl(identity: .plain("quuz3"), url: "http://localhost/quuz3", requirement: .revision("abcdefg")))
+            
+            return manifest
+        }
     }
 
     func testBuildToolPluginTarget() async throws {
@@ -89,13 +97,17 @@ final class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, customManifestLoader: loader, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.targets[0].type, .plugin)
-        XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
+            XCTAssertEqual(manifest.targets[0].type, .plugin)
+            XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
+            
+            return manifest
+        }
     }
 
     func testPluginTargetRequiresPluginCapability() async throws {
@@ -139,16 +151,20 @@ final class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, customManifestLoader: loader, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.targets[0].type, .plugin)
-        XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
-        XCTAssertEqual(manifest.targets[0].path, "Sources/Foo")
-        XCTAssertEqual(manifest.targets[0].exclude, ["IAmOut.swift"])
-        XCTAssertEqual(manifest.targets[0].sources, ["CountMeIn.swift"])
+            XCTAssertEqual(manifest.targets[0].type, .plugin)
+            XCTAssertEqual(manifest.targets[0].pluginCapability, .buildTool)
+            XCTAssertEqual(manifest.targets[0].path, "Sources/Foo")
+            XCTAssertEqual(manifest.targets[0].exclude, ["IAmOut.swift"])
+            XCTAssertEqual(manifest.targets[0].sources, ["CountMeIn.swift"])
+            
+            return manifest
+        }
     }
 
     func testCustomPlatforms() async throws {
@@ -220,22 +236,30 @@ final class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
-    /// Tests use of Context.current.packageDirectory
+    /// Tests use of Context.packageDirectory
     func testPackageContextName() async throws {
         let content = """
             import PackageDescription
             let package = Package(name: Context.packageDirectory)
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertNotNil(parsedManifest)
-        XCTAssertNotNil(parsedManifest.parentDirectory)
-        let name = try XCTUnwrap(parsedManifest.parentDirectory).pathString
-        XCTAssertEqual(manifest.displayName, name)
+            XCTAssertNotNil(parsedManifest)
+            XCTAssertNotNil(parsedManifest.parentDirectory)
+            let name = try XCTUnwrap(parsedManifest.parentDirectory).pathString
+            XCTAssertEqual(manifest.displayName, name)
+            
+            return manifest
+        }
     }
 
     /// Tests access to the package's directory contents.
@@ -281,12 +305,94 @@ final class PackageDescription5_6LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, customManifestLoader: loader, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.targets[0].type, .plugin)
-        XCTAssertEqual(manifest.targets[0].pluginCapability, .command(intent: .custom(verb: "mycmd", description: "helpful description of mycmd"), permissions: [.writeToPackageDirectory(reason: "YOLO")]))
+            XCTAssertEqual(manifest.targets[0].type, .plugin)
+            XCTAssertEqual(manifest.targets[0].pluginCapability, .command(intent: .custom(verb: "mycmd", description: "helpful description of mycmd"), permissions: [.writeToPackageDirectory(reason: "YOLO")]))
+
+            return manifest
+        }
+    }
+
+    func testPluginUsages() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+               name: "MyPackage",
+               dependencies: [
+                   .package(url: "http://localhost/PluginPackage", from: "1.0.0"),
+               ],
+               targets: [
+                   .target(
+                       name: "MyTarget",
+                       plugins: ["LocalPlugin"]
+                   ),
+                   .target(
+                       name: "MyTarget2",
+                       plugins: [
+                           .plugin(name: "ExternalPlugin", package: "PluginPackage")
+                       ]
+                   ),
+                   .target(
+                       name: "MyTarget3",
+                       plugins: [
+                           "LocalPlugin",
+                           .plugin(name: "ExternalPlugin", package: "PluginPackage"),
+                           .plugin(name: "AnotherLocalPlugin")
+                       ]
+                   ),
+                   .plugin(
+                       name: "LocalPlugin",
+                       capability: .buildTool()
+                   ),
+                   .plugin(
+                       name: "AnotherLocalPlugin",
+                       capability: .buildTool()
+                   )
+               ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, customManifestLoader: loader, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            // Check MyTarget
+            XCTAssertEqual(manifest.targets[0].name, "MyTarget")
+            XCTAssertEqual(manifest.targets[0].pluginUsages, [
+                .plugin(name: "LocalPlugin", package: nil)
+            ])
+
+            // Check MyTarget2
+            XCTAssertEqual(manifest.targets[1].name, "MyTarget2")
+            XCTAssertEqual(manifest.targets[1].pluginUsages, [
+                .plugin(name: "ExternalPlugin", package: "PluginPackage")
+            ])
+
+            // Check MyTarget3 with mixed usages
+            XCTAssertEqual(manifest.targets[2].name, "MyTarget3")
+            XCTAssertEqual(manifest.targets[2].pluginUsages, [
+                .plugin(name: "LocalPlugin", package: nil),
+                .plugin(name: "ExternalPlugin", package: "PluginPackage"),
+                .plugin(name: "AnotherLocalPlugin", package: nil)
+            ])
+
+            // Plugin targets themselves should not have plugin usages
+            XCTAssertEqual(manifest.targets[3].name, "LocalPlugin")
+            XCTAssertEqual(manifest.targets[3].type, .plugin)
+            XCTAssertNil(manifest.targets[3].pluginUsages)
+
+            XCTAssertEqual(manifest.targets[4].name, "AnotherLocalPlugin")
+            XCTAssertEqual(manifest.targets[4].type, .plugin)
+            XCTAssertNil(manifest.targets[4].pluginUsages)
+
+            return manifest
+        }
     }
 }

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
@@ -331,7 +331,7 @@ final class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
                         .plugin(
                             name: "Generate",
                             capability: .command(
-                                intent: .documentationGeneration()
+                                intent: .documentationGeneration
                             )
                         ),
                         .plugin(
@@ -346,7 +346,7 @@ final class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
                         .plugin(
                             name: "Format",
                             capability: .command(
-                                intent: .sourceCodeFormatting()
+                                intent: .sourceCodeFormatting
                             )
                         ),
                     ]

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
@@ -52,17 +52,25 @@ final class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(deps["x.foo"], .registry(identity: "x.foo", requirement: .range("1.1.1" ..< "2.0.0")))
-        XCTAssertEqual(deps["x.bar"], .registry(identity: "x.bar", requirement: .exact("1.1.1")))
-        XCTAssertEqual(deps["x.baz"], .registry(identity: "x.baz", requirement: .range("1.1.1" ..< "2.0.0")))
-        XCTAssertEqual(deps["x.qux"], .registry(identity: "x.qux", requirement: .range("1.1.1" ..< "1.2.0")))
-        XCTAssertEqual(deps["x.quux"], .registry(identity: "x.quux", requirement: .range("1.1.1" ..< "3.0.0")))
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(deps["x.foo"], .registry(identity: "x.foo", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["x.bar"], .registry(identity: "x.bar", requirement: .exact("1.1.1")))
+            XCTAssertEqual(deps["x.baz"], .registry(identity: "x.baz", requirement: .range("1.1.1" ..< "2.0.0")))
+            XCTAssertEqual(deps["x.qux"], .registry(identity: "x.qux", requirement: .range("1.1.1" ..< "1.2.0")))
+            XCTAssertEqual(deps["x.quux"], .registry(identity: "x.quux", requirement: .range("1.1.1" ..< "3.0.0")))
+            
+            return manifest
+        }
     }
 
     func testConditionalTargetDependencies() async throws {
@@ -82,14 +90,22 @@ final class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        let dependencies = manifest.targets[0].dependencies
-        XCTAssertEqual(dependencies[0], .target(name: "Bar", condition: .none))
-        XCTAssertEqual(dependencies[1], .target(name: "Baz", condition: .init(platformNames: ["linux"], config: .none)))
+            let dependencies = manifest.targets[0].dependencies
+            XCTAssertEqual(dependencies[0], .target(name: "Bar", condition: .none))
+            XCTAssertEqual(dependencies[1], .target(name: "Baz", condition: .init(platformNames: ["linux"], config: .none)))
+            
+            return manifest
+        }
     }
 
     func testConditionalTargetDependenciesDeprecation() async throws {
@@ -157,19 +173,27 @@ final class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.platforms, [
-            PlatformDescription(name: "macos", version: "13.0"),
-            PlatformDescription(name: "ios", version: "16.0"),
-            PlatformDescription(name: "tvos", version: "16.0"),
-            PlatformDescription(name: "watchos", version: "9.0"),
-            PlatformDescription(name: "maccatalyst", version: "16.0"),
-            PlatformDescription(name: "driverkit", version: "22.0"),
-        ])
+            XCTAssertEqual(manifest.platforms, [
+                PlatformDescription(name: "macos", version: "13.0"),
+                PlatformDescription(name: "ios", version: "16.0"),
+                PlatformDescription(name: "tvos", version: "16.0"),
+                PlatformDescription(name: "watchos", version: "9.0"),
+                PlatformDescription(name: "maccatalyst", version: "16.0"),
+                PlatformDescription(name: "driverkit", version: "22.0"),
+            ])
+            
+            return manifest
+        }
     }
 
     func testImportRestrictions() async throws {
@@ -212,13 +236,147 @@ final class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-            let observability = ObservabilitySystem.makeForTesting()
-            let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-            XCTAssertNoDiagnostics(observability.diagnostics)
-            testDiagnostics(validationDiagnostics) { result in
-                result.checkUnordered(diagnostic: "unknown package 'org.baz' in dependencies of target 'Target1'; valid packages are: 'org.foo', 'org.bar'", severity: .error)
-                result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'org.foo', 'org.bar'", severity: .error)
+            try await forEachManifestLoader { loader in
+                let observability = ObservabilitySystem.makeForTesting()
+                let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                    content,
+                    customManifestLoader: loader,
+                    observabilityScope: observability.topScope
+                )
+                XCTAssertNoDiagnostics(observability.diagnostics)
+                testDiagnostics(validationDiagnostics) { result in
+                    result.checkUnordered(diagnostic: "unknown package 'org.baz' in dependencies of target 'Target1'; valid packages are: 'org.foo', 'org.bar'", severity: .error)
+                    result.checkUnordered(diagnostic: "unknown dependency 'foos' in target 'Target2'; valid dependencies are: 'org.foo', 'org.bar'", severity: .error)
+                }
+                return manifest
             }
+        }
+    }
+
+    func testModuleAliases() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                dependencies: [
+                    .package(path: "/Bar"),
+                    .package(path: "/Baz"),
+                ],
+                targets: [
+                    .target(
+                        name: "Foo",
+                        dependencies: [
+                            .product(
+                                name: "Bar",
+                                package: "Bar",
+                                moduleAliases: ["Logging": "BarLogging", "Utils": "BarUtils"]
+                            ),
+                            .product(
+                                name: "Baz",
+                                package: "Baz",
+                                moduleAliases: ["Logging": "BazLogging"]
+                            )
+                        ]
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let dependencies = manifest.targets[0].dependencies
+            XCTAssertEqual(dependencies.count, 2)
+            
+            XCTAssertEqual(
+                dependencies[0],
+                .product(
+                    name: "Bar",
+                    package: "Bar",
+                    moduleAliases: ["Logging": "BarLogging", "Utils": "BarUtils"],
+                    condition: nil
+                )
+            )
+            
+            XCTAssertEqual(
+                dependencies[1],
+                .product(
+                    name: "Baz",
+                    package: "Baz",
+                    moduleAliases: ["Logging": "BazLogging"],
+                    condition: nil
+                )
+            )
+            
+            return manifest
+        }
+    }
+
+    func testPluginCommandIntentWithParens() async throws {
+        let content = """
+                import PackageDescription
+                let package = Package(
+                    name: "DocCPlugin",
+                    products: [
+                        .plugin(name: "Generate", targets: ["Generate"]),
+                    ],
+                    targets: [
+                        .plugin(
+                            name: "Generate",
+                            capability: .command(
+                                intent: .documentationGeneration()
+                            )
+                        ),
+                        .plugin(
+                            name: "Preview",
+                            capability: .command(
+                                intent: .custom(
+                                    verb: "preview-docs",
+                                    description: "Preview documentation."
+                                )
+                            )
+                        ),
+                        .plugin(
+                            name: "Format",
+                            capability: .command(
+                                intent: .sourceCodeFormatting()
+                            )
+                        ),
+                    ]
+                )
+                """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets.count, 3)
+
+            XCTAssertEqual(manifest.targets[0].name, "Generate")
+            XCTAssertEqual(manifest.targets[0].type, .plugin)
+            XCTAssertEqual(manifest.targets[0].pluginCapability, .command(intent: .documentationGeneration, permissions: []))
+
+            XCTAssertEqual(manifest.targets[1].name, "Preview")
+            XCTAssertEqual(manifest.targets[1].type, .plugin)
+            XCTAssertEqual(manifest.targets[1].pluginCapability, .command(intent: .custom(verb: "preview-docs", description: "Preview documentation."), permissions: []))
+
+            XCTAssertEqual(manifest.targets[2].name, "Format")
+            XCTAssertEqual(manifest.targets[2].type, .plugin)
+            XCTAssertEqual(manifest.targets[2].pluginCapability, .command(intent: .sourceCodeFormatting, permissions: []))
+
+            return manifest
         }
     }
 }

--- a/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_9_LoadingTests.swift
@@ -34,20 +34,28 @@ final class PackageDescription5_9LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.platforms, [
-            PlatformDescription(name: "macos", version: "14.0"),
-            PlatformDescription(name: "ios", version: "17.0"),
-            PlatformDescription(name: "tvos", version: "17.0"),
-            PlatformDescription(name: "watchos", version: "10.0"),
-            PlatformDescription(name: "visionos", version: "1.0"),
-            PlatformDescription(name: "maccatalyst", version: "17.0"),
-            PlatformDescription(name: "driverkit", version: "23.0"),
-        ])
+            XCTAssertEqual(manifest.platforms, [
+                PlatformDescription(name: "macos", version: "14.0"),
+                PlatformDescription(name: "ios", version: "17.0"),
+                PlatformDescription(name: "tvos", version: "17.0"),
+                PlatformDescription(name: "watchos", version: "10.0"),
+                PlatformDescription(name: "visionos", version: "1.0"),
+                PlatformDescription(name: "maccatalyst", version: "17.0"),
+                PlatformDescription(name: "driverkit", version: "23.0"),
+            ])
+            
+            return manifest
+        }
     }
 
     func testMacroTargets() async throws {
@@ -62,8 +70,151 @@ final class PackageDescription5_9LoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (_, diagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertEqual(diagnostics.count, 0, "unexpected diagnostics: \(diagnostics)")
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets.count, 1)
+            XCTAssertEqual(manifest.targets[0].name, "MyMacro")
+            XCTAssertEqual(manifest.targets[0].type, .macro)
+
+            return manifest
+        }
+    }
+
+    func testPackageAccess() async throws {
+        let content = """
+            import PackageDescription
+
+            let package = Package(
+                name: "MyPackage",
+                targets: [
+                    .target(name: "PublicTarget", packageAccess: true),
+                    .target(name: "PrivateTarget", packageAccess: false),
+                    .target(name: "DefaultTarget"),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            // Check target with packageAccess: true
+            XCTAssertEqual(manifest.targets[0].name, "PublicTarget")
+            XCTAssertTrue(manifest.targets[0].packageAccess)
+
+            // Check target with packageAccess: false
+            XCTAssertEqual(manifest.targets[1].name, "PrivateTarget")
+            XCTAssertFalse(manifest.targets[1].packageAccess)
+
+            // Check target with default packageAccess (should be true per PackageDescription API)
+            XCTAssertEqual(manifest.targets[2].name, "DefaultTarget")
+            XCTAssertTrue(manifest.targets[2].packageAccess)
+
+            return manifest
+        }
+    }
+
+    func testBinaryTargetPackageAccess() async throws {
+        // Binary targets always have packageAccess: false. The PackageDescription
+        // binaryTarget(…) factory methods do not expose a packageAccess parameter,
+        // and they hardcode it to false. This must hold even at tools versions ≥ 5.9
+        // where the default packageAccess for regular targets is true.
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .binaryTarget(
+                        name: "RemoteBinary",
+                        url: "https://example.com/RemoteBinary-1.0.0.zip",
+                        checksum: "abc123"),
+                    .binaryTarget(
+                        name: "LocalBinary",
+                        path: "LocalBinary.xcframework"),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let targets = Dictionary(uniqueKeysWithValues: manifest.targets.map({ ($0.name, $0) }))
+
+            // Both binary targets must have packageAccess: false regardless of
+            // the tools version default (which is true at v5_9+).
+            XCTAssertEqual(targets["RemoteBinary"]?.type, .binary)
+            XCTAssertEqual(targets["RemoteBinary"]?.packageAccess, false)
+
+            XCTAssertEqual(targets["LocalBinary"]?.type, .binary)
+            XCTAssertEqual(targets["LocalBinary"]?.packageAccess, false)
+
+            return manifest
+        }
+    }
+
+    func testSystemLibraryTargetPackageAccess() async throws {
+        // System library targets always have packageAccess: false. The
+        // PackageDescription systemLibrary(…) factory method does not expose a
+        // packageAccess parameter and hardcodes it to false. This must hold even
+        // at tools versions ≥ 5.9 where the default packageAccess for regular
+        // targets is true.
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .systemLibrary(
+                        name: "CBar",
+                        pkgConfig: "bar",
+                        providers: [
+                            .brew(["bar"]),
+                            .apt(["libbar-dev"]),
+                        ]),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let target = try XCTUnwrap(manifest.targetMap["CBar"])
+
+            // System library target must have packageAccess: false regardless
+            // of the tools version default (which is true at v5_9+).
+            XCTAssertEqual(target.type, .system)
+            XCTAssertEqual(target.packageAccess, false)
+            XCTAssertEqual(target.pkgConfig, "bar")
+            XCTAssertEqual(target.providers, [.brew(["bar"]), .apt(["libbar-dev"])])
+
+            return manifest
+        }
     }
 }

--- a/Tests/PackageLoadingTests/PD_6_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_6_0_LoadingTests.swift
@@ -84,11 +84,84 @@ final class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
                 )
                 """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(validationDiagnostics)
-        testDiagnostics(observability.diagnostics) { result in
-            result.checkUnordered(diagnostic: .contains("'swiftLanguageVersion' is deprecated: renamed to 'swiftLanguageMode(_:_:)'"), severity: .warning)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            // Verify the manifest structure
+            XCTAssertEqual(manifest.targets.count, 2)
+            XCTAssertEqual(manifest.targets[0].name, "Foo")
+            XCTAssertEqual(manifest.targets[1].name, "Bar")
+
+            // Check for deprecation warnings (only present in compilation-based loader)
+            if loader == nil {
+                testDiagnostics(observability.diagnostics) { result in
+                    result.checkUnordered(diagnostic: .contains("'swiftLanguageVersion' is deprecated: renamed to 'swiftLanguageMode(_:_:)'"), severity: .warning)
+                }
+            }
+
+            return manifest
+        }
+    }
+
+    func testSwiftLanguageModesPackageLevel() async throws {
+        // Test the new swiftLanguageModes parameter name (6.0+)
+        let contentWithNewName = """
+                import PackageDescription
+                let package = Package(
+                    name: "Foo",
+                    swiftLanguageModes: [.v5, .v6]
+                )
+                """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                contentWithNewName,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.swiftLanguageVersions, [.v5, .v6])
+
+            return manifest
+        }
+
+        // Test the deprecated swiftLanguageVersions parameter name (still valid)
+        let contentWithOldName = """
+                import PackageDescription
+                let package = Package(
+                    name: "Foo",
+                    swiftLanguageVersions: [.v4, .v5]
+                )
+                """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                contentWithOldName,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.swiftLanguageVersions, [.v4, .v5])
+
+            // Check for deprecation warning (only present in compilation-based loader)
+            if loader == nil {
+                testDiagnostics(observability.diagnostics) { result in
+                    result.checkUnordered(diagnostic: .contains("is deprecated"), severity: .warning)
+                }
+            }
+
+            return manifest
         }
     }
 
@@ -109,15 +182,20 @@ final class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
             try repo.commit(message: "best")
             try repo.tag(name: "lunch")
 
-            let manifest = try await manifestLoader.load(
-                manifestPath: manifestPath,
-                packageKind: .root(tmpdir),
-                toolsVersion: self.toolsVersion,
-                fileSystem: localFileSystem,
-                observabilityScope: observability.topScope
-            )
+            try await forEachManifestLoader { loader in
+                let loader = loader ?? self.manifestLoader
+                let manifest = try await loader.load(
+                    manifestPath: manifestPath,
+                    packageKind: .root(tmpdir),
+                    toolsVersion: self.toolsVersion,
+                    fileSystem: localFileSystem,
+                    observabilityScope: observability.topScope
+                )
 
-            try validator(manifest, observability)
+                try validator(manifest, observability)
+
+                return manifest
+            }
         }
     }
 }

--- a/Tests/PackageLoadingTests/PD_6_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_6_2_LoadingTests.swift
@@ -14,15 +14,14 @@ import Basics
 import PackageLoading
 import PackageModel
 import _InternalTestSupport
-import Testing
+import XCTest
 
-struct PackageDescription6_2LoadingTests {
-    @Test(
-        .tags(
-            Tag.Feature.TargetSettings
-        )
-    )
-    func warningControlFlags() async throws {
+class PackageDescription6_2LoadingTests: PackageDescriptionLoadingTests {
+    override var toolsVersion: ToolsVersion {
+        .v6_2
+    }
+
+    func testWarningControlFlags() async throws {
         let content = """
             import PackageDescription
             let package = Package(
@@ -71,30 +70,33 @@ struct PackageDescription6_2LoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        try await withKnownIssue("https://github.com/swiftlang/swift-package-manager/issues/8543: there are compilation errors on Windows", isIntermittent: true) {
-            let (_, validationDiagnostics) = try await PackageDescriptionLoadingTests
-                .loadAndValidateManifest(
-                    content,
-                    toolsVersion: .v6_2,
-                    packageKind: .fileSystem(.root),
-                    manifestLoader: ManifestLoader(
-                        toolchain: try! UserToolchain.default
-                    ),
-                    observabilityScope: observability.topScope
-                )
-            try expectDiagnostics(validationDiagnostics) { results in
-                results.checkIsEmpty()
-            }
-            try expectDiagnostics(observability.diagnostics) { results in
-                results.checkIsEmpty()
-            }
-        } when: {
-            isWindows && !CiEnvironment.runningInSmokeTestPipeline
+        // Skip on Windows if not running in smoke test pipeline
+        // See: https://github.com/swiftlang/swift-package-manager/issues/8543
+        if isWindows && !CiEnvironment.runningInSmokeTestPipeline {
+            throw XCTSkip("Skipping test on Windows due to compilation errors")
+        }
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+            
+            // Verify the settings were parsed correctly
+            let fooTarget = manifest.targets.first { $0.name == "Foo" }
+            let barTarget = manifest.targets.first { $0.name == "Bar" }
+            
+            XCTAssertNotNil(fooTarget)
+            XCTAssertNotNil(barTarget)
+            
+            return manifest
         }
     }
 }
-
 private var isWindows: Bool {
 #if os(Windows)
     true
@@ -102,3 +104,4 @@ private var isWindows: Bool {
     false
 #endif
 }
+

--- a/Tests/PackageLoadingTests/ParsingLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ParsingLoaderTests.swift
@@ -955,4 +955,39 @@ final class ParsingLoaderTests: PackageDescriptionLoadingTests {
             return manifest
         }
     }
+
+    func testLanguageModeAdjustment() async throws {
+        let content = """
+            // swift-tools-version:5.5
+            import PackageDescription
+
+            #if swift(>=5.6)
+            let package = Package(
+                name: "UseDocC",
+                products: [
+                    .library(name: "A", targets: ["A"]),
+                ],
+                targets: [
+                    // Product Targets
+                    .target(
+                        name: "A"
+                    ),
+                ]
+            )
+            #endif
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            return manifest
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/ParsingLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ParsingLoaderTests.swift
@@ -868,4 +868,46 @@ final class ParsingLoaderTests: PackageDescriptionLoadingTests {
             // The canImport check was correctly reported as a limitation.
         }
     }
+
+    func testTernaryInDefineValueRecordsLimitation() async throws {
+        guard let parsingManifestLoader else {
+            XCTSkip("Host compiler doesn't support the static build configurations")
+            return
+        }
+
+        // A ternary expression in the 'to:' argument of .define() cannot be
+        // evaluated by the parsing loader. It must record a limitation rather
+        // than silently dropping the value.
+        let content = """
+            import PackageDescription
+            let useNeon = true
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        cSettings: [
+                            .define("OPT", to: useNeon ? "2" : "0")
+                        ]
+                    ),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        do {
+            _ = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: parsingManifestLoader,
+                observabilityScope: observability.topScope
+            )
+            XCTFail("Expected a limitations error for ternary in define value")
+        } catch let error as ManifestParserError {
+            guard case .limitations = error else {
+                XCTFail("Expected .limitations error, got: \(error)")
+                return
+            }
+            // The ternary expression was correctly reported as a limitation.
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/ParsingLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ParsingLoaderTests.swift
@@ -990,4 +990,54 @@ final class ParsingLoaderTests: PackageDescriptionLoadingTests {
             return manifest
         }
     }
+
+    func testPackageAppend() async throws {
+        let content = """
+            // swift-tools-version:5.5
+            import PackageDescription
+
+            let package = Package(
+                name: "MyPackage",
+                products: [
+                    .library(name: "A", targets: ["A"]),
+                ],
+                dependencies: [
+                    .package(url: "https://github.com/vapor/vapor", from: "4.0.0"),
+                ],
+                targets: [
+                    // Product Targets
+                    .target(
+                        name: "A",
+                        dependencies: [
+                            .product(name: "Vapor", package: "vapor"),
+                        ]
+                    ),
+                ]
+            )
+
+            package.dependencies.append(
+                .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+            )
+            package.targets.append(contentsOf: [
+                .target(name: "B"),
+                .target(name: "C"),
+            ])
+            package.products += [
+                .library(name: "B", targets: ["B"]),
+            ]
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            return manifest
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/ParsingLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ParsingLoaderTests.swift
@@ -377,4 +377,451 @@ final class ParsingLoaderTests: PackageDescriptionLoadingTests {
             // The unknown argument was correctly reported as a limitation.
         }
     }
+    
+    // MARK: - Global Variable Tests
+    
+    func testGlobalVariableStringInPackageName() async throws {
+        let content = """
+            import PackageDescription
+            let packageName = "MyAwesomePackage"
+            let package = Package(
+                name: packageName,
+                targets: [
+                    .target(name: "Foo"),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.displayName, "MyAwesomePackage")
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableWithTypeAnnotation() async throws {
+        let content = """
+            import PackageDescription
+            let packageName: String = "TypedPackage"
+            let package = Package(
+                name: packageName,
+                targets: [
+                    .target(name: "Core"),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.displayName, "TypedPackage")
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableStringArrayInTargetExcludes() async throws {
+        let content = """
+            import PackageDescription
+            let excludedFiles = ["Tests", "Documentation"]
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        exclude: excludedFiles
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets[0].exclude, ["Tests", "Documentation"])
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableArrayConcatenation() async throws {
+        let content = """
+            import PackageDescription
+            let commonSources = ["Common.swift", "Utilities.swift"]
+            let platformSources = ["Platform.swift"]
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        sources: commonSources + platformSources
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets[0].sources, ["Common.swift", "Utilities.swift", "Platform.swift"])
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableMultipleArrayConcatenation() async throws {
+        let content = """
+            import PackageDescription
+            let coreFiles = ["Core.swift"]
+            let utilFiles = ["Util.swift"]
+            let platformFiles = ["Platform.swift"]
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        sources: coreFiles + utilFiles + platformFiles
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets[0].sources, ["Core.swift", "Util.swift", "Platform.swift"])
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableMixedArrayConcatenation() async throws {
+        let content = """
+            import PackageDescription
+            let baseExcludes = ["Tests", "Docs"]
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        exclude: baseExcludes + ["Build", "Cache"]
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets[0].exclude, ["Tests", "Docs", "Build", "Cache"])
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableInTargetDependencies() async throws {
+        let content = """
+            import PackageDescription
+            var metricsDep: Target.Dependency = "Metrics"
+            let sharedDeps: [Target.Dependency] = ["Logging"] + [metricsDep]
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        dependencies: sharedDeps
+                    ),
+                    .target(name: "Logging"),
+                    .target(name: "Metrics"),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets[0].dependencies.count, 2)
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableInProductTargets() async throws {
+        let content = """
+            import PackageDescription
+            let libraryTargets = ["Core", "Utilities"]
+            let coreTarget: Target = .target(name: "Core")
+            let package = Package(
+                name: "Foo",
+                products: [
+                    .library(name: "Foo", targets: libraryTargets),
+                ],
+                targets: [
+                    coreTarget,
+                    .target(name: "Utilities"),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.products[0].targets, ["Core", "Utilities"])
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableWithContextExpression() async throws {
+        guard let parsingManifestLoader else {
+            XCTSkip("Host compiler doesn't support the static build configurations")
+            return
+        }
+
+        let content = """
+            import PackageDescription
+            let targetName = Context.environment["SWIFT_TARGET_NAME"] ?? "DefaultTarget"
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(name: targetName),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+            content,
+            customManifestLoader: parsingManifestLoader,
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
+
+        XCTAssertEqual(manifest.targets[0].name, "MyTarget")
+    }
+    
+    func testGlobalVariableStringInterpolation() async throws {
+        let content = """
+            import PackageDescription
+            let version = "1.0.0"
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        cSettings: [
+                            .define("VERSION", to: "\\(version)")
+                        ]
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let settings = manifest.targets[0].settings
+            XCTAssertEqual(settings[0], .init(tool: .c, kind: .define("VERSION=1.0.0")))
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableInBuildSettingValues() async throws {
+        let content = """
+            import PackageDescription
+            let headerPath = "include/mylib"
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        cSettings: [
+                            .headerSearchPath(headerPath)
+                        ]
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let settings = manifest.targets[0].settings
+            XCTAssertEqual(settings[0], .init(tool: .c, kind: .headerSearchPath("include/mylib")))
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableInTraits() async throws {
+        let content = """
+            import PackageDescription
+            let enabledTraits: Set<String> = ["Feature1", "Feature2"]
+            let package = Package(
+                name: "Foo",
+                traits: [
+                  .trait(name: "Feature1"),
+                  .trait(name: "Feature2"),
+                  .trait(name: "AllFeatures", enabledTraits: enabledTraits)
+                ],
+                targets: [
+                    .target(name: "Foo"),
+                ],
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            // The manifest should contain the traits we explicitly declared
+            let allFeaturesTrait = manifest.traits.first { $0.name == "AllFeatures" }
+            XCTAssertNotNil(allFeaturesTrait)
+            XCTAssertEqual(allFeaturesTrait?.enabledTraits.sorted(), ["Feature1", "Feature2"])
+            return manifest
+        }
+    }
+    
+    func testGlobalVariableNestedReferences() async throws {
+        let content = """
+            import PackageDescription
+            let baseName = "MyLibrary"
+            let fullName = baseName
+            let package = Package(
+                name: fullName,
+                targets: [
+                    .target(name: "Foo"),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.displayName, "MyLibrary")
+            return manifest
+        }
+    }
+    
+    func testMultipleGlobalVariablesInSingleManifest() async throws {
+        let content = """
+            import PackageDescription
+            let packageName: String = "ComplexPackage"
+            let mainTarget = "Core"
+            let testTarget = "CoreTests"
+            let excludedDirs: [String] = ["Docs", "Examples"]
+            let commonDeps: [Target.Dependency] = ["Logging"]
+            
+            let package = Package(
+                name: packageName,
+                targets: [
+                    .target(
+                        name: mainTarget,
+                        dependencies: commonDeps,
+                        exclude: excludedDirs
+                    ),
+                    .testTarget(
+                        name: testTarget,
+                        dependencies: [.target(name: mainTarget)]
+                    ),
+                    .target(name: "Logging"),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.displayName, "ComplexPackage")
+            XCTAssertEqual(manifest.targets[0].name, "Core")
+            XCTAssertEqual(manifest.targets[0].exclude, ["Docs", "Examples"])
+            XCTAssertEqual(manifest.targets[0].dependencies.count, 1)
+            XCTAssertEqual(manifest.targets[1].name, "CoreTests")
+            return manifest
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/ParsingLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ParsingLoaderTests.swift
@@ -1,0 +1,380 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageLoading
+import PackageModel
+import SourceControl
+import _InternalTestSupport
+import XCTest
+
+final class ParsingLoaderTests: PackageDescriptionLoadingTests {
+    override var toolsVersion: ToolsVersion {
+        .v6_2
+    }
+
+    override var environment: [String : String]? {
+        ["SWIFT_TARGET_NAME": "MyTarget"]
+    }
+
+    func testSupportedPlatformCustom() async throws {
+        // SupportedPlatform.custom(_:versionString:) lets packages declare a minimum
+        // deployment version for a platform not listed in the named-platform enum.
+        // The parser must recognise the .custom("name", versionString: "x.y") form
+        // in the Package's platforms: array.
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                platforms: [
+                    .macOS(.v13),
+                    .custom("otheros", versionString: "1.0"),
+                    .custom("embedded", versionString: "2.1"),
+                ],
+                targets: [
+                    .target(name: "Foo"),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.platforms.count, 3)
+            XCTAssertEqual(manifest.platforms[0], PlatformDescription(name: "macos", version: "13.0"))
+            XCTAssertEqual(manifest.platforms[1], PlatformDescription(name: "otheros", version: "1.0"))
+            XCTAssertEqual(manifest.platforms[2], PlatformDescription(name: "embedded", version: "2.1"))
+            return manifest
+        }
+    }
+
+    func testPoundIf() async throws {
+        let content =  """
+            import PackageDescription
+            #if os(macOS)
+            let package = Package(
+                name: "Foo",
+                targets: [
+                  .target(name: "MacTarget")
+                ],
+            )
+            #else
+            let package = Package(
+                name: "Foo",
+                targets: [
+                  .target(name: "OtherTarget")
+                ],
+            )
+            #endif
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets.count, 1)
+            #if os(macOS)
+            XCTAssertEqual(manifest.targets[0].name, "MacTarget")
+            #else
+            XCTAssertEqual(manifest.targets[0].name, "OtherTarget")
+            #endif
+            return manifest
+        }
+    }
+
+    func testPoundIfErrors() async throws {
+        let content =  """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                  .target(name: "MyTarget")
+                ],
+            )
+
+            #if compiler(>=5.3) && BAD_CODE
+            this is bad
+            #endif
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            XCTAssertEqual(manifest.targets.count, 1)
+            XCTAssertEqual(manifest.targets[0].name, "MyTarget")
+            return manifest
+        }
+    }
+
+    func testBuildSettingDefineWithEscapedQuotes() async throws {
+        // C preprocessor defines can have values with embedded quotes, e.g.:
+        //   .define("VERSION", to: "\"1.0.0\"")
+        // The value "\"1.0.0\"" is the Swift string literal for "1.0.0" (with
+        // actual double quotes). The parsing loader must interpret the escape
+        // sequences in the string literal rather than returning the raw source text.
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        cSettings: [
+                            .define("PLAIN"),
+                            .define("WITH_VALUE", to: "42"),
+                            .define("QUOTED_VALUE", to: "\\"hello\\""),
+                            .define("QUOTED_WITH_SPACES", to: "\\"hello world\\""),
+                        ]
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let settings = manifest.targets[0].settings
+            XCTAssertEqual(settings[0], .init(tool: .c, kind: .define("PLAIN")))
+            XCTAssertEqual(settings[1], .init(tool: .c, kind: .define("WITH_VALUE=42")))
+            XCTAssertEqual(settings[2], .init(tool: .c, kind: .define("QUOTED_VALUE=\"hello\"")))
+            XCTAssertEqual(settings[3], .init(tool: .c, kind: .define("QUOTED_WITH_SPACES=\"hello world\"")))
+            return manifest
+        }
+    }
+
+    func testDefaultIsolation() async throws {
+        // .defaultIsolation takes MainActor.Type? — not a leading-dot enum.
+        // The two valid call forms are:
+        //   .defaultIsolation(MainActor.self)  → MainActor isolation
+        //   .defaultIsolation(nil)             → nonisolated
+        // Both forms may also carry an optional platform/configuration condition.
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        swiftSettings: [
+                            .defaultIsolation(MainActor.self),
+                            .defaultIsolation(nil),
+                            .defaultIsolation(MainActor.self, .when(platforms: [.macOS])),
+                            .defaultIsolation(nil, .when(platforms: [.linux])),
+                        ]
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let settings = manifest.targets[0].settings
+            XCTAssertEqual(settings[0], .init(tool: .swift, kind: .defaultIsolation(.MainActor)))
+            XCTAssertEqual(settings[1], .init(tool: .swift, kind: .defaultIsolation(.nonisolated)))
+            XCTAssertEqual(settings[2], .init(tool: .swift, kind: .defaultIsolation(.MainActor),
+                                              condition: .init(platformNames: ["macos"])))
+            XCTAssertEqual(settings[3], .init(tool: .swift, kind: .defaultIsolation(.nonisolated),
+                                              condition: .init(platformNames: ["linux"])))
+            return manifest
+        }
+    }
+
+    func testStrictMemorySafetyWithCondition() async throws {
+        // .strictMemorySafety() is unusual among build settings: it has no required value
+        // argument — its sole argument is the optional condition. The condition-parsing
+        // logic must not skip it when scanning for the condition.
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        swiftSettings: [
+                            .strictMemorySafety(),
+                            .strictMemorySafety(.when(platforms: [.linux])),
+                            .strictMemorySafety(.when(platforms: [.macOS, .linux])),
+                        ]
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let settings = manifest.targets[0].settings
+            XCTAssertEqual(settings[0], .init(tool: .swift, kind: .strictMemorySafety))
+            XCTAssertEqual(settings[1], .init(tool: .swift, kind: .strictMemorySafety,
+                                              condition: .init(platformNames: ["linux"])))
+            XCTAssertEqual(settings[2], .init(tool: .swift, kind: .strictMemorySafety,
+                                              condition: .init(platformNames: ["macos", "linux"])))
+            return manifest
+        }
+    }
+
+    func testBuildSettingCustomPlatformCondition() async throws {
+        // Platform conditions can include custom platform names via .custom("name"),
+        // e.g. .linkedLibrary("pthread", .when(platforms: [.linux, .custom("freebsd")])).
+        // The parsing loader must recognise .custom("name") and include its name in the
+        // condition, rather than silently dropping it.
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        linkerSettings: [
+                            .linkedLibrary("dl", .when(platforms: [.linux])),
+                            .linkedLibrary("pthread", .when(platforms: [.linux, .custom("freebsd")])),
+                            .linkedLibrary("unconditional"),
+                        ]
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let settings = manifest.targets[0].settings
+            XCTAssertEqual(settings[0], .init(tool: .linker, kind: .linkedLibrary("dl"),
+                                              condition: .init(platformNames: ["linux"])))
+            XCTAssertEqual(settings[1], .init(tool: .linker, kind: .linkedLibrary("pthread"),
+                                              condition: .init(platformNames: ["linux", "freebsd"])))
+            XCTAssertEqual(settings[2], .init(tool: .linker, kind: .linkedLibrary("unconditional")))
+            return manifest
+        }
+    }
+
+    func testEnvironment() async throws {
+        guard let parsingManifestLoader else {
+            XCTSkip("Host compiler doesn't support the static build configurations")
+            return
+        }
+
+        let content =  """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                  .target(name: Context.environment["SWIFT_TARGET_NAME"] ?? "OtherTarget")
+                ],
+            )
+            """
+
+        // NOTE: non-parsing manifest loader doesn't support testing the
+        // environment.
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+            content,
+            customManifestLoader: parsingManifestLoader,
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
+
+        XCTAssertEqual(manifest.targets.count, 1)
+        XCTAssertEqual(manifest.targets[0].name, "MyTarget")
+    }
+
+    func testUnknownTargetArgumentRecordsLimitation() async throws {
+        guard let parsingManifestLoader else {
+            XCTSkip("Host compiler doesn't support the static build configurations")
+            return
+        }
+
+        // An unknown target argument must cause the parsing loader to record a
+        // limitation. Before this fix, the argument was silently ignored, which
+        // could produce a wrong manifest with no indication that something was
+        // wrong. This manifest is syntactically valid Swift (the parser can read
+        // it) but will not compile; we only need the parsing loader to see it.
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        unknownFutureArgument: "value"
+                    ),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        do {
+            _ = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: parsingManifestLoader,
+                observabilityScope: observability.topScope
+            )
+            XCTFail("Expected a limitations error for the unknown target argument")
+        } catch let error as ManifestParserError {
+            guard case .limitations = error else {
+                XCTFail("Expected .limitations error, got: \(error)")
+                return
+            }
+            // The unknown argument was correctly reported as a limitation.
+        }
+    }
+}

--- a/Tests/PackageLoadingTests/ParsingLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ParsingLoaderTests.swift
@@ -824,4 +824,48 @@ final class ParsingLoaderTests: PackageDescriptionLoadingTests {
             return manifest
         }
     }
+
+    func testCanImportRecordsLimitation() async throws {
+        guard let parsingManifestLoader else {
+            XCTSkip("Host compiler doesn't support the static build configurations")
+            return
+        }
+
+        // canImport() cannot be evaluated by the static build configuration,
+        // so the parsing loader must record a limitation and fall back to the
+        // executing loader rather than silently picking the wrong #if branch.
+        let content = """
+            import PackageDescription
+            #if canImport(Darwin)
+            let excludedFiles: [String] = []
+            #else
+            let excludedFiles = ["PrivacyInfo.xcprivacy"]
+            #endif
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        exclude: excludedFiles
+                    ),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        do {
+            _ = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: parsingManifestLoader,
+                observabilityScope: observability.topScope
+            )
+            XCTFail("Expected a limitations error for canImport")
+        } catch let error as ManifestParserError {
+            guard case .limitations = error else {
+                XCTFail("Expected .limitations error, got: \(error)")
+                return
+            }
+            // The canImport check was correctly reported as a limitation.
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/ParsingLoaderTests.swift
+++ b/Tests/PackageLoadingTests/ParsingLoaderTests.swift
@@ -910,4 +910,49 @@ final class ParsingLoaderTests: PackageDescriptionLoadingTests {
             // The ternary expression was correctly reported as a limitation.
         }
     }
+
+    func testSwiftVersionCheckMatchesToolsVersion() async throws {
+        // The #if swift(...) condition should use the language mode implied
+        // by the manifest's tools version, not the compiler's default. With
+        // tools version >= 6.0 the language mode is Swift 6, so
+        // #if swift(>=6) should be true and #if swift(<6) should be false.
+        let content = """
+            import PackageDescription
+            #if swift(<6)
+            let swiftSettings: [SwiftSetting] = [
+                .enableExperimentalFeature("ExistentialAny"),
+            ]
+            #else
+            let swiftSettings: [SwiftSetting] = [
+                .enableUpcomingFeature("ExistentialAny"),
+            ]
+            #endif
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Foo",
+                        swiftSettings: swiftSettings
+                    ),
+                ]
+            )
+            """
+
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
+
+            let settings = manifest.targets[0].settings
+            XCTAssertEqual(settings.count, 1)
+            // With Swift 6 language mode, the #else branch should be taken
+            XCTAssertEqual(settings[0], .init(tool: .swift, kind: .enableUpcomingFeature("ExistentialAny")))
+            return manifest
+        }
+    }
 }

--- a/Tests/PackageLoadingTests/TraitLoadingTests.swift
+++ b/Tests/PackageLoadingTests/TraitLoadingTests.swift
@@ -34,16 +34,24 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.traits, [
-            TraitDescription(name: "Trait1"),
-            TraitDescription(name: "Trait2", description: "Trait 2 description"),
-            TraitDescription(name: "Trait3", description: "Trait 3 description", enabledTraits: ["Trait1"]),
-        ])
+            XCTAssertEqual(manifest.traits, [
+                TraitDescription(name: "Trait1"),
+                TraitDescription(name: "Trait2", description: "Trait 2 description"),
+                TraitDescription(name: "Trait3", description: "Trait 3 description", enabledTraits: ["Trait1"]),
+            ])
+            
+            return manifest
+        }
     }
 
     func testTraits_whenTooMany() async throws {
@@ -162,17 +170,25 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.traits, [
-            TraitDescription(name: "default", description: "The default traits of this package.", enabledTraits: ["Trait1", "Trait3"]),
-            TraitDescription(name: "Trait1"),
-            TraitDescription(name: "Trait2"),
-            TraitDescription(name: "Trait3", enabledTraits: ["Trait1"]),
-        ])
+            XCTAssertEqual(manifest.traits, [
+                TraitDescription(name: "default", description: "The default traits of this package.", enabledTraits: ["Trait1", "Trait3"]),
+                TraitDescription(name: "Trait1"),
+                TraitDescription(name: "Trait2"),
+                TraitDescription(name: "Trait3", enabledTraits: ["Trait1"]),
+            ])
+            
+            return manifest
+        }
     }
 
     func testDependencies() async throws {
@@ -241,78 +257,86 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             )
             """
 
-        let observability = ObservabilitySystem.makeForTesting()
-        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        XCTAssertNoDiagnostics(validationDiagnostics)
+        try await forEachManifestLoader { loader in
+            let observability = ObservabilitySystem.makeForTesting()
+            let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+                content,
+                customManifestLoader: loader,
+                observabilityScope: observability.topScope
+            )
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            XCTAssertNoDiagnostics(validationDiagnostics)
 
-        XCTAssertEqual(manifest.traits, [
-            TraitDescription(name: "default", description: "The default traits of this package.", enabledTraits: ["Trait1", "Trait2"]),
-            TraitDescription(name: "Trait1"),
-            TraitDescription(name: "Trait2"),
-        ])
-        let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
-        XCTAssertEqual(
-            deps["x.foo"]?.traits,
-            [
-                .init(name: "FooTrait1"),
-                .init(name: "FooTrait2", condition: .init(traits: ["Trait1"])),
-                .init(name: "FooTrait3", condition: .init(traits: ["Trait2"])),
-                .init(name: "default"),
-            ]
-        )
-        XCTAssertEqual(
-            deps["bar"]?.traits,
-            [
-                .init(name: "BarTrait1"),
-                .init(name: "BarTrait2", condition: .init(traits: ["Trait1"])),
-                .init(name: "BarTrait3", condition: .init(traits: ["Trait2"])),
-                .init(name: "default"),
-            ]
-        )
-        XCTAssertEqual(
-            deps["foobar"]?.traits,
-            [
-                .init(name: "FooBarTrait1"),
-                .init(name: "FooBarTrait2", condition: .init(traits: ["Trait1"])),
-                .init(name: "FooBarTrait3", condition: .init(traits: ["Trait2"])),
-                .init(name: "default"),
-            ]
-        )
-        XCTAssertEqual(
-            manifest.targets.first,
-            try .init(
-                name: "Target",
-                dependencies: [
-                    .product(
-                        name: "Product1",
-                        package: "foobar",
-                        condition: .init(traits: ["Trait1"])
-                    ),
-                    .product(
-                        name: "Product2",
-                        package: "bar",
-                        condition: .init(traits: ["Trait2"])
-                    ),
-                ],
-                settings: [
-                    .init(
-                        tool: .swift,
-                        kind: .define("DEFINE1"),
-                        condition: .init(traits: ["Trait1"])
-                    ),
-                    .init(
-                        tool: .swift,
-                        kind: .define("DEFINE2"),
-                        condition: .init(traits: ["Trait2"])
-                    ),
-                    .init(
-                        tool: .swift,
-                        kind: .define("DEFINE3"),
-                        condition: .init(traits: ["Trait1", "Trait2"])
-                    ),
+            XCTAssertEqual(manifest.traits, [
+                TraitDescription(name: "default", description: "The default traits of this package.", enabledTraits: ["Trait1", "Trait2"]),
+                TraitDescription(name: "Trait1"),
+                TraitDescription(name: "Trait2"),
+            ])
+            let deps = Dictionary(uniqueKeysWithValues: manifest.dependencies.map{ ($0.identity.description, $0) })
+            XCTAssertEqual(
+                deps["x.foo"]?.traits,
+                [
+                    .init(name: "FooTrait1"),
+                    .init(name: "FooTrait2", condition: .init(traits: ["Trait1"])),
+                    .init(name: "FooTrait3", condition: .init(traits: ["Trait2"])),
+                    .init(name: "default"),
                 ]
             )
-        )
+            XCTAssertEqual(
+                deps["bar"]?.traits,
+                [
+                    .init(name: "BarTrait1"),
+                    .init(name: "BarTrait2", condition: .init(traits: ["Trait1"])),
+                    .init(name: "BarTrait3", condition: .init(traits: ["Trait2"])),
+                    .init(name: "default"),
+                ]
+            )
+            XCTAssertEqual(
+                deps["foobar"]?.traits,
+                [
+                    .init(name: "FooBarTrait1"),
+                    .init(name: "FooBarTrait2", condition: .init(traits: ["Trait1"])),
+                    .init(name: "FooBarTrait3", condition: .init(traits: ["Trait2"])),
+                    .init(name: "default"),
+                ]
+            )
+            XCTAssertEqual(
+                manifest.targets.first,
+                try .init(
+                    name: "Target",
+                    dependencies: [
+                        .product(
+                            name: "Product1",
+                            package: "foobar",
+                            condition: .init(traits: ["Trait1"])
+                        ),
+                        .product(
+                            name: "Product2",
+                            package: "bar",
+                            condition: .init(traits: ["Trait2"])
+                        ),
+                    ],
+                    settings: [
+                        .init(
+                            tool: .swift,
+                            kind: .define("DEFINE1"),
+                            condition: .init(traits: ["Trait1"])
+                        ),
+                        .init(
+                            tool: .swift,
+                            kind: .define("DEFINE2"),
+                            condition: .init(traits: ["Trait2"])
+                        ),
+                        .init(
+                            tool: .swift,
+                            kind: .define("DEFINE3"),
+                            condition: .init(traits: ["Trait1", "Trait2"])
+                        ),
+                    ]
+                )
+            )
+            
+            return manifest
+        }
     }
 }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -563,7 +563,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
     }
 
     /// Tests a fully customized iOSApplication (one that exercises every parameter in at least some way).
-    func testAppleProductSettings() throws {
+    func testAppleProductSettings() async throws {
       #if ENABLE_APPLE_PRODUCT_TYPES
         let manifestContents = """
             // swift-tools-version: 999.0
@@ -640,7 +640,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
                 ]
             )
             """
-        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
+        try await testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
       #else
         throw XCTSkip("ENABLE_APPLE_PRODUCT_TYPES is not set")
       #endif
@@ -648,7 +648,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
 
     /// Tests loading an iOSApplication product configured with the `.asset(_)` variant of the
     /// appIcon and accentColor parameters.
-    func testAssetBasedAccentColorAndAppIconAppleProductSettings() throws {
+    func testAssetBasedAccentColorAndAppIconAppleProductSettings() async throws {
       #if ENABLE_APPLE_PRODUCT_TYPES
         let manifestContents = """
             // swift-tools-version: 999.0
@@ -670,14 +670,14 @@ final class ManifestSourceGenerationTests: XCTestCase {
                 ]
             )
             """
-        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
+        try await testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
       #else
         throw XCTSkip("ENABLE_APPLE_PRODUCT_TYPES is not set")
       #endif
     }
 
     /// Tests loading an iOSApplication product configured with legacy 'iconAssetName' and 'accentColorAssetName' parameters.
-    func testLegacyAccentColorAndAppIconAppleProductSettings() throws {
+    func testLegacyAccentColorAndAppIconAppleProductSettings() async throws {
       #if ENABLE_APPLE_PRODUCT_TYPES
         let manifestContents = """
             // swift-tools-version: 999.0
@@ -699,14 +699,14 @@ final class ManifestSourceGenerationTests: XCTestCase {
                 ]
             )
             """
-        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
+        try await testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
       #else
         throw XCTSkip("ENABLE_APPLE_PRODUCT_TYPES is not set")
       #endif
     }
 
     /// Tests the smallest allowed iOSApplication (one that has default values for everything not required). Make sure no defaults get added to it.
-    func testMinimalAppleProductSettings() throws {
+    func testMinimalAppleProductSettings() async throws {
       #if ENABLE_APPLE_PRODUCT_TYPES
         let manifestContents = """
             // swift-tools-version: 999.0
@@ -733,7 +733,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
                 ]
             )
             """
-        try testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
+        try await testManifestWritingRoundTrip(manifestContents: manifestContents, toolsVersion: .v5_5)
       #else
         throw XCTSkip("ENABLE_APPLE_PRODUCT_TYPES is not set")
       #endif


### PR DESCRIPTION
Extends the parsing manifest loader introduced in https://github.com/swiftlang/swift-package-manager/pull/9759 to handle more package manifests and have a more regular internal structure.

### Motivation:

The parsing manifest loader handles declarative package manifests. By teaching it to handle more common patterns in real-world package manifests, it can provide its optimizations for more use cases.

### Modifications:

There are three major changes here:
* Addition of support for global variables in package manifests, so if you pull out some common logic into a global variable and use it in your package manifest, the parsing manifest loader can still handle it.
* Addition of support for appending to package targets/products/dependencies/etc. after the initial package declaration.
* Reworked the implementation to make it more internally consistent and declarative, collapsing if-else chains into switch statements, using error handling to ensure that we record limitations consistently, and generally improving the quality and maintainability of the code.

### Result:

A bunch more package manifests can be handled by the parsing manifest loader over the original PR.