### PR TITLE
Add experimental `swift test` command line flags for test repetition

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -603,12 +603,19 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 additionalArguments += ["--xunit-output", xunitPath.pathString]
             }
 
+            var hasRepetitionArgument = false
             if let maximumRepetitions = options.experimentalMaximumRepetitions {
                 additionalArguments += ["--repetitions", String(maximumRepetitions)]
+                hasRepetitionArgument = true
             }
 
             if let repeatUntil = options.experimentalRepeatUntil {
                 additionalArguments += ["--repeat-until", repeatUntil]
+                hasRepetitionArgument = true
+            }
+
+            if hasRepetitionArgument {
+                additionalArguments.append("--experimental-per-test-case-repetition")
             }
         }
 

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -168,6 +168,16 @@ struct TestCommandOptions: ParsableArguments {
     @Option(help: .hidden)
     var experimentalMaximumParallelizationWidth: Int? = nil
 
+    /// The maximum number of times each test will repeat (Swift Testing only).
+    @Option(name: .customLong("maximum-repetitions"),
+            help: "The maximum number of times each test will repeat (Swift Testing only).")
+    var maximumRepetitions: Int?
+
+    /// The condition upon which to stop repeating (Swift Testing only).
+    @Option(name: .customLong("repeat-until"),
+            help: "The condition upon which to stop repeating. Possible values: pass, fail (Swift Testing only).")
+    var repeatUntil: String?
+
     /// List the tests and exit.
     @Flag(name: [.customLong("list-tests"), .customShort("l")],
           help: "List test methods in specifier format.")
@@ -573,7 +583,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             var commandLineArguments = [String]()
             var originalCommandLineArguments = CommandLine.arguments.dropFirst().makeIterator()
             while let arg = originalCommandLineArguments.next() {
-                if arg == "--xunit-output" {
+                if arg == "--xunit-output" || arg == "--maximum-repetitions" {
                     _ = originalCommandLineArguments.next()
                 } else {
                     commandLineArguments.append(arg)
@@ -593,6 +603,10 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     xunitPath = xunitPath.parentDirectory.appending(xunitFileName)
                 }
                 additionalArguments += ["--xunit-output", xunitPath.pathString]
+            }
+
+            if let maximumRepetitions = options.maximumRepetitions {
+                additionalArguments += ["--repetitions", String(maximumRepetitions)]
             }
         }
 

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -169,14 +169,12 @@ struct TestCommandOptions: ParsableArguments {
     var experimentalMaximumParallelizationWidth: Int? = nil
 
     /// The maximum number of times each test will repeat (Swift Testing only).
-    @Option(name: .customLong("maximum-repetitions"),
-            help: "The maximum number of times each test will repeat (Swift Testing only).")
-    var maximumRepetitions: Int?
+    @Option(help: .hidden)
+    var experimentalMaximumRepetitions: Int?
 
     /// The condition upon which to stop repeating (Swift Testing only).
-    @Option(name: .customLong("repeat-until"),
-            help: "The condition upon which to stop repeating. Possible values: pass, fail (Swift Testing only).")
-    var repeatUntil: String?
+    @Option(help: .hidden)
+    var experimentalRepeatUntil: String?
 
     /// List the tests and exit.
     @Flag(name: [.customLong("list-tests"), .customShort("l")],
@@ -583,7 +581,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             var commandLineArguments = [String]()
             var originalCommandLineArguments = CommandLine.arguments.dropFirst().makeIterator()
             while let arg = originalCommandLineArguments.next() {
-                if arg == "--xunit-output" || arg == "--maximum-repetitions" {
+                if arg == "--xunit-output" || arg == "--experimental-maximum-repetitions" || arg == "--experimental-repeat-until" {
                     _ = originalCommandLineArguments.next()
                 } else {
                     commandLineArguments.append(arg)
@@ -605,8 +603,12 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 additionalArguments += ["--xunit-output", xunitPath.pathString]
             }
 
-            if let maximumRepetitions = options.maximumRepetitions {
+            if let maximumRepetitions = options.experimentalMaximumRepetitions {
                 additionalArguments += ["--repetitions", String(maximumRepetitions)]
+            }
+
+            if let repeatUntil = options.experimentalRepeatUntil {
+                additionalArguments += ["--repeat-until", repeatUntil]
             }
         }
 


### PR DESCRIPTION
This adds `--experimental-maximum-repetitions` and `--experimental-repeat-until` flags to `swift test` for Swift Testing tests.

### Motivation:

In order for clients to actually use test repetitions, the runner needs to be able to provide these flags to Swift Testing. This just implements the two flags that Swift Testing already uses.

### Modifications:

Adds new recognized flags to SwiftTestCommand and allow them to be forwarded along. Per some discussion offline, we have decided `maximum-repetitions` is a better name than `repetitions` because it communicates the conditionality and reads better along with `repeat-until`.

### Result:

After this change, clients can request their Swift Testing tests be repeated using `swift test`.