### PR TITLE
SwiftBuild: add scratch path symbolic links

### DIFF
--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -141,7 +141,8 @@ private struct SwiftBuildSystemFactory: BuildSystemFactory {
                 workDirectory: try self.swiftCommandState.getActiveWorkspace().location.pluginWorkingDirectory,
                 disableSandbox: self.swiftCommandState.shouldDisableSandbox
             ),
-            delegate: delegate
+            delegate: delegate,
+            scratchDirectory: self.swiftCommandState.scratchDirectory,
         )
     }
 }

--- a/Sources/SwiftBuildSupport/CMakeLists.txt
+++ b/Sources/SwiftBuildSupport/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(SwiftBuildSupport
   TraceEventsWriter.swift
   Diagnostics+Extensions.swift
   DotPIFSerializer.swift
+  FileSystem+Utils.swift
   PackagePIFBuilder.swift
   PackagePIFBuilder+Helpers.swift
   PackagePIFBuilder+Plugins.swift

--- a/Sources/SwiftBuildSupport/FileSystem+Utils.swift
+++ b/Sources/SwiftBuildSupport/FileSystem+Utils.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct Basics.AbsolutePath
+import protocol Basics.FileSystem
+import var Basics.localFileSystem
+import class Basics.ObservabilityScope
+
+package func createBuildSymbolicLinks(
+    _ path: Basics.AbsolutePath,
+    pointingAt: Basics.AbsolutePath,
+    fileSystem: FileSystem = localFileSystem,
+    observabilityScope: ObservabilityScope,
+) {
+    if fileSystem.exists(path, followSymlink: true) {
+        do {
+            // This does not delete the directory pointed to by the symbolic link
+            try fileSystem.removeFileTree(path)
+        }
+        catch {
+            observabilityScope.emit(
+                warning: "unable to delete \(path), skip creating symbolic link",
+                underlyingError: error
+            )
+        }
+    }
+
+    do {
+        try fileSystem.createSymbolicLink(
+            path,
+            pointingAt: pointingAt,
+            relative: true,
+        )
+    } catch {
+        observabilityScope.emit(
+            warning: "unable to create symbolic link at \(path)",
+            underlyingError: error
+        )
+    }
+}

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -242,6 +242,7 @@ package final class SwiftBuildSystemPlanningOperationDelegate: SWBPlanningOperat
 }
 
 public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
+    internal let scratchDirectory: Basics.AbsolutePath
     package let buildParameters: BuildParameters
     package let hostBuildParameters: BuildParameters
     private let packageGraphLoader: () async throws -> ModulesGraph
@@ -317,7 +318,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         pluginConfiguration: PluginConfiguration,
-        delegate: BuildSystemDelegate?
+        delegate: BuildSystemDelegate?,
+        scratchDirectory: Basics.AbsolutePath, // currently used to create the symbolic links
     ) throws {
         self.buildParameters = buildParameters
         self.hostBuildParameters = hostBuildParameters
@@ -330,6 +332,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         self.observabilityScope = observabilityScope.makeChildScope(description: "Swift Build System")
         self.pluginConfiguration = pluginConfiguration
         self.delegate = delegate
+        self.scratchDirectory = scratchDirectory
     }
 
     private func createREPLArguments(
@@ -405,6 +408,17 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             serializedDiagnosticPathsByTargetName: .failure(StringError("Building was skipped")),
             replArguments: nil,
         )
+
+        defer {
+            if self.fileSystem.exists(self.buildParameters.buildPath, followSymlink: true) {
+                createBuildSymbolicLinks(
+                    self.scratchDirectory.appending(component: self.buildParameters.configuration.dirname),
+                    pointingAt: self.buildParameters.buildPath,
+                    fileSystem: self.fileSystem,
+                    observabilityScope: self.observabilityScope,
+                )
+            }
+        }
 
         guard !buildParameters.shouldSkipBuilding else {
             result.serializedDiagnosticPathsByTargetName = .failure(StringError("Building was skipped"))

--- a/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
@@ -193,6 +193,32 @@ package func expectDirectoryContainsFile(
     Issue.record("Directory \(dir) does not contain \(filename)", sourceLocation: sourceLocation)
 }
 
+public func expectSymlink(
+    _ path: AbsolutePath,
+    pointsTo target: AbsolutePath,
+    fileSystem fs: FileSystem = localFileSystem,
+    sourceLocation: SourceLocation = #_sourceLocation,
+) throws {
+    #expect(
+        fs.isSymlink(path),
+        "Source (\(path)) is not a symbolic link",
+        sourceLocation: sourceLocation,
+    )
+
+    #expect(
+        fs.exists(path, followSymlink: true),
+        "Source (\(path)) does not exists while following symliks",
+        sourceLocation: sourceLocation,
+    )
+
+    let resolvedSymlinkLocation = try resolveSymlinks(path)
+    let resolvedtarget = try resolveSymlinks(target)
+    #expect(
+        resolvedSymlinkLocation == resolvedtarget,
+        "Resolved symlink location does not match the resolved target",
+        sourceLocation: sourceLocation,
+    )
+}
 
 /// Expects that the expression throws a CommandExecutionError and passes it to the provided throwing error handler.
 /// - Parameters:

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -610,39 +610,6 @@ private func swiftArgs(
     return args
 }
 
-@available(*,
-    deprecated,
-    renamed: "loadModulesGraph",
-    message: "Rename for consistency: the type of this functions return value is named `ModulesGraph`."
-)
-public func loadPackageGraph(
-    identityResolver: IdentityResolver = DefaultIdentityResolver(),
-    fileSystem: FileSystem,
-    manifests: [Manifest],
-    binaryArtifacts: [PackageIdentity: [String: BinaryArtifact]] = [:],
-    explicitProduct: String? = .none,
-    shouldCreateMultipleTestProducts: Bool = false,
-    createREPLProduct: Bool = false,
-    useXCBuildFileRules: Bool = false,
-    customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
-    observabilityScope: ObservabilityScope,
-    traitConfiguration: TraitConfiguration = .default
-) throws -> ModulesGraph {
-    try loadModulesGraph(
-        identityResolver: identityResolver,
-        fileSystem: fileSystem,
-        manifests: manifests,
-        binaryArtifacts: binaryArtifacts,
-        explicitProduct: explicitProduct,
-        shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
-        createREPLProduct: createREPLProduct,
-        useXCBuildFileRules: useXCBuildFileRules,
-        customXCTestMinimumDeploymentTargets: customXCTestMinimumDeploymentTargets,
-        observabilityScope: observabilityScope,
-        traitConfiguration: traitConfiguration
-    )
-}
-
 public let emptyZipFile = ByteString([0x80, 0x75, 0x05, 0x06] + [UInt8](repeating: 0x00, count: 18))
 
 extension FileSystem {

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -437,6 +437,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
                         disableSandbox: false
                     ),
                     delegate: nil,
+                    scratchDirectory: scratchDirectory,
                 )
             }
         }

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -22,7 +22,6 @@ import class PackageModel.Manifest
 import struct PackageModel.TargetDescription
 import enum PackageModel.ProductType
 import struct SPMBuildCore.BuildParameters
-import func _InternalTestSupport.loadPackageGraph
 
 import func _InternalTestSupport.embeddedCxxInteropPackageGraph
 import func _InternalTestSupport.macrosPackageGraph

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -155,18 +155,42 @@ struct BuildCommandTestCases {
         let configuration = buildData.config
         // Test is not implemented for Xcode build system
         try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
-            let fullPath = try resolveSymlinks(fixturePath)
+            try await withTemporaryDirectory { tempDir in
+                let scratchPath = tempDir.appending("build")
+                let fullPath = try resolveSymlinks(fixturePath)
+                let originalSymlink = scratchPath.appending("\(configuration)")
 
-            let targetPath = try fullPath.appending(components: buildSystem.binPath(for: configuration))
-            let path = try await execute(
-                ["--show-bin-path"],
-                packagePath: fullPath,
-                configuration: configuration,
-                buildSystem: buildSystem,
-            ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-            #expect(
-                AbsolutePath(path).pathString == targetPath.pathString
-            )
+                let targetPath = try scratchPath.appending(components: buildSystem.binPath(for: configuration, scratchPath: []))
+                let commonBuildArgs = [
+                    "--scratch-path",
+                    scratchPath.pathString,
+                ]
+                let path = try await execute(
+                    [
+                        "--show-bin-path",
+                    ] + commonBuildArgs,
+                    packagePath: fullPath,
+                    configuration: configuration,
+                    buildSystem: buildSystem,
+                ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                #expect(
+                    AbsolutePath(path).pathString == targetPath.pathString
+                )
+
+                // The original symlink should not exists
+                expectFileDoesNotExists(at: originalSymlink)
+
+                // Let's build the package
+                try await executeSwiftBuild(
+                    fullPath,
+                    configuration: configuration,
+                    extraArgs: commonBuildArgs,
+                    buildSystem: buildSystem,
+                )
+
+                try expectSymlink(originalSymlink, pointsTo: AbsolutePath(path))
+            }
         }
     }
 

--- a/Tests/SwiftBuildSupportTests/FileSystemUtilsTests.swift
+++ b/Tests/SwiftBuildSupportTests/FileSystemUtilsTests.swift
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// import class Basics.InMemoryFileSystem
+import struct Basics.AbsolutePath
+import protocol Basics.FileSystem
+import class Basics.ObservabilitySystem
+import func Basics.resolveSymlinks
+import func Basics.withTemporaryDirectory
+import var Basics.localFileSystem
+import struct TSCBasic.StringError
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
+import enum TSCBasic.FileMode
+
+import func SwiftBuildSupport.createBuildSymbolicLinks
+
+import _InternalTestSupport
+import Testing
+
+typealias AbsolutePath = Basics.AbsolutePath
+
+@Suite(
+    .tags(
+        .TestSize.small,
+    ),
+)
+struct CreateBuildSymbolicLinkFunction {
+    @Test(
+    )
+    func createBuildSymbolicLinkCreation() async throws {
+        let fs = localFileSystem
+        try withTemporaryDirectory(removeTreeOnDeinit: false) { tmpDir in
+            // Arrange
+            let observability = ObservabilitySystem.makeForTesting()
+            let source = tmpDir.appending("source")
+            let target = tmpDir.appending(components: "my","target","directory")
+            try localFileSystem.createDirectory(target, recursive: true)
+
+            // Act
+            createBuildSymbolicLinks(
+                source,
+                pointingAt: target,
+                fileSystem: fs,
+                observabilityScope: observability.topScope,
+            )
+
+            // Assert
+            try expectSymlink(
+                source,
+                pointsTo: target,
+                fileSystem: fs,
+            )
+            expectNoDiagnostics(observability.diagnostics)
+        }
+    }
+
+    @Test
+    func failingToRemoveSourceSymlinkGeneratedAWarning() async throws {
+        // Arrange
+        struct FileSystemDouble: FileSystem {
+            func createSymbolicLink(_ path: TSCBasic.AbsolutePath, pointingAt destination: TSCBasic.AbsolutePath, relative: Bool) throws {
+                throw StringError("Purposely failing in \(#function)")
+            }
+
+            func removeFileTree(_ path: TSCBasic.AbsolutePath) throws {
+                throw StringError("Purposely failing in \(#function)")
+            }
+
+            func removeFileTree(_ path: AbsolutePath) throws {
+                throw StringError("Purposely failing in \(#function)")
+            }
+            func createSymbolicLink( source: AbsolutePath, pointingAt target: AbsolutePath ) throws {
+                throw StringError("Purposely failing in \(#function)")
+            }
+
+            func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {}
+            func copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {}
+            func chmod(_ mode: TSCBasic.FileMode, path: TSCBasic.AbsolutePath, options: Set<TSCBasic.FileMode.Option>) throws {}
+            func writeFileContents(_ path: TSCBasic.AbsolutePath, bytes: TSCBasic.ByteString) throws {}
+            func readFileContents(_ path: TSCBasic.AbsolutePath) throws -> TSCBasic.ByteString {
+                TSCBasic.ByteString()
+            }
+            func createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws {}
+            let tempDirectory: TSCBasic.AbsolutePath
+            let cachesDirectory: TSCBasic.AbsolutePath?
+            let homeDirectory: TSCBasic.AbsolutePath
+            func changeCurrentWorkingDirectory(to path: TSCBasic.AbsolutePath) throws {}
+            let currentWorkingDirectory: TSCBasic.AbsolutePath?
+            func getDirectoryContents(_ path: TSCBasic.AbsolutePath) throws -> [String] {
+                return []
+            }
+            func isWritable(_ path: TSCBasic.AbsolutePath) -> Bool { false }
+            func isReadable(_ path: TSCBasic.AbsolutePath) -> Bool { false }
+            func isSymlink(_ path: TSCBasic.AbsolutePath) -> Bool { false }
+            func isExecutableFile(_ path: TSCBasic.AbsolutePath) -> Bool { false }
+            func isFile(_ path: TSCBasic.AbsolutePath) -> Bool { false }
+            func isDirectory(_ path: TSCBasic.AbsolutePath) -> Bool { false }
+            func exists(_ path: TSCBasic.AbsolutePath, followSymlink: Bool) -> Bool { false }
+            func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool { false }
+        }
+
+        let fs = FileSystemDouble(
+            tempDirectory: TSCBasic.AbsolutePath.root.appending(components: "tmp", "\(#function)", "tmp"),
+            cachesDirectory: nil,
+            homeDirectory:  TSCBasic.AbsolutePath.root.appending(components: "tmp", "\(#function)", "home"),
+            currentWorkingDirectory: nil,
+        )
+        let observability = ObservabilitySystem.makeForTesting()
+
+        // Act
+        createBuildSymbolicLinks(
+            AbsolutePath("/foo/bar"),
+            pointingAt: AbsolutePath("/foo/ping/pong"),
+            fileSystem: fs,
+            observabilityScope: observability.topScope,
+        )
+
+        testDiagnostics(observability.diagnostics) { result in
+            result.check(
+                diagnostic: .contains("unable to delete"),
+                severity: .warning
+            )
+
+            result.check(
+                diagnostic: .contains("unable to create symbolic link"),
+                severity: .warning
+            )
+
+        }
+    }
+
+}

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -75,10 +75,11 @@ func withInstantiatedSwiftBuildSystem(
                 observabilityScope: observabilitySystem.topScope,
                 pluginConfiguration: PluginConfiguration(
                     scriptRunner: pluginScriptRunner,
-                    workDirectory: AbsolutePath("/tmp/plugin-script-working-dir"),
+                    workDirectory: tmpDir.appending("plugin-script-working-dir"),
                     disableSandbox: true,
                 ),
                 delegate: nil,
+                scratchDirectory: tmpDir.appending("scratchDirectory"),
             )
 
             try await SwiftBuildSupport.withService(


### PR DESCRIPTION
The native build system would create the `debug` and `release` symbolic link in the scratch path as they were the original output location before triple support was added.

Although this is not an officially support feature, add the `debug` and `release` symbolic links when using Swift Build to ease the transition until a better solution is avaiable.

Fixes: #9963
Issue: rdar://175144467

Merge with: https://github.com/swiftlang/sourcekit-lsp/pull/2620 (passed) or with https://github.com/swiftlang/sourcekit-lsp/pull/2621 (passed)