### PR TITLE
Fix `swift test --xunit-output=output.xml`

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -575,6 +575,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             while let arg = originalCommandLineArguments.next() {
                 if arg == "--xunit-output" {
                     _ = originalCommandLineArguments.next()
+                } else if arg.hasPrefix("--xunit-output=") {
+                    // Drop the combined form so it is not passed through in addition to SPM's `--xunit-output`.
                 } else {
                     commandLineArguments.append(arg)
                 }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -539,6 +539,66 @@ struct TestCommandTests {
         }
     }
 
+    /// Regression: `--xunit-output=PATH` must be stripped when forwarding argv to Swift Testing so only
+    /// SPM's suffixed path is passed; otherwise the helper receives duplicate `--xunit-output` flags and
+    /// overwrites the XCTest JUnit file. See discussion in swift-package-manager around combined forms.
+    @Test(
+        .tags(
+            .Feature.TargetType.Executable,
+            .Feature.CommandLineArguments.TestParallel,
+            .Feature.CommandLineArguments.TestOutputXunit,
+            .Feature.CommandLineArguments.TestEnableXCTest,
+            .Feature.CommandLineArguments.TestEnableSwiftTesting,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9960", relationship: .verifies),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9982", relationship: .defect),
+        arguments: SupportedBuildSystemOnAllPlatforms.filter { $0 != .xcode },
+    )
+    func swiftTestParallelXunitOutputCombinedEqualsForm(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await withKnownIssue(isIntermittent: true) {
+            try await fixture(name: "Miscellaneous/DefaultInteropMode") { fixturePath in
+                let xUnitOutput = fixturePath.appending("output.xml")
+                let swiftTestingXUnitOutput = fixturePath.appending("output-swift-testing.xml")
+                _ = try await execute(
+                    [
+                        "--parallel",
+                        "--enable-xctest",
+                        "--enable-swift-testing",
+                        "--xunit-output=\(xUnitOutput.pathString)",
+                    ],
+                    packagePath: fixturePath,
+                    configuration: configuration,
+                    buildSystem: buildSystem,
+                )
+
+                expectFileExists(at: xUnitOutput, "\(xUnitOutput) does not exist")
+                expectFileExists(at: swiftTestingXUnitOutput, "\(swiftTestingXUnitOutput) does not exist")
+
+                let xctestContents: String = try localFileSystem.readFileContents(xUnitOutput)
+                #expect(
+                    xctestContents.contains(#"<testsuite name="TestResults""#),
+                    "XCTest JUnit should be generated at the base path; got:\n\(xctestContents)",
+                )
+                #expect(
+                    xctestContents.contains(#"name="testInteropSetToComplete""#),
+                    "Expected XCTest case in base xUnit file; got:\n\(xctestContents)",
+                )
+
+                let swiftTestingContents: String = try localFileSystem.readFileContents(swiftTestingXUnitOutput)
+                #expect(
+                    swiftTestingContents.contains("DefaultInteropModeSwiftTestingTests")
+                        || swiftTestingContents.contains("Interop mode should be set to complete"),
+                    "Expected Swift Testing output in suffixed xUnit file; got:\n\(swiftTestingContents)",
+                )
+            }
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows
+        }
+    }
+
     enum TestRunner {
         case XCTest
         case SwiftTesting


### PR DESCRIPTION
Fixes #9960

Fix `swift test --xunit-output=output.xml` (which incorrectly behaved differently from `swift test --xunit-output output.xml` with no equals sign)

### Motivation:

I lost hours trying to figure out why my XCTest xunit output was missing. #9960 was the reason why; this one-liner PR fixes it.

### Modifications:

`SwiftTestCommand.swift` had code to strip `--xunit-output` from the output arguments, but it considered only the two-argument form `--xunit-output output.xml`. It both didn't _append_ the argument, and it skipped the following argument.

I added a one-line fix (with an additional line of comment) to also skip the one-argument form `--xunit-output=output.xml`

### Result:

Now, `--xunit-output=output.xml` will behave exactly the same as `--xunit-output output.xml`. In `--parallel` mode, `swift test` will generate an `output.xml` file for XCTest results and a separate `output-swift-testing.xml` for Swift Testing results.