### PR TITLE
Emit warning when SCM-to-registry identity lookup finds no mapping

### DIFF
--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -350,7 +350,7 @@ extension Workspace {
                 let identity = identities.sorted().first
                 if identity == nil {
                     observabilityScope.emit(
-                        warning: "no registry identity found for '\(url)'; dependency will not be transformed. Ensure the package is published with 'repositoryURLs' metadata."
+                        warning: "No registry identity found for '\(url)'; dependency will not be transformed. The package was not published with 'repositoryURLs' metadata."
                     )
                 }
                 self.identityLookupCache[url] = (result: .success(identity), expirationTime: .now() + self.cacheTTL)

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -348,6 +348,11 @@ extension Workspace {
                     observabilityScope: observabilityScope
                 )
                 let identity = identities.sorted().first
+                if identity == nil {
+                    observabilityScope.emit(
+                        warning: "no registry identity found for '\(url)'; dependency will not be transformed. Ensure the package is published with 'repositoryURLs' metadata."
+                    )
+                }
                 self.identityLookupCache[url] = (result: .success(identity), expirationTime: .now() + self.cacheTTL)
                 return identity
             } catch {


### PR DESCRIPTION
## Summary

- Fixes #9953
- When using `--replace-scm-with-registry` or `--use-registry-identity-for-scm`, if the registry's identifiers endpoint returns no mapping for a source control URL, the dependency is silently left unchanged. This adds a warning in `mapRegistryIdentity` so users know why a dependency was not transformed and what to fix (missing `repositoryURLs` metadata on the published package).

## Motivation

The existing code emits a warning when the identity lookup *throws an error* (network failure, server error), but not when the lookup succeeds with an empty result — which is the far more common failure mode. Users running `--replace-scm-with-registry` get no feedback when a dependency isn't transformed, making it very difficult to diagnose.

## Changes

In `Workspace+Registry.swift`, `mapRegistryIdentity` now emits a warning when `lookupIdentities` returns an empty set:

```
warning: no registry identity found for 'https://github.com/example/package.git'; 
dependency will not be transformed. Ensure the package is published with 'repositoryURLs' metadata.
```

## Manual Test

Here is the test I ran (me, Gabe, not the AI 😛):

I have a Swift package with this `Package.swift`:

```swift
// swift-tools-version: 6.3
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "AdobeRepro",
    dependencies: [
        .package(url: "https://github.com/apple/swift-numerics.git", from: "1.1.1")
    ],
    // ... rest of file...
)
```

I have a package in my registry called `my-registry.swift-numerics`, so when I run `swift-package resolve --replace-scm-with-registry`, I expect a dependency of type `registry` in my resolved file. Because I didn't include a repository URL in the package metadata, SPM can't map swift-numerics to a package in the registry. 

Before, this would silently fail, and write a package of type `remoteSourceControl` to the resolved file. 

Now, it still writes the package of type `remoteSourceControl`, but it outputs this warning: 

```
warning: '<project name>': no registry identity found for 'https://github.com/apple/swift-numerics.git'; dependency will not be transformed. Ensure the package is published with 'repositoryURLs' metadata.
```

❗ this is completely generated with AI. 