### PR TITLE
RegistryClient: Cap parallel downloads per host to avoid timeouts

### DIFF
--- a/Sources/Basics/HTTPClient/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient/HTTPClient.swift
@@ -37,6 +37,9 @@ public actor HTTPClient {
     /// An `async`-friendly semaphore to handle limits on the number of concurrent requests.
     private let tokenBucket: TokenBucket
 
+    /// Per-host token buckets. Enforces `configuration.maxConcurrentRequestsPerHost` when set.
+    private var perHostTokenBuckets: [String: TokenBucket] = [:]
+
     /// Array of `HostErrors` values, which is used for applying a circuit-breaking strategy.
     private var hostsErrors = [String: HostErrors]()
 
@@ -47,6 +50,28 @@ public actor HTTPClient {
         self.configuration = configuration
         self.implementation = implementation ?? URLSessionHTTPClient().execute
         self.tokenBucket = TokenBucket(tokens: configuration.maxConcurrentRequests ?? Concurrency.maxOperations)
+    }
+
+    private func perHostTokenBucket(for host: String, limit: Int) -> TokenBucket {
+        if let existing = self.perHostTokenBuckets[host] {
+            return existing
+        }
+        let bucket = TokenBucket(tokens: limit)
+        self.perHostTokenBuckets[host] = bucket
+        return bucket
+    }
+
+    private func withPerHostGate<T: Sendable>(
+        for url: URL,
+        body: @Sendable () async throws -> T
+    ) async throws -> T {
+        guard let limit = configuration.maxConcurrentRequestsPerHost,
+              let host = url.host?.lowercased()
+        else {
+            return try await body()
+        }
+        let bucket = self.perHostTokenBucket(for: host, limit: limit)
+        return try await bucket.withToken(body)
     }
 
     /// Execute an HTTP request asynchronously
@@ -123,19 +148,21 @@ public actor HTTPClient {
         }
 
         let task = Task {
-            let response = try await self.tokenBucket.withToken {
-                try Task.checkCancellation()
+            let response = try await self.withPerHostGate(for: request.url) {
+                try await self.tokenBucket.withToken {
+                    try Task.checkCancellation()
 
-                return try await self.implementation(request) { received, expected in
-                    if let max = request.options.maximumResponseSizeInBytes {
-                        guard received < max else {
-                            // It's a responsibility of the underlying client implementation to cancel the request
-                            // when this closure throws an error
-                            throw HTTPClientError.responseTooLarge(received)
+                    return try await self.implementation(request) { received, expected in
+                        if let max = request.options.maximumResponseSizeInBytes {
+                            guard received < max else {
+                                // It's a responsibility of the underlying client implementation to cancel the request
+                                // when this closure throws an error
+                                throw HTTPClientError.responseTooLarge(received)
+                            }
                         }
-                    }
 
-                    try progress?(received, expected)
+                        try progress?(received, expected)
+                    }
                 }
             }
 

--- a/Sources/Basics/HTTPClient/HTTPClientConfiguration.swift
+++ b/Sources/Basics/HTTPClient/HTTPClientConfiguration.swift
@@ -23,7 +23,8 @@ public struct HTTPClientConfiguration: Sendable {
         authorizationProvider: AuthorizationProvider? = nil,
         retryStrategy: HTTPClientRetryStrategy? = nil,
         circuitBreakerStrategy: HTTPClientCircuitBreakerStrategy? = nil,
-        maxConcurrentRequests: Int? = nil
+        maxConcurrentRequests: Int? = nil,
+        maxConcurrentRequestsPerHost: Int? = nil
     ) {
         self.requestHeaders = requestHeaders
         self.requestTimeout = requestTimeout
@@ -31,6 +32,7 @@ public struct HTTPClientConfiguration: Sendable {
         self.retryStrategy = retryStrategy
         self.circuitBreakerStrategy = circuitBreakerStrategy
         self.maxConcurrentRequests = maxConcurrentRequests
+        self.maxConcurrentRequestsPerHost = maxConcurrentRequestsPerHost
     }
 
     public var requestHeaders: HTTPClientHeaders?
@@ -40,6 +42,7 @@ public struct HTTPClientConfiguration: Sendable {
     public var retryStrategy: HTTPClientRetryStrategy?
     public var circuitBreakerStrategy: HTTPClientCircuitBreakerStrategy?
     public var maxConcurrentRequests: Int?
+    public var maxConcurrentRequestsPerHost: Int?
 }
 
 public enum HTTPClientRetryStrategy: Sendable {

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -37,6 +37,16 @@ public final class RegistryClient: AsyncCancellable {
     private static let availabilityCacheTTL: DispatchTimeInterval = .seconds(5 * 60)
     private static let metadataCacheTTL: DispatchTimeInterval = .seconds(60 * 60)
 
+    /// A value below Foundation's `httpMaximumConnectionsPerHost` default of 6. 
+    /// Without this limit the RegistryClient may fetch too many resources in parallel
+    /// from the same registry, which can lead to starvation of other requests due to
+    /// libcurl's pending queue. If pending requests don't start receiving bytes within
+    /// 60s requests will fail with a timeout (NSURLError -1001). By ensuring we're below
+    /// the Foundation default we ensure requests aren't started by blocked behind the 6
+    /// active connections, waiting for bytes and potentially timing out if the requests in
+    /// flight take a long time to complete.
+    private static let defaultMaxConcurrentRequestsPerHost: Int = 4
+
     private var configuration: RegistryConfiguration
     private let archiverProvider: (FileSystem) -> Archiver
     private let httpClient: HTTPClient
@@ -106,7 +116,9 @@ public final class RegistryClient: AsyncCancellable {
             self.authorizationProvider = .none
         }
 
-        self.httpClient = customHTTPClient ?? HTTPClient()
+        self.httpClient = customHTTPClient ?? HTTPClient(
+            configuration: .init(maxConcurrentRequestsPerHost: Self.defaultMaxConcurrentRequestsPerHost)
+        )
         self.archiverProvider = customArchiverProvider ?? { fileSystem in UniversalArchiver(fileSystem) }
         self.fingerprintStorage = fingerprintStorage
         self.fingerprintCheckingMode = fingerprintCheckingMode

--- a/Tests/BasicsTests/HTTPClientTests.swift
+++ b/Tests/BasicsTests/HTTPClientTests.swift
@@ -449,6 +449,141 @@ struct HTTPClientTests {
         }
     }
 
+    @Test
+    func maxConcurrentRequestsPerHostAndMaxConcurrentRequestsCompose() async throws {
+        let globalLimit = 3
+        let perHostLimit = 2
+        let globalCount = SendableBox(0)
+        let hostACount = SendableBox(0)
+        let hostBCount = SendableBox(0)
+
+        var configuration = HTTPClient.Configuration()
+        configuration.maxConcurrentRequests = globalLimit
+        configuration.maxConcurrentRequestsPerHost = perHostLimit
+        let httpClient = HTTPClient(configuration: configuration) { request, _ in
+            await globalCount.increment()
+            let hostCounter = request.url.host == "hosta" ? hostACount : hostBCount
+            await hostCounter.increment()
+            if await globalCount.value > globalLimit {
+                Issue.record("global concurrency exceeded: \(await globalCount.value) > \(globalLimit)")
+            }
+            if await hostCounter.value > perHostLimit {
+                Issue.record("per-host concurrency for \(request.url.host ?? "?") exceeded: \(await hostCounter.value) > \(perHostLimit)")
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+            await hostCounter.decrement()
+            await globalCount.decrement()
+            return .okay()
+        }
+
+        try await withThrowingTaskGroup(of: HTTPClient.Response.self) { group in
+            for _ in 0..<4 {
+                group.addTask { try await httpClient.get("http://hosta/test") }
+                group.addTask { try await httpClient.get("http://hostb/test") }
+            }
+            var results = [HTTPClient.Response]()
+            for try await result in group {
+                results.append(result)
+            }
+            #expect(results.count == 8)
+        }
+    }
+
+    @Test
+    func maxConcurrentRequestsPerHostNilByDefaultPreservesBehavior() async throws {
+        let maxConcurrentRequests = 4
+        let concurrentRequests = SendableBox(0)
+        let observedMax = SendableBox(0)
+
+        var configuration = HTTPClient.Configuration()
+        configuration.maxConcurrentRequests = maxConcurrentRequests
+        let httpClient = HTTPClient(configuration: configuration) { _, _ in
+            await concurrentRequests.increment()
+            let current = await concurrentRequests.value
+            let previousMax = await observedMax.value
+            if current > previousMax {
+                await observedMax.set(current)
+            }
+            if current > maxConcurrentRequests {
+                Issue.record("global concurrency exceeded: \(current) > \(maxConcurrentRequests)")
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+            await concurrentRequests.decrement()
+            return .okay()
+        }
+
+        try await withThrowingTaskGroup(of: HTTPClient.Response.self) { group in
+            for _ in 0..<20 {
+                group.addTask { try await httpClient.get("http://localhost/test") }
+            }
+            for try await _ in group {}
+        }
+        #expect(await observedMax.value == maxConcurrentRequests, "global gate should still allow up to \(maxConcurrentRequests) when per-host gate is nil")
+    }
+
+    @Test
+    func maxConcurrentRequestsPerHostBypassedForHostlessURL() async throws {
+        let concurrentRequests = SendableBox(0)
+        let observedMax = SendableBox(0)
+
+        var configuration = HTTPClient.Configuration()
+        configuration.maxConcurrentRequestsPerHost = 1
+        let httpClient = HTTPClient(configuration: configuration) { _, _ in
+            await concurrentRequests.increment()
+            let current = await concurrentRequests.value
+            let previousMax = await observedMax.value
+            if current > previousMax {
+                await observedMax.set(current)
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+            await concurrentRequests.decrement()
+            return .okay()
+        }
+
+        try await withThrowingTaskGroup(of: HTTPClient.Response.self) { group in
+            for _ in 0..<5 {
+                group.addTask { try await httpClient.get("file:///tmp/x") }
+            }
+            for try await _ in group {}
+        }
+        #expect(await observedMax.value > 1, "per-host gate should be bypassed when url has no host")
+    }
+
+    @Test
+    func maxConcurrentRequestsPerHost() async throws {
+        let maxConcurrentRequestsPerHost = 2
+        let hostACount = SendableBox(0)
+        let hostBCount = SendableBox(0)
+
+        var configuration = HTTPClient.Configuration()
+        configuration.maxConcurrentRequestsPerHost = maxConcurrentRequestsPerHost
+        let httpClient = HTTPClient(configuration: configuration) { request, _ in
+            let counter = request.url.host == "hosta" ? hostACount : hostBCount
+            await counter.increment()
+            if await counter.value > maxConcurrentRequestsPerHost {
+                Issue.record("too many concurrent requests for \(request.url.host ?? "?"): \(await counter.value), expected at most \(maxConcurrentRequestsPerHost)")
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+            await counter.decrement()
+            return .okay()
+        }
+
+        try await withThrowingTaskGroup(of: HTTPClient.Response.self) { group in
+            for _ in 0..<5 {
+                group.addTask { try await httpClient.get("http://hosta/test") }
+                group.addTask { try await httpClient.get("http://hostb/test") }
+            }
+            var results = [HTTPClient.Response]()
+            for try await result in group {
+                results.append(result)
+            }
+            #expect(results.count == 10)
+            for result in results {
+                #expect(result.statusCode == 200)
+            }
+        }
+    }
+
     private func expectRequestHeaders(_ headers: HTTPClientHeaders, expected: HTTPClientHeaders, sourceLocation: SourceLocation = #_sourceLocation) {
         let noAgent = HTTPClientHeaders(headers.filter { $0.name != "User-Agent" })
         #expect(noAgent == expected, sourceLocation: sourceLocation)


### PR DESCRIPTION
When doing a `package resolve` for a project with many registry dependencies some resolutions may sometimes fail with `NSURLError -1001` (timed out)

This was tracked down to queue starvation in Foundation's networking layer. SwiftPM dispatches up to `ProcessInfo.processInfo.activeProcessorCount` parallel package downloads, which on a beefy machine can be 12-16 cores. (Note: This cap can be overridden today with `SWIFTPM_MAX_CONCURRENT_OPERATIONS`)

Foundation's `URLSession` enforces `httpMaximumConnectionsPerHost = 6` via libcurl's `CURLMOPT_MAX_HOST_CONNECTIONS`. Any requests beyond the first 6 to the same host sit in libcurl's internal pending queue with their per-request 60s timeout timer already running. This timer is reset every time bytes are received. A queued request never receives bytes, so it expires before its connection ever opens. This typically manifests when there are some very large packages to download that take a long time. These large packages consume some of the 6 available slots, and that may leave only a few slots for smaller packages to resolve. Packages further down the list stay pending, not receiving bytes but whose timeouts are still counting down.

Add `maxConcurrentRequestsPerHost: Int?` to `HTTPClientConfiguration` and a per-host `TokenBucket` map in `HTTPClient`. The per-host gate is acquired *outside* the existing global gate based on `maxConcurrentRequests`, so lock order is consistent.

`RegistryClient` opts in with a default `maxConcurrentRequestsPerHost` value of 4. This is below Foundation's max of 6, leaving 2 connections for libcurl's keep-alive/DNS connection recycling to be safe. The per-host bucket prevents requests from being created at all, avoiding the contention and allowing all requests to start receiving bytes immediately.

Adds tests exercising per-host enforcement, composition with `maxConcurrentRequests`, no-op behavior when the per-host config is `nil`, and that the gate is bypassed for hostless URLs (e.g. file://).

Issue: #9922
