### PR TITLE
Error if multiple Swift SDKs match `--swift-sdk <selector>`

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -786,7 +786,7 @@ public struct SwiftSDK: Equatable {
             swiftSDK = targetSwiftSDK
         } else if let swiftSDKSelector {
             do {
-                swiftSDK = try store.selectBundle(matching: swiftSDKSelector, hostTriple: hostTriple, targetTriple: customCompileTriple)
+                (_, swiftSDK) = try store.selectBundle(matching: swiftSDKSelector, hostTriple: hostTriple, targetTriple: customCompileTriple)
             } catch {
                 // If a user-installed bundle for the selector doesn't exist, check if the
                 // selector is recognized as a default SDK.

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
@@ -79,15 +79,14 @@ extension [SwiftSDKBundle] {
     /// - Parameters:
     ///   - selector: either an artifact ID or target triple to filter with.
     ///   - hostTriple: triple of the host building with these Swift SDKs.
-    ///   - observabilityScope: observability scope to log warnings about multiple matches.
-    /// - Returns: ``SwiftSDK`` value matching `query` either by artifact ID or target triple, `nil` if none found.
+    /// - Returns: a tuple containing all `selector` matches to the artifact ID or target triple,
+    ///            including the corresponding artifact ID for each target triple matched
     func selectSwiftSDK(
         matching selector: String,
-        hostTriple: Triple,
-        observabilityScope: ObservabilityScope
-    ) -> SwiftSDK? {
-        var matchedByID: (path: AbsolutePath, variant: SwiftSDKBundle.Variant, swiftSDK: SwiftSDK)?
-        var matchedByTriple: (path: AbsolutePath, variant: SwiftSDKBundle.Variant, swiftSDK: SwiftSDK)?
+        hostTriple: Triple
+    ) -> (idMatches: [SwiftSDK], tripleMatches: [String: SwiftSDK]) {
+        var idHits: [SwiftSDK] = []
+        var tripleHits: [String: SwiftSDK] = [:]
 
         for bundle in self {
             for (artifactID, variants) in bundle.artifacts {
@@ -95,56 +94,22 @@ extension [SwiftSDKBundle] {
                     guard variant.isSupporting(hostTriple: hostTriple) else { continue }
 
                     for swiftSDK in variant.swiftSDKs {
+                        // All artifact IDs are checked by installIfValid() to be
+                        // unique, but the selected ID must only have one target triple,
+                        // in this method where no target triple is specified with the ID.
                         if artifactID == selector {
-                            if let matchedByID {
-                                observabilityScope.emit(
-                                    warning:
-                                    """
-                                    multiple Swift SDKs match ID `\(artifactID)` and host triple \(
-                                        hostTriple.tripleString
-                                    ), selected one at \(
-                                        matchedByID.path.appending(matchedByID.variant.metadata.path)
-                                    )
-                                    """
-                                )
-                            } else {
-                                matchedByID = (bundle.path, variant, swiftSDK)
-                            }
+                            idHits.append(swiftSDK)
                         }
-
+                        // Multiple SDKs can vend the same triple, so list them all and
+                        // return the corresponding artifact ID also.
                         if swiftSDK.targetTriple?.tripleString == selector {
-                            if let matchedByTriple {
-                                observabilityScope.emit(
-                                    warning:
-                                    """
-                                    multiple Swift SDKs match target triple `\(selector)` and host triple \(
-                                        hostTriple.tripleString
-                                    ), selected one at \(
-                                        matchedByTriple.path.appending(matchedByTriple.variant.metadata.path)
-                                    )
-                                    """
-                                )
-                            } else {
-                                matchedByTriple = (bundle.path, variant, swiftSDK)
-                            }
+                            tripleHits[artifactID] = swiftSDK
                         }
                     }
                 }
             }
         }
-
-        if let matchedByID, let matchedByTriple, matchedByID != matchedByTriple {
-            observabilityScope.emit(
-                warning:
-                """
-                multiple Swift SDKs match the query `\(selector)` and host triple \(
-                    hostTriple.tripleString
-                ), selected one at \(matchedByID.path.appending(matchedByID.variant.metadata.path))
-                """
-            )
-        }
-
-        return matchedByID?.swiftSDK ?? matchedByTriple?.swiftSDK
+        return (idMatches: idHits, tripleMatches: tripleHits)
     }
 
     public var sortedArtifactIDs: [String] {

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
@@ -46,22 +46,43 @@ public final class SwiftSDKBundleStore {
     }
 
     enum Error: Swift.Error, CustomStringConvertible {
+        case matchingBothToSwiftSDK(selector: String, hostTriple: Triple)
+        case multipleSDKMatchesForID(selector: String, hostTriple: Triple)
+        case multipleSDKMatchesForTriple(selector: String, hostTriple: Triple, matches: [String])
         case noMatchingSwiftSDK(selector: String, hostTriple: Triple)
         case noMatchingSwiftSDKWithTriple(selector: String, hostTriple: Triple, targetTriple: Triple)
 
         var description: String {
             switch self {
+            case let .matchingBothToSwiftSDK(selector, hostTriple):
+                return """
+                The query for `\(selector)` and host triple `\(hostTriple.tripleString)` \
+                matched both an SDK and a target triple. Use the `swift sdk list` command \
+                to see available Swift SDKs and remove one of them.
+                """
+            case let .multipleSDKMatchesForID(selector, hostTriple):
+                return """
+                The query for `\(selector)` and host triple `\(hostTriple.tripleString)` \
+                has multiple target triples. Use the `--triple` flag to specify a triple.
+                """
+            case let .multipleSDKMatchesForTriple(selector, hostTriple, matches):
+                return """
+                The query for `\(selector)` and host triple `\(hostTriple.tripleString)` \
+                matched multiple SDKs: \(matches.joined(separator: ", ")). Use the \
+                `swift sdk list` command to see available Swift SDKs and try a different \
+                query like `--swift-sdk \(matches[0]) --triple \(selector)` or remove an SDK.
+                """
             case let .noMatchingSwiftSDK(selector, hostTriple):
                 return """
                 No Swift SDK found matching query `\(selector)` and host triple \
-                `\(hostTriple.tripleString)`. Use `swift sdk list` command to see \
+                `\(hostTriple.tripleString)`. Use the `swift sdk list` command to see \
                 available Swift SDKs.
                 """
             case let .noMatchingSwiftSDKWithTriple(selector, hostTriple, targetTriple):
                 return """
                 No Swift SDK found matching query `\(selector)`, target triple \
                 `\(targetTriple.tripleString)`, and host triple `\(hostTriple.tripleString)`. \
-                Use `swift sdk list` command to see available Swift SDKs.
+                Use the `swift sdk list` command to see available Swift SDKs.
                 """
             }
         }
@@ -128,15 +149,16 @@ public final class SwiftSDKBundleStore {
     /// Select a Swift SDK matching a given query and host triple from all Swift SDKs available in
     /// ``SwiftSDKBundleStore//swiftSDKsDirectory``.
     /// - Parameters:
-    ///   - query: either an artifact ID or target triple to filter with.
+    ///   - selector: either an artifact ID or target triple to filter with.
     ///   - hostTriple: triple of the host building with these Swift SDKs.
     ///   - targetTriple: optional separate target triple to look for
-    /// - Returns: ``SwiftSDK`` value matching `query` either by artifact ID or target triple, `nil` if none found.
+    /// - Returns: tuple with the Artifact ID and ``SwiftSDK`` value that matched `selector` either by
+    ///            artifact ID or target triple, throws if multiple or none found.
     public func selectBundle(
         matching selector: String,
         hostTriple: Triple,
         targetTriple: Triple? = nil
-    ) throws -> SwiftSDK {
+    ) throws -> (String, SwiftSDK) {
         let validBundles = try self.allValidBundles
 
         guard !validBundles.isEmpty else {
@@ -154,20 +176,32 @@ public final class SwiftSDKBundleStore {
                 throw Error.noMatchingSwiftSDKWithTriple(selector: selector, hostTriple: hostTriple, targetTriple: triple)
             }
             selectedSwiftSDK.applyPathCLIOptions()
-            return selectedSwiftSDK
+            return (selector, selectedSwiftSDK)
         }
 
-        guard var selectedSwiftSDKs = validBundles.selectSwiftSDK(
-            matching: selector,
-            hostTriple: hostTriple,
-            observabilityScope: self.observabilityScope
-        ) else {
+        var selectedSwiftSDK: SwiftSDK
+        var id: String
+        let SDKs = validBundles.selectSwiftSDK(matching: selector, hostTriple: hostTriple)
+        if SDKs.tripleMatches.count > 1 {
+            throw Error.multipleSDKMatchesForTriple(selector: selector, hostTriple: hostTriple, matches: Array(SDKs.tripleMatches.keys).sorted())
+        } else if SDKs.idMatches.count > 1 {
+            throw Error.multipleSDKMatchesForID(selector: selector, hostTriple: hostTriple)
+        } else if SDKs.idMatches.count == 1 {
+            guard SDKs.tripleMatches.count == 0 else {
+              throw Error.matchingBothToSwiftSDK(selector: selector, hostTriple: hostTriple)
+            }
+            id = selector
+            selectedSwiftSDK = SDKs.idMatches[0]
+        } else if let match = SDKs.tripleMatches.first {
+            id = match.key
+            selectedSwiftSDK = match.value
+        } else {
             throw Error.noMatchingSwiftSDK(selector: selector, hostTriple: hostTriple)
         }
 
-        selectedSwiftSDKs.applyPathCLIOptions()
+        selectedSwiftSDK.applyPathCLIOptions()
 
-        return selectedSwiftSDKs
+        return (id, selectedSwiftSDK)
     }
 
     /// Installs a Swift SDK bundle from a given path or URL to ``SwiftSDKBundleStore//swiftSDKsDirectory``.

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -375,12 +375,13 @@ final class SwiftSDKBundleTests: XCTestCase {
             try await store.install(bundlePathOrURL: bundle.path, archiver)
         }
 
-        let sdk = try store.selectBundle(
+        let (id, sdk) = try store.selectBundle(
             matching: "\(testArtifactID)1",
             hostTriple: Triple("arm64-apple-macosx14.0")
         )
 
         XCTAssertEqual(sdk.targetTriple, targetTriple)
+        XCTAssertEqual(id, "\(testArtifactID)1")
         XCTAssertEqual(output, [
             .installationSuccessful(
                 bundlePathOrURL: bundles[0].path,
@@ -392,13 +393,107 @@ final class SwiftSDKBundleTests: XCTestCase {
             ),
         ])
 
-        let tripleSDK = try store.selectBundle(
+        let (name, tripleSDK) = try store.selectBundle(
             matching: "\(testArtifactID)1",
             hostTriple: Triple("arm64-apple-macosx14.0"),
             targetTriple: targetTriple
         )
 
         XCTAssertEqual(tripleSDK.targetTriple, targetTriple)
+        XCTAssertEqual(name, "\(testArtifactID)1")
+
+        let (match, matchSDK) = try store.selectBundle(
+            matching: "\(targetTriple.tripleString)",
+            hostTriple: Triple("i686-apple-macosx14.0")
+        )
+
+        XCTAssertEqual(matchSDK.targetTriple, targetTriple)
+        XCTAssertEqual(match, "\(testArtifactID)2")
+    }
+
+    func testBundleSelectionByTripleAndErrors() async throws {
+        let (fileSystem, bundles, swiftSDKsDirectory) = try generateTestFileSystem(
+            bundleArtifacts: [
+                .init(id: "\(testArtifactID)1", supportedTriples: [arm64Triple]),
+                .init(id: "\(testArtifactID)2", supportedTriples: [arm64Triple]),
+                .init(id: "\(targetTriple.tripleString)", supportedTriples: [i686Triple])
+            ]
+        )
+        let system = ObservabilitySystem.makeForTesting()
+
+        var output = [SwiftSDKBundleStore.Output]()
+        let store = SwiftSDKBundleStore(
+            swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: "/tmp",
+            fileSystem: fileSystem,
+            observabilityScope: system.topScope,
+            outputHandler: {
+                output.append($0)
+            }
+        )
+
+        let archiver = MockArchiver()
+        for bundle in bundles {
+            try await store.install(bundlePathOrURL: bundle.path, archiver)
+        }
+
+        XCTAssertThrowsError(try store.selectBundle(
+            matching: "\(testArtifactID)3",
+            hostTriple: Triple("arm64-apple-macosx14.0"),
+            targetTriple: targetTriple
+        )) { error in
+            XCTAssertEqual(
+                "\(error)",
+                """
+                No Swift SDK found matching query `\(testArtifactID)3`, target triple \
+                `\(targetTriple.tripleString)`, and host triple `arm64-apple-macosx14.0`. \
+                Use the `swift sdk list` command to see available Swift SDKs.
+                """
+            )
+        }
+
+        XCTAssertThrowsError(try store.selectBundle(
+            matching: targetTriple.tripleString,
+            hostTriple: Triple("arm64-apple-macosx14.0")
+        )) { error in
+            XCTAssertEqual(
+                "\(error)",
+                """
+                The query for `\(targetTriple.tripleString)` and host triple `arm64-apple-macosx14.0` \
+                matched multiple SDKs: \(testArtifactID)1, \(testArtifactID)2. Use the \
+                `swift sdk list` command to see available Swift SDKs and try a different \
+                query like `--swift-sdk \(testArtifactID)1 --triple \(targetTriple.tripleString)` or remove an SDK.
+                """
+            )
+        }
+
+        XCTAssertThrowsError(try store.selectBundle(
+            matching: "\(targetTriple.tripleString)",
+            hostTriple: Triple("i686-apple-macosx14.0")
+        )) { error in
+            XCTAssertEqual(
+                "\(error)",
+                """
+                The query for `\(targetTriple.tripleString)` and host triple `i686-apple-macosx14.0` \
+                matched both an SDK and a target triple. Use the `swift sdk list` command \
+                to see available Swift SDKs and remove one of them.
+                """
+            )
+        }
+
+        XCTAssertThrowsError(try store.selectBundle(
+            matching: "armv7-unknown-linux",
+            hostTriple: Triple("arm64-apple-macosx14.0")
+        )) { error in
+            XCTAssertEqual(
+                "\(error)",
+                """
+                No Swift SDK found matching query `armv7-unknown-linux` and host triple \
+                `arm64-apple-macosx14.0`. Use the `swift sdk list` command to see \
+                available Swift SDKs.
+                """
+            )
+        }
     }
 
     func testTargetSDKDerivation() async throws {
@@ -586,12 +681,13 @@ final class SwiftSDKBundleTests: XCTestCase {
             }
 
             let hostTriple = try Triple("arm64-apple-macosx14.0")
-            let sdk = try store.selectBundle(
+            let (id, sdk) = try store.selectBundle(
                 matching: testArtifactID,
                 hostTriple: hostTriple
             )
 
             XCTAssertEqual(sdk.targetTriple, targetTriple)
+            XCTAssertEqual(id, testArtifactID)
             XCTAssertEqual(output, [
                 .installationSuccessful(
                     bundlePathOrURL: bundles[0].path,

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -26,6 +26,7 @@ private let olderHostTriple = try! Triple("arm64-apple-darwin20.1.0")
 private let linuxGNUTargetTriple = try! Triple("x86_64-unknown-linux-gnu")
 private let linuxMuslTargetTriple = try! Triple("x86_64-unknown-linux-musl")
 private let androidTargetTriple = try! Triple("aarch64-unknown-linux-android28")
+private let androidx64TargetTriple = try! Triple("x86_64-unknown-linux-android35")
 private let wasiTargetTriple = try! Triple("wasm32-unknown-wasi")
 private let extraFlags = BuildFlags(
     cCompilerFlags: ["-fintegrated-as"].constructBuildFlags(source: .swiftSDK),
@@ -193,6 +194,20 @@ private let androidWithoutSDKRootPathSwiftSDKv4 = (
     {
         "targetTriples": {
             "\#(androidTargetTriple.tripleString)": {
+                "toolsetPaths": ["/tools/otherToolsNoRoot.json"]
+            }
+        },
+        "schemaVersion": "4.0"
+    }
+    """# as SerializedJSON
+)
+
+private let androidx64WithoutSDKRootPathSwiftSDKv4 = (
+    path: bundleRootPath.appending(component: "androidWithoutSDKRootPathSwiftSDKv4.json"),
+    json: #"""
+    {
+        "targetTriples": {
+            "\#(androidx64TargetTriple.tripleString)": {
                 "toolsetPaths": ["/tools/otherToolsNoRoot.json"]
             }
         },
@@ -379,6 +394,24 @@ private let parsedToolsetNoSDKRootPathDestination = SwiftSDK(
         rootPaths: []
     ),
     swiftSDKManifest: androidWithoutSDKRootPathSwiftSDKv4.path,
+    pathsConfiguration: .init(
+        sdkRootPath: nil,
+        toolsetPaths: ["/tools/otherToolsNoRoot.json"]
+            .map { try! AbsolutePath(validating: $0) }
+    )
+)
+
+private let parsedAndroidToolsetNoSDKRootPathDestination = SwiftSDK(
+    targetTriple: androidx64TargetTriple,
+    toolset: .init(
+        knownTools: [
+            .librarian: .init(path: try! AbsolutePath(validating: "\(usrBinTools[.librarian]!)")),
+            .linker: .init(path: try! AbsolutePath(validating: "\(usrBinTools[.linker]!)")),
+            .debugger: .init(path: try! AbsolutePath(validating: "\(usrBinTools[.debugger]!)")),
+        ],
+        rootPaths: []
+    ),
+    swiftSDKManifest: androidx64WithoutSDKRootPathSwiftSDKv4.path,
     pathsConfiguration: .init(
         sdkRootPath: nil,
         toolsetPaths: ["/tools/otherToolsNoRoot.json"]
@@ -678,14 +711,11 @@ final class SwiftSDKTests: XCTestCase {
             ),
         ]
 
-        let system = ObservabilitySystem.makeForTesting()
-
         XCTAssertEqual(
             bundles.selectSwiftSDK(
                 matching: "id1",
-                hostTriple: hostTriple,
-                observabilityScope: system.topScope
-            ),
+                hostTriple: hostTriple
+            ).idMatches.first,
             parsedDestinationV2GNU
         )
 
@@ -694,17 +724,15 @@ final class SwiftSDKTests: XCTestCase {
         XCTAssertNil(
             bundles.selectSwiftSDK(
                 matching: "id2",
-                hostTriple: hostTriple,
-                observabilityScope: system.topScope
-            )
+                hostTriple: hostTriple
+            ).idMatches.first
         )
 
         XCTAssertEqual(
             bundles.selectSwiftSDK(
                 matching: "id3",
-                hostTriple: hostTriple,
-                observabilityScope: system.topScope
-            ),
+                hostTriple: hostTriple
+            ).idMatches.first,
             parsedDestinationV2Musl
         )
 
@@ -720,9 +748,8 @@ final class SwiftSDKTests: XCTestCase {
         XCTAssertEqual(
             bundles.selectSwiftSDK(
                 matching: "id4",
-                hostTriple: hostTriple,
-                observabilityScope: system.topScope
-            ),
+                hostTriple: hostTriple
+            ).idMatches.first,
             parsedDestinationForOlderHost
         )
 
@@ -738,9 +765,8 @@ final class SwiftSDKTests: XCTestCase {
         XCTAssertEqual(
             bundles.selectSwiftSDK(
                 matching: "id5",
-                hostTriple: hostTriple,
-                observabilityScope: system.topScope
-            ),
+                hostTriple: hostTriple
+            ).idMatches.first,
             parsedDestinationV2GNU
         )
     }
@@ -768,5 +794,75 @@ final class SwiftSDKTests: XCTestCase {
         XCTAssert(cFlags.contains(["-F", "\(iOSPlatform.pathString)/Developer/Library/Frameworks"]))
         XCTAssertFalse(cFlags.contains { $0.lowercased().contains("macos") }, "Found macOS path in \(cFlags)")
         #endif
+    }
+
+    func testSelectSDKWithMultipleMatches() throws {
+        let bundles = [
+            SwiftSDKBundle(
+                path: try AbsolutePath(validating: "/droidSDKs.artifactsbundle"),
+                artifacts: [
+                    "droid-multiarch": [
+                        .init(
+                            metadata: .init(
+                                path: "droid",
+                                supportedTriples: [hostTriple]
+                            ),
+                            swiftSDKs: [parsedToolsetNoSDKRootPathDestination, parsedAndroidToolsetNoSDKRootPathDestination]
+                        ),
+                    ],
+                    "droid-single": [
+                        .init(
+                            metadata: .init(
+                                path: "droid-single",
+                                supportedTriples: [hostTriple]
+                            ),
+                            swiftSDKs: [parsedToolsetNoSDKRootPathDestination]
+                        ),
+                    ],
+                ]
+            ),
+        ]
+
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                id: "droid-multiarch",
+                hostTriple: hostTriple,
+                targetTriple: androidTargetTriple
+            ),
+            parsedToolsetNoSDKRootPathDestination
+        )
+
+        XCTAssertNil(
+            bundles.selectSwiftSDK(
+                id: "droid-single",
+                hostTriple: hostTriple,
+                targetTriple: androidx64TargetTriple
+            )
+        )
+
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                matching: androidTargetTriple.tripleString,
+                hostTriple: hostTriple
+            ).tripleMatches,
+            ["droid-multiarch" : parsedToolsetNoSDKRootPathDestination,
+             "droid-single" : parsedToolsetNoSDKRootPathDestination]
+        )
+
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                matching: androidx64TargetTriple.tripleString,
+                hostTriple: hostTriple
+            ).tripleMatches,
+            ["droid-multiarch" : parsedAndroidToolsetNoSDKRootPathDestination]
+        )
+
+        XCTAssertEqual(
+            bundles.selectSwiftSDK(
+                matching: "droid-multiarch",
+                hostTriple: hostTriple
+            ).idMatches,
+            [parsedToolsetNoSDKRootPathDestination, parsedAndroidToolsetNoSDKRootPathDestination]
+        )
     }
 }

--- a/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -80,7 +80,7 @@ private func findWasmKit(sdkID: String) throws -> AbsolutePath? {
     let hostTriple = try Triple.getVersionedHostTriple(
         usingSwiftCompiler: hostToolchain.swiftCompilerPath
     )
-    let swiftSDK = try bundleStore.selectBundle(matching: sdkID, hostTriple: hostTriple)
+    let (_, swiftSDK) = try bundleStore.selectBundle(matching: sdkID, hostTriple: hostTriple)
 
     return swiftSDK.toolset.knownTools[.debugger]?.path
 }


### PR DESCRIPTION
### Motivation:

SDK search assumed you knew what you're doing and would pick any SDK that matched, time to make that more strict.

### Modifications:

Collect all matches instead, then spit out different errors if there were multiple matches.

### Result:

Emphasize to SDK users that they need to have their installed SDKs not contain the same target triples, when selecting with a triple alone.

This was spun off from ~the third commit from~ #9229.

