### PR TITLE
[SE-0535] Add --global flag to CLI for editing and viewing shared mirrors configuration

### DIFF
--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -46,6 +46,9 @@ extension SwiftPackageCommand.Config {
         @Option(name: .customLong("mirror-url"), help: .hidden)
         var _deprecate_mirrorURL: String?
 
+        @Flag(help: "Apply settings to all projects for this user.")
+        var global: Bool = false
+
         @Option(help: "The original url or identity.")
         var original: String?
 
@@ -53,8 +56,6 @@ extension SwiftPackageCommand.Config {
         var mirror: String?
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
-            let config = try getMirrorsConfig(swiftCommandState)
-
             if self._deprecate_packageURL != nil {
                 swiftCommandState.observabilityScope.emit(
                     warning: "'--package-url' option is deprecated; use '--original' instead"
@@ -81,8 +82,15 @@ extension SwiftPackageCommand.Config {
                 throw ExitCode.failure
             }
 
-            try config.applyLocal { mirrors in
-                try mirrors.set(mirror: mirror, for: original)
+            let config = try getMirrorsConfig(swiftCommandState, global: self.global)
+            if self.global {
+                try config.applyShared { mirrors in
+                    try mirrors.set(mirror: mirror, for: original)
+                }
+            } else {
+                try config.applyLocal { mirrors in
+                    try mirrors.set(mirror: mirror, for: original)
+                }
             }
         }
     }
@@ -104,6 +112,9 @@ extension SwiftPackageCommand.Config {
         @Option(name: .customLong("mirror-url"), help: .hidden)
         var _deprecate_mirrorURL: String?
 
+        @Flag(help: "Apply settings to all projects for this user.")
+        var global: Bool = false
+
         @Option(help: "The original url or identity.")
         var original: String?
 
@@ -111,8 +122,6 @@ extension SwiftPackageCommand.Config {
         var mirror: String?
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
-            let config = try getMirrorsConfig(swiftCommandState)
-
             if self._deprecate_packageURL != nil {
                 swiftCommandState.observabilityScope.emit(
                     warning: "'--package-url' option is deprecated; use '--original' instead"
@@ -136,8 +145,15 @@ extension SwiftPackageCommand.Config {
                 throw ExitCode.failure
             }
 
-            try config.applyLocal { mirrors in
-                try mirrors.unset(originalOrMirror: originalOrMirror)
+            let config = try getMirrorsConfig(swiftCommandState, global: self.global)
+            if self.global {
+                try config.applyShared { mirrors in
+                    try mirrors.unset(originalOrMirror: originalOrMirror)
+                }
+            } else {
+                try config.applyLocal { mirrors in
+                    try mirrors.unset(originalOrMirror: originalOrMirror)
+                }
             }
         }
     }
@@ -155,12 +171,13 @@ extension SwiftPackageCommand.Config {
         @Option(name: .customLong("original-url"), help: .hidden)
         var _deprecate_originalURL: String?
 
+        @Flag(help: "Read only settings applied to all projects for this user.")
+        var global: Bool = false
+
         @Option(help: "The original url or identity.")
         var original: String?
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
-            let config = try getMirrorsConfig(swiftCommandState)
-
             if self._deprecate_packageURL != nil {
                 swiftCommandState.observabilityScope.emit(
                     warning: "'--package-url' option is deprecated; use '--original' instead"
@@ -177,6 +194,7 @@ extension SwiftPackageCommand.Config {
                 throw ExitCode.failure
             }
 
+            let config = try getMirrorsConfig(swiftCommandState, global: self.global)
             if let mirror = config.mirrors.mirror(for: original) {
                 print(mirror)
             } else {
@@ -187,7 +205,18 @@ extension SwiftPackageCommand.Config {
         }
     }
 
-    static func getMirrorsConfig(_ swiftCommandState: SwiftCommandState) throws -> Workspace.Configuration.Mirrors {
+    static func getMirrorsConfig(_ swiftCommandState: SwiftCommandState, global: Bool) throws -> Workspace.Configuration.Mirrors {
+        if global {
+            let sharedMirrorsFile = Workspace.DefaultLocations.mirrorsConfigurationFile(
+                at: swiftCommandState.sharedConfigurationDirectory
+            )
+            // Workspace not needed when working with user-level mirrors config
+            return try .init(
+                fileSystem: swiftCommandState.fileSystem,
+                localMirrorsFile: .none,
+                sharedMirrorsFile: sharedMirrorsFile
+            )
+        }
         let workspace = try swiftCommandState.getActiveWorkspace()
         return try .init(
             fileSystem: swiftCommandState.fileSystem,

--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -37,6 +37,9 @@ extension SwiftPackageCommand.Config {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
+        @Flag(help: "Apply settings to all projects for this user.")
+        var global: Bool = false
+
         @Option(help: "The original url or identity.")
         var original: String
 
@@ -44,11 +47,15 @@ extension SwiftPackageCommand.Config {
         var mirror: String
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
-            let config = try getMirrorsConfig(swiftCommandState)
-
-
-            try config.applyLocal { mirrors in
-                try mirrors.set(mirror: self.mirror, for: self.original)
+            let config = try getMirrorsConfig(swiftCommandState, global: self.global)
+            if self.global {
+                try config.applyShared { mirrors in
+                    try mirrors.set(mirror: mirror, for: original)
+                }
+            } else {
+                try config.applyLocal { mirrors in
+                    try mirrors.set(mirror: mirror, for: original)
+                }
             }
         }
     }
@@ -61,6 +68,9 @@ extension SwiftPackageCommand.Config {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
+        @Flag(help: "Apply settings to all projects for this user.")
+        var global: Bool = false
+
         @Option(help: "The original url or identity.")
         var original: String?
 
@@ -68,16 +78,21 @@ extension SwiftPackageCommand.Config {
         var mirror: String?
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
-            let config = try getMirrorsConfig(swiftCommandState)
-
             guard let originalOrMirror = self.original ?? self.mirror
             else {
                 swiftCommandState.observabilityScope.emit(.missingRequiredArg("--original or --mirror"))
                 throw ExitCode.failure
             }
 
-            try config.applyLocal { mirrors in
-                try mirrors.unset(originalOrMirror: originalOrMirror)
+            let config = try getMirrorsConfig(swiftCommandState, global: self.global)
+            if self.global {
+                try config.applyShared { mirrors in
+                    try mirrors.unset(originalOrMirror: originalOrMirror)
+                }
+            } else {
+                try config.applyLocal { mirrors in
+                    try mirrors.unset(originalOrMirror: originalOrMirror)
+                }
             }
         }
     }
@@ -90,11 +105,14 @@ extension SwiftPackageCommand.Config {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
+        @Flag(help: "Read only settings applied to all projects for this user.")
+        var global: Bool = false
+
         @Option(help: "The original url or identity.")
         var original: String
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
-            let config = try getMirrorsConfig(swiftCommandState)
+            let config = try getMirrorsConfig(swiftCommandState, global: self.global)
 
             if let mirror = config.mirrors.mirror(for: self.original) {
                 print(mirror)
@@ -106,7 +124,18 @@ extension SwiftPackageCommand.Config {
         }
     }
 
-    static func getMirrorsConfig(_ swiftCommandState: SwiftCommandState) throws -> Workspace.Configuration.Mirrors {
+    static func getMirrorsConfig(_ swiftCommandState: SwiftCommandState, global: Bool) throws -> Workspace.Configuration.Mirrors {
+        if global {
+            let sharedMirrorsFile = Workspace.DefaultLocations.mirrorsConfigurationFile(
+                at: swiftCommandState.sharedConfigurationDirectory
+            )
+            // Workspace not needed when working with user-level mirrors config
+            return try .init(
+                fileSystem: swiftCommandState.fileSystem,
+                localMirrorsFile: .none,
+                sharedMirrorsFile: sharedMirrorsFile
+            )
+        }
         let workspace = try swiftCommandState.getActiveWorkspace()
         return try .init(
             fileSystem: swiftCommandState.fileSystem,

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -469,7 +469,7 @@ extension Workspace.Configuration {
 
 extension Workspace.Configuration {
     public struct Mirrors {
-        private let localMirrors: MirrorsStorage
+        private let localMirrors: MirrorsStorage?
         private let sharedMirrors: MirrorsStorage?
         private let fileSystem: FileSystem
 
@@ -511,10 +511,16 @@ extension Workspace.Configuration {
         ///   - sharedMirrorsFile: Path to the shared mirrors configuration file, defaults to the standard location.
         public init(
             fileSystem: FileSystem,
-            localMirrorsFile: AbsolutePath,
+            localMirrorsFile: AbsolutePath?,
             sharedMirrorsFile: AbsolutePath?
         ) throws {
-            self.localMirrors = .init(path: localMirrorsFile, fileSystem: fileSystem, deleteWhenEmpty: true)
+            // At least one of local or shared is required
+            if localMirrorsFile == nil, sharedMirrorsFile == nil {
+                throw StringError("No mirrors configuration provided")
+            }
+
+            self.localMirrors = localMirrorsFile
+                .map { .init(path: $0, fileSystem: fileSystem, deleteWhenEmpty: true) }
             self.sharedMirrors = sharedMirrorsFile
                 .map { .init(path: $0, fileSystem: fileSystem, deleteWhenEmpty: false) }
             self.fileSystem = fileSystem
@@ -525,7 +531,10 @@ extension Workspace.Configuration {
 
         @discardableResult
         public func applyLocal(handler: (inout DependencyMirrors) throws -> Void) throws -> DependencyMirrors {
-            try self.localMirrors.apply(handler: handler)
+            guard let localMirrors else {
+                throw InternalError("local mirrors not configured")
+            }
+            try localMirrors.apply(handler: handler)
             try self.computeMirrors()
             return self.mirrors
         }
@@ -547,8 +556,7 @@ extension Workspace.Configuration {
                 self._mirrors.removeAll()
 
                 // prefer local mirrors to shared ones
-                let local = try self.localMirrors.get()
-                if !local.isEmpty {
+                if let local = try self.localMirrors?.get(), !local.isEmpty {
                     try self._mirrors.append(contentsOf: local)
                     return
                 }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3747,8 +3747,11 @@ struct PackageCommandTests {
                 let fs = localFileSystem
                 let packageRoot = fixturePath.appending("Foo")
                 let configOverride = fixturePath.appending("configoverride")
-                let configFile = Workspace.DefaultLocations.mirrorsConfigurationFile(
+                let localConfigFile = Workspace.DefaultLocations.mirrorsConfigurationFile(
                     forRootPackage: packageRoot
+                )
+                let sharedConfigFile = Workspace.DefaultLocations.mirrorsConfigurationFile(
+                    at: try fs.swiftPMConfigurationDirectory
                 )
 
                 fs.createEmptyFiles(
@@ -3780,7 +3783,19 @@ struct PackageCommandTests {
                     configuration: config,
                     buildSystem: buildSystem,
                 )
-                #expect(fs.isFile(configFile))
+                #expect(fs.isFile(localConfigFile))
+
+                // Test writing.
+                try await execute(
+                    [
+                        "config", "set-mirror", "--global", "--original", "https://github.com/foo/bar", "--mirror",
+                        "https://globalgithub.com/foo/bar",
+                    ],
+                    packagePath: packageRoot,
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(fs.isFile(sharedConfigFile))
 
                 // Test env override.
                 try await execute(
@@ -3806,6 +3821,13 @@ struct PackageCommandTests {
                 )
                 #expect(stdout.spm_chomp() == "https://mygithub.com/foo/bar")
                 (stdout, _) = try await execute(
+                    ["config", "get-mirror", "--global", "--original", "https://github.com/foo/bar"],
+                    packagePath: packageRoot,
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout.spm_chomp() == "https://globalgithub.com/foo/bar")
+                (stdout, _) = try await execute(
                     [
                         "config", "get-mirror", "--original",
                         "git@github.com:swiftlang/swift-package-manager.git",
@@ -3830,6 +3852,14 @@ struct PackageCommandTests {
                         buildSystem: buildSystem,
                     )
                 }
+                await check(stderr: "not found\n") {
+                    try await execute(
+                        ["config", "get-mirror", "--global", "--original", "git@github.com:swiftlang/swift-package-manager.git"],
+                        packagePath: packageRoot,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
+                }
 
                 // Test deletion.
                 try await execute(
@@ -3848,14 +3878,15 @@ struct PackageCommandTests {
                     buildSystem: buildSystem,
                 )
 
-                await check(stderr: "not found\n") {
-                    try await execute(
-                        ["config", "get-mirror", "--original", "https://github.com/foo/bar"],
-                        packagePath: packageRoot,
-                        configuration: config,
-                        buildSystem: buildSystem,
-                    )
-                }
+                // Still found via global
+                (stdout, _) = try await execute(
+                    ["config", "get-mirror", "--original", "https://github.com/foo/bar"],
+                    packagePath: packageRoot,
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout.spm_chomp() == "https://globalgithub.com/foo/bar")
+
                 await check(stderr: "not found\n") {
                     try await execute(
                         [

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4025,8 +4025,11 @@ struct PackageCommandTests {
                 let fs = localFileSystem
                 let packageRoot = fixturePath.appending("Foo")
                 let configOverride = fixturePath.appending("configoverride")
-                let configFile = Workspace.DefaultLocations.mirrorsConfigurationFile(
+                let localConfigFile = Workspace.DefaultLocations.mirrorsConfigurationFile(
                     forRootPackage: packageRoot
+                )
+                let sharedConfigFile = Workspace.DefaultLocations.mirrorsConfigurationFile(
+                    at: try fs.swiftPMConfigurationDirectory
                 )
 
                 fs.createEmptyFiles(
@@ -4058,7 +4061,19 @@ struct PackageCommandTests {
                     configuration: config,
                     buildSystem: buildSystem,
                 )
-                #expect(fs.isFile(configFile))
+                #expect(fs.isFile(localConfigFile))
+
+                // Test writing.
+                try await execute(
+                    [
+                        "config", "set-mirror", "--global", "--original", "https://github.com/foo/bar", "--mirror",
+                        "https://globalgithub.com/foo/bar",
+                    ],
+                    packagePath: packageRoot,
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(fs.isFile(sharedConfigFile))
 
                 // Test env override.
                 try await execute(
@@ -4084,6 +4099,13 @@ struct PackageCommandTests {
                 )
                 #expect(stdout.spm_chomp() == "https://mygithub.com/foo/bar")
                 (stdout, _) = try await execute(
+                    ["config", "get-mirror", "--global", "--original", "https://github.com/foo/bar"],
+                    packagePath: packageRoot,
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout.spm_chomp() == "https://globalgithub.com/foo/bar")
+                (stdout, _) = try await execute(
                     [
                         "config", "get-mirror", "--original",
                         "git@github.com:swiftlang/swift-package-manager.git",
@@ -4108,6 +4130,14 @@ struct PackageCommandTests {
                         buildSystem: buildSystem,
                     )
                 }
+                await check(stderr: "not found\n") {
+                    try await execute(
+                        ["config", "get-mirror", "--global", "--original", "git@github.com:swiftlang/swift-package-manager.git"],
+                        packagePath: packageRoot,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
+                }
 
                 // Test deletion.
                 try await execute(
@@ -4126,14 +4156,15 @@ struct PackageCommandTests {
                     buildSystem: buildSystem,
                 )
 
-                await check(stderr: "not found\n") {
-                    try await execute(
-                        ["config", "get-mirror", "--original", "https://github.com/foo/bar"],
-                        packagePath: packageRoot,
-                        configuration: config,
-                        buildSystem: buildSystem,
-                    )
-                }
+                // Still found via global
+                (stdout, _) = try await execute(
+                    ["config", "get-mirror", "--original", "https://github.com/foo/bar"],
+                    packagePath: packageRoot,
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout.spm_chomp() == "https://globalgithub.com/foo/bar")
+
                 await check(stderr: "not found\n") {
                     try await execute(
                         [

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -111,6 +111,19 @@ fileprivate struct MirrorsConfigurationTests {
     }
 
     @Test
+    func throwsWhenBothLocalAndSharedAreNil() throws {
+        let fs = InMemoryFileSystem()
+
+        #expect(throws: StringError("No mirrors configuration provided")) {
+            try Workspace.Configuration.Mirrors(
+                fileSystem: fs,
+                localMirrorsFile: nil,
+                sharedMirrorsFile: nil
+            )
+        }
+    }
+
+    @Test
     func localAndShared() throws {
         let fs = InMemoryFileSystem()
         let localConfigFile = AbsolutePath("/config/local-mirrors.json")
@@ -151,5 +164,41 @@ fileprivate struct MirrorsConfigurationTests {
         // should not see the shared any longer
         #expect(config.mirrors.mirror(for: original1URL) == nil)
         #expect(config.mirrors.original(for: mirror1URL) == nil)
+    }
+
+    @Test
+    func onlyShared() throws {
+        let fs = InMemoryFileSystem()
+        let sharedConfigFile = AbsolutePath("/config/shared-mirrors.json")
+
+        let config = try Workspace.Configuration.Mirrors(
+            fileSystem: fs,
+            localMirrorsFile: nil,
+            sharedMirrorsFile: sharedConfigFile
+        )
+
+        // can write to shared location
+
+        let original1URL = "https://github.com/apple/swift-argument-parser.git"
+        let mirror1URL = "https://github.com/mona/swift-argument-parser.git"
+
+        try config.applyShared { mirrors in
+            try mirrors.set(mirror: mirror1URL, for: original1URL)
+        }
+
+        // cannot write to local location
+
+        let original2URL = "https://github.com/apple/swift-nio.git"
+        let mirror2URL = "https://github.com/mona/swift-nio.git"
+
+        #expect(throws: (any Error).self) {
+            try config.applyLocal { mirrors in
+                try mirrors.set(mirror: mirror2URL, for: original2URL)
+            }
+        }
+
+        #expect(config.mirrors.count == 1)
+        #expect(config.mirrors.mirror(for: original1URL) == mirror1URL)
+        #expect(config.mirrors.original(for: mirror1URL) == original1URL)
     }
 }

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -114,6 +114,19 @@ fileprivate struct MirrorsConfigurationTests {
     }
 
     @Test
+    func throwsWhenBothLocalAndSharedAreNil() throws {
+        let fs = InMemoryFileSystem()
+
+        #expect(throws: StringError("No mirrors configuration provided")) {
+            try Workspace.Configuration.Mirrors(
+                fileSystem: fs,
+                localMirrorsFile: nil,
+                sharedMirrorsFile: nil
+            )
+        }
+    }
+
+    @Test
     func localAndShared() throws {
         let fs = InMemoryFileSystem()
         let localConfigFile = AbsolutePath("/config/local-mirrors.json")
@@ -154,6 +167,42 @@ fileprivate struct MirrorsConfigurationTests {
         // should not see the shared any longer
         #expect(config.mirrors.mirror(for: original1URL) == nil)
         #expect(config.mirrors.original(for: mirror1URL) == nil)
+    }
+
+    @Test
+    func onlyShared() throws {
+        let fs = InMemoryFileSystem()
+        let sharedConfigFile = AbsolutePath("/config/shared-mirrors.json")
+
+        let config = try Workspace.Configuration.Mirrors(
+            fileSystem: fs,
+            localMirrorsFile: nil,
+            sharedMirrorsFile: sharedConfigFile
+        )
+
+        // can write to shared location
+
+        let original1URL = "https://github.com/apple/swift-argument-parser.git"
+        let mirror1URL = "https://github.com/mona/swift-argument-parser.git"
+
+        try config.applyShared { mirrors in
+            try mirrors.set(mirror: mirror1URL, for: original1URL)
+        }
+
+        // cannot write to local location
+
+        let original2URL = "https://github.com/apple/swift-nio.git"
+        let mirror2URL = "https://github.com/mona/swift-nio.git"
+
+        #expect(throws: (any Error).self) {
+            try config.applyLocal { mirrors in
+                try mirrors.set(mirror: mirror2URL, for: original2URL)
+            }
+        }
+
+        #expect(config.mirrors.count == 1)
+        #expect(config.mirrors.mirror(for: original1URL) == mirror1URL)
+        #expect(config.mirrors.original(for: mirror1URL) == original1URL)
     }
 
     // MARK: - Deterministic Output Tests


### PR DESCRIPTION
Add `--global` flag to CLI for editing and viewing shared mirrors configuration

### Motivation:

When working with mirrors in SPM, it's sometimes desirable to have a global (per-user) configuration, rather than a local (per-project). Support for a global mirrors configuration file was added in https://github.com/swiftlang/swift-package-manager/pull/3670, but no CLI tool was added for editing the global configuration file. 
Similar to how the commands for editing the (package) registries configuration file have a `--global` flag, it feels natural that the commands for editing the mirrors configuration file have the same flag.
Closes https://github.com/swiftlang/swift-package-manager/issues/9947

### Modifications:

Add a new flag `--global` to the following commands

* `swift package config set-mirror`
* `swift package config unset-mirror`
* `swift package config get-mirror`

for interacting with the global mirrors configuration file.
When passing it to `set-mirror` or `unset-mirror`, the global configuration file is modified. When passing it to `get-mirror`, only the global configuration file is read.

### Result:

Users can now easily create and maintain a global mirrors configuration file, which was a somewhat hidden feature before.