### PR TITLE
[6.3] Add environment variable-based authentication for registries and HTTP downloads

### DIFF
--- a/Documentation/PackageRegistry/PackageRegistryUsage.md
+++ b/Documentation/PackageRegistry/PackageRegistryUsage.md
@@ -121,8 +121,75 @@ $ swift package-registry login https://packages.example.com
 ```
 
 SwiftPM will save the credentials to the operating system's credential store
-(e.g., Keychain in macOS) or netrc file (which by default is located at `~/.netrc`) 
+(e.g., Keychain in macOS) or netrc file (which by default is located at `~/.netrc`)
 and apply them automatically when making registry API requests.
+
+#### Environment variable authentication
+
+For CI environments where keychain and `.netrc` files are impractical,
+credentials can be provided via environment variables. Environment
+variables take the highest precedence, overriding both keychain and
+netrc credentials when set.
+
+**All-host registry credentials:**
+
+| Variable | Description |
+|---|---|
+| `SWIFTPM_REGISTRY_TOKEN` | Bearer token for package registry authentication |
+| `SWIFTPM_REGISTRY_LOGIN` | Username for Basic auth (must be paired with `SWIFTPM_REGISTRY_PASSWORD`) |
+| `SWIFTPM_REGISTRY_PASSWORD` | Password for Basic auth (must be paired with `SWIFTPM_REGISTRY_LOGIN`) |
+
+If `SWIFTPM_REGISTRY_TOKEN` is set, it takes precedence over
+`SWIFTPM_REGISTRY_LOGIN`/`SWIFTPM_REGISTRY_PASSWORD`.
+
+Example CI usage with token authentication:
+```bash
+export SWIFTPM_REGISTRY_TOKEN="$CI_REGISTRY_TOKEN"
+swift build
+```
+
+**All-host credentials for binary artifact and prebuilt downloads:**
+
+| Variable | Description |
+|---|---|
+| `SWIFTPM_SOURCE_CONTROL_TOKEN` | Token for HTTP downloads of binary artifacts and prebuilts |
+
+`SWIFTPM_SOURCE_CONTROL_TOKEN` authenticates HTTP requests that SwiftPM
+makes to download binary target archives (declared via `.binaryTarget(url:)`
+in `Package.swift`) and prebuilt package archives. It does **not** affect
+`git clone` or `git fetch` operations, which use git's own credential
+system (credential helpers, SSH keys, etc.).
+
+**Per-host credentials via inline netrc:**
+
+| Variable | Description |
+|---|---|
+| `SWIFTPM_NETRC_DATA` | Inline netrc-formatted content for per-host credentials |
+
+For scenarios requiring different credentials per host (e.g., multiple
+registries or a mix of registry and source control hosts), use
+`SWIFTPM_NETRC_DATA` with standard netrc format:
+
+```bash
+export SWIFTPM_NETRC_DATA="machine registry1.example.com login user1 password pass1
+machine registry2.example.com login user2 password pass2
+machine github.com login token password ghp_abc123"
+swift build
+```
+
+**Credential precedence order:**
+
+For registry operations:
+1. `SWIFTPM_REGISTRY_TOKEN` / `SWIFTPM_REGISTRY_LOGIN`+`PASSWORD` (all-host, highest)
+2. `SWIFTPM_NETRC_DATA` (per-host)
+3. Keychain (macOS only)
+4. `~/.netrc` file
+
+For binary artifact and prebuilt downloads:
+1. `SWIFTPM_SOURCE_CONTROL_TOKEN` (all-host, highest)
+2. `SWIFTPM_NETRC_DATA` (per-host)
+3. `~/.netrc` file
+4. Keychain (macOS only)
 
 ## Dependency Resolution Using Registry
 
@@ -276,9 +343,11 @@ optionally signs the package release, and
 [publishes the package release](Registry.md#endpoint-6)
 to the registry.
 
-If authentication is required for package publication, 
+If authentication is required for package publication,
 package author should [configure registry login](#registry-authentication)
-before running `publish`.
+before running `publish`. For CI-based publishing workflows,
+[environment variable authentication](#environment-variable-authentication)
+can be used as an alternative to `swift package-registry login`.
 
 ### Package release metadata
 

--- a/Sources/Basics/AuthorizationProvider.swift
+++ b/Sources/Basics/AuthorizationProvider.swift
@@ -51,6 +51,63 @@ extension AuthorizationProvider {
     }
 }
 
+// MARK: - Environment
+
+public struct EnvironmentAuthorizationProvider: AuthorizationProvider {
+    private let environment: Environment
+
+    public enum Kind: Sendable {
+        case registry
+        case sourceControl
+    }
+
+    private let kind: Kind
+
+    public init(environment: Environment = .current, kind: Kind) {
+        self.environment = environment
+        self.kind = kind
+    }
+
+    public func authentication(for url: URL) -> (user: String, password: String)? {
+        switch kind {
+        case .registry:
+            if let token = nonEmpty(environment[.swiftpmRegistryToken]) {
+                return (user: "token", password: token)
+            }
+            if let login = nonEmpty(environment[.swiftpmRegistryLogin]),
+               let password = nonEmpty(environment[.swiftpmRegistryPassword]) {
+                return (user: login, password: password)
+            }
+            return nil
+        case .sourceControl:
+            if let token = nonEmpty(environment[.swiftpmSourceControlToken]) {
+                return (user: "token", password: token)
+            }
+            return nil
+        }
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+// MARK: - In-memory netrc
+
+public struct InMemoryNetrcAuthorizationProvider: AuthorizationProvider {
+    private let netrc: Netrc
+
+    public init(content: String) throws {
+        self.netrc = try NetrcParser.parse(content)
+    }
+
+    public func authentication(for url: URL) -> (user: String, password: String)? {
+        guard let auth = netrc.authorization(for: url) else { return nil }
+        return (user: auth.login, password: auth.password)
+    }
+}
+
 // MARK: - netrc
 
 public final class NetrcAuthorizationProvider: AuthorizationProvider, AuthorizationWriter {
@@ -468,6 +525,10 @@ public struct CompositeAuthorizationProvider: AuthorizationProvider {
         for provider in self.providers {
             if let authentication = provider.authentication(for: url) {
                 switch provider {
+                case is EnvironmentAuthorizationProvider:
+                    self.observabilityScope.emit(info: "credentials for \(url) found in environment variables")
+                case is InMemoryNetrcAuthorizationProvider:
+                    self.observabilityScope.emit(info: "credentials for \(url) found in SWIFTPM_NETRC_DATA environment variable")
                 case let provider as NetrcAuthorizationProvider:
                     self.observabilityScope.emit(info: "credentials for \(url) found in netrc file at \(provider.path)")
                 #if canImport(Security)

--- a/Sources/Basics/Environment/EnvironmentKey.swift
+++ b/Sources/Basics/Environment/EnvironmentKey.swift
@@ -24,6 +24,12 @@ public struct EnvironmentKey {
 extension EnvironmentKey {
     package static let path: Self = "PATH"
 
+    package static let swiftpmRegistryToken: Self = "SWIFTPM_REGISTRY_TOKEN"
+    package static let swiftpmRegistryLogin: Self = "SWIFTPM_REGISTRY_LOGIN"
+    package static let swiftpmRegistryPassword: Self = "SWIFTPM_REGISTRY_PASSWORD"
+    package static let swiftpmSourceControlToken: Self = "SWIFTPM_SOURCE_CONTROL_TOKEN"
+    package static let swiftpmNetrcData: Self = "SWIFTPM_NETRC_DATA"
+
     package static var libraryPath: Self {
         #if os(Windows)
         path
@@ -51,6 +57,11 @@ extension EnvironmentKey {
         "VSCODE_IPC_HOOK_CLI",
         "HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET",
         "SSH_AUTH_SOCK",
+        .swiftpmRegistryToken,
+        .swiftpmRegistryLogin,
+        .swiftpmRegistryPassword,
+        .swiftpmSourceControlToken,
+        .swiftpmNetrcData,
     ]
 }
 

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -77,20 +77,29 @@ public final class RegistryClient: AsyncCancellable {
 
         if let authorizationProvider {
             self.authorizationProvider = { url in
-                guard let registryAuthentication = try? configuration.authentication(for: url) else {
-                    return .none
-                }
                 guard let (user, password) = authorizationProvider.authentication(for: url) else {
                     return .none
                 }
 
-                switch registryAuthentication.type {
+                // authentication(for:) throws only for hostless URLs, which environment
+                // variable providers may still return credentials for. In that case, fall
+                // through to type inference below.
+                let authType = (try? configuration.authentication(for: url))?.type
+
+                switch authType {
                 case .basic:
                     let authorizationString = "\(user):\(password)"
                     let authorizationData = Data(authorizationString.utf8)
                     return "Basic \(authorizationData.base64EncodedString())"
                 case .token: // `user` value is irrelevant in this case
                     return "Bearer \(password)"
+                case nil:
+                    if user == "token" {
+                        return "Bearer \(password)"
+                    }
+                    let authorizationString = "\(user):\(password)"
+                    let authorizationData = Data(authorizationString.utf8)
+                    return "Basic \(authorizationData.base64EncodedString())"
                 }
             }
         } else {

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -309,6 +309,22 @@ extension Workspace.Configuration {
         ) throws -> AuthorizationProvider? {
             var providers = [AuthorizationProvider]()
 
+            let env = Environment.current
+            if let token = env[.swiftpmSourceControlToken], !token.isEmpty {
+                providers.append(EnvironmentAuthorizationProvider(kind: .sourceControl))
+            }
+
+            if let netrcData = env[.swiftpmNetrcData], !netrcData.isEmpty {
+                do {
+                    providers.append(try InMemoryNetrcAuthorizationProvider(content: netrcData))
+                } catch {
+                    observabilityScope.emit(
+                        warning: "Failed to parse SWIFTPM_NETRC_DATA environment variable",
+                        underlyingError: error
+                    )
+                }
+            }
+
             switch self.netrc {
             case .custom(let path):
                 guard fileSystem.exists(path) else {
@@ -354,6 +370,33 @@ extension Workspace.Configuration {
             fileSystem: FileSystem,
             observabilityScope: ObservabilityScope
         ) throws -> AuthorizationProvider? {
+            let env = Environment.current
+            if let token = env[.swiftpmRegistryToken], !token.isEmpty {
+                return EnvironmentAuthorizationProvider(kind: .registry)
+            }
+            if let login = env[.swiftpmRegistryLogin], !login.isEmpty,
+               let password = env[.swiftpmRegistryPassword], !password.isEmpty {
+                return EnvironmentAuthorizationProvider(kind: .registry)
+            } else if let login = env[.swiftpmRegistryLogin], !login.isEmpty {
+                observabilityScope.emit(
+                    warning: "SWIFTPM_REGISTRY_LOGIN is set but SWIFTPM_REGISTRY_PASSWORD is not; both are required for login/password authentication"
+                )
+            } else if let password = env[.swiftpmRegistryPassword], !password.isEmpty {
+                observabilityScope.emit(
+                    warning: "SWIFTPM_REGISTRY_PASSWORD is set but SWIFTPM_REGISTRY_LOGIN is not; both are required for login/password authentication"
+                )
+            }
+            if let netrcData = env[.swiftpmNetrcData], !netrcData.isEmpty {
+                do {
+                    return try InMemoryNetrcAuthorizationProvider(content: netrcData)
+                } catch {
+                    observabilityScope.emit(
+                        warning: "Failed to parse SWIFTPM_NETRC_DATA environment variable",
+                        underlyingError: error
+                    )
+                }
+            }
+
             var providers = [AuthorizationProvider]()
 
             // OS-specific AuthorizationProvider has higher precedence

--- a/Tests/BasicsTests/AuthorizationProviderTests.swift
+++ b/Tests/BasicsTests/AuthorizationProviderTests.swift
@@ -245,6 +245,201 @@ final class AuthorizationProviderTests: XCTestCase {
         }
     }
 
+    // MARK: - EnvironmentAuthorizationProvider Tests
+
+    func testEnvironmentRegistryToken() {
+        var env = Environment()
+        env[.swiftpmRegistryToken] = "my-registry-token"
+
+        let provider = EnvironmentAuthorizationProvider(environment: env, kind: .registry)
+        let url = URL("https://registry.example.com")
+
+        let auth = provider.authentication(for: url)
+        XCTAssertEqual(auth?.user, "token")
+        XCTAssertEqual(auth?.password, "my-registry-token")
+    }
+
+    func testEnvironmentRegistryLoginPassword() {
+        var env = Environment()
+        env[.swiftpmRegistryLogin] = "myuser"
+        env[.swiftpmRegistryPassword] = "mypassword"
+
+        let provider = EnvironmentAuthorizationProvider(environment: env, kind: .registry)
+        let url = URL("https://registry.example.com")
+
+        let auth = provider.authentication(for: url)
+        XCTAssertEqual(auth?.user, "myuser")
+        XCTAssertEqual(auth?.password, "mypassword")
+    }
+
+    func testEnvironmentRegistryTokenPrecedence() {
+        var env = Environment()
+        env[.swiftpmRegistryToken] = "my-token"
+        env[.swiftpmRegistryLogin] = "myuser"
+        env[.swiftpmRegistryPassword] = "mypassword"
+
+        let provider = EnvironmentAuthorizationProvider(environment: env, kind: .registry)
+        let url = URL("https://registry.example.com")
+
+        let auth = provider.authentication(for: url)
+        XCTAssertEqual(auth?.user, "token")
+        XCTAssertEqual(auth?.password, "my-token")
+    }
+
+    func testEnvironmentSourceControlToken() {
+        var env = Environment()
+        env[.swiftpmSourceControlToken] = "sc-token-123"
+
+        let provider = EnvironmentAuthorizationProvider(environment: env, kind: .sourceControl)
+        let url = URL("https://github.com/org/repo")
+
+        let auth = provider.authentication(for: url)
+        XCTAssertEqual(auth?.user, "token")
+        XCTAssertEqual(auth?.password, "sc-token-123")
+    }
+
+    func testEnvironmentNoVarsReturnsNil() {
+        let env = Environment()
+
+        let registryProvider = EnvironmentAuthorizationProvider(environment: env, kind: .registry)
+        XCTAssertNil(registryProvider.authentication(for: URL("https://registry.example.com")))
+
+        let scProvider = EnvironmentAuthorizationProvider(environment: env, kind: .sourceControl)
+        XCTAssertNil(scProvider.authentication(for: URL("https://github.com/org/repo")))
+    }
+
+    func testEnvironmentPartialLoginOnly() {
+        var env = Environment()
+        env[.swiftpmRegistryLogin] = "myuser"
+
+        let provider = EnvironmentAuthorizationProvider(environment: env, kind: .registry)
+        XCTAssertNil(provider.authentication(for: URL("https://registry.example.com")))
+    }
+
+    func testEnvironmentEmptyStringTreatedAsUnset() {
+        var env = Environment()
+        env[.swiftpmRegistryToken] = ""
+        env[.swiftpmRegistryLogin] = ""
+        env[.swiftpmRegistryPassword] = ""
+        env[.swiftpmSourceControlToken] = ""
+
+        let registryProvider = EnvironmentAuthorizationProvider(environment: env, kind: .registry)
+        XCTAssertNil(registryProvider.authentication(for: URL("https://registry.example.com")))
+
+        let scProvider = EnvironmentAuthorizationProvider(environment: env, kind: .sourceControl)
+        XCTAssertNil(scProvider.authentication(for: URL("https://github.com/org/repo")))
+    }
+
+    func testEnvironmentInComposite() {
+        var env = Environment()
+        env[.swiftpmRegistryToken] = "env-token"
+
+        let url = URL("https://registry.example.com")
+        let envProvider = EnvironmentAuthorizationProvider(environment: env, kind: .registry)
+        let fileProvider = TestProvider(map: [url: (user: "fileuser", password: "filepass")])
+
+        let composite = CompositeAuthorizationProvider(
+            envProvider,
+            fileProvider,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
+
+        let auth = composite.authentication(for: url)
+        XCTAssertEqual(auth?.user, "token")
+        XCTAssertEqual(auth?.password, "env-token")
+    }
+
+    func testEnvironmentFallthroughInComposite() {
+        let env = Environment()
+
+        let url = URL("https://registry.example.com")
+        let envProvider = EnvironmentAuthorizationProvider(environment: env, kind: .registry)
+        let fileProvider = TestProvider(map: [url: (user: "fileuser", password: "filepass")])
+
+        let composite = CompositeAuthorizationProvider(
+            envProvider,
+            fileProvider,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
+
+        let auth = composite.authentication(for: url)
+        XCTAssertEqual(auth?.user, "fileuser")
+        XCTAssertEqual(auth?.password, "filepass")
+    }
+
+    // MARK: - InMemoryNetrcAuthorizationProvider Tests
+
+    func testInMemoryNetrcBasicParsing() throws {
+        let content = "machine host.example.com login myuser password mypass"
+        let provider = try InMemoryNetrcAuthorizationProvider(content: content)
+
+        let auth = provider.authentication(for: URL("https://host.example.com"))
+        XCTAssertEqual(auth?.user, "myuser")
+        XCTAssertEqual(auth?.password, "mypass")
+    }
+
+    func testInMemoryNetrcMultipleHosts() throws {
+        let content = """
+            machine registry1.example.com login user1 password pass1
+            machine registry2.example.com login user2 password pass2
+            """
+        let provider = try InMemoryNetrcAuthorizationProvider(content: content)
+
+        let auth1 = provider.authentication(for: URL("https://registry1.example.com"))
+        XCTAssertEqual(auth1?.user, "user1")
+        XCTAssertEqual(auth1?.password, "pass1")
+
+        let auth2 = provider.authentication(for: URL("https://registry2.example.com"))
+        XCTAssertEqual(auth2?.user, "user2")
+        XCTAssertEqual(auth2?.password, "pass2")
+    }
+
+    func testInMemoryNetrcDefaultMachine() throws {
+        let content = """
+            machine known.example.com login knownuser password knownpass
+            default login defaultuser password defaultpass
+            """
+        let provider = try InMemoryNetrcAuthorizationProvider(content: content)
+
+        let knownAuth = provider.authentication(for: URL("https://known.example.com"))
+        XCTAssertEqual(knownAuth?.user, "knownuser")
+        XCTAssertEqual(knownAuth?.password, "knownpass")
+
+        let unknownAuth = provider.authentication(for: URL("https://unknown.example.com"))
+        XCTAssertEqual(unknownAuth?.user, "defaultuser")
+        XCTAssertEqual(unknownAuth?.password, "defaultpass")
+    }
+
+    func testInMemoryNetrcNoMatch() throws {
+        let content = "machine host.example.com login myuser password mypass"
+        let provider = try InMemoryNetrcAuthorizationProvider(content: content)
+
+        let auth = provider.authentication(for: URL("https://other.example.com"))
+        XCTAssertNil(auth)
+    }
+
+    func testInMemoryNetrcInvalidContent() {
+        XCTAssertThrowsError(try InMemoryNetrcAuthorizationProvider(content: "invalid content"))
+    }
+
+    func testInMemoryNetrcInComposite() throws {
+        let content = "machine specific.example.com login netrcuser password netrcpass"
+        let netrcProvider = try InMemoryNetrcAuthorizationProvider(content: content)
+
+        let url = URL("https://specific.example.com")
+        let otherProvider = TestProvider(map: [url: (user: "otheruser", password: "otherpass")])
+
+        let composite = CompositeAuthorizationProvider(
+            netrcProvider,
+            otherProvider,
+            observabilityScope: ObservabilitySystem.NOOP
+        )
+
+        let auth = composite.authentication(for: url)
+        XCTAssertEqual(auth?.user, "netrcuser")
+        XCTAssertEqual(auth?.password, "netrcpass")
+    }
+
     private func assertAuthentication(
         _ provider: AuthorizationProvider,
         for url: URL,

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -3148,6 +3148,147 @@ fileprivate var availabilityURL = URL("\(registryURL)/availability")
         let identities = try await registryClient.lookupIdentities(scmURL: packageURL)
         #expect([PackageIdentity.plain("mona.LinkedList")] == identities)
     }
+
+    @Test func requestAuthorization_inferredToken() async throws {
+        let token = "top-sekret"
+
+        let handler: HTTPClient.Implementation = { request, _ in
+            switch (request.method, request.url) {
+            case (.get, identifiersURL):
+                #expect(request.headers.get("Authorization").first == "Bearer \(token)")
+                #expect(request.headers.get("Accept").first == "application/vnd.swift.registry.v1+json")
+
+                let data = #"""
+                {
+                    "identifiers": [
+                    "mona.LinkedList"
+                    ]
+                }
+                """#.data(using: .utf8)!
+
+                return .init(
+                    statusCode: 200,
+                    headers: .init([
+                        .init(name: "Content-Length", value: "\(data.count)"),
+                        .init(name: "Content-Type", value: "application/json"),
+                        .init(name: "Content-Version", value: "1"),
+                    ]),
+                    body: data
+                )
+            default:
+                throw StringError("method and url should match")
+            }
+        }
+
+        let httpClient = HTTPClient(implementation: handler)
+        var configuration = RegistryConfiguration()
+        configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
+
+        let authorizationProvider = TestProvider(map: [registryURL.host!: ("token", token)])
+
+        let registryClient = makeRegistryClient(
+            configuration: configuration,
+            httpClient: httpClient,
+            authorizationProvider: authorizationProvider
+        )
+        let identities = try await registryClient.lookupIdentities(scmURL: packageURL)
+        #expect([PackageIdentity.plain("mona.LinkedList")] == identities)
+    }
+
+    @Test func requestAuthorization_inferredBasic() async throws {
+        let user = "jappleseed"
+        let password = "top-sekret"
+
+        let handler: HTTPClient.Implementation = { request, _ in
+            switch (request.method, request.url) {
+            case (.get, identifiersURL):
+                #expect(request.headers.get("Authorization").first == "Basic \(Data("\(user):\(password)".utf8).base64EncodedString())")
+                #expect(request.headers.get("Accept").first == "application/vnd.swift.registry.v1+json")
+
+                let data = #"""
+                {
+                    "identifiers": [
+                    "mona.LinkedList"
+                    ]
+                }
+                """#.data(using: .utf8)!
+
+                return .init(
+                    statusCode: 200,
+                    headers: .init([
+                        .init(name: "Content-Length", value: "\(data.count)"),
+                        .init(name: "Content-Type", value: "application/json"),
+                        .init(name: "Content-Version", value: "1"),
+                    ]),
+                    body: data
+                )
+            default:
+                throw StringError("method and url should match")
+            }
+        }
+
+        let httpClient = HTTPClient(implementation: handler)
+        var configuration = RegistryConfiguration()
+        configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
+
+        let authorizationProvider = TestProvider(map: [registryURL.host!: (user, password)])
+
+        let registryClient = makeRegistryClient(
+            configuration: configuration,
+            httpClient: httpClient,
+            authorizationProvider: authorizationProvider
+        )
+        let identities = try await registryClient.lookupIdentities(scmURL: packageURL)
+        #expect([PackageIdentity.plain("mona.LinkedList")] == identities)
+    }
+
+    @Test func requestAuthorization_explicitConfigOverridesInference() async throws {
+        let user = "token"
+        let password = "top-sekret"
+
+        let handler: HTTPClient.Implementation = { request, _ in
+            switch (request.method, request.url) {
+            case (.get, identifiersURL):
+                #expect(request.headers.get("Authorization").first == "Basic \(Data("\(user):\(password)".utf8).base64EncodedString())")
+                #expect(request.headers.get("Accept").first == "application/vnd.swift.registry.v1+json")
+
+                let data = #"""
+                {
+                    "identifiers": [
+                    "mona.LinkedList"
+                    ]
+                }
+                """#.data(using: .utf8)!
+
+                return .init(
+                    statusCode: 200,
+                    headers: .init([
+                        .init(name: "Content-Length", value: "\(data.count)"),
+                        .init(name: "Content-Type", value: "application/json"),
+                        .init(name: "Content-Version", value: "1"),
+                    ]),
+                    body: data
+                )
+            default:
+                throw StringError("method and url should match")
+            }
+        }
+
+        let httpClient = HTTPClient(implementation: handler)
+        var configuration = RegistryConfiguration()
+        configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
+        configuration.registryAuthentication[registryURL.host!] = .init(type: .basic)
+
+        let authorizationProvider = TestProvider(map: [registryURL.host!: (user, password)])
+
+        let registryClient = makeRegistryClient(
+            configuration: configuration,
+            httpClient: httpClient,
+            authorizationProvider: authorizationProvider
+        )
+        let identities = try await registryClient.lookupIdentities(scmURL: packageURL)
+        #expect([PackageIdentity.plain("mona.LinkedList")] == identities)
+    }
 }
 
 @Suite("Login") struct Login {


### PR DESCRIPTION
Cherry pick of https://github.com/swiftlang/swift-package-manager/pull/9925 to `release/6.3`

Introduce `EnvironmentAuthorizationProvider` and
`InMemoryNetrcAuthorizationProvider` to support using environment variables to authenticate with registries and to download binary artifacts from authenticated locations. This should better enable CI/CD workflows without requiring a keychain (macOS only) or .netrc files, which is the only option on for auth on non macOS platforms.

Environment variables:
- `SWIFTPM_REGISTRY_TOKEN`: Bearer token for all registries
- `SWIFTPM_REGISTRY_LOGIN/PASSWORD`: Basic auth for all registries
- `SWIFTPM_SOURCE_CONTROL_TOKEN`: Token for binary artifact/prebuilt downloads
- `SWIFTPM_NETRC_DATA`: Inline netrc content for per-host credentials

Environment variables take highest precedence over existing credential sources. When no explicit auth type is configured in `registries.json`, the `RegistryClient` infers Bearer vs Basic from the credential shape, allowing env var auth to work without running `swift package-registry login` first.

Issue: #9920