### PR TITLE
Incrementally migrate AsyncProcess usages to swift-subprocess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
 if(FIND_PM_DEPS)
   find_package(SwiftSystem CONFIG REQUIRED)
   find_package(TSC CONFIG REQUIRED)
-
+  find_package(SwiftSubprocess CONFIG REQUIRED)
   find_package(LLBuild CONFIG)
   if(NOT LLBuild_FOUND)
     find_package(LLBuild REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
 if(FIND_PM_DEPS)
   find_package(SwiftSystem CONFIG REQUIRED)
   find_package(TSC CONFIG REQUIRED)
-
+  find_package(SwiftSubprocess REQUIRED)
   find_package(LLBuild CONFIG)
   if(NOT LLBuild_FOUND)
     find_package(LLBuild REQUIRED)

--- a/Package.swift
+++ b/Package.swift
@@ -248,6 +248,7 @@ let package = Package(
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SystemPackage", package: "swift-system"),
+                .product(name: "Subprocess", package: "swift-subprocess"),
             ] + swiftToolsCoreSupportAutoDeps,
             exclude: ["CMakeLists.txt", "Vendor/README.md"],
             swiftSettings: swift6CompatibleExperimentalFeatures + [
@@ -314,6 +315,8 @@ let package = Package(
             name: "BinarySymbols",
             dependencies: [
                 "Basics",
+                .product(name: "Subprocess", package: "swift-subprocess"),
+                .product(name: "SystemPackage", package: "swift-system"),
             ] + swiftTSCBasicsDeps,
             exclude: ["CMakeLists.txt"],
             swiftSettings: commonExperimentalFeatures
@@ -571,6 +574,7 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SystemPackage", package: "swift-system"),
+                .product(name: "Subprocess", package: "swift-subprocess"),
                 "Basics",
                 "BinarySymbols",
                 "Build",
@@ -805,6 +809,7 @@ let package = Package(
                 "PackageSigning",
                 "SourceControl",
                 .product(name: "OrderedCollections", package: "swift-collections"),
+                .product(name: "Subprocess", package: "swift-subprocess"),
                 "Workspace",
             ] + swiftTSCTestSupportDeps,
         ),
@@ -868,7 +873,14 @@ let package = Package(
         ),
         .testTarget(
             name: "BuildTests",
-            dependencies: ["Build", "PackageModel", "Commands", "_InternalTestSupport", "_InternalBuildTestSupport"]
+            dependencies: [
+                "Build",
+                "PackageModel",
+                "Commands",
+                "_InternalTestSupport",
+                "_InternalBuildTestSupport",
+                .product(name: "Subprocess", package: "swift-subprocess"),
+            ]
         ),
         .testTarget(
             name: "LLBuildManifestTests",
@@ -1021,6 +1033,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
                 "swift-package-manager",
                 "PackageModel",
                 "_InternalTestSupport",
+                .product(name: "Subprocess", package: "swift-subprocess"),
             ]
         ),
         .executableTarget(
@@ -1055,6 +1068,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
                 "_InternalTestSupport",
                 "Workspace",
                 "dummy-swiftc",
+                .product(name: "Subprocess", package: "swift-subprocess"),
             ]
         ),
         .testTarget(
@@ -1062,6 +1076,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
             dependencies: [
                 "SwiftPMBuildServer",
                 "_InternalTestSupport",
+                .product(name: "Subprocess", package: "swift-subprocess"),
             ] + swiftToolsProtocolsDeps
         ),
     ])
@@ -1120,6 +1135,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-argument-parser.git", revision: "1.6.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", revision: "3.12.5"),
         .package(url: "https://github.com/apple/swift-system.git", revision: "1.5.0"),
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0"),
         .package(url: "https://github.com/apple/swift-collections.git", revision: "1.1.6"),
         .package(url: "https://github.com/apple/swift-certificates.git", revision: "1.10.1"),
         .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", revision: "1.0.7"),

--- a/Package.swift
+++ b/Package.swift
@@ -248,6 +248,7 @@ let package = Package(
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SystemPackage", package: "swift-system"),
+                .product(name: "Subprocess", package: "swift-subprocess"),
             ] + swiftToolsCoreSupportAutoDeps,
             exclude: ["CMakeLists.txt", "Vendor/README.md"],
             swiftSettings: swift6CompatibleExperimentalFeatures + [
@@ -314,6 +315,8 @@ let package = Package(
             name: "BinarySymbols",
             dependencies: [
                 "Basics",
+                .product(name: "Subprocess", package: "swift-subprocess"),
+                .product(name: "SystemPackage", package: "swift-system"),
             ] + swiftTSCBasicsDeps,
             exclude: ["CMakeLists.txt"],
             swiftSettings: commonExperimentalFeatures
@@ -571,6 +574,7 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SystemPackage", package: "swift-system"),
+                .product(name: "Subprocess", package: "swift-subprocess"),
                 "Basics",
                 "BinarySymbols",
                 "Build",
@@ -814,6 +818,7 @@ let package = Package(
                 "PackageSigning",
                 "SourceControl",
                 .product(name: "OrderedCollections", package: "swift-collections"),
+                .product(name: "Subprocess", package: "swift-subprocess"),
                 "Workspace",
             ] + swiftTSCTestSupportDeps,
         ),
@@ -877,7 +882,14 @@ let package = Package(
         ),
         .testTarget(
             name: "BuildTests",
-            dependencies: ["Build", "PackageModel", "Commands", "_InternalTestSupport", "_InternalBuildTestSupport"]
+            dependencies: [
+                "Build",
+                "PackageModel",
+                "Commands",
+                "_InternalTestSupport",
+                "_InternalBuildTestSupport",
+                .product(name: "Subprocess", package: "swift-subprocess"),
+            ]
         ),
         .testTarget(
             name: "LLBuildManifestTests",
@@ -1038,6 +1050,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
                 "swift-package-manager",
                 "PackageModel",
                 "_InternalTestSupport",
+                .product(name: "Subprocess", package: "swift-subprocess"),
             ]
         ),
         .executableTarget(
@@ -1072,6 +1085,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
                 "_InternalTestSupport",
                 "Workspace",
                 "dummy-swiftc",
+                .product(name: "Subprocess", package: "swift-subprocess"),
             ]
         ),
         .testTarget(
@@ -1079,6 +1093,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_DISABLE_SDK_DEPENDENT_TESTS"] ==
             dependencies: [
                 "SwiftPMBuildServer",
                 "_InternalTestSupport",
+                .product(name: "Subprocess", package: "swift-subprocess"),
             ] + swiftToolsProtocolsDeps
         ),
     ])
@@ -1137,6 +1152,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-argument-parser.git", revision: "1.6.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", revision: "3.12.5"),
         .package(url: "https://github.com/apple/swift-system.git", revision: "1.5.0"),
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", .upToNextMinor(from: "0.5.0")),
         .package(url: "https://github.com/apple/swift-collections.git", revision: "1.1.6"),
         .package(url: "https://github.com/apple/swift-certificates.git", revision: "1.10.1"),
         .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", revision: "1.0.9"),
@@ -1155,6 +1171,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-crypto"),
         .package(path: "../swift-syntax"),
         .package(path: "../swift-system"),
+        .package(path: "../swift-subprocess"),
         .package(path: "../swift-collections"),
         .package(path: "../swift-certificates"),
         .package(path: "../swift-toolchain-sqlite"),

--- a/Sources/Basics/Archiver/Archiver.swift
+++ b/Sources/Basics/Archiver/Archiver.swift
@@ -23,13 +23,10 @@ public protocol Archiver: Sendable {
     /// - Parameters:
     ///   - archivePath: The `AbsolutePath` to the archive to extract.
     ///   - destinationPath: The `AbsolutePath` to the directory to extract to.
-    ///   - completion: The completion handler that will be called when the operation finishes to notify of its success.
-    @available(*, noasync, message: "Use the async alternative")
     func extract(
         from archivePath: AbsolutePath,
-        to destinationPath: AbsolutePath,
-        completion: @escaping @Sendable (Result<Void, Error>) -> Void
-    )
+        to destinationPath: AbsolutePath
+    ) async throws
 
     /// Asynchronously compress the contents of a directory to a destination archive.
     ///
@@ -57,29 +54,12 @@ public protocol Archiver: Sendable {
     ///
     /// - Parameters:
     ///   - path: The `AbsolutePath` to the archive to validate.
-    ///   - completion: The completion handler that will be called when the operation finishes to notify of its success.
-    @available(*, noasync, message: "Use the async alternative")
     func validate(
-        path: AbsolutePath,
-        completion: @escaping @Sendable (Result<Bool, Error>) -> Void
-    )
+        path: AbsolutePath
+    ) async throws -> Bool
 }
 
 extension Archiver {
-    /// Asynchronously extracts the contents of an archive to a destination folder.
-    ///
-    /// - Parameters:
-    ///   - archivePath: The `AbsolutePath` to the archive to extract.
-    ///   - destinationPath: The `AbsolutePath` to the directory to extract to.
-    public func extract(
-        from archivePath: AbsolutePath,
-        to destinationPath: AbsolutePath
-    ) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            self.extract(from: archivePath, to: destinationPath, completion: { continuation.resume(with: $0) })
-        }
-    }
-
     /// Asynchronously compress the contents of a directory to a destination archive.
     ///
     /// - Parameters:
@@ -94,18 +74,6 @@ extension Archiver {
             from: directory.parentDirectory,
             to: destinationPath
         )
-    }
-
-    /// Asynchronously validates if a file is an archive.
-    ///
-    /// - Parameters:
-    ///   - path: The `AbsolutePath` to the archive to validate.
-    public func validate(
-        path: AbsolutePath
-    ) async throws -> Bool {
-        try await withCheckedThrowingContinuation { continuation in
-            self.validate(path: path, completion: { continuation.resume(with: $0) })
-        }
     }
 
     package func isFileSupported(_ lastPathComponent: String) -> Bool {

--- a/Sources/Basics/Archiver/TarArchiver.swift
+++ b/Sources/Basics/Archiver/TarArchiver.swift
@@ -14,6 +14,12 @@ import Foundation
 import class Dispatch.DispatchQueue
 import struct Dispatch.DispatchTime
 import struct TSCBasic.FileSystemError
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 #if os(Windows)
 import WinSDK
@@ -104,22 +110,28 @@ public struct TarArchiver: Archiver {
             throw FileSystemError(.notDirectory, directory.underlying)
         }
 
-        let process = AsyncProcess(
-            arguments: [self.tarCommand, "acf", destinationPath.pathString, directory.basename],
-            environment: .current,
-            workingDirectory: directory.parentDirectory
-        )
+        #if os(Windows)
+        let executable = Subprocess.Executable.path(FilePath(self.tarCommand))
+        #else
+        let executable = Subprocess.Executable.name(self.tarCommand)
+        #endif
 
-        guard let registrationKey = self.cancellator.register(process) else {
-            throw CancellationError.failedToRegisterProcess(process)
+        let outcome = try await self.cancellator.withCancellable(name: self.tarCommand) {
+            try await Subprocess.run(
+                executable,
+                arguments: Subprocess.Arguments(["acf", destinationPath.pathString, directory.basename]),
+                workingDirectory: FilePath(directory.parentDirectory.pathString),
+                error: .combinedWithOutput
+            ) { _, outputSequence -> String in
+                var output = ""
+                for try await buffer in outputSequence {
+                    buffer.withUnsafeBytes { output += String(decoding: $0, as: UTF8.self) }
+                }
+                return output
+            }
         }
-
-        defer { self.cancellator.deregister(registrationKey) }
-
-        try process.launch()
-        let processResult = try await process.waitUntilExit()
-        guard processResult.exitStatus == .terminated(code: 0) else {
-            throw try StringError(processResult.utf8stderrOutput())
+        guard outcome.terminationStatus.isSuccess else {
+            throw StringError(outcome.value)
         }
     }
 

--- a/Sources/Basics/Archiver/TarArchiver.swift
+++ b/Sources/Basics/Archiver/TarArchiver.swift
@@ -11,9 +11,23 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import class Dispatch.DispatchQueue
 import struct Dispatch.DispatchTime
 import struct TSCBasic.FileSystemError
+#if USE_IMPL_ONLY_IMPORTS
+@_implementationOnly import Subprocess
+#if canImport(System)
+@_implementationOnly import System
+#else
+@_implementationOnly import SystemPackage
+#endif
+#else
+internal import Subprocess
+#if canImport(System)
+internal import System
+#else
+internal import SystemPackage
+#endif
+#endif
 
 #if os(Windows)
 import WinSDK
@@ -60,38 +74,34 @@ public struct TarArchiver: Archiver {
 
     public func extract(
         from archivePath: AbsolutePath,
-        to destinationPath: AbsolutePath,
-        completion: @escaping @Sendable (Result<Void, Error>) -> Void
-    ) {
-        do {
-            guard self.fileSystem.exists(archivePath) else {
-                throw FileSystemError(.noEntry, archivePath.underlying)
-            }
+        to destinationPath: AbsolutePath
+    ) async throws {
+        guard self.fileSystem.exists(archivePath) else {
+            throw FileSystemError(.noEntry, archivePath.underlying)
+        }
 
-            guard self.fileSystem.isDirectory(destinationPath) else {
-                throw FileSystemError(.notDirectory, destinationPath.underlying)
-            }
+        guard self.fileSystem.isDirectory(destinationPath) else {
+            throw FileSystemError(.notDirectory, destinationPath.underlying)
+        }
 
-            let process = AsyncProcess(
-                arguments: [self.tarCommand, "xf", archivePath.pathString, "-C", destinationPath.pathString]
+        #if os(Windows)
+        let executable = Subprocess.Executable.path(FilePath(self.tarCommand))
+        #else
+        let executable = Subprocess.Executable.name(self.tarCommand)
+        #endif
+
+        let result = try await self.cancellator.withCancellable(name: self.tarCommand) {
+            try await Subprocess.run(
+                executable,
+                arguments: Subprocess.Arguments([
+                    "xf", archivePath.pathString, "-C", destinationPath.pathString,
+                ]),
+                output: .string(limit: .max),
+                error: .string(limit: .max)
             )
-
-            guard let registrationKey = self.cancellator.register(process) else {
-                throw CancellationError.failedToRegisterProcess(process)
-            }
-
-            DispatchQueue.sharedConcurrent.async {
-                defer { self.cancellator.deregister(registrationKey) }
-                completion(.init(catching: {
-                    try process.launch()
-                    let processResult = try process.waitUntilExit()
-                    guard processResult.exitStatus == .terminated(code: 0) else {
-                        throw try StringError(processResult.utf8stderrOutput())
-                    }
-                }))
-            }
-        } catch {
-            return completion(.failure(error))
+        }
+        guard result.terminationStatus.isSuccess else {
+            throw StringError((result.standardOutput ?? "") + (result.standardError ?? ""))
         }
     }
 
@@ -104,47 +114,46 @@ public struct TarArchiver: Archiver {
             throw FileSystemError(.notDirectory, parent.underlying)
         }
 
-        let process = AsyncProcess(
-            arguments: [self.tarCommand, "acf", destinationPath.pathString] + paths.map(\.pathString),
-            environment: .current,
-            workingDirectory: parent
-        )
+        #if os(Windows)
+        let executable = Subprocess.Executable.path(FilePath(self.tarCommand))
+        #else
+        let executable = Subprocess.Executable.name(self.tarCommand)
+        #endif
 
-        guard let registrationKey = self.cancellator.register(process) else {
-            throw CancellationError.failedToRegisterProcess(process)
+        let result = try await self.cancellator.withCancellable(name: self.tarCommand) {
+            try await Subprocess.run(
+                executable,
+                arguments: Subprocess.Arguments(["acf", destinationPath.pathString] + paths.map(\.pathString)),
+                workingDirectory: FilePath(parent.pathString),
+                output: .string(limit: .max),
+                error: .string(limit: .max)
+            )
         }
-
-        defer { self.cancellator.deregister(registrationKey) }
-
-        try process.launch()
-        let processResult = try await process.waitUntilExit()
-        guard processResult.exitStatus == .terminated(code: 0) else {
-            throw try StringError(processResult.utf8stderrOutput())
+        guard result.terminationStatus.isSuccess else {
+            throw StringError((result.standardOutput ?? "") + (result.standardError ?? ""))
         }
     }
 
-    public func validate(path: AbsolutePath, completion: @escaping @Sendable (Result<Bool, Error>) -> Void) {
-        do {
-            guard self.fileSystem.exists(path) else {
-                throw FileSystemError(.noEntry, path.underlying)
-            }
-
-            let process = AsyncProcess(arguments: [self.tarCommand, "tf", path.pathString])
-            guard let registrationKey = self.cancellator.register(process) else {
-                throw CancellationError.failedToRegisterProcess(process)
-            }
-
-            DispatchQueue.sharedConcurrent.async {
-                defer { self.cancellator.deregister(registrationKey) }
-                completion(.init(catching: {
-                    try process.launch()
-                    let processResult = try process.waitUntilExit()
-                    return processResult.exitStatus == .terminated(code: 0)
-                }))
-            }
-        } catch {
-            return completion(.failure(error))
+    public func validate(path: AbsolutePath) async throws -> Bool {
+        guard self.fileSystem.exists(path) else {
+            throw FileSystemError(.noEntry, path.underlying)
         }
+
+        #if os(Windows)
+        let executable = Subprocess.Executable.path(FilePath(self.tarCommand))
+        #else
+        let executable = Subprocess.Executable.name(self.tarCommand)
+        #endif
+
+        let result = try await self.cancellator.withCancellable(name: self.tarCommand) {
+            try await Subprocess.run(
+                executable,
+                arguments: Subprocess.Arguments(["tf", path.pathString]),
+                output: .discarded,
+                error: .discarded
+            )
+        }
+        return result.terminationStatus.isSuccess
     }
 
     public func cancel(deadline: DispatchTime) throws {

--- a/Sources/Basics/Archiver/UniversalArchiver.swift
+++ b/Sources/Basics/Archiver/UniversalArchiver.swift
@@ -72,15 +72,10 @@ public struct UniversalArchiver: Archiver {
 
     public func extract(
         from archivePath: AbsolutePath,
-        to destinationPath: AbsolutePath,
-        completion: @escaping @Sendable (Result<Void, Swift.Error>) -> Void
-    ) {
-        do {
-            let archiver = try archiver(for: archivePath)
-            archiver.extract(from: archivePath, to: destinationPath, completion: completion)
-        } catch {
-            completion(.failure(error))
-        }
+        to destinationPath: AbsolutePath
+    ) async throws {
+        let archiver = try archiver(for: archivePath)
+        try await archiver.extract(from: archivePath, to: destinationPath)
     }
 
     public func compress(
@@ -93,14 +88,9 @@ public struct UniversalArchiver: Archiver {
     }
 
     public func validate(
-        path: AbsolutePath,
-        completion: @escaping @Sendable (Result<Bool, Swift.Error>) -> Void
-    ) {
-        do {
-            let archiver = try archiver(for: path)
-            archiver.validate(path: path, completion: completion)
-        } catch {
-            completion(.failure(error))
-        }
+        path: AbsolutePath
+    ) async throws -> Bool {
+        let archiver = try archiver(for: path)
+        return try await archiver.validate(path: path)
     }
 }

--- a/Sources/Basics/Archiver/ZipArchiver.swift
+++ b/Sources/Basics/Archiver/ZipArchiver.swift
@@ -12,6 +12,12 @@
 
 import Dispatch
 import struct TSCBasic.FileSystemError
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 /// An `Archiver` that handles ZIP archives using the command-line `zip` and `unzip` tools.
 public struct ZipArchiver: Archiver, Cancellable {
@@ -90,41 +96,31 @@ public struct ZipArchiver: Archiver, Cancellable {
         }
 
         #if os(FreeBSD)
-        // On FreeBSD, the unzip command is available in base but not the zip command.
-        // Therefore; we use libarchive(bsdtar) to produce the ZIP archive instead.
-        let process = AsyncProcess(
-                arguments: [
-                    self.tar, "-c", "--format", "zip", "-f", destinationPath.pathString,
-                    directory.basename,
-                ],
-          workingDirectory: directory.parentDirectory
-        )
+        let executable = Subprocess.Executable.name(self.tar)
+        let args = ["-c", "--format", "zip", "-f", destinationPath.pathString, directory.basename]
+        let workingDirectory: FilePath? = FilePath(directory.parentDirectory.pathString)
         #else
-        // This is to work around `swift package-registry publish` tool failing on
-        // Amazon Linux 2 due to it having an earlier Glibc version (rdar://116370323)
-        // and therefore posix_spawn_file_actions_addchdir_np is unavailable.
-        // Instead of passing `workingDirectory` param to TSC.Process, which will trigger
-        // SPM_posix_spawn_file_actions_addchdir_np_supported check, we shell out and
-        // do `cd` explicitly before `zip`.
-        let process = AsyncProcess(
-            arguments: [
-                "/bin/sh",
-                "-c",
-                    "cd \(directory.parentDirectory.underlying.pathString) && \(self.zip) -ry \(destinationPath.pathString) \(directory.basename)"
-            ]
-        )
+        let executable = Subprocess.Executable.path(FilePath("/bin/sh"))
+        let args = ["-c", "cd \(directory.parentDirectory.underlying.pathString) && \(self.zip) -ry \(destinationPath.pathString) \(directory.basename)"]
+        let workingDirectory: FilePath? = nil
         #endif
 
-        guard let registrationKey = self.cancellator.register(process) else {
-            throw CancellationError.failedToRegisterProcess(process)
+        let outcome = try await self.cancellator.withCancellable(name: self.zip) {
+            try await Subprocess.run(
+                executable,
+                arguments: Subprocess.Arguments(args),
+                workingDirectory: workingDirectory,
+                error: .combinedWithOutput
+            ) { _, outputSequence -> String in
+                var output = ""
+                for try await buffer in outputSequence {
+                    buffer.withUnsafeBytes { output += String(decoding: $0, as: UTF8.self) }
+                }
+                return output
+            }
         }
-
-        defer { self.cancellator.deregister(registrationKey) }
-
-        try process.launch()
-        let processResult = try await process.waitUntilExit()
-        guard processResult.exitStatus == .terminated(code: 0) else {
-            throw try StringError(processResult.utf8stderrOutput())
+        guard outcome.terminationStatus.isSuccess else {
+            throw StringError(outcome.value)
         }
     }
 

--- a/Sources/Basics/Archiver/ZipArchiver.swift
+++ b/Sources/Basics/Archiver/ZipArchiver.swift
@@ -12,6 +12,21 @@
 
 import Dispatch
 import struct TSCBasic.FileSystemError
+#if USE_IMPL_ONLY_IMPORTS
+@_implementationOnly import Subprocess
+#if canImport(System)
+@_implementationOnly import System
+#else
+@_implementationOnly import SystemPackage
+#endif
+#else
+internal import Subprocess
+#if canImport(System)
+internal import System
+#else
+internal import SystemPackage
+#endif
+#endif
 
 /// An `Archiver` that handles ZIP archives using the command-line `zip` and `unzip` tools.
 public struct ZipArchiver: Archiver, Cancellable {
@@ -47,37 +62,28 @@ public struct ZipArchiver: Archiver, Cancellable {
 
     public func extract(
         from archivePath: AbsolutePath,
-        to destinationPath: AbsolutePath,
-        completion: @escaping @Sendable (Result<Void, Error>) -> Void
-    ) {
-        do {
-            guard self.fileSystem.exists(archivePath) else {
-                throw FileSystemError(.noEntry, archivePath.underlying)
-            }
+        to destinationPath: AbsolutePath
+    ) async throws {
+        guard self.fileSystem.exists(archivePath) else {
+            throw FileSystemError(.noEntry, archivePath.underlying)
+        }
 
-            guard self.fileSystem.isDirectory(destinationPath) else {
-                throw FileSystemError(.notDirectory, destinationPath.underlying)
-            }
+        guard self.fileSystem.isDirectory(destinationPath) else {
+            throw FileSystemError(.notDirectory, destinationPath.underlying)
+        }
 
-            let process = AsyncProcess(arguments: [
-                self.unzip, archivePath.pathString, "-d", destinationPath.pathString,
-            ])
-            guard let registrationKey = self.cancellator.register(process) else {
-                throw CancellationError.failedToRegisterProcess(process)
-            }
-
-            DispatchQueue.sharedConcurrent.async {
-                defer { self.cancellator.deregister(registrationKey) }
-                completion(.init(catching: {
-                    try process.launch()
-                    let processResult = try process.waitUntilExit()
-                    guard processResult.exitStatus == .terminated(code: 0) else {
-                        throw try StringError(processResult.utf8stderrOutput())
-                    }
-                }))
-            }
-        } catch {
-            return completion(.failure(error))
+        let result = try await self.cancellator.withCancellable(name: self.unzip) {
+            try await Subprocess.run(
+                Subprocess.Executable.name(self.unzip),
+                arguments: Subprocess.Arguments([
+                    archivePath.pathString, "-d", destinationPath.pathString,
+                ]),
+                output: .string(limit: .max),
+                error: .string(limit: .max)
+            )
+        }
+        guard result.terminationStatus.isSuccess else {
+            throw StringError((result.standardOutput ?? "") + (result.standardError ?? ""))
         }
     }
 
@@ -93,12 +99,9 @@ public struct ZipArchiver: Archiver, Cancellable {
         #if os(FreeBSD)
         // On FreeBSD, the unzip command is available in base but not the zip command.
         // Therefore; we use libarchive(bsdtar) to produce the ZIP archive instead.
-        let process = AsyncProcess(
-                arguments: [
-                    self.tar, "-c", "--format", "zip", "-f", destinationPath.pathString,
-                ] + paths.map(\.pathString),
-          workingDirectory: parent
-        )
+        let executable = Subprocess.Executable.name(self.tar)
+        let args = ["-c", "--format", "zip", "-f", destinationPath.pathString] + paths.map(\.pathString)
+        let workingDirectory: FilePath? = FilePath(parent.pathString)
         #else
         // This is to work around `swift package-registry publish` tool failing on
         // Amazon Linux 2 due to it having an earlier Glibc version (rdar://116370323)
@@ -106,50 +109,41 @@ public struct ZipArchiver: Archiver, Cancellable {
         // Instead of passing `workingDirectory` param to TSC.Process, which will trigger
         // SPM_posix_spawn_file_actions_addchdir_np_supported check, we shell out and
         // do `cd` explicitly before `zip`.
-        let process = AsyncProcess(
-            arguments: [
-                "/bin/sh",
-                "-c",
-                "cd \(parent.underlying.pathString) && \(self.zip) -ry \(destinationPath.pathString) \(paths.map(\.pathString).joined(separator: " "))"
-            ]
-        )
+        let executable = Subprocess.Executable.path(FilePath("/bin/sh"))
+        let inputs = paths.map(\.pathString).joined(separator: " ")
+        let command = "cd \(parent.underlying.pathString) && \(self.zip) -ry \(destinationPath.pathString) \(inputs)"
+        let args = ["-c", command]
+        let workingDirectory: FilePath? = nil
         #endif
 
-        guard let registrationKey = self.cancellator.register(process) else {
-            throw CancellationError.failedToRegisterProcess(process)
+        let result = try await self.cancellator.withCancellable(name: self.zip) {
+            try await Subprocess.run(
+                executable,
+                arguments: Subprocess.Arguments(args),
+                workingDirectory: workingDirectory,
+                output: .string(limit: .max),
+                error: .string(limit: .max)
+            )
         }
-
-        defer { self.cancellator.deregister(registrationKey) }
-
-        try process.launch()
-        let processResult = try await process.waitUntilExit()
-        guard processResult.exitStatus == .terminated(code: 0) else {
-            throw try StringError(processResult.utf8stderrOutput())
+        guard result.terminationStatus.isSuccess else {
+            throw StringError((result.standardOutput ?? "") + (result.standardError ?? ""))
         }
     }
 
-    public func validate(path: AbsolutePath, completion: @escaping @Sendable (Result<Bool, Error>) -> Void) {
-        do {
-            guard self.fileSystem.exists(path) else {
-                throw FileSystemError(.noEntry, path.underlying)
-            }
-
-            let process = AsyncProcess(arguments: [self.unzip, "-t", path.pathString])
-            guard let registrationKey = self.cancellator.register(process) else {
-                throw CancellationError.failedToRegisterProcess(process)
-            }
-
-            DispatchQueue.sharedConcurrent.async {
-                defer { self.cancellator.deregister(registrationKey) }
-                completion(.init(catching: {
-                    try process.launch()
-                    let processResult = try process.waitUntilExit()
-                    return processResult.exitStatus == .terminated(code: 0)
-                }))
-            }
-        } catch {
-            return completion(.failure(error))
+    public func validate(path: AbsolutePath) async throws -> Bool {
+        guard self.fileSystem.exists(path) else {
+            throw FileSystemError(.noEntry, path.underlying)
         }
+
+        let result = try await self.cancellator.withCancellable(name: self.unzip) {
+            try await Subprocess.run(
+                Subprocess.Executable.name(self.unzip),
+                arguments: Subprocess.Arguments(["-t", path.pathString]),
+                output: .discarded,
+                error: .discarded
+            )
+        }
+        return result.terminationStatus.isSuccess
     }
 
     public func cancel(deadline: DispatchTime) throws {

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -86,7 +86,8 @@ target_link_libraries(Basics PUBLIC
   _AsyncFileSystem
   SwiftCollections::OrderedCollections
   TSCBasic
-  TSCUtility)
+  TSCUtility
+  SwiftSubprocess::SubProcess)
 target_link_libraries(Basics PRIVATE
   SwiftCollections::DequeModule
   SPMSQLite3

--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -90,6 +90,8 @@ target_link_libraries(Basics PUBLIC
   TSCUtility)
 target_link_libraries(Basics PRIVATE
   SwiftCollections::DequeModule
+  SwiftSubprocess::Subprocess
+  SwiftSystem::SystemPackage
   SPMSQLite3
   TSCclibc)
 

--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -138,6 +138,35 @@ public final class Cancellator: Cancellable, Sendable {
         self.registry[key] = nil
     }
 
+    /// Runs `block` as a cancellable task, hooking it into the Cancellator so that
+    /// an OS-level cancellation signal (e.g. SIGINT) causes the task — and any
+    /// Subprocess running inside it — to be cancelled cooperatively.
+    ///
+    /// A single `ThreadSafeBox` holding both the task reference and the cancellation
+    /// flag ensures that "store task + check cancelled" and "set cancelled + cancel task"
+    /// are each atomic, closing the race between registration and task creation.
+    public func withCancellable<T: Sendable>(
+        name: String,
+        _ block: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        let state = ThreadSafeBox<(task: Task<T, any Error>?, cancelled: Bool)>((task: nil, cancelled: false))
+        guard let registrationKey = self.register(name: name, handler: { _ in
+            state.mutate { s in
+                s.cancelled = true
+                s.task?.cancel()
+            }
+        }) else {
+            throw CancellationError()
+        }
+        defer { self.deregister(registrationKey) }
+        let task = Task { try await block() }
+        state.mutate { s in
+            s.task = task
+            if s.cancelled { task.cancel() }
+        }
+        return try await task.value
+    }
+
     public func cancel(deadline: DispatchTime) throws {
         self._cancel(deadline: deadline)
     }

--- a/Sources/Basics/ImportScanning.swift
+++ b/Sources/Basics/ImportScanning.swift
@@ -13,6 +13,12 @@
 import Dispatch
 
 import class Foundation.JSONDecoder
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 private let defaultImports = ["Swift", "SwiftOnoneSupport", "_Concurrency",
                               "_StringProcessing", "_SwiftConcurrencyShims"]
@@ -45,9 +51,20 @@ public struct SwiftcImportScanner: ImportScanner {
                    filePathToScan.pathString,
                    "-scan-dependencies", "-Xfrontend", "-import-prescan"] + self.swiftCompilerFlags
 
-        let result = try await AsyncProcess.popen(arguments: cmd, environment: self.swiftCompilerEnvironment)
-
-        let stdout = try result.utf8Output()
+        let result = try await Subprocess.run(
+            .path(FilePath(cmd[0])),
+            arguments: Subprocess.Arguments(Array(cmd.dropFirst())),
+            environment: Subprocess.Environment.custom(
+                Dictionary(uniqueKeysWithValues: self.swiftCompilerEnvironment.map {
+                    (Subprocess.Environment.Key(rawValue: $0.key.rawValue)!, $0.value)
+                })
+            ),
+            output: .string(limit: .max)
+        )
+        guard result.terminationStatus.isSuccess else {
+            throw InternalError("import scanning failed")
+        }
+        let stdout = result.standardOutput ?? ""
         return try JSONDecoder.makeWithDefaults().decode(Imports.self, from: stdout).imports
             .filter { !defaultImports.contains($0) }
     }

--- a/Sources/Basics/ImportScanning.swift
+++ b/Sources/Basics/ImportScanning.swift
@@ -13,6 +13,21 @@
 import Dispatch
 
 import class Foundation.JSONDecoder
+#if USE_IMPL_ONLY_IMPORTS
+@_implementationOnly import Subprocess
+#if canImport(System)
+@_implementationOnly import System
+#else
+@_implementationOnly import SystemPackage
+#endif
+#else
+internal import Subprocess
+#if canImport(System)
+internal import System
+#else
+internal import SystemPackage
+#endif
+#endif
 
 private let defaultImports = ["Swift", "SwiftOnoneSupport", "_Concurrency",
                               "_StringProcessing", "_SwiftConcurrencyShims"]
@@ -45,9 +60,20 @@ public struct SwiftcImportScanner: ImportScanner {
                    filePathToScan.pathString,
                    "-scan-dependencies", "-Xfrontend", "-import-prescan"] + self.swiftCompilerFlags
 
-        let result = try await AsyncProcess.popen(arguments: cmd, environment: self.swiftCompilerEnvironment)
-
-        let stdout = try result.utf8Output()
+        let result = try await Subprocess.run(
+            .path(FilePath(cmd[0])),
+            arguments: Subprocess.Arguments(Array(cmd.dropFirst())),
+            environment: Subprocess.Environment.custom(
+                Dictionary(uniqueKeysWithValues: self.swiftCompilerEnvironment.map {
+                    (Subprocess.Environment.Key(rawValue: $0.key.rawValue)!, $0.value)
+                })
+            ),
+            output: .string(limit: .max)
+        )
+        guard result.terminationStatus.isSuccess else {
+            throw InternalError("import scanning failed")
+        }
+        let stdout = result.standardOutput ?? ""
         return try JSONDecoder.makeWithDefaults().decode(Imports.self, from: stdout).imports
             .filter { !defaultImports.contains($0) }
     }

--- a/Sources/BinarySymbols/CMakeLists.txt
+++ b/Sources/BinarySymbols/CMakeLists.txt
@@ -12,7 +12,8 @@ add_library(BinarySymbols STATIC
   ReferencedSymbols.swift
   SymbolProvider.swift)
 target_link_libraries(BinarySymbols PUBLIC
-  Basics)
+  Basics
+  SwiftSubprocess::Subprocess)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(BinarySymbols PROPERTIES

--- a/Sources/BinarySymbols/CMakeLists.txt
+++ b/Sources/BinarySymbols/CMakeLists.txt
@@ -12,7 +12,9 @@ add_library(BinarySymbols STATIC
   ReferencedSymbols.swift
   SymbolProvider.swift)
 target_link_libraries(BinarySymbols PUBLIC
-  Basics)
+  Basics
+  SwiftSubprocess::Subprocess
+  SwiftSystem::SystemPackage)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(BinarySymbols PROPERTIES

--- a/Sources/BinarySymbols/LLVMObjdumpSymbolProvider.swift
+++ b/Sources/BinarySymbols/LLVMObjdumpSymbolProvider.swift
@@ -12,6 +12,12 @@
 
 import Basics
 import RegexBuilder
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 package struct LLVMObjdumpSymbolProvider: SymbolProvider {
     private let objdumpPath: AbsolutePath
@@ -21,15 +27,16 @@ package struct LLVMObjdumpSymbolProvider: SymbolProvider {
     }
 
     package func symbols(for binary: AbsolutePath, symbols: inout ReferencedSymbols, recordUndefined: Bool = true) async throws {
-        let objdumpProcess = AsyncProcess(args: objdumpPath.pathString, "-t", "-T", binary.pathString)
-        try objdumpProcess.launch()
-        let result = try await objdumpProcess.waitUntilExit()
-        guard case .terminated(let status) = result.exitStatus,
-            status == 0 else {
+        let result = try await run(
+            .path(FilePath(objdumpPath.pathString)),
+            arguments: ["-t", "-T", binary.pathString],
+            output: .string(limit: .max)
+        )
+        guard result.terminationStatus.isSuccess else {
             throw InternalError("Unable to run llvm-objdump")
         }
 
-        try parse(output: try result.utf8Output(), symbols: &symbols, recordUndefined: recordUndefined)
+        try parse(output: result.standardOutput ?? "", symbols: &symbols, recordUndefined: recordUndefined)
     }
 
     package func parse(output: String, symbols: inout ReferencedSymbols, recordUndefined: Bool = true) throws {

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -84,7 +84,8 @@ target_link_libraries(Commands PUBLIC
   SwiftBuild::SwiftBuild
   SwiftToolsProtocols::BuildServerProtocol
   SwiftToolsProtocols::LanguageServerProtocol
-  SwiftToolsProtocols::LanguageServerProtocolTransport)
+  SwiftToolsProtocols::LanguageServerProtocolTransport
+  SwiftSubprocess::SubProcess)
 target_link_libraries(Commands PRIVATE
   DriverSupport
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -86,7 +86,8 @@ target_link_libraries(Commands PUBLIC
   SwiftBuild::SwiftBuild
   SwiftToolsProtocols::BuildServerProtocol
   SwiftToolsProtocols::LanguageServerProtocol
-  SwiftToolsProtocols::LanguageServerProtocolTransport)
+  SwiftToolsProtocols::LanguageServerProtocolTransport
+  SwiftSubprocess::Subprocess)
 target_link_libraries(Commands PRIVATE
   DriverSupport
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)

--- a/Sources/Commands/PackageCommands/Format.swift
+++ b/Sources/Commands/PackageCommands/Format.swift
@@ -17,8 +17,12 @@ import PackageModel
 import PackageGraph
 import TSCBasic
 import Workspace
-
-import class Basics.AsyncProcess
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 import enum TSCUtility.Diagnostics
 
@@ -40,7 +44,7 @@ extension SwiftPackageCommand {
             // Look for swift-format binary.
             // FIXME: This should be moved to user toolchain.
             let swiftFormatInEnv = Basics.lookupExecutablePath(filename: Environment.current["SWIFT_FORMAT"])
-            guard let swiftFormat = swiftFormatInEnv ?? AsyncProcess.findExecutable("swift-format") else {
+            guard let swiftFormat = swiftFormatInEnv ?? Basics.lookupExecutablePath(filename: "swift-format") else {
                 swiftCommandState.observabilityScope.emit(error: "Could not find swift-format in PATH or SWIFT_FORMAT")
                 throw TSCUtility.Diagnostics.fatalError
             }
@@ -73,11 +77,16 @@ extension SwiftPackageCommand {
             let args = [swiftFormat.pathString] + formatOptions + [packagePath.pathString] + paths
             print("Running:", args.map{ $0.spm_shellEscaped() }.joined(separator: " "))
 
-            let result = try await AsyncProcess.popen(arguments: args)
-            let output = try (result.utf8Output() + result.utf8stderrOutput())
+            let result = try await Subprocess.run(
+                .path(FilePath(args[0])),
+                arguments: Subprocess.Arguments(Array(args.dropFirst())),
+                output: .string(limit: .max),
+                error: .string(limit: .max)
+            )
+            let output = (result.standardOutput ?? "") + (result.standardError ?? "")
 
-            if result.exitStatus != .terminated(code: 0) {
-                print("Non-zero exit", result.exitStatus)
+            if !result.terminationStatus.isSuccess {
+                print("Non-zero exit", result.terminationStatus)
             }
             if !output.isEmpty {
                 print(output)

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -24,7 +24,6 @@ import SPMBuildCore
 import XCBuildSupport
 import SwiftBuildSupport
 
-import class Basics.AsyncProcess
 import var TSCBasic.stdoutStream
 
 import enum TSCUtility.Diagnostics

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -34,7 +34,12 @@ import TSCUtility
 import func TSCLibc.exit
 import Workspace
 
-import class Basics.AsyncProcess
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 import struct TSCBasic.ByteString
 import struct TSCBasic.FileSystemError
 import enum TSCBasic.JSON
@@ -618,7 +623,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         )
 
         // Run the tests and collect per-product results.
-        return runner.testPerProduct(outputHandler: {
+        return await runner.testPerProduct(outputHandler: {
             // command's result output goes on stdout
             // ie "swift test" should output to stdout
             print($0, terminator: "")
@@ -704,7 +709,14 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
         }
         args += ["-o", productsBuildParameters.codeCovDataFile.pathString]
-        try await AsyncProcess.checkNonZeroExit(arguments: args)
+        let mergeResult = try await Subprocess.run(
+            .path(FilePath(args[0])),
+            arguments: Subprocess.Arguments(Array(args.dropFirst())),
+            output: .discarded
+        )
+        guard mergeResult.terminationStatus.isSuccess else {
+            throw StringError("Unable to merge code coverage data")
+        }
     }
 
     /// Exports profdata as a JSON file.
@@ -728,13 +740,19 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         ] + archArgs + [
             testBinary.pathString,
         ]
-        let result = try await AsyncProcess.popen(arguments: args)
+        let result = try await Subprocess.run(
+            .path(FilePath(args[0])),
+            arguments: Subprocess.Arguments(Array(args.dropFirst())),
+            output: .bytes(limit: .max),
+            error: .string(limit: .max)
+        )
 
-        if result.exitStatus != .terminated(code: 0) {
-            let output = try result.utf8Output() + result.utf8stderrOutput()
-            throw StringError("Unable to export code coverage:\n \(output)")
+        if !result.terminationStatus.isSuccess {
+            let stdout = String(decoding: result.standardOutput, as: UTF8.self)
+            let stderr = result.standardError ?? ""
+            throw StringError("Unable to export code coverage:\n \(stdout + stderr)")
         }
-        try swiftCommandState.fileSystem.writeFileContents(path, bytes: ByteString(result.output.get()))
+        try swiftCommandState.fileSystem.writeFileContents(path, bytes: ByteString(result.standardOutput))
     }
 
     /// Builds the "test" target if enabled in options.
@@ -920,7 +938,7 @@ extension SwiftTestCommand {
                     )
 
                     // Finally, run the tests.
-                    let result = runner.test(outputHandler: {
+                    let result = await runner.test(outputHandler: {
                         // command's result output goes on stdout
                         // ie "swift test" should output to stdout
                         print($0, terminator: "")
@@ -994,7 +1012,7 @@ final class TestRunner {
     // The toolchain to use.
     private let toolchain: UserToolchain
 
-    private let testEnv: Environment
+    private let testEnv: Basics.Environment
 
     /// ObservabilityScope  to emit diagnostics.
     private let observabilityScope: ObservabilityScope
@@ -1028,7 +1046,7 @@ final class TestRunner {
         additionalArguments: [String],
         cancellator: Cancellator,
         toolchain: UserToolchain,
-        testEnv: Environment,
+        testEnv: Basics.Environment,
         observabilityScope: ObservabilityScope,
         library: TestingLibrary
     ) {
@@ -1057,12 +1075,12 @@ final class TestRunner {
 
     /// Executes and returns execution status. Prints test output on standard streams if requested
     /// - Returns: Result of spawning and running the test process, and the output stream result
-    func test(outputHandler: @escaping @Sendable (String) -> Void) -> Result {
-        testPerProduct(outputHandler: outputHandler).map(\.result).reduce()
+    func test(outputHandler: @escaping @Sendable (String) -> Void) async -> Result {
+        await testPerProduct(outputHandler: outputHandler).map(\.result).reduce()
     }
 
     /// Executes and returns per-product results.
-    func testPerProduct(outputHandler: @escaping @Sendable (String) -> Void) -> [SwiftTestCommand.TestProductResult] {
+    func testPerProduct(outputHandler: @escaping @Sendable (String) -> Void) async -> [SwiftTestCommand.TestProductResult] {
         var results: [SwiftTestCommand.TestProductResult] = []
         for product in testProducts {
             let path: AbsolutePath
@@ -1072,7 +1090,7 @@ final class TestRunner {
             case .swiftTesting:
                 path = product.binaryPath
             }
-            results.append(.init(productName: product.productName, library: library, result: self.test(at: path, outputHandler: outputHandler)))
+            await results.append(.init(productName: product.productName, library: library, result: self.test(at: path, outputHandler: outputHandler)))
         }
         return results
     }
@@ -1115,34 +1133,38 @@ final class TestRunner {
         return args
     }
 
-    private func test(at path: AbsolutePath, outputHandler: @escaping @Sendable (String) -> Void) -> Result {
+    private func test(at path: AbsolutePath, outputHandler: @escaping @Sendable (String) -> Void) async -> Result {
         let testObservabilityScope = self.observabilityScope.makeChildScope(description: "running test at \(path)")
 
         do {
-            let outputHandler: @Sendable ([UInt8]) -> Void = { (bytes: [UInt8]) in
-                if let output = String(bytes: bytes, encoding: .utf8) {
-                    outputHandler(output)
+            let arguments = try args(forTestAt: path)
+            let subprocessEnv = Subprocess.Environment.custom(
+                Dictionary(uniqueKeysWithValues: self.testEnv.map {
+                    (Subprocess.Environment.Key(rawValue: $0.key.rawValue)!, $0.value)
+                })
+            )
+            let outcome = try await self.cancellator.withCancellable(name: arguments.joined(separator: " ")) {
+                try await Subprocess.run(
+                    .path(FilePath(arguments[0])),
+                    arguments: Subprocess.Arguments(Array(arguments.dropFirst())),
+                    environment: subprocessEnv,
+                    error: .combinedWithOutput,
+                    preferredBufferSize: 128,
+                ) { _, outputSequence in
+                    for try await buffer in outputSequence {
+                        buffer.withUnsafeBytes { ptr in
+                            outputHandler(String(decoding: ptr, as: UTF8.self))
+                        }
+                    }
                 }
             }
-            let outputRedirection = AsyncProcess.OutputRedirection.stream(
-                stdout: outputHandler,
-                stderr: outputHandler
-            )
-            let arguments = try args(forTestAt: path)
-            let process = AsyncProcess(arguments: arguments, environment: self.testEnv, outputRedirection: outputRedirection)
-            guard let terminationKey = self.cancellator.register(process) else {
-                return .failure // terminating
-            }
-            defer { self.cancellator.deregister(terminationKey) }
-            try process.launch()
-            let result = try process.waitUntilExit()
-            switch result.exitStatus {
-            case .terminated(code: 0):
+            switch outcome.terminationStatus {
+            case .exited(0):
                 return .success
-            case .terminated(code: EXIT_NO_TESTS_FOUND) where library == .swiftTesting:
+            case .exited(TerminationStatus.Code(EXIT_NO_TESTS_FOUND)) where library == .swiftTesting:
                 return .noMatchingTests
             #if !os(Windows)
-            case .signalled(let signal) where ![SIGINT, SIGKILL, SIGTERM].contains(signal):
+            case .signaled(let signal) where ![SIGINT, SIGKILL, SIGTERM].contains(signal):
                 testObservabilityScope.emit(error: "Process '\(arguments.joined(separator: " "))' exited with unexpected signal code \(signal)")
                 return .failure
             #endif
@@ -1312,7 +1334,14 @@ final class ParallelTestRunner {
                     )
                     let output = ThreadSafeBox<String>("")
                     let start = DispatchTime.now()
-                    let result = testRunner.test(outputHandler: { _output in output.append(_output) })
+                    let resultBox = ThreadSafeBox<TestRunner.Result>(.failure)
+                    let semaphore = DispatchSemaphore(value: 0)
+                    Task {
+                        resultBox.put(await testRunner.test(outputHandler: { _output in output.append(_output) }))
+                        semaphore.signal()
+                    }
+                    semaphore.wait()
+                    let result = resultBox.get()
                     let duration = start.distance(to: .now())
                     if result == .failure {
                         self.ranSuccessfully = false

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -34,7 +34,12 @@ import TSCUtility
 import func TSCLibc.exit
 import Workspace
 
-import class Basics.AsyncProcess
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 import struct TSCBasic.ByteString
 import struct TSCBasic.FileSystemError
 import enum TSCBasic.JSON
@@ -778,7 +783,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         )
 
         // Run the tests and collect per-product results.
-        return runner.testPerProduct(outputHandler: {
+        return await runner.testPerProduct(outputHandler: {
             // command's result output goes on stdout
             // ie "swift test" should output to stdout
             print($0, terminator: "")
@@ -868,7 +873,14 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
         }
         args += ["-o", try await buildSystem.codeCovDataFile(for: productsBuildParameters).pathString]
-        try await AsyncProcess.checkNonZeroExit(arguments: args)
+        let mergeResult = try await Subprocess.run(
+            .path(FilePath(args[0])),
+            arguments: Subprocess.Arguments(Array(args.dropFirst())),
+            output: .discarded
+        )
+        guard mergeResult.terminationStatus.isSuccess else {
+            throw StringError("Unable to merge code coverage data")
+        }
     }
 
     /// Exports profdata as a JSON file.
@@ -893,13 +905,19 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         ] + archArgs + [
             testBinary.pathString,
         ]
-        let result = try await AsyncProcess.popen(arguments: args)
+        let result = try await Subprocess.run(
+            .path(FilePath(args[0])),
+            arguments: Subprocess.Arguments(Array(args.dropFirst())),
+            output: .bytes(limit: .max),
+            error: .string(limit: .max)
+        )
 
-        if result.exitStatus != .terminated(code: 0) {
-            let output = try result.utf8Output() + result.utf8stderrOutput()
-            throw StringError("Unable to export code coverage:\n \(output)")
+        if !result.terminationStatus.isSuccess {
+            let stdout = String(decoding: result.standardOutput, as: UTF8.self)
+            let stderr = result.standardError ?? ""
+            throw StringError("Unable to export code coverage:\n \(stdout + stderr)")
         }
-        try swiftCommandState.fileSystem.writeFileContents(path, bytes: ByteString(result.output.get()))
+        try swiftCommandState.fileSystem.writeFileContents(path, bytes: ByteString(result.standardOutput))
     }
 
     /// Builds the "test" target if enabled in options.
@@ -1135,7 +1153,7 @@ extension SwiftTestCommand {
                     )
 
                     // Finally, run the tests.
-                    let result = runner.test(outputHandler: {
+                    let result = await runner.test(outputHandler: {
                         // command's result output goes on stdout
                         // ie "swift test" should output to stdout
                         print($0, terminator: "")
@@ -1209,7 +1227,7 @@ final class TestRunner {
     // The toolchain to use.
     private let toolchain: UserToolchain
 
-    private let testEnv: Environment
+    private let testEnv: Basics.Environment
 
     /// The `ObservabilityScope`  to emit diagnostics.
     private let observabilityScope: ObservabilityScope
@@ -1243,7 +1261,7 @@ final class TestRunner {
         additionalArguments: [String],
         cancellator: Cancellator,
         toolchain: UserToolchain,
-        testEnv: Environment,
+        testEnv: Basics.Environment,
         observabilityScope: ObservabilityScope,
         library: TestingLibrary
     ) {
@@ -1272,12 +1290,12 @@ final class TestRunner {
 
     /// Executes and returns the execution status. Prints the test output on standard streams if requested.
     /// - Returns: Result of spawning and running the test process, and the output stream result.
-    func test(outputHandler: @escaping @Sendable (String) -> Void) -> Result {
-        testPerProduct(outputHandler: outputHandler).map(\.result).reduce()
+    func test(outputHandler: @escaping @Sendable (String) -> Void) async -> Result {
+        await testPerProduct(outputHandler: outputHandler).map(\.result).reduce()
     }
 
     /// Executes and returns per-product results.
-    func testPerProduct(outputHandler: @escaping @Sendable (String) -> Void) -> [SwiftTestCommand.TestProductResult] {
+    func testPerProduct(outputHandler: @escaping @Sendable (String) -> Void) async -> [SwiftTestCommand.TestProductResult] {
         var results: [SwiftTestCommand.TestProductResult] = []
         for product in testProducts {
             let path: AbsolutePath
@@ -1287,7 +1305,7 @@ final class TestRunner {
             case .swiftTesting:
                 path = product.binaryPath
             }
-            results.append(.init(productName: product.productName, library: library, result: self.test(at: path, outputHandler: outputHandler)))
+            await results.append(.init(productName: product.productName, library: library, result: self.test(at: path, outputHandler: outputHandler)))
         }
         return results
     }
@@ -1330,34 +1348,39 @@ final class TestRunner {
         return args
     }
 
-    private func test(at path: AbsolutePath, outputHandler: @escaping @Sendable (String) -> Void) -> Result {
+    private func test(at path: AbsolutePath, outputHandler: @escaping @Sendable (String) -> Void) async -> Result {
         let testObservabilityScope = self.observabilityScope.makeChildScope(description: "running test at \(path)")
 
         do {
-            let outputHandler: @Sendable ([UInt8]) -> Void = { (bytes: [UInt8]) in
-                if let output = String(bytes: bytes, encoding: .utf8) {
-                    outputHandler(output)
+            let arguments = try args(forTestAt: path)
+            let subprocessEnv = Subprocess.Environment.custom(
+                Dictionary(uniqueKeysWithValues: self.testEnv.map {
+                    (Subprocess.Environment.Key(rawValue: $0.key.rawValue)!, $0.value)
+                })
+            )
+            let outcome = try await self.cancellator.withCancellable(name: arguments.joined(separator: " ")) {
+                try await Subprocess.run(
+                    .path(FilePath(arguments[0])),
+                    arguments: Subprocess.Arguments(Array(arguments.dropFirst())),
+                    environment: subprocessEnv,
+                    input: .none,
+                    output: .sequence,
+                    error: .combinedWithOutput
+                ) { execution in
+                    for try await buffer in execution.standardOutput {
+                        buffer.withUnsafeBytes { ptr in
+                            outputHandler(String(decoding: ptr, as: UTF8.self))
+                        }
+                    }
                 }
             }
-            let outputRedirection = AsyncProcess.OutputRedirection.stream(
-                stdout: outputHandler,
-                stderr: outputHandler
-            )
-            let arguments = try args(forTestAt: path)
-            let process = AsyncProcess(arguments: arguments, environment: self.testEnv, outputRedirection: outputRedirection)
-            guard let terminationKey = self.cancellator.register(process) else {
-                return .failure // terminating
-            }
-            defer { self.cancellator.deregister(terminationKey) }
-            try process.launch()
-            let result = try process.waitUntilExit()
-            switch result.exitStatus {
-            case .terminated(code: 0):
+            switch outcome.terminationStatus {
+            case .exited(0):
                 return .success
-            case .terminated(code: EXIT_NO_TESTS_FOUND) where library == .swiftTesting:
+            case .exited(TerminationStatus.Code(EXIT_NO_TESTS_FOUND)) where library == .swiftTesting:
                 return .noMatchingTests
             #if !os(Windows)
-            case .signalled(let signal) where ![SIGINT, SIGKILL, SIGTERM].contains(signal):
+            case .signaled(let signal) where ![SIGINT, SIGKILL, SIGTERM].contains(signal):
                 testObservabilityScope.emit(error: "Process '\(arguments.joined(separator: " "))' exited with unexpected signal code \(signal)")
                 return .failure
             #endif
@@ -1532,7 +1555,14 @@ final class ParallelTestRunner {
                     )
                     let output = ThreadSafeBox<String>("")
                     let start = DispatchTime.now()
-                    let result = testRunner.test(outputHandler: { _output in output.append(_output) })
+                    let resultBox = ThreadSafeBox<TestRunner.Result>(.failure)
+                    let semaphore = DispatchSemaphore(value: 0)
+                    Task {
+                        resultBox.put(await testRunner.test(outputHandler: { _output in output.append(_output) }))
+                        semaphore.signal()
+                    }
+                    semaphore.wait()
+                    let result = resultBox.get()
                     let duration = start.distance(to: .now())
                     if result == .failure {
                         self.ranSuccessfully = false

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -291,7 +291,7 @@ final class PluginDelegate: PluginInvocationDelegate {
 
                         // Run the test — for now we run the sequentially so we can capture accurate timing results.
                         let startTime = DispatchTime.now()
-                        let result = testRunner.test(outputHandler: { _ in }) // this drops the tests output
+                        let result = await testRunner.test(outputHandler: { _ in }) // this drops the tests output
                         let duration = Double(startTime.distance(to: .now()).milliseconds() ?? 0) / 1000.0
                         numFailedTests += (result != .failure) ? 0 : 1
                         testResults.append(

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -20,8 +20,13 @@ import PackageGraph
 
 import protocol TSCBasic.OutputByteStream
 import class TSCBasic.BufferedOutputByteStream
-import class Basics.AsyncProcess
 import struct Basics.AsyncProcessResult
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 final class PluginDelegate: PluginInvocationDelegate {
     let swiftCommandState: SwiftCommandState
@@ -283,7 +288,7 @@ final class PluginDelegate: PluginInvocationDelegate {
 
                         // Run the test — for now we run the sequentially so we can capture accurate timing results.
                         let startTime = DispatchTime.now()
-                        let result = testRunner.test(outputHandler: { _ in }) // this drops the tests output
+                        let result = await testRunner.test(outputHandler: { _ in }) // this drops the tests output
                         let duration = Double(startTime.distance(to: .now()).milliseconds() ?? 0) / 1000.0
                         numFailedTests += (result != .failure) ? 0 : 1
                         testResults.append(
@@ -330,7 +335,14 @@ final class PluginDelegate: PluginInvocationDelegate {
                 llvmProfCommand.append(filePath.pathString)
             }
             llvmProfCommand += ["-o", mergedCovFile.pathString]
-            try await AsyncProcess.checkNonZeroExit(arguments: llvmProfCommand)
+            let mergeResult = try await Subprocess.run(
+                .path(FilePath(llvmProfCommand[0])),
+                arguments: Subprocess.Arguments(Array(llvmProfCommand.dropFirst())),
+                output: .discarded
+            )
+            guard mergeResult.terminationStatus.isSuccess else {
+                throw StringError("failed to merge code coverage data")
+            }
 
             // Use `llvm-cov` to export the merged `.profdata` file contents in JSON form.
             var llvmCovCommand = [try toolchain.getLLVMCov().pathString]
@@ -340,7 +352,18 @@ final class PluginDelegate: PluginInvocationDelegate {
                 llvmCovCommand.append(product.binaryPath.pathString)
             }
             // We get the output on stdout, and have to write it to a JSON ourselves.
-            let jsonOutput = try await AsyncProcess.checkNonZeroExit(arguments: llvmCovCommand)
+            let covResult = try await Subprocess.run(
+                .path(FilePath(llvmCovCommand[0])),
+                arguments: Subprocess.Arguments(Array(llvmCovCommand.dropFirst())),
+                output: .string(limit: .max),
+                error: .string(limit: .max)
+            )
+            guard covResult.terminationStatus.isSuccess else {
+                throw StringError(
+                    "failed to export code coverage: \((covResult.standardOutput ?? "") + (covResult.standardError ?? ""))"
+                )
+            }
+            let jsonOutput = covResult.standardOutput ?? ""
             let jsonCovFile = mergedCovFile.parentDirectory.appending(
                 component: mergedCovFile.basenameWithoutExt + ".json"
             )

--- a/Sources/_InternalTestSupport/MockArchiver.swift
+++ b/Sources/_InternalTestSupport/MockArchiver.swift
@@ -75,18 +75,18 @@ package final class MockArchiver: Archiver {
 
     package func extract(
         from archivePath: AbsolutePath,
-        to destinationPath: AbsolutePath,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
-        do {
-            if let handler = self.extractionHandler {
-                try handler(self, archivePath, destinationPath, completion)
-            } else {
-                self.extractions.append(Extraction(archivePath: archivePath, destinationPath: destinationPath))
-                completion(.success(()))
+        to destinationPath: AbsolutePath
+    ) async throws {
+        if let handler = self.extractionHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                do {
+                    try handler(self, archivePath, destinationPath, { continuation.resume(with: $0) })
+                } catch {
+                    continuation.resume(throwing: error)
+                }
             }
-        } catch {
-            completion(.failure(error))
+        } else {
+            self.extractions.append(Extraction(archivePath: archivePath, destinationPath: destinationPath))
         }
     }
 
@@ -109,15 +109,17 @@ package final class MockArchiver: Archiver {
         self.compressions.append(Compression(paths: paths, parent: parent, destinationPath: destinationPath))
     }
 
-    package func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {
-        do {
-            if let handler = self.validationHandler {
-                try handler(self, path, completion)
-            } else {
-                completion(.success(true))
+    package func validate(path: AbsolutePath) async throws -> Bool {
+        if let handler = self.validationHandler {
+            return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, Error>) in
+                do {
+                    try handler(self, path, { continuation.resume(with: $0) })
+                } catch {
+                    continuation.resume(throwing: error)
+                }
             }
-        } catch {
-            completion(.failure(error))
+        } else {
+            return true
         }
     }
 }

--- a/Sources/_InternalTestSupport/MockRegistry.swift
+++ b/Sources/_InternalTestSupport/MockRegistry.swift
@@ -400,29 +400,23 @@ private struct MockRegistryArchiver: Archiver {
 
     func extract(
         from archivePath: AbsolutePath,
-        to destinationPath: AbsolutePath,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
-        do {
-            let lines = try self.readFileContents(archivePath)
-            guard lines.count >= 2 else {
-                throw StringError("invalid mock zip format, not enough lines")
+        to destinationPath: AbsolutePath
+    ) async throws {
+        let lines = try self.readFileContents(archivePath)
+        guard lines.count >= 2 else {
+            throw StringError("invalid mock zip format, not enough lines")
+        }
+        let rootPath = lines[1]
+        for path in lines[2 ..< lines.count] {
+            let relativePath = String(path.dropFirst(rootPath.count + 1))
+            let targetPath = try AbsolutePath(
+                validating: relativePath,
+                relativeTo: destinationPath.appending("package")
+            )
+            if !self.fileSystem.exists(targetPath.parentDirectory) {
+                try self.fileSystem.createDirectory(targetPath.parentDirectory, recursive: true)
             }
-            let rootPath = lines[1]
-            for path in lines[2 ..< lines.count] {
-                let relativePath = String(path.dropFirst(rootPath.count + 1))
-                let targetPath = try AbsolutePath(
-                    validating: relativePath,
-                    relativeTo: destinationPath.appending("package")
-                )
-                if !self.fileSystem.exists(targetPath.parentDirectory) {
-                    try self.fileSystem.createDirectory(targetPath.parentDirectory, recursive: true)
-                }
-                try self.fileSystem.copy(from: try AbsolutePath(validating: path), to: targetPath)
-            }
-            completion(.success(()))
-        } catch {
-            completion(.failure(error))
+            try self.fileSystem.copy(from: try AbsolutePath(validating: path), to: targetPath)
         }
     }
 
@@ -437,13 +431,9 @@ private struct MockRegistryArchiver: Archiver {
         fatalError("not implemented")
     }
 
-    func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {
-        do {
-            let lines = try self.readFileContents(path)
-            completion(.success(lines.count >= 2))
-        } catch {
-            completion(.failure(error))
-        }
+    func validate(path: AbsolutePath) async throws -> Bool {
+        let lines = try self.readFileContents(path)
+        return lines.count >= 2
     }
 
     private func readFileContents(_ path: AbsolutePath) throws -> [String] {

--- a/Sources/_InternalTestSupport/SwiftPMProduct.swift
+++ b/Sources/_InternalTestSupport/SwiftPMProduct.swift
@@ -12,11 +12,18 @@
 
 import Basics
 import Foundation
-
-import class Basics.AsyncProcess
-import struct Basics.AsyncProcessResult
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 import enum TSCBasic.ProcessEnv
+
+package struct NonZeroExitError: Error {
+    package let terminationStatus: TerminationStatus
+}
 
 // Fan out from invocation of SPM 'swift-*' commands can be quite large.  Limit the number of concurrent tasks to a fraction of total CPUs.
 private let swiftPMExecutionQueue = AsyncOperationQueue(concurrentTasks: Int(Double(ProcessInfo.processInfo.activeProcessorCount) * 0.5))
@@ -82,7 +89,7 @@ extension SwiftPM {
     public func execute(
         _ args: [String] = [],
         packagePath: AbsolutePath? = nil,
-        env: Environment? = nil,
+        env: Basics.Environment? = nil,
         throwIfCommandFails: Bool = true
     ) async throws -> (stdout: String, stderr: String) {
         // Swift Testing uses Swift concurrency for test execution and creates a task for each test to run in parallel.
@@ -98,17 +105,17 @@ extension SwiftPM {
                 env: env
             )
             // Remove /r from stdout/stderr so that tests do not have to deal with them
-            let stdout = try String(decoding: result.output.get().filter { $0 != 13 }, as: Unicode.UTF8.self)
-            let stderr = try String(decoding: result.stderrOutput.get().filter { $0 != 13 }, as: Unicode.UTF8.self)
+            let stdout = String(decoding: result.stdout.filter { $0 != 13 }, as: Unicode.UTF8.self)
+            let stderr = String(decoding: result.stderr.filter { $0 != 13 }, as: Unicode.UTF8.self)
 
             let returnValue = (stdout: stdout, stderr: stderr)
             if !throwIfCommandFails { return returnValue }
 
-            if result.exitStatus == .terminated(code: 0) {
+            if result.terminationStatus.isSuccess {
                 return returnValue
             }
             throw SwiftPMError.executionFailure(
-                underlying: AsyncProcessResult.Error.nonZeroExit(result),
+                underlying: NonZeroExitError(terminationStatus: result.terminationStatus),
                 stdout: stdout,
                 stderr: stderr
             )
@@ -118,9 +125,9 @@ extension SwiftPM {
     private func executeProcess(
         _ args: [String],
         packagePath: AbsolutePath? = nil,
-        env: Environment? = nil
-    ) async throws -> AsyncProcessResult {
-        var environment = Environment.current
+        env: Basics.Environment? = nil
+    ) async throws -> (stdout: [UInt8], stderr: [UInt8], terminationStatus: TerminationStatus) {
+        var environment = Basics.Environment.current
 #if !os(Windows)
         environment["SDKROOT"] = nil
 #endif
@@ -149,7 +156,22 @@ extension SwiftPM {
         }
         completeArgs += args
 
-        return try await AsyncProcess.popen(arguments: completeArgs, environment: environment)
+        let result = try await Subprocess.run(
+            .path(FilePath(completeArgs[0])),
+            arguments: Subprocess.Arguments(Array(completeArgs.dropFirst())),
+            environment: Subprocess.Environment.custom(
+                Dictionary(uniqueKeysWithValues: environment.map {
+                    (Subprocess.Environment.Key(rawValue: $0.key.rawValue)!, $0.value)
+                })
+            ),
+            output: .bytes(limit: .max),
+            error: .bytes(limit: .max)
+        )
+        return (
+            stdout: result.standardOutput,
+            stderr: result.standardError,
+            terminationStatus: result.terminationStatus
+        )
     }
 }
 

--- a/Sources/_InternalTestSupport/SwiftPMProduct.swift
+++ b/Sources/_InternalTestSupport/SwiftPMProduct.swift
@@ -12,11 +12,18 @@
 
 import Basics
 import Foundation
-
-import class Basics.AsyncProcess
-import struct Basics.AsyncProcessResult
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 import enum TSCBasic.ProcessEnv
+
+package struct NonZeroExitError: Error {
+    package let terminationStatus: TerminationStatus
+}
 
 // Fan out from invocation of SPM 'swift-*' commands can be quite large.  Limit the number of concurrent tasks to a fraction of total CPUs.
 private let swiftPMExecutionQueue = AsyncOperationQueue(concurrentTasks: Int(Double(ProcessInfo.processInfo.activeProcessorCount) * 0.5))
@@ -82,7 +89,7 @@ extension SwiftPM {
     public func execute(
         _ args: [String] = [],
         packagePath: AbsolutePath? = nil,
-        env: Environment? = nil,
+        env: Basics.Environment? = nil,
         throwIfCommandFails: Bool = true,
         commandPrefix: [String] = [],
     ) async throws -> (stdout: String, stderr: String) {
@@ -100,17 +107,17 @@ extension SwiftPM {
                 commandPrefix: commandPrefix,
             )
             // Remove /r from stdout/stderr so that tests do not have to deal with them
-            let stdout = try String(decoding: result.output.get().filter { $0 != 13 }, as: Unicode.UTF8.self)
-            let stderr = try String(decoding: result.stderrOutput.get().filter { $0 != 13 }, as: Unicode.UTF8.self)
+            let stdout = String(decoding: result.stdout.filter { $0 != 13 }, as: Unicode.UTF8.self)
+            let stderr = String(decoding: result.stderr.filter { $0 != 13 }, as: Unicode.UTF8.self)
 
             let returnValue = (stdout: stdout, stderr: stderr)
             if !throwIfCommandFails { return returnValue }
 
-            if result.exitStatus == .terminated(code: 0) {
+            if result.terminationStatus.isSuccess {
                 return returnValue
             }
             throw SwiftPMError.executionFailure(
-                underlying: AsyncProcessResult.Error.nonZeroExit(result),
+                underlying: NonZeroExitError(terminationStatus: result.terminationStatus),
                 stdout: stdout,
                 stderr: stderr
             )
@@ -120,10 +127,10 @@ extension SwiftPM {
     private func executeProcess(
         _ args: [String],
         packagePath: AbsolutePath? = nil,
-        env: Environment? = nil,
+        env: Basics.Environment? = nil,
         commandPrefix: [String],
-    ) async throws -> AsyncProcessResult {
-        var environment = Environment.current
+    ) async throws -> (stdout: [UInt8], stderr: [UInt8], terminationStatus: TerminationStatus) {
+        var environment = Basics.Environment.current
 #if !os(Windows)
         environment["SDKROOT"] = nil
 #endif
@@ -152,7 +159,22 @@ extension SwiftPM {
         }
         completeArgs += args
 
-        return try await AsyncProcess.popen(arguments: completeArgs, environment: environment)
+        let result = try await Subprocess.run(
+            .path(FilePath(completeArgs[0])),
+            arguments: Subprocess.Arguments(Array(completeArgs.dropFirst())),
+            environment: Subprocess.Environment.custom(
+                Dictionary(uniqueKeysWithValues: environment.map {
+                    (Subprocess.Environment.Key(rawValue: $0.key.rawValue)!, $0.value)
+                })
+            ),
+            output: .bytes(limit: .max),
+            error: .bytes(limit: .max)
+        )
+        return (
+            stdout: result.standardOutput,
+            stderr: result.standardError,
+            terminationStatus: result.terminationStatus
+        )
     }
 }
 

--- a/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
@@ -12,6 +12,12 @@
 
 import Basics
 import Testing
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 
 fileprivate func fileErrorMessage(
@@ -248,10 +254,9 @@ private func _expectThrowsCommandExecutionError<R, T>(
 
     guard let error = err,
           case .executionFailure(let processError, let stdout, let stderr) = error,
-          case AsyncProcessResult.Error.nonZeroExit(let processResult) = processError,
-          processResult.exitStatus != .terminated(code: 0) else {
+          let nonZeroExitError = processError as? NonZeroExitError else {
         Issue.record("Unexpected error type: \(err?.interpolationDescription ?? "<unknown>")", sourceLocation: sourceLocation)
         return Optional<R>.none
     }
-    return try errorHandler(CommandExecutionError(result: processResult, stdout: stdout, stderr: stderr))
+    return try errorHandler(CommandExecutionError(terminationStatus: nonZeroExitError.terminationStatus, stdout: stdout, stderr: stderr))
 }

--- a/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
@@ -14,6 +14,12 @@ import Basics
 import Testing
 import Foundation
 import class TSCBasic.BufferedOutputByteStream
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 
 fileprivate func fileErrorMessage(
@@ -340,12 +346,11 @@ private func _expectThrowsCommandExecutionError<R, T>(
 
     guard let error = err,
           case .executionFailure(let processError, let stdout, let stderr) = error,
-          case AsyncProcessResult.Error.nonZeroExit(let processResult) = processError,
-          processResult.exitStatus != .terminated(code: 0) else {
+          let nonZeroExitError = processError as? NonZeroExitError else {
         Issue.record("Unexpected error type: \(err?.interpolationDescription ?? "<unknown>")", sourceLocation: sourceLocation)
         return Optional<R>.none
     }
-    return try errorHandler(CommandExecutionError(result: processResult, stdout: stdout, stderr: stderr))
+    return try errorHandler(CommandExecutionError(terminationStatus: nonZeroExitError.terminationStatus, stdout: stdout, stderr: stderr))
 }
 
 /// Checks if an output stream contains a specific string, with retry logic for asynchronous writes.

--- a/Sources/_InternalTestSupport/XCTAssertHelpers.swift
+++ b/Sources/_InternalTestSupport/XCTAssertHelpers.swift
@@ -22,6 +22,12 @@ import XCTest
 import Testing
 
 import struct Basics.AsyncProcessResult
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 
 import struct TSCUtility.Version
 
@@ -177,7 +183,7 @@ public func XCTAssertBuilds(
     Xcc: [String] = [],
     Xld: [String] = [],
     Xswiftc: [String] = [],
-    env: Environment? = nil,
+    env: Basics.Environment? = nil,
     file: StaticString = #file,
     line: UInt = #line,
     buildSystem: BuildSystemProvider.Kind,
@@ -208,7 +214,7 @@ public func XCTAssertSwiftTest(
     Xcc: [String] = [],
     Xld: [String] = [],
     Xswiftc: [String] = [],
-    env: Environment? = nil,
+    env: Basics.Environment? = nil,
     file: StaticString = #file,
     line: UInt = #line,
     buildSystem: BuildSystemProvider.Kind,
@@ -236,7 +242,7 @@ public func XCTAssertBuildFails(
     Xcc: [String] = [],
     Xld: [String] = [],
     Xswiftc: [String] = [],
-    env: Environment? = nil,
+    env: Basics.Environment? = nil,
     file: StaticString = #file,
     line: UInt = #line,
     buildSystem: BuildSystemProvider.Kind,
@@ -316,11 +322,10 @@ public func XCTAssertThrowsCommandExecutionError<T>(
     swiftTestingTestCalledAnXCTestAPI()
     await XCTAssertAsyncThrowsError(try await expression(), message(), file: file, line: line) { error in
         guard case SwiftPMError.executionFailure(let processError, let stdout, let stderr) = error,
-              case AsyncProcessResult.Error.nonZeroExit(let processResult) = processError,
-              processResult.exitStatus != .terminated(code: 0) else {
+              let nonZeroExitError = processError as? NonZeroExitError else {
             return XCTFail("Unexpected error type: \(error.interpolationDescription)", file: file, line: line)
         }
-        errorHandler(CommandExecutionError(result: processResult, stdout: stdout, stderr: stderr))
+        errorHandler(CommandExecutionError(terminationStatus: nonZeroExitError.terminationStatus, stdout: stdout, stderr: stderr))
     }
 }
 
@@ -356,13 +361,13 @@ public func XCTAsyncUnwrap<T>(
 
 
 public struct CommandExecutionError: Error {
-    package let result: AsyncProcessResult
+    public let terminationStatus: TerminationStatus
     public let stdout: String
     public let stderr: String
     public let consoleOutput: String
 
-    package init(result: AsyncProcessResult, stdout: String, stderr: String) {
-        self.result = result
+    package init(terminationStatus: TerminationStatus, stdout: String, stderr: String) {
+        self.terminationStatus = terminationStatus
         self.stdout = stdout
         self.stderr = stderr
         self.consoleOutput = stdout + stderr

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -34,7 +34,6 @@ import struct XCTest.XCTSkip
 
 import class TSCBasic.Process
 import struct TSCBasic.ByteString
-import struct Basics.AsyncProcessResult
 
 import enum TSCUtility.Git
 

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -21,8 +21,6 @@ import _InternalTestSupport
 import Workspace
 import Testing
 
-import class Basics.AsyncProcess
-
 @Suite(
     .serializedIfOnWindows,
     .tags(
@@ -146,9 +144,12 @@ struct CFamilyTargetTestCase {
                 )
             }
 
-            let errString = "\(error)"
             let missingIncludeDirStr = "\(ModuleError.invalidPublicHeadersDirectory("Cfactorial"))"
-            #expect(errString.contains(missingIncludeDirStr))
+            guard case SwiftPMError.executionFailure(_, let stdout, let stderr) = error else {
+                Issue.record("Unexpected error type: \(error)")
+                return
+            }
+            #expect((stdout + stderr).contains(missingIncludeDirStr))
         }
     }
 

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -21,8 +21,6 @@ import _InternalTestSupport
 import Workspace
 import Testing
 
-import class Basics.AsyncProcess
-
 @Suite(
     .serializedIfOnWindows,
     .tags(
@@ -158,9 +156,12 @@ struct CFamilyTargetTestCase {
                 )
             }
 
-            let errString = "\(error)"
             let missingIncludeDirStr = "\(ModuleError.invalidPublicHeadersDirectory("Cfactorial"))"
-            #expect(errString.contains(missingIncludeDirStr))
+            guard case SwiftPMError.executionFailure(_, let stdout, let stderr) = error else {
+                Issue.record("Unexpected error type: \(error)")
+                return
+            }
+            #expect((stdout + stderr).contains(missingIncludeDirStr))
         }
     }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -21,6 +21,12 @@ import Testing
 import Testing
 
 import class Basics.AsyncProcess
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 import struct SPMBuildCore.BuildSystemProvider
 import enum TSCUtility.Git
 
@@ -138,7 +144,7 @@ struct MiscellaneousTestCase {
             )
         ) { error in
             // if our code crashes we'll get an exit code of 256
-            guard error.result.exitStatus == .terminated(code: 1) else {
+            guard error.terminationStatus == .exited(1) else {
                 Issue.record("failed in an unexpected manner: \(error)")
                 return
             }
@@ -147,7 +153,6 @@ struct MiscellaneousTestCase {
 
     @Test(
         .tags(
-            .Feature.Command.Build,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
@@ -164,7 +169,7 @@ struct MiscellaneousTestCase {
                 )
             ) { error in
                 // if our code crashes we'll get an exit code of 256
-                guard error.result.exitStatus == .terminated(code: 1) else {
+                guard error.terminationStatus == .exited(1) else {
                     Issue.record("failed in an unexpected manner: \(error)")
                     return
                 }
@@ -488,7 +493,7 @@ struct MiscellaneousTestCase {
             )
 
             let moduleUser = fixturePath.appending("SystemModuleUserClang")
-            let env: Environment = ["PKG_CONFIG_PATH": fixturePath.pathString]
+            let env: Basics.Environment = ["PKG_CONFIG_PATH": fixturePath.pathString]
             let binPath = try moduleUser.appending(components: buildSystem.binPath(for: configuration))
             await withKnownIssue(isIntermittent: true) {
                 await #expect(throws: Never.self) {
@@ -819,7 +824,6 @@ struct MiscellaneousTestCase {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue {
         try await fixture(name: "Miscellaneous/TestableAsyncExe") { fixturePath in
             let (stdout, stderr) = try await executeSwiftTest(
                 fixturePath,
@@ -845,10 +849,6 @@ struct MiscellaneousTestCase {
             #expect(stdout.contains("Hello, async planet"), "stderr: \(stderr)")
             #expect(stdout.contains("Hello, async galaxy"), "stderr: \(stderr)")
             #expect(stdout.contains("Hello, async universe"), "stderr: \(stderr)")
-        }
-        } when: {
-            // error: FileSystemError(kind: TSCBasic.FileSystemError.Kind.noEntry, path: Optional(<AbsolutePath:"C:\Users\ContainerAdministrator\AppData\Local\Temp\Miscellaneous_TestableAsyncExe.74Koc7\Miscellaneous_TestableAsyncExe\.build\out\Intermediates.noindex\TestableAsyncExe.build\Debug-windows\TestableAsyncExe4.build\Objects-normal\x86_64\TestableAsyncExe4.LinkFileList">))
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
 
@@ -900,7 +900,7 @@ struct MiscellaneousTestCase {
                 )
             ) { error in
                 // if our code crashes we'll get an exit code of 256
-                guard error.result.exitStatus == .terminated(code: 1) else {
+                guard error.terminationStatus == .exited(1) else {
                     Issue.record("failed in an unexpected manner: \(error)")
                     return
                 }
@@ -1331,7 +1331,7 @@ struct MiscellaneousSwiftTestingTests {
             )
 
             let moduleUser = fixturePath.appending("SystemModuleUserClang")
-            let env: Environment = ["PKG_CONFIG_PATH": fixturePath.pathString]
+            let env: Basics.Environment = ["PKG_CONFIG_PATH": fixturePath.pathString]
             _ = try await executeSwiftBuild(
                 moduleUser,
                 env: env,

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -21,6 +21,12 @@ import Testing
 import Testing
 
 import class Basics.AsyncProcess
+import Subprocess
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 import struct SPMBuildCore.BuildSystemProvider
 import enum TSCUtility.Git
 
@@ -142,7 +148,7 @@ struct MiscellaneousTestCase {
             )
         ) { error in
             // if our code crashes we'll get an exit code of 256
-            guard error.result.exitStatus == .terminated(code: 1) else {
+            guard error.terminationStatus == .exited(1) else {
                 Issue.record("failed in an unexpected manner: \(error)")
                 return
             }
@@ -151,7 +157,6 @@ struct MiscellaneousTestCase {
 
     @Test(
         .tags(
-            .Feature.Command.Build,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
@@ -168,7 +173,7 @@ struct MiscellaneousTestCase {
                 )
             ) { error in
                 // if our code crashes we'll get an exit code of 256
-                guard error.result.exitStatus == .terminated(code: 1) else {
+                guard error.terminationStatus == .exited(1) else {
                     Issue.record("failed in an unexpected manner: \(error)")
                     return
                 }
@@ -508,7 +513,7 @@ struct MiscellaneousTestCase {
             )
 
             let moduleUser = fixturePath.appending("SystemModuleUserClang")
-            let env: Environment = ["PKG_CONFIG_PATH": fixturePath.pathString]
+            let env: Basics.Environment = ["PKG_CONFIG_PATH": fixturePath.pathString]
             try await withKnownIssue(isIntermittent: true) {
                 await #expect(throws: Never.self) {
                     _ = try await executeSwiftBuild(
@@ -930,7 +935,7 @@ struct MiscellaneousTestCase {
                 )
             ) { error in
                 // if our code crashes we'll get an exit code of 256
-                guard error.result.exitStatus == .terminated(code: 1) else {
+                guard error.terminationStatus == .exited(1) else {
                     Issue.record("failed in an unexpected manner: \(error)")
                     return
                 }
@@ -1457,7 +1462,7 @@ struct MiscellaneousSwiftTestingTests {
             )
 
             let moduleUser = fixturePath.appending("SystemModuleUserClang")
-            let env: Environment = ["PKG_CONFIG_PATH": fixturePath.pathString]
+            let env: Basics.Environment = ["PKG_CONFIG_PATH": fixturePath.pathString]
             _ = try await executeSwiftBuild(
                 moduleUser,
                 env: env,

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -239,6 +239,7 @@ def parse_global_args(args):
     args.source_dirs["swift-driver"]          = os.path.join(args.project_root, "..", "swift-driver")
     args.source_dirs["swift-system"]          = os.path.join(args.project_root, "..", "swift-system")
     args.source_dirs["swift-collections"]     = os.path.join(args.project_root, "..", "swift-collections")
+    args.source_dirs["swift-subprocess"]      = os.path.join(args.project_root, "..", "swift-subprocess")
     args.source_dirs["swift-tools-protocols"] = os.path.join(args.project_root, "..", "swift-tools-protocols")
     args.source_dirs["swift-certificates"]    = os.path.join(args.project_root, "..", "swift-certificates")
     args.source_dirs["swift-asn1"]            = os.path.join(args.project_root, "..", "swift-asn1")
@@ -386,15 +387,15 @@ def build(args):
         # tsc depends on swift-system so they must be built first.
         build_dependency(args, "swift-system")
         # swift-driver depends on tsc and swift-argument-parser so they must be built first.
-        tsc_cmake_flags = [
+        swift_system_dep_flags = [
             "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
         ]
-        build_dependency(args, "tsc", tsc_cmake_flags)
+        build_dependency(args, "tsc", swift_system_dep_flags)
         build_dependency(args, "swift-argument-parser", ["-DBUILD_TESTING=NO", "-DBUILD_EXAMPLES=NO"])
 
-        swift_driver_cmake_flags = [
+        build_dependency(args, "swift-subprocess", swift_system_dep_flags)
+        swift_driver_cmake_flags = swift_system_dep_flags + [
             get_llbuild_cmake_arg(args),
-            "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
             "-DTSC_DIR=" + os.path.join(args.build_dirs["tsc"], "cmake/modules"),
             "-DArgumentParser_DIR=" + os.path.join(args.build_dirs["swift-argument-parser"], "cmake/modules"),
         ]
@@ -407,9 +408,9 @@ def build(args):
         build_dependency(args, "swift-certificates",
             ["-DSwiftASN1_DIR=" + os.path.join(args.build_dirs["swift-asn1"], "cmake/modules"),
              "-DSwiftCrypto_DIR=" + os.path.join(args.build_dirs["swift-crypto"], "cmake/modules")])
-        swift_build_cmake_flags = [
+        swift_build_cmake_flags = swift_system_dep_flags + [
             get_llbuild_cmake_arg(args),
-            "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
+            "-DSwiftSubprocess_DIR="  + os.path.join(args.build_dirs["swift-subprocess"], "cmake/modules"),
             "-DSwiftASN1_DIR=" + os.path.join(args.build_dirs["swift-asn1"], "cmake/modules"),
             "-DSwiftCrypto_DIR=" + os.path.join(args.build_dirs["swift-crypto"], "cmake/modules"),
             "-DTSC_DIR=" + os.path.join(args.build_dirs["tsc"], "cmake/modules"),
@@ -676,6 +677,7 @@ def build_swiftpm_with_cmake(args):
         "-DSwiftToolsProtocols_DIR=" + os.path.join(args.build_dirs["swift-tools-protocols"], "cmake/modules"),
         "-DSwiftDriver_DIR="         + os.path.join(args.build_dirs["swift-driver"],          "cmake/modules"),
         "-DSwiftSystem_DIR="         + os.path.join(args.build_dirs["swift-system"],          "cmake/modules"),
+        "-DSwiftSubprocess_DIR="     + os.path.join(args.build_dirs["swift-subprocess"],      "cmake/modules"),
         "-DSwiftCollections_DIR="    + os.path.join(args.build_dirs["swift-collections"],     "cmake/modules"),
         "-DSwiftCrypto_DIR="         + os.path.join(args.build_dirs["swift-crypto"],          "cmake/modules"),
         "-DSwiftASN1_DIR="           + os.path.join(args.build_dirs["swift-asn1"],            "cmake/modules"),
@@ -709,6 +711,7 @@ def build_swiftpm_with_cmake(args):
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-crypto"],          "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-driver"],          "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-system"],          "lib"))
+        add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-subprocess"],      "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-collections"],     "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-tools-protocols"], "lib"))
         add_rpath_for_cmake_build(args, os.path.join(args.build_dirs["swift-asn1"],            "lib"))
@@ -867,6 +870,7 @@ def get_swiftpm_env_cmd(args):
             os.path.join(args.build_dirs["swift-crypto"],          "lib"),
             os.path.join(args.build_dirs["swift-driver"],          "lib"),
             os.path.join(args.build_dirs["swift-system"],          "lib"),
+            os.path.join(args.build_dirs["swift-subprocess"],      "lib"),
             os.path.join(args.build_dirs["swift-collections"],     "lib"),
             os.path.join(args.build_dirs["swift-tools-protocols"], "lib"),
             os.path.join(args.build_dirs["swift-asn1"],            "lib"),

--- a/Utilities/bootstrap
+++ b/Utilities/bootstrap
@@ -239,6 +239,7 @@ def parse_global_args(args):
     args.source_dirs["swift-driver"]          = os.path.join(args.project_root, "..", "swift-driver")
     args.source_dirs["swift-system"]          = os.path.join(args.project_root, "..", "swift-system")
     args.source_dirs["swift-collections"]     = os.path.join(args.project_root, "..", "swift-collections")
+    args.source_dirs["swift-subprocess"]      = os.path.join(args.project_root, "..", "swift-subprocess")
     args.source_dirs["swift-tools-protocols"] = os.path.join(args.project_root, "..", "swift-tools-protocols")
     args.source_dirs["swift-certificates"]    = os.path.join(args.project_root, "..", "swift-certificates")
     args.source_dirs["swift-asn1"]            = os.path.join(args.project_root, "..", "swift-asn1")
@@ -386,15 +387,15 @@ def build(args):
         # tsc depends on swift-system so they must be built first.
         build_dependency(args, "swift-system")
         # swift-driver depends on tsc and swift-argument-parser so they must be built first.
-        tsc_cmake_flags = [
+        swift_system_dep_flags = [
             "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
         ]
-        build_dependency(args, "tsc", tsc_cmake_flags)
+        build_dependency(args, "tsc", swift_system_dep_flags)
         build_dependency(args, "swift-argument-parser", ["-DBUILD_TESTING=NO", "-DBUILD_EXAMPLES=NO"])
 
-        swift_driver_cmake_flags = [
+        build_dependency(args, "swift-subprocess", swift_system_dep_flags)
+        swift_driver_cmake_flags = swift_system_dep_flags + [
             get_llbuild_cmake_arg(args),
-            "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
             "-DTSC_DIR=" + os.path.join(args.build_dirs["tsc"], "cmake/modules"),
             "-DArgumentParser_DIR=" + os.path.join(args.build_dirs["swift-argument-parser"], "cmake/modules"),
         ]
@@ -407,9 +408,9 @@ def build(args):
         build_dependency(args, "swift-certificates",
             ["-DSwiftASN1_DIR=" + os.path.join(args.build_dirs["swift-asn1"], "cmake/modules"),
              "-DSwiftCrypto_DIR=" + os.path.join(args.build_dirs["swift-crypto"], "cmake/modules")])
-        swift_build_cmake_flags = [
+        swift_build_cmake_flags = swift_system_dep_flags + [
             get_llbuild_cmake_arg(args),
-            "-DSwiftSystem_DIR="    + os.path.join(args.build_dirs["swift-system"], "cmake/modules"),
+            "-DSwiftSubprocess_DIR="  + os.path.join(args.build_dirs["swift-subprocess"], "cmake/modules"),
             "-DSwiftASN1_DIR=" + os.path.join(args.build_dirs["swift-asn1"], "cmake/modules"),
             "-DSwiftCrypto_DIR=" + os.path.join(args.build_dirs["swift-crypto"], "cmake/modules"),
             "-DTSC_DIR=" + os.path.join(args.build_dirs["tsc"], "cmake/modules"),
@@ -676,6 +677,7 @@ def build_swiftpm_with_cmake(args):
         "-DSwiftToolsProtocols_DIR=" + os.path.join(args.build_dirs["swift-tools-protocols"], "cmake/modules"),
         "-DSwiftDriver_DIR="         + os.path.join(args.build_dirs["swift-driver"],          "cmake/modules"),
         "-DSwiftSystem_DIR="         + os.path.join(args.build_dirs["swift-system"],          "cmake/modules"),
+        "-DSwiftSubprocess_DIR="     + os.path.join(args.build_dirs["swift-subprocess"],      "cmake/modules"),
         "-DSwiftCollections_DIR="    + os.path.join(args.build_dirs["swift-collections"],     "cmake/modules"),
         "-DSwiftCrypto_DIR="         + os.path.join(args.build_dirs["swift-crypto"],          "cmake/modules"),
         "-DSwiftASN1_DIR="           + os.path.join(args.build_dirs["swift-asn1"],            "cmake/modules"),


### PR DESCRIPTION
Replace AsyncProcess with Subprocess.run() across BinarySymbols, Basics (ImportScanning, TarArchiver, ZipArchiver), Commands (Format, SwiftTestCommand), and test support (_InternalTestSupport).
