### PR TITLE
Tests: Remove withKnownIssue from tests that use TestableExe fixture

### DIFF
--- a/Tests/BuildTests/BuildSystemDelegateTests.swift
+++ b/Tests/BuildTests/BuildSystemDelegateTests.swift
@@ -74,7 +74,6 @@ struct BuildSystemDelegateTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let config = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             // Note: we can re-use the `TestableExe` fixture here since we just need an executable.
             try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
                 _ = try await executeSwiftBuild(
@@ -92,11 +91,14 @@ struct BuildSystemDelegateTests {
                     configuration: config,
                     buildSystem: buildSystem,
                 )
-                #expect(!stdout.contains("replacing existing signature"), "log contained non-fatal codesigning messages stderr: '\(stderr)'")
-                #expect(!stderr.contains("replacing existing signature"), "log contained non-fatal codesigning messages. stdout: '\(stdout)'")
+                #expect(
+                    stdout.contains("replacing existing signature") == false,
+                    "log contained non-fatal codesigning messages stderr: '\(stderr)'",
+                )
+                #expect(
+                    stderr.contains("replacing existing signature") == false,
+                    "log contained non-fatal codesigning messages. stdout: '\(stdout)'",
+                )
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
-        }
     }
 }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -224,7 +224,6 @@ struct TestCommandTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue("fails to build the package", isIntermittent: true) {
             // default should run with testability
             try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
                 let result = try await execute(
@@ -233,11 +232,8 @@ struct TestCommandTests {
                     configuration: configuration,
                     buildSystem: buildSystem,
                 )
-                #expect(result.stderr.contains("-enable-testing"))
+                #expect(result.stderr.contains("-enable-testing") == true)
             }
-        } when: {
-            buildSystem == .swiftbuild && .windows == ProcessInfo.hostOperatingSystem
-        }
     }
 
     @Test(
@@ -252,7 +248,6 @@ struct TestCommandTests {
     ) async throws {
         let configuration = BuildConfiguration.debug
         // disabled
-        try await withKnownIssue("fails to build", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
                 let error = await #expect(throws: SwiftPMError.self) {
                     try await execute(
@@ -272,9 +267,6 @@ struct TestCommandTests {
                     "got stdout: \(stdout), stderr: \(stderr)",
                 )
             }
-        } when: {
-            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
-        }
     }
 
     @Test(
@@ -287,7 +279,6 @@ struct TestCommandTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue("failes to build the package", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
                 let result = try await execute(
                     ["--enable-testable-imports", "--vv"],
@@ -295,11 +286,8 @@ struct TestCommandTests {
                     configuration: configuration,
                     buildSystem: buildSystem,
                 )
-                #expect(result.stderr.contains("-enable-testing"))
+                #expect(result.stderr.contains("-enable-testing") == true)
             }
-        } when: {
-            (buildSystem == .swiftbuild && .windows == ProcessInfo.hostOperatingSystem)
-        }
     }
 
     @Test(

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -772,7 +772,6 @@ struct MiscellaneousTestCase {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
         try await fixture(name: "Miscellaneous/TestableExe") { fixturePath in
             do {
                 let (stdout, stderr) = try await executeSwiftTest(
@@ -815,9 +814,6 @@ struct MiscellaneousTestCase {
                 Issue.record("\(error)")
 #endif
             }
-        }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
 


### PR DESCRIPTION
Once upon a time, the `Fixtures/Miscellaneous/TestableExe` fixture failed to build on Windows with the SwiftBuild build system.  Since then, numerous improvements and fixes have been.

Remove the `withKnownIssue` in tests that use the `TestableExe` fixture.

Relates to: #8540
Issue: rdar://149707071