### PR TITLE
Fix target triple's toolset options leaking to host triple products

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -891,14 +891,9 @@ private func createResolvedPackages(
 
 // Adjust the graph to integrate prebuilts
 private func handlePrebuilts(packageBuilders: [ResolvedPackageBuilder], root: PackageGraphRoot) {
-    // Skip this if there are no prebuilts. Modules are unconstrained by default.
-    guard packageBuilders.contains(where: { $0.prebuilts != nil }) else {
-        return
-    }
-
     // First decorate the platform constraints from products in the root packages
     for packageBuilder in packageBuilders where root.isExporting(packageBuilder.package.identity) {
-        for productBuilder in packageBuilder.products {
+        for productBuilder in packageBuilder.products where !productBuilder.product.isImplicit {
             for moduleBuilder in productBuilder.moduleBuilders {
                 func markExternal(_ depModule: ResolvedModuleBuilder) {
                     guard depModule.platformConstraint != .all else {
@@ -954,6 +949,10 @@ private func handlePrebuilts(packageBuilders: [ResolvedPackageBuilder], root: Pa
             }
             _ = markHost(moduleBuilder)
         }
+    }
+
+    guard packageBuilders.contains(where: { $0.prebuilts != nil }) else {
+        return
     }
 
     // Also for now, to ensure we're not mixing prebuilts and not prebuilts in the build graph,
@@ -1518,7 +1517,7 @@ private final class ResolvedModuleBuilder: ResolvedBuilder<ResolvedModule> {
     var platformConstraint: PlatformConstraint? = nil
 
     var isHostOnly: Bool {
-        module.type == .macro || (module.type == .test && dependencies.contains(where: {
+        module.type == .macro || module.type == .plugin || (module.type == .test && dependencies.contains(where: {
                 switch $0 {
                 case .product(let productDependency, _):
                     productDependency.product.type == .macro

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -167,7 +167,8 @@ public struct ResolvedModule {
     public let supportedPlatforms: [SupportedPlatform]
 
     /// A constraint on which platforms this module needs to build for.
-    /// Note: currently only set to .host if prebuilts are enabled.
+    /// `.host` for modules reachable only via host-only paths (macros, plugins,
+    /// macro-dependent tests); `.all` otherwise.
     public let platformConstraint: PlatformConstraint
 
     @_spi(SwiftPMInternal)

--- a/Sources/_InternalTestSupport/MockPackageGraphs.swift
+++ b/Sources/_InternalTestSupport/MockPackageGraphs.swift
@@ -372,6 +372,124 @@ package func embeddedCxxInteropPackageGraph() throws -> MockPackageGraph {
     return (graph, fs, observability.topScope)
 }
 
+package func pluginWithExecutableDepGraph() throws -> MockPackageGraph {
+    let fs = InMemoryFileSystem(emptyFiles:
+        "/my-app/Sources/MyApp/source.swift",
+        "/my-app/Sources/MyMacros/source.swift",
+        "/my-app/Plugins/MyBuildPlugin/source.swift",
+        "/my-app/Sources/MyTool/source.swift",
+        "/my-app/Tests/MyAppTests/source.swift",
+        "/my-app/Tests/MyPluginUserTests/source.swift",
+        "/swift-syntax/Sources/SwiftSyntax/source.swift",
+        "/swift-syntax/Sources/SwiftCompilerPlugin/source.swift",
+        "/swift-syntax/Sources/SwiftCompilerPluginMessageHandling/source.swift"
+    )
+
+    let observability = ObservabilitySystem.makeForTesting()
+    let graph = try loadModulesGraph(
+        fileSystem: fs,
+        manifests: [
+            Manifest.createRootManifest(
+                displayName: "my-app",
+                path: "/my-app",
+                dependencies: [
+                    .localSourceControl(
+                        path: "/swift-syntax",
+                        requirement: .upToNextMajor(from: "1.0.0")
+                    )
+                ],
+                products: [
+                    ProductDescription(
+                        name: "MyApp",
+                        type: .library(.automatic),
+                        targets: ["MyApp"]
+                    ),
+                    ProductDescription(
+                        name: "MyBuildPlugin",
+                        type: .plugin,
+                        targets: ["MyBuildPlugin"]
+                    ),
+                ],
+                targets: [
+                    TargetDescription(
+                        name: "MyApp",
+                        dependencies: [.target(name: "MyMacros")]
+                    ),
+                    TargetDescription(
+                        name: "MyMacros",
+                        dependencies: [.product(name: "SwiftCompilerPlugin", package: "swift-syntax")],
+                        type: .macro
+                    ),
+                    TargetDescription(
+                        name: "MyBuildPlugin",
+                        dependencies: [.target(name: "MyTool")],
+                        type: .plugin,
+                        pluginCapability: .buildTool
+                    ),
+                    TargetDescription(
+                        name: "MyTool",
+                        dependencies: [.product(name: "SwiftSyntax", package: "swift-syntax")],
+                        type: .executable
+                    ),
+                    TargetDescription(
+                        name: "MyAppTests",
+                        dependencies: [.target(name: "MyApp")],
+                        type: .test
+                    ),
+                    TargetDescription(
+                        name: "MyPluginUserTests",
+                        dependencies: [.target(name: "MyApp")],
+                        type: .test
+                    ),
+                ],
+                traits: []
+            ),
+            Manifest.createFileSystemManifest(
+                displayName: "swift-syntax",
+                path: "/swift-syntax",
+                products: [
+                    ProductDescription(
+                        name: "SwiftSyntax",
+                        type: .library(.automatic),
+                        targets: ["SwiftSyntax"]
+                    ),
+                    ProductDescription(
+                        name: "SwiftCompilerPlugin",
+                        type: .library(.automatic),
+                        targets: ["SwiftCompilerPlugin"]
+                    ),
+                    ProductDescription(
+                        name: "SwiftCompilerPluginMessageHandling",
+                        type: .library(.automatic),
+                        targets: ["SwiftCompilerPluginMessageHandling"]
+                    ),
+                ],
+                targets: [
+                    TargetDescription(name: "SwiftSyntax", dependencies: []),
+                    TargetDescription(
+                        name: "SwiftCompilerPlugin",
+                        dependencies: [
+                            .target(name: "SwiftCompilerPluginMessageHandling"),
+                            .target(name: "SwiftSyntax"),
+                        ]
+                    ),
+                    TargetDescription(
+                        name: "SwiftCompilerPluginMessageHandling",
+                        dependencies: [.target(name: "SwiftSyntax")]
+                    ),
+                ],
+                traits: []
+            ),
+        ],
+        observabilityScope: observability.topScope,
+        traitConfiguration: .default,
+        enabledTraitsMap: .init()
+    )
+
+    XCTAssertNoDiagnostics(observability.diagnostics)
+    return (graph, fs, observability.topScope)
+}
+
 package func toolsExplicitLibrariesGraph(linkage: ProductType.LibraryType) throws -> MockPackageGraph {
     let fs = InMemoryFileSystem(emptyFiles:
         "/swift-mmio/Sources/MMIOMacros/source.swift",

--- a/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
+++ b/Tests/PackageGraphTests/CrossCompilationPackageGraphTests.swift
@@ -150,4 +150,28 @@ final class CrossCompilationPackageGraphTests: XCTestCase {
             }
         }
     }
+
+    func testMacroDepsArePropagatedAsHost() throws {
+        let graph = try macrosPackageGraph().graph
+        XCTAssertEqual(graph.module(for: "MMIOMacros")?.platformConstraint, .host)
+        XCTAssertEqual(graph.module(for: "SwiftSyntax")?.platformConstraint, .host)
+        XCTAssertEqual(graph.module(for: "MMIO")?.platformConstraint, .all)
+        XCTAssertEqual(graph.module(for: "Core")?.platformConstraint, .all)
+        XCTAssertEqual(graph.module(for: "HAL")?.platformConstraint, .all)
+        XCTAssertEqual(graph.module(for: "CoreTests")?.platformConstraint, .all)
+        XCTAssertEqual(graph.module(for: "HALTests")?.platformConstraint, .all)
+    }
+
+    func testPluginDepsArePropagatedAsHost() throws {
+        let graph = try pluginWithExecutableDepGraph().graph
+        XCTAssertEqual(graph.module(for: "MyBuildPlugin")?.platformConstraint, .host)
+        XCTAssertEqual(graph.module(for: "MyTool")?.platformConstraint, .host)
+        XCTAssertEqual(graph.module(for: "MyMacros")?.platformConstraint, .host)
+        XCTAssertEqual(graph.module(for: "SwiftSyntax")?.platformConstraint, .host)
+        XCTAssertEqual(graph.module(for: "SwiftCompilerPlugin")?.platformConstraint, .host)
+        XCTAssertEqual(graph.module(for: "SwiftCompilerPluginMessageHandling")?.platformConstraint, .host)
+        XCTAssertEqual(graph.module(for: "MyApp")?.platformConstraint, .all)
+        XCTAssertEqual(graph.module(for: "MyAppTests")?.platformConstraint, .all)
+        XCTAssertEqual(graph.module(for: "MyPluginUserTests")?.platformConstraint, .all)
+    }
 }


### PR DESCRIPTION
### Motivation:

Using Swift SDKs/toolsets with packages that have plugins and other products that run on the host system leaks toolset options that are required for the target triple. For example, building packages depending on `BridgeJS` plugin from https://github.com/swiftwasm/JavaScriptKit is broken since `swift-DEVELOPMENT-SNAPSHOT-2026-04-01` with Swift Build becoming the default build system:

The error is `Driver threw -static-stdlib is no longer supported for Apple platforms` on host-targeted `swift-syntax` modules with Wasm Swift SDK toolset's `-static-stdlib` leaking onto host build tools.

### Modifications:

Updated `isHostOnly` on `ResolvedModuleBuilder` to return `true` if `module.type == .plugin`. Also checking for `productBuilder.product.isImplicit`, which handles synthetic products created for executable targets that are dependencies of plugins.

### Result:

Regression with the new build system in SwiftPM for adopters of https://github.com/swiftwasm/JavaScriptKit is fixed.

Resolves https://github.com/swiftlang/swift-package-manager/issues/9970.