### PR TITLE
BSP: emit package-reload WorkDoneProgress notifications

### DIFF
--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -525,7 +525,14 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
 
     public func scheduleRegeneratingBuildDescription() {
         packageLoadingQueue.async { [buildSystem] in
+            let reloadingTaskID = TaskId(id: "package-reloading")
             do {
+                self.connectionToClient.send(
+                    TaskStartNotification(
+                        taskId: reloadingTaskID,
+                        data: WorkDoneProgressTask(title: "SwiftPM: Reloading Package").encodeToLSPAny()
+                    )
+                )
                 let result = try await buildSystem.generatePIFAndAccompanyingMetadata(preserveStructure: false)
                 try localFileSystem.writeIfChanged(path: buildSystem.buildParameters.pifManifest, string: result.pif)
                 await self.rebuildHeaderMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
@@ -534,8 +541,14 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                     .init(uri: .init(buildSystem.buildParameters.pifManifest.asURL), type: .changed)
                 ]))
                 _ = try await self.connectionToUnderlyingBuildServer.send(WorkspaceWaitForBuildSystemUpdatesRequest())
+                self.connectionToClient.send(
+                    TaskFinishNotification(taskId: reloadingTaskID, status: .ok)
+                )
             } catch {
                 self.logToClient(.warning, "error regenerating build description: \(error)")
+                self.connectionToClient.send(
+                    TaskFinishNotification(taskId: reloadingTaskID, status: .error)
+                )
             }
         }
     }

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -20,9 +20,19 @@ import SwiftPMBuildServer
 import _InternalTestSupport
 import Testing
 
-final fileprivate class NotificationCollectingMessageHandler: MessageHandler {
-    func handle(_ notification: some NotificationType) {}
+final fileprivate class NotificationCollectingMessageHandler: MessageHandler, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _notifications: [Any] = []
+
+    func handle(_ notification: some NotificationType) {
+        lock.withLock { _notifications.append(notification) }
+    }
+
     func handle<Request>(_ request: Request, id: RequestID, reply: @escaping @Sendable (LSPResult<Request.Response>) -> Void) where Request : RequestType {}
+
+    func notifications<T: NotificationType>(of type: T.Type) -> [T] {
+        lock.withLock { _notifications.compactMap { $0 as? T } }
+    }
 }
 
 fileprivate func withSwiftPMBSP(fixtureName: String, extraBSPArgs: [String] = [], body: (Connection, NotificationCollectingMessageHandler, AbsolutePath) async throws -> Void) async throws {
@@ -168,6 +178,39 @@ struct SwiftPMBuildServerTests {
             let updatedSourcesItem = try #require(updatedSourcesResponse.items.only)
             #expect(updatedSourcesItem.sources.count == 2)
             #expect(updatedSourcesItem.sources.map(\.uri.fileURL?.lastPathComponent).sorted() == ["Bar.swift", "Foo.swift"])
+        }
+    }
+
+    @Test
+    func packageReloadNotifications() async throws {
+        try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, notificationCollector, fixturePath in
+            #expect(notificationCollector.notifications(of: TaskStartNotification.self).count == 1)
+            #expect(notificationCollector.notifications(of: TaskFinishNotification.self).count == 1)
+
+            try localFileSystem.writeFileContents(fixturePath.appending(component: "Bar.swift"), body: {
+                $0.write("public let baz = \"hello\"")
+            })
+
+            connection.send(OnWatchedFilesDidChangeNotification(changes: [
+                .init(uri: .init(.init(filePath: fixturePath.appending(component: "Bar.swift").pathString)), type: .created)
+            ]))
+            _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
+
+            #expect(notificationCollector.notifications(of: TaskStartNotification.self).count == 2)
+            #expect(notificationCollector.notifications(of: TaskFinishNotification.self).count == 2)
+
+            let taskStarts = notificationCollector.notifications(of: TaskStartNotification.self)
+            #expect(taskStarts.count == 2)
+            for start in taskStarts {
+                #expect(start.taskId.id == "package-reloading")
+                #expect(WorkDoneProgressTask(fromLSPAny: start.data)?.title == "SwiftPM: Reloading Package")
+            }
+
+            let taskFinishes = notificationCollector.notifications(of: TaskFinishNotification.self)
+            #expect(taskFinishes.count == 2)
+            for finish in taskFinishes {
+                #expect(finish.taskId.id == "package-reloading")
+            }
         }
     }
 


### PR DESCRIPTION
Add a package reload progress notification which matches the current behavior of SourceKit-LSP. This improves the UX a bit and allows us to pass more of the SourceKit-LSP test suite using the BSP implementation