### PR TITLE
Ensure swift package experimental-build-server can recover from invalid manifests

### DIFF
--- a/Fixtures/Miscellaneous/BrokenManifest/Package.swift
+++ b/Fixtures/Miscellaneous/BrokenManifest/Package.swift
@@ -1,0 +1,11 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let foo: Int = "this is not an int"
+
+let package = Package(
+    name: "BrokenManifest",
+    targets: [
+        .target(name: "MyLib"),
+    ]
+)

--- a/Fixtures/Miscellaneous/BrokenManifest/Sources/MyLib/foo.swift
+++ b/Fixtures/Miscellaneous/BrokenManifest/Sources/MyLib/foo.swift
@@ -1,0 +1,1 @@
+public let x = 42

--- a/Fixtures/Miscellaneous/MissingSources/Package.swift
+++ b/Fixtures/Miscellaneous/MissingSources/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "MissingSources",
+    targets: [
+        .target(name: "MyLib"),
+    ]
+)

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -786,18 +786,24 @@ public final class SwiftCommandState {
         do {
             let workspace = try getActiveWorkspace(enableAllTraits: enableAllTraits)
 
+            // Create a dedicated observability scope for package graph loading so that the `packageGraphObservabilityScope.errorsReported`
+            // below only considers errors reported from this call to `loadPackageGraph`. This ensures that in an interactive context like
+            // when using `swift package experimental-build-server`, a package graph load which initially fails doesn't cause all subsequent
+            // package graph load attempts to also fail due to sharing the same `errorsReported` bit.
+            let packageGraphObservabilityScope = self.observabilityScope.makeChildScope(description: "Loading Package Graph")
+
             // Fetch and load the package graph.
             let graph = try await workspace.loadPackageGraph(
                 rootInput: self.getWorkspaceRoot(),
                 explicitProduct: explicitProduct,
                 forceResolvedVersions: self.options.resolver.forceResolvedVersions,
                 testEntryPointPath: testEntryPointPath,
-                observabilityScope: self.observabilityScope
+                observabilityScope: packageGraphObservabilityScope
             )
 
             // Throw if there were errors when loading the graph.
             // The actual errors will be printed before exiting.
-            guard !self.observabilityScope.errorsReported else {
+            guard !packageGraphObservabilityScope.errorsReported else {
                 throw ExitCode.failure
             }
             return graph

--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -216,7 +216,19 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
             await request.reply {
                 var underlyingRequest = request.params
                 underlyingRequest.targets.removeAll(where: \.isSwiftPMBuildServerTargetID)
-                var sourcesResponse = try await connectionToUnderlyingBuildServer.send(underlyingRequest)
+                var sourcesResponse: BuildTargetSourcesResponse
+                do {
+                    sourcesResponse = try await connectionToUnderlyingBuildServer.send(underlyingRequest)
+                } catch {
+                    // If the client requested info for at least one target with the SwiftPM scheme (a manifest/plugin),
+                    // warn and return a potentially partial response. Otherwise, report the underlying error.
+                    if request.params.targets.contains(where: \.isSwiftPMBuildServerTargetID) {
+                        logToClient(.warning, "Underlying build server reported error for BuildTargetSources request: '\(error)'")
+                        sourcesResponse = .init(items: [])
+                    } else {
+                        throw error
+                    }
+                }
                 for target in request.params.targets.filter({ $0.isSwiftPMBuildServerTargetID }) {
                     if target == .forPackageManifest {
                         sourcesResponse.items.append(manifestSourcesItem())
@@ -274,7 +286,13 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
             }
         case let request as RequestAndReply<WorkspaceBuildTargetsRequest>:
             await request.reply {
-                var targetsResponse = try await connectionToUnderlyingBuildServer.send(request.params)
+                var targetsResponse: WorkspaceBuildTargetsResponse
+                do {
+                    targetsResponse = try await connectionToUnderlyingBuildServer.send(request.params)
+                } catch {
+                    logToClient(.warning, "Underlying build server reported error for WorkspaceBuildTargets request: '\(error)'")
+                    targetsResponse = .init(targets: [])
+                }
                 targetsResponse.targets.append(manifestTarget())
                 targetsResponse.targets.append(contentsOf: pluginTargetsList())
                 return targetsResponse

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -263,6 +263,86 @@ struct SwiftPMBuildServerTests {
     }
 
     @Test
+    func missingTargetSources() async throws {
+        try await withSwiftPMBSP(fixtureName: "Miscellaneous/MissingSources") { connection, _, fixturePath in
+            // The manifest compiles successfully even though MyLib has no sources, verify we can fetch compiler args for the manifest.
+            let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            let manifestTarget = try #require(targetResponse.targets.first(where: { $0.displayName == "Package Manifest" }))
+            let manifestSourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [manifestTarget.id]))
+            let manifestItem = try #require(manifestSourcesResponse.items.only?.sources.only)
+            #expect(manifestItem.uri.fileURL?.lastPathComponent == "Package.swift")
+            let manifestSettingsResponse = try #require(try await connection.send(TextDocumentSourceKitOptionsRequest(textDocument: TextDocumentIdentifier(manifestItem.uri), target: manifestTarget.id, language: .swift)))
+            try await AsyncProcess.checkNonZeroExit(arguments: [UserToolchain.default.swiftCompilerPath.pathString, "-typecheck"] + manifestSettingsResponse.compilerArguments)
+
+            // Now add the missing source file and check we can get args for it.
+            let sourcesDir = fixturePath.appending(components: "Sources", "MyLib")
+            try localFileSystem.createDirectory(sourcesDir, recursive: true)
+            let sourceFilePath = sourcesDir.appending(component: "MyLib.swift")
+            try localFileSystem.writeFileContents(sourceFilePath, body: {
+                $0.write("public let greeting = \"hello\"")
+            })
+            connection.send(OnWatchedFilesDidChangeNotification(changes: [
+                .init(uri: .init(.init(filePath: sourceFilePath.pathString)), type: .created)
+            ]))
+            _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
+            let updatedTargetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            let myLibTarget = try #require(updatedTargetResponse.targets.first(where: { $0.displayName == "MyLib" }))
+            let myLibID = myLibTarget.id
+            let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [myLibID]))
+            let sourceItem = try #require(sourcesResponse.items.only?.sources.only)
+            #expect(sourceItem.uri.fileURL?.lastPathComponent == "MyLib.swift")
+            _ = try await connection.send(BuildTargetPrepareRequest(targets: [myLibID]))
+            let settingsResponse = try #require(try await connection.send(TextDocumentSourceKitOptionsRequest(textDocument: TextDocumentIdentifier(sourceItem.uri), target: myLibID, language: .swift)))
+            #expect(settingsResponse.compilerArguments.contains(["-module-name", "MyLib"]))
+            try await AsyncProcess.checkNonZeroExit(arguments: [UserToolchain.default.swiftCompilerPath.pathString, "-typecheck"] + settingsResponse.compilerArguments)
+        }
+    }
+
+    @Test
+    func brokenManifestArgs() async throws {
+        try await withSwiftPMBSP(fixtureName: "Miscellaneous/BrokenManifest") { connection, handler, fixturePath in
+            // The manifest does not compile, but the build server should still report it as a target and return compiler args for it.
+            let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            let manifestTarget = try #require(targetResponse.targets.first(where: { $0.displayName == "Package Manifest" }))
+            let manifestID = manifestTarget.id
+            let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [manifestID]))
+            let manifestItem = try #require(sourcesResponse.items.only?.sources.only)
+            #expect(manifestItem.uri.fileURL?.lastPathComponent == "Package.swift")
+            let settingsResponse = try #require(try await connection.send(TextDocumentSourceKitOptionsRequest(textDocument: TextDocumentIdentifier(manifestItem.uri), target: manifestID, language: .swift)))
+            #expect(settingsResponse.compilerArguments.contains("-package-description-version"))
+
+            // Fix the manifest, then ensure we can get the full list of targets and compiler args.
+            try localFileSystem.writeFileContents(fixturePath.appending(component: "Package.swift"), body: {
+                $0.write("""
+                // swift-tools-version:5.9
+                import PackageDescription
+
+                let package = Package(
+                    name: "BrokenManifest",
+                    targets: [
+                        .target(name: "MyLib"),
+                    ]
+                )
+                """)
+            })
+            connection.send(OnWatchedFilesDidChangeNotification(changes: [
+                .init(uri: .init(.init(filePath: fixturePath.appending(component: "Package.swift").pathString)), type: .changed)
+            ]))
+            _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
+            let updatedTargetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            let myLibID = try #require(updatedTargetResponse.targets.first(where: { $0.displayName == "MyLib" })).id
+            let updatedSourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [myLibID]))
+            let item = try #require(updatedSourcesResponse.items.only?.sources.only)
+            #expect(item.kind == .file)
+            #expect(item.uri.fileURL?.lastPathComponent == "foo.swift")
+            _ = try await connection.send(BuildTargetPrepareRequest(targets: [myLibID]))
+            let updatedSettingsResponse = try #require(try await connection.send(TextDocumentSourceKitOptionsRequest(textDocument: TextDocumentIdentifier(item.uri), target: myLibID, language: .swift)))
+            #expect(updatedSettingsResponse.compilerArguments.contains(["-module-name", "MyLib"]))
+            try await AsyncProcess.checkNonZeroExit(arguments: [UserToolchain.default.swiftCompilerPath.pathString, "-typecheck"] + updatedSettingsResponse.compilerArguments)
+        }
+    }
+
+    @Test
     func pluginScriptArgs() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Plugins/MySourceGenPlugin") { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())


### PR DESCRIPTION
Add tests ensuring
- We can get compiler args for a manifest even when target sources are missing, and can get args for the target sources once they're created
- We can get compiler args for a manifest that does not compile successfully, and can retrieve info on the rest of the package once that issue is fixed

Fixing the second test required some small fixes to loadPackageGraph and recovery in SwiftPMBuildServer