### PR TITLE
Ensure plugin products and targets are handled the same by the BSP implementation

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -146,7 +146,8 @@ extension PackagePIFProjectBuilder {
             linkedPackageBinaries: [],
             swiftLanguageVersion: nil,
             declaredPlatforms: self.declaredPlatforms,
-            deploymentTargets: self.deploymentTargets
+            deploymentTargets: self.deploymentTargets,
+            toolsVersion: pifBuilder.packageManifest.toolsVersion
         )
         self.builtModulesAndProducts.append(pluginModuleMetadata)
     }

--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -478,7 +478,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
     private func rebuildPluginMapping(pifAccompanyingMetadata: [PackagePIFBuilder.ModuleOrProduct]) {
         var plugins: [BuildTargetIdentifier: PluginInfo] = [:]
         for moduleOrProduct in pifAccompanyingMetadata {
-            guard [.buildToolPlugin, .commandPlugin].contains(moduleOrProduct.type),
+            guard [.buildToolPlugin, .commandPlugin, .plugin].contains(moduleOrProduct.type),
                   let moduleName = moduleOrProduct.moduleName,
                   let toolsVersion = moduleOrProduct.toolsVersion,
                   !moduleOrProduct.pluginScriptSourcePaths.isEmpty else {


### PR DESCRIPTION
Ensure we're tracking plugins when they appear as either a product or a target in the manifest. Otherwise, the BSP implementation may drop information about some plugins