### PR TITLE
Fix searching for SDKs when a `--triple` is specified along with the SDK name

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -786,7 +786,7 @@ public struct SwiftSDK: Equatable {
             swiftSDK = targetSwiftSDK
         } else if let swiftSDKSelector {
             do {
-                swiftSDK = try store.selectBundle(matching: swiftSDKSelector, hostTriple: hostTriple)
+                swiftSDK = try store.selectBundle(matching: swiftSDKSelector, hostTriple: hostTriple, targetTriple: customCompileTriple)
             } catch {
                 // If a user-installed bundle for the selector doesn't exist, check if the
                 // selector is recognized as a default SDK.

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundle.swift
@@ -67,7 +67,7 @@ extension [SwiftSDKBundle] {
                         }
                     }
 
-                    return variant.swiftSDKs.first { $0.targetTriple == targetTriple }
+                    return variant.swiftSDKs.first { $0.targetTriple?.tripleString == targetTriple.tripleString }
                 }
             }
         }

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift
@@ -47,6 +47,7 @@ public final class SwiftSDKBundleStore {
 
     enum Error: Swift.Error, CustomStringConvertible {
         case noMatchingSwiftSDK(selector: String, hostTriple: Triple)
+        case noMatchingSwiftSDKWithTriple(selector: String, hostTriple: Triple, targetTriple: Triple)
 
         var description: String {
             switch self {
@@ -55,6 +56,12 @@ public final class SwiftSDKBundleStore {
                 No Swift SDK found matching query `\(selector)` and host triple \
                 `\(hostTriple.tripleString)`. Use `swift sdk list` command to see \
                 available Swift SDKs.
+                """
+            case let .noMatchingSwiftSDKWithTriple(selector, hostTriple, targetTriple):
+                return """
+                No Swift SDK found matching query `\(selector)`, target triple \
+                `\(targetTriple.tripleString)`, and host triple `\(hostTriple.tripleString)`. \
+                Use `swift sdk list` command to see available Swift SDKs.
                 """
             }
         }
@@ -123,10 +130,12 @@ public final class SwiftSDKBundleStore {
     /// - Parameters:
     ///   - query: either an artifact ID or target triple to filter with.
     ///   - hostTriple: triple of the host building with these Swift SDKs.
+    ///   - targetTriple: optional separate target triple to look for
     /// - Returns: ``SwiftSDK`` value matching `query` either by artifact ID or target triple, `nil` if none found.
     public func selectBundle(
         matching selector: String,
-        hostTriple: Triple
+        hostTriple: Triple,
+        targetTriple: Triple? = nil
     ) throws -> SwiftSDK {
         let validBundles = try self.allValidBundles
 
@@ -134,6 +143,18 @@ public final class SwiftSDKBundleStore {
             throw StringError(
                 "No valid Swift SDK bundles found at \(self.swiftSDKsDirectory)."
             )
+        }
+
+        if let triple = targetTriple {
+            guard var selectedSwiftSDK = validBundles.selectSwiftSDK(
+                id: selector,
+                hostTriple: hostTriple,
+                targetTriple: triple
+            ) else {
+                throw Error.noMatchingSwiftSDKWithTriple(selector: selector, hostTriple: hostTriple, targetTriple: triple)
+            }
+            selectedSwiftSDK.applyPathCLIOptions()
+            return selectedSwiftSDK
         }
 
         guard var selectedSwiftSDKs = validBundles.selectSwiftSDK(

--- a/Tests/CommandsTests/SwiftSDKCommandTests.swift
+++ b/Tests/CommandsTests/SwiftSDKCommandTests.swift
@@ -295,6 +295,21 @@ struct SwiftSDKCommandTests {
                 }
             }
 
+            await expectThrowsCommandExecutionError(
+                try await command.execute(
+                    [
+                       "configure", "--show-configuration",
+                        "--swift-sdks-path", fixturePath.pathString,
+                        "test-artifact",
+                        "aarch64-unknown-linux-gnu11.0",
+                    ]
+                )
+            ) { error in
+                let stderr = error.stderr
+                #expect(stderr.contains("Error: Swift SDK with ID `test-artifact`, host triple "))
+                #expect(stderr.contains(", and target triple aarch64-unknown-linux-gnu11.0 is not currently installed."))
+            }
+
             (stdout, stderr) = try await command.execute(
                 ["remove", "--swift-sdks-path", fixturePath.pathString, "test-artifact"])
 

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -391,6 +391,14 @@ final class SwiftSDKBundleTests: XCTestCase {
                 bundleName: AbsolutePath(bundles[1].path).components.last!
             ),
         ])
+
+        let tripleSDK = try store.selectBundle(
+            matching: "\(testArtifactID)1",
+            hostTriple: Triple("arm64-apple-macosx14.0"),
+            targetTriple: targetTriple
+        )
+
+        XCTAssertEqual(tripleSDK.targetTriple, targetTriple)
     }
 
     func testTargetSDKDerivation() async throws {


### PR DESCRIPTION
Extend `selectBundle()` to use the existing `selectSwiftSDK(id:hostTriple:targetTriple)` overload, plus fix the latter to check the full triple string, which affects `swift sdk configure` also.

Fixes https://github.com/swiftlang/swift-package-manager/issues/7973 and https://github.com/swiftlang/swift-package-manager/issues/9220

Spun off from #9229, ~I'll~ added some tests ~and~ to get this in.