### PR TITLE
swift package experimental-build-server should return compiler args for plugin scripts

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -29,6 +29,7 @@ import enum PackageModel.PrebuiltsPlatform
 import struct PackageModel.Resource
 import struct PackageModel.PackageIdentity
 import enum PackageModel.ProductType
+import struct PackageModel.ToolsVersion
 
 import struct PackageGraph.ModulesGraph
 import struct PackageGraph.ResolvedModule
@@ -350,7 +351,8 @@ public final class PackagePIFBuilder {
             linkedPackageBinaries: [],
             swiftLanguageVersion: nil,
             declaredPlatforms: nil,
-            deploymentTargets: nil
+            deploymentTargets: nil,
+            toolsVersion: nil
         )
         return placeholderModule
     }
@@ -369,12 +371,17 @@ public final class PackagePIFBuilder {
 
         public var indexableFileURLs: [SourceControlURL]
         public var headerFiles: Set<AbsolutePath>
+        /// Source files implementing the plugin represented by this target, which
+        /// are compiled during build planning as opposed to participating in the
+        /// build itself.
+        public var pluginScriptSourcePaths: [AbsolutePath]
         public var linkedPackageBinaries: [LinkedPackageBinary]
 
         public var swiftLanguageVersion: String?
 
         public var declaredPlatforms: [PackageModel.Platform]?
         public var deploymentTargets: [PackageModel.Platform: String?]?
+        public var toolsVersion: ToolsVersion?
     }
 
     public struct LinkedPackageBinary {
@@ -721,22 +728,26 @@ extension PackagePIFBuilder.ModuleOrProduct {
         moduleName: String?,
         pifTarget: ProjectModel.BaseTarget?,
         indexableFileURLs: [SourceControlURL] = [],
+        pluginScriptSourcePaths: [AbsolutePath] = [],
         headerFiles: Set<AbsolutePath> = [],
         linkedPackageBinaries: [PackagePIFBuilder.LinkedPackageBinary] = [],
         swiftLanguageVersion: String? = nil,
         declaredPlatforms: [PackageModel.Platform]? = [],
-        deploymentTargets: [PackageModel.Platform: String?]? = [:]
+        deploymentTargets: [PackageModel.Platform: String?]? = [:],
+        toolsVersion: ToolsVersion?
     ) {
         self.type = moduleOrProductType
         self.name = name
         self.moduleName = moduleName
         self.pifTarget = pifTarget
         self.indexableFileURLs = indexableFileURLs
+        self.pluginScriptSourcePaths = pluginScriptSourcePaths
         self.headerFiles = headerFiles
         self.linkedPackageBinaries = linkedPackageBinaries
         self.swiftLanguageVersion = swiftLanguageVersion
         self.declaredPlatforms = declaredPlatforms
         self.deploymentTargets = deploymentTargets
+        self.toolsVersion = toolsVersion
     }
 }
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -142,6 +142,7 @@ extension PackagePIFProjectBuilder {
             pifTarget: .target(self.project[keyPath: pluginTargetKeyPath]),
             indexableFileURLs: [],
             headerFiles: [],
+            pluginScriptSourcePaths: pluginModule.sources.paths,
             linkedPackageBinaries: [],
             swiftLanguageVersion: nil,
             declaredPlatforms: self.declaredPlatforms,
@@ -877,7 +878,8 @@ extension PackagePIFProjectBuilder {
             linkedPackageBinaries: linkedPackageBinaries,
             swiftLanguageVersion: sourceModule.packageSwiftLanguageVersion(manifest: packageManifest),
             declaredPlatforms: self.declaredPlatforms,
-            deploymentTargets: self.deploymentTargets
+            deploymentTargets: self.deploymentTargets,
+            toolsVersion: pifBuilder.packageManifest.toolsVersion
         )
 
         return (moduleOrProduct, resourceBundleName)
@@ -963,7 +965,8 @@ extension PackagePIFProjectBuilder {
             linkedPackageBinaries: [],
             swiftLanguageVersion: nil,
             declaredPlatforms: self.declaredPlatforms,
-            deploymentTargets: self.deploymentTargets
+            deploymentTargets: self.deploymentTargets,
+            toolsVersion: pifBuilder.packageManifest.toolsVersion
         )
         self.builtModulesAndProducts.append(systemModule)
     }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -540,7 +540,8 @@ extension PackagePIFProjectBuilder {
             linkedPackageBinaries: linkedPackageBinaries,
             swiftLanguageVersion: mainModule.packageSwiftLanguageVersion(manifest: packageManifest),
             declaredPlatforms: self.declaredPlatforms,
-            deploymentTargets: mainTargetDeploymentTargets
+            deploymentTargets: mainTargetDeploymentTargets,
+            toolsVersion: pifBuilder.packageManifest.toolsVersion
         )
         self.builtModulesAndProducts.append(moduleOrProduct)
 
@@ -926,7 +927,8 @@ extension PackagePIFProjectBuilder {
             linkedPackageBinaries: linkedPackageBinaries,
             swiftLanguageVersion: nil,
             declaredPlatforms: self.declaredPlatforms,
-            deploymentTargets: self.deploymentTargets
+            deploymentTargets: self.deploymentTargets,
+            toolsVersion: pifBuilder.packageManifest.toolsVersion
         )
     }
 
@@ -976,7 +978,8 @@ extension PackagePIFProjectBuilder {
             linkedPackageBinaries: [],
             swiftLanguageVersion: nil,
             declaredPlatforms: self.declaredPlatforms,
-            deploymentTargets: self.deploymentTargets
+            deploymentTargets: self.deploymentTargets,
+            toolsVersion: pifBuilder.packageManifest.toolsVersion
         )
         self.builtModulesAndProducts.append(systemLibrary)
     }
@@ -1035,11 +1038,13 @@ extension PackagePIFProjectBuilder {
             moduleName: pluginProduct.c99name,
             pifTarget: .aggregate(self.project[keyPath: pluginTargetKeyPath]),
             indexableFileURLs: [],
+            pluginScriptSourcePaths: pluginProduct.pluginModules?.only?.sources.paths ?? [],
             headerFiles: [],
             linkedPackageBinaries: [],
             swiftLanguageVersion: nil,
             declaredPlatforms: self.declaredPlatforms,
-            deploymentTargets: self.deploymentTargets
+            deploymentTargets: self.deploymentTargets,
+            toolsVersion: pifBuilder.packageManifest.toolsVersion
         )
         self.builtModulesAndProducts.append(pluginProductMetadata)
     }
@@ -1143,7 +1148,8 @@ extension PackagePIFProjectBuilder {
             linkedPackageBinaries: [],
             swiftLanguageVersion: nil,
             declaredPlatforms: self.declaredPlatforms,
-            deploymentTargets: self.deploymentTargets
+            deploymentTargets: self.deploymentTargets,
+            toolsVersion: pifBuilder.packageManifest.toolsVersion
         )
         self.builtModulesAndProducts.append(testRunner)
     }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder.swift
@@ -251,7 +251,8 @@ struct PackagePIFProjectBuilder {
             linkedPackageBinaries: [],
             swiftLanguageVersion: nil,
             declaredPlatforms: [],
-            deploymentTargets: [:]
+            deploymentTargets: [:],
+            toolsVersion: pifBuilder.packageManifest.toolsVersion
         )
 
         return (result, resourceBundle)

--- a/Sources/SwiftBuildSupport/PluginConfiguration.swift
+++ b/Sources/SwiftBuildSupport/PluginConfiguration.swift
@@ -15,13 +15,13 @@
 
 public struct PluginConfiguration {
     /// Entity responsible for compiling and running plugin scripts.
-    let scriptRunner: PluginScriptRunner
+    public let scriptRunner: PluginScriptRunner
 
     /// Directory where plugin intermediate files are stored.
-    let workDirectory: Basics.AbsolutePath
+    public let workDirectory: Basics.AbsolutePath
 
     /// Whether to sandbox commands from build tool plugins.
-    let disableSandbox: Bool
+    public let disableSandbox: Bool
 
     public init(
         scriptRunner: PluginScriptRunner,

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -259,7 +259,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
     public weak var delegate: SPMBuildCore.BuildSystemDelegate?
 
     /// Configuration for building and invoking plugins.
-    private let pluginConfiguration: PluginConfiguration
+    package let pluginConfiguration: PluginConfiguration
 
     /// Additional rules for different file types generated from plugins.
     private let additionalFileRules: [FileRuleDescription]

--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -21,6 +21,7 @@ import Workspace
 import BuildServerProtocol
 import LanguageServerProtocol
 import LanguageServerProtocolTransport
+import PackageModel
 import ToolsProtocolsSwiftExtensions
 
 // Remove these extensions once they've been added to swift-tools-protocols
@@ -113,6 +114,13 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
     var state: ServerState = .waitingForInitializeRequest
 
     private var headersByTargetGUID: [String: Set<Basics.AbsolutePath>] = [:]
+
+    private struct PluginInfo {
+        var name: String
+        var sourceFiles: [Basics.AbsolutePath]
+        var toolsVersion: ToolsVersion
+    }
+    private var pluginsByTargetGUID: [BuildTargetIdentifier: PluginInfo] = [:]
 
     /// Allows customization of server exit behavior.
     var exitHandler: (Int) -> Void
@@ -211,9 +219,16 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                 var sourcesResponse = try await connectionToUnderlyingBuildServer.send(underlyingRequest)
                 for target in request.params.targets.filter({ $0.isSwiftPMBuildServerTargetID }) {
                     if target == .forPackageManifest {
-                        sourcesResponse.items.append(await manifestSourcesItem())
+                        sourcesResponse.items.append(manifestSourcesItem())
+                    } else if let pluginInfo = self.pluginsByTargetGUID[target] {
+                        sourcesResponse.items.append(SourcesItem(
+                            target: target,
+                            sources: pluginInfo.sourceFiles.map { path in
+                                SourceItem(uri: DocumentURI(path.asURL), kind: .file, generated: false)
+                            }
+                        ))
                     } else {
-                        await logToClient(.warning, "SwiftPM build server processed target sources request for unexpected target '\(target)'")
+                        logToClient(.warning, "SwiftPM build server processed target sources request for unexpected target '\(target)'")
                     }
                 }
 
@@ -242,8 +257,11 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
             await request.reply { try await self.initialize(request: request.params) }
         case let request as RequestAndReply<TextDocumentSourceKitOptionsRequest>:
             await request.reply {
-                if request.params.target.isSwiftPMBuildServerTargetID {
+                if request.params.target == .forPackageManifest {
                     return try await manifestSourceKitOptions(request: request.params)
+                }
+                if let pluginInfo = pluginsByTargetGUID[request.params.target] {
+                    return try pluginSourceKitOptions(request: request.params, pluginInfo: pluginInfo)
                 }
                 if let targetGUID = request.params.target.targetGUID,
                    let headers = headersByTargetGUID[targetGUID],
@@ -257,7 +275,8 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         case let request as RequestAndReply<WorkspaceBuildTargetsRequest>:
             await request.reply {
                 var targetsResponse = try await connectionToUnderlyingBuildServer.send(request.params)
-                targetsResponse.targets.append(await manifestTarget())
+                targetsResponse.targets.append(manifestTarget())
+                targetsResponse.targets.append(contentsOf: pluginTargetsList())
                 return targetsResponse
             }
         case let request as RequestAndReply<WorkspaceWaitForBuildSystemUpdatesRequest>:
@@ -297,7 +316,6 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
     }
 
     private func manifestTarget() -> BuildTarget {
-        // In the future, we should add a new target to represent plugin scripts so they can load the PackagePlugin module.
         return BuildTarget(
             id: .forPackageManifest,
             displayName: "Package Manifest",
@@ -305,6 +323,18 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
             languageIds: [.swift],
             dependencies: []
         )
+    }
+
+    private func pluginTargetsList() -> [BuildTarget] {
+        pluginsByTargetGUID.map { (targetGUID, pluginInfo) in
+            BuildTarget(
+                id: targetGUID,
+                displayName: pluginInfo.name,
+                tags: [.notBuildable],
+                languageIds: [.swift],
+                dependencies: []
+            )
+        }
     }
 
     private let versionSpecificManifestRegex = #/^Package@swift-(\d+)(?:\.(\d+))?(?:\.(\d+))?.swift$/#
@@ -341,6 +371,17 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         }
         let compilerArgs = try workspace.interpreterFlags(for: path) + [path.pathString]
         return TextDocumentSourceKitOptionsResponse(compilerArguments: compilerArgs)
+    }
+
+    private func pluginSourceKitOptions(request: TextDocumentSourceKitOptionsRequest, pluginInfo: PluginInfo) throws -> TextDocumentSourceKitOptionsResponse? {
+        let compilerArgs = self.buildSystem.pluginConfiguration.scriptRunner.buildCommandLine(
+            sourceFiles: pluginInfo.sourceFiles,
+            pluginName: pluginInfo.name,
+            toolsVersion: pluginInfo.toolsVersion,
+            workers: buildSystem.buildParameters.workers,
+            observabilityScope: nil
+        ).commandLine.dropFirst()
+        return TextDocumentSourceKitOptionsResponse(compilerArguments: Array(compilerArgs))
     }
 
     /// If the requested file is a known header, returns compiler arguments derived from a substitute source file
@@ -416,6 +457,26 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         self.headersByTargetGUID = headers
     }
 
+    private func rebuildPluginMapping(pifAccompanyingMetadata: [PackagePIFBuilder.ModuleOrProduct]) {
+        var plugins: [BuildTargetIdentifier: PluginInfo] = [:]
+        for moduleOrProduct in pifAccompanyingMetadata {
+            guard [.buildToolPlugin, .commandPlugin].contains(moduleOrProduct.type),
+                  let moduleName = moduleOrProduct.moduleName,
+                  let toolsVersion = moduleOrProduct.toolsVersion,
+                  !moduleOrProduct.pluginScriptSourcePaths.isEmpty else {
+                continue
+            }
+            let targetID = BuildTargetIdentifier.forPlugin(name: moduleName)
+            plugins[targetID] = PluginInfo(
+                name: moduleName,
+                sourceFiles: moduleOrProduct.pluginScriptSourcePaths,
+                toolsVersion: toolsVersion
+            )
+
+        }
+        self.pluginsByTargetGUID = plugins
+    }
+
     private func shutdown() -> VoidResponse {
         state = .shutdown
         return VoidResponse()
@@ -450,6 +511,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                 let result = try await buildSystem.generatePIFAndAccompanyingMetadata(preserveStructure: false)
                 try localFileSystem.writeIfChanged(path: buildSystem.buildParameters.pifManifest, string: result.pif)
                 await self.rebuildHeaderMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
+                self.rebuildPluginMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
                 self.connectionToUnderlyingBuildServer.send(OnWatchedFilesDidChangeNotification(changes: [
                     .init(uri: .init(buildSystem.buildParameters.pifManifest.asURL), type: .changed)
                 ]))
@@ -465,6 +527,10 @@ extension BuildTargetIdentifier {
     static let swiftPMBuildServerTargetScheme = "swiftpm"
 
     static let forPackageManifest = BuildTargetIdentifier(uri: try! URI(string: "\(swiftPMBuildServerTargetScheme)://package-manifest"))
+
+    static func forPlugin(name: String) -> BuildTargetIdentifier {
+        BuildTargetIdentifier(uri: try! URI(string: "\(swiftPMBuildServerTargetScheme)://plugin?name=\(name)"))
+    }
 
     var isSwiftPMBuildServerTargetID: Bool {
         uri.scheme == Self.swiftPMBuildServerTargetScheme

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -261,5 +261,30 @@ struct SwiftPMBuildServerTests {
             #expect(settingsResponse.compilerArguments.contains(["-Xcc", "-DBar"]))
         }
     }
+
+    @Test
+    func pluginScriptArgs() async throws {
+        try await withSwiftPMBSP(fixtureName: "Miscellaneous/Plugins/MySourceGenPlugin") { connection, _, _ in
+            let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+
+            let pluginTargets = targetResponse.targets.filter { ($0.displayName == "MySourceGenBuildToolPlugin" || $0.displayName == "MySourceGenPrebuildPlugin") && $0.id.uri.scheme == "swiftpm" }
+            #expect(pluginTargets.count == 2)
+            for pluginTarget in pluginTargets {
+                #expect(pluginTarget.tags.contains(.notBuildable))
+
+                let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [pluginTarget.id]))
+                let pluginSources = try #require(sourcesResponse.items.only?.sources)
+                #expect(!pluginSources.isEmpty)
+                #expect(pluginSources.allSatisfy { $0.uri.fileURL?.pathExtension == "swift" })
+
+                for source in pluginSources {
+                    let settingsResponse = try #require(try await connection.send(TextDocumentSourceKitOptionsRequest(textDocument: TextDocumentIdentifier(source.uri), target: pluginTarget.id, language: .swift)))
+                    #expect(settingsResponse.compilerArguments.contains("-package-description-version"))
+                    #expect(settingsResponse.compilerArguments.contains("-parse-as-library"))
+                    try await AsyncProcess.checkNonZeroExit(arguments: [UserToolchain.default.swiftCompilerPath.pathString, "-typecheck"] + settingsResponse.compilerArguments)
+                }
+            }
+        }
+    }
 }
 #endif


### PR DESCRIPTION
This is roughly the same as https://github.com/swiftlang/swift-package-manager/pull/9583, but for `swift package experimental-build-server`