### PR TITLE
[Swift Build] Match native build system for extra tool flags passed via command plugins

### DIFF
--- a/Fixtures/Miscellaneous/FlagOverrides/Package.swift
+++ b/Fixtures/Miscellaneous/FlagOverrides/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "FlagOverrides",
+    targets: [
+        .executableTarget(
+            name: "FlagOverrides",
+            plugins: [
+                "GenerateSourcePlugin",
+            ]
+        ),
+        .plugin(
+            name: "GenerateSourcePlugin",
+            capability: .buildTool(),
+            dependencies: [
+                "GenerateTool",
+            ]
+        ),
+        .executableTarget(
+            name: "GenerateTool"
+        ),
+        .plugin(
+            name: "BuildAndRunPlugin",
+            capability: .command(
+                intent: .custom(verb: "build-and-run", description: "Build and run the executable")
+            )
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/FlagOverrides/Plugins/BuildAndRunPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/FlagOverrides/Plugins/BuildAndRunPlugin/plugin.swift
@@ -1,0 +1,19 @@
+import PackagePlugin
+
+@main
+struct BuildAndRunPlugin: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        var parameters = PackageManager.BuildParameters()
+        parameters.otherSwiftcFlags = arguments
+        let result = try packageManager.build(.product("FlagOverrides"), parameters: parameters)
+        guard result.succeeded else {
+            throw "Build failed: \(result.logText)"
+        }
+        guard let executable = result.builtArtifacts.first(where: { $0.kind == .executable }) else {
+            throw "No executable artifact found"
+        }
+        print(executable.url.path)
+    }
+}
+
+extension String: @retroactive Error {}

--- a/Fixtures/Miscellaneous/FlagOverrides/Plugins/GenerateSourcePlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/FlagOverrides/Plugins/GenerateSourcePlugin/plugin.swift
@@ -1,0 +1,21 @@
+import PackagePlugin
+import Foundation
+
+@main
+struct GenerateSourcePlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        guard let target = target as? SourceModuleTarget else { return [] }
+        return try target.sourceFiles.compactMap { file -> Command? in
+            guard file.url.pathExtension == "dat" else { return nil }
+            let outputName = file.url.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
+            return .buildCommand(
+                displayName: "Generating \(outputName) from \(file.url.lastPathComponent)",
+                executable: try context.tool(named: "GenerateTool").url,
+                arguments: [outputPath.path],
+                inputFiles: [file.url],
+                outputFiles: [outputPath]
+            )
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/FlagOverrides/Sources/FlagOverrides/Generated.dat
+++ b/Fixtures/Miscellaneous/FlagOverrides/Sources/FlagOverrides/Generated.dat
@@ -1,0 +1,1 @@
+generate

--- a/Fixtures/Miscellaneous/FlagOverrides/Sources/FlagOverrides/main.swift
+++ b/Fixtures/Miscellaneous/FlagOverrides/Sources/FlagOverrides/main.swift
@@ -1,0 +1,8 @@
+#if ONE
+print("Executable flag: ONE")
+#elseif TWO
+print("Executable flag: TWO")
+#else
+print("Executable flag: NONE")
+#endif
+generatedFunction()

--- a/Fixtures/Miscellaneous/FlagOverrides/Sources/GenerateTool/main.swift
+++ b/Fixtures/Miscellaneous/FlagOverrides/Sources/GenerateTool/main.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+#if ONE
+let flag = "ONE"
+#elseif TWO
+let flag = "TWO"
+#else
+let flag = "NONE"
+#endif
+
+let outputFile = ProcessInfo.processInfo.arguments[1]
+let source = """
+func generatedFunction() {
+    print("Plugin tool flag: \(flag)")
+}
+"""
+try source.write(toFile: outputFile, atomically: true, encoding: .utf8)

--- a/Sources/Runtimes/PackagePlugin/PackageManagerProxy.swift
+++ b/Sources/Runtimes/PackagePlugin/PackageManagerProxy.swift
@@ -69,16 +69,16 @@ public struct PackageManager {
         /// A Boolean value that indicates whether to print build logs to the console.
         public var echoLogs: Bool
 
-        /// Additional flags to pass to all C compiler invocations.
+        /// Additional flags to pass to all C compiler invocations for the destination platform.
         public var otherCFlags: [String] = []
 
-        /// Additional flags to pass to all C++ compiler invocations.
+        /// Additional flags to pass to all C++ compiler invocations for the destination platform.
         public var otherCxxFlags: [String] = []
 
-        /// Additional flags to pass to all Swift compiler invocations.
+        /// Additional flags to pass to all Swift compiler invocations for the destination platform.
         public var otherSwiftcFlags: [String] = []
 
-        /// Additional flags to pass to all linker invocations.
+        /// Additional flags to pass to all linker invocations for the destination platform.
         public var otherLinkerFlags: [String] = []
 
         /// Creates a new sert of build parameters.

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -901,40 +901,11 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             }
         }
 
-        var swiftCompilerFlags = buildParameters.toolchain.extraFlags.swiftCompilerFlags + buildParameters.flags.swiftCompilerFlags
-        swiftCompilerFlags += buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
-        // User arguments (from -Xcc) should follow generated arguments to allow user overrides
-        swiftCompilerFlags += buildParameters.flags.cCompilerFlags.asSwiftcCCompilerFlags()
-
-        // TODO: Pass -Xcxx flags to swiftc (#6491)
-        // Uncomment when downstream support arrives.
-        // swiftCompilerFlags += buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()
-        // // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
-        // swiftCompilerFlags += buildParameters.flags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()
-        let compilerAndLinkerFlags = [
-            "OTHER_CFLAGS": buildParameters.toolchain.extraFlags.cCompilerFlags + buildParameters.flags.cCompilerFlags,
-            "OTHER_CPLUSPLUSFLAGS": buildParameters.toolchain.extraFlags.cxxCompilerFlags + buildParameters.flags.cxxCompilerFlags,
-            "OTHER_SWIFT_FLAGS": swiftCompilerFlags,
-            "OTHER_LDFLAGS": (buildParameters.toolchain.extraFlags.linkerFlags + buildParameters.flags.linkerFlags)
-        ]
-        for (settingName, buildFlags) in compilerAndLinkerFlags {
-            var rawFlags = buildFlags.rawFlagsForSwiftBuild
-            if settingName == "OTHER_LDFLAGS" {
-                rawFlags = rawFlags.asSwiftcLinkerFlags()
-            }
-            settings[settingName] = (verboseFlag + ["$(inherited)"] +
-                rawFlags.map { $0.shellEscaped() }).joined(separator: " ")
+        func reportConflict(_ a: String, _ b: String) throws -> String {
+            throw StringError("Build parameters constructed conflicting settings overrides '\(a)' and '\(b)'")
         }
 
-        // Historically, SwiftPM passed -Xswiftc flags to swiftc when used as a linker driver.
-        // To maintain compatibility, forward swift compiler flags to OTHER_LDFLAGS when using
-        // swiftc to link.
-        if !swiftCompilerFlags.rawFlagsForSwiftBuild.isEmpty {
-            settings["OTHER_LDFLAGS_SWIFTC_LINKER_DRIVER_swiftc"] =
-            (["$(inherited)"] + swiftCompilerFlags.rawFlagsForSwiftBuild.map { $0.shellEscaped() }).joined(separator: " ")
-            settings["OTHER_LDFLAGS"] =
-                (settings["OTHER_LDFLAGS"] ?? "$(inherited)") + " $(OTHER_LDFLAGS_SWIFTC_LINKER_DRIVER_$(LINKER_DRIVER))"
-        }
+        try settings.merge(Self.constructExtraToolFlagsSettingsOverrides(from: buildParameters, verbosityFlags: verboseFlag), uniquingKeysWith: reportConflict)
 
         if buildParameters.driverParameters.emitSILFiles {
             settings["SWIFT_EMIT_SIL_FILES"] = "YES"
@@ -1008,9 +979,6 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         settings["ADD_TOOLCHAIN_CONCURRENCY_BACK_DEPLOY_RPATH"] = "YES"
         settings["ADD_TOOLCHAIN_SPAN_BACK_DEPLOY_RPATH"] = "YES"
 
-        func reportConflict(_ a: String, _ b: String) throws -> String {
-            throw StringError("Build parameters constructed conflicting settings overrides '\(a)' and '\(b)'")
-        }
         try settings.merge(Self.constructDebuggingSettingsOverrides(from: buildParameters.debuggingParameters), uniquingKeysWith: reportConflict)
         try settings.merge(Self.constructDriverSettingsOverrides(from: buildParameters.driverParameters), uniquingKeysWith: reportConflict)
         try settings.merge(self.constructLinkerSettingsOverrides(from: buildParameters.linkingParameters, triple: buildParameters.triple), uniquingKeysWith: reportConflict)
@@ -1094,6 +1062,83 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         }
 
         return request
+    }
+
+    private static func constructExtraToolFlagsSettingsOverrides(from buildParameters: BuildParameters, verbosityFlags: [String]) -> [String: String] {
+        var settings: [String: String] = [:]
+        var swiftCompilerFlags = buildParameters.toolchain.extraFlags.swiftCompilerFlags + buildParameters.flags.swiftCompilerFlags
+        swiftCompilerFlags += buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
+        // User arguments (from -Xcc) should follow generated arguments to allow user overrides
+        swiftCompilerFlags += buildParameters.flags.cCompilerFlags.asSwiftcCCompilerFlags()
+        // TODO: Pass -Xcxx flags to swiftc (#6491)
+        // Uncomment when downstream support arrives.
+        // swiftCompilerFlags += buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()
+        // // User arguments (from -Xcxx) should follow generated arguments to allow user overrides
+        // swiftCompilerFlags += buildParameters.flags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()
+        let compilerAndLinkerFlags = [
+            "OTHER_CFLAGS": buildParameters.toolchain.extraFlags.cCompilerFlags + buildParameters.flags.cCompilerFlags,
+            "OTHER_CPLUSPLUSFLAGS": buildParameters.toolchain.extraFlags.cxxCompilerFlags + buildParameters.flags.cxxCompilerFlags,
+            "OTHER_SWIFT_FLAGS": swiftCompilerFlags,
+            // Historically, SwiftPM passed -Xswiftc flags to swiftc when used as a linker driver.
+            // To maintain compatibility, forward swift compiler flags to OTHER_LDFLAGS when using
+            // swiftc to link.
+            "OTHER_LDFLAGS_SWIFTC_LINKER_DRIVER_swiftc": swiftCompilerFlags,
+            "OTHER_LDFLAGS": (buildParameters.toolchain.extraFlags.linkerFlags + buildParameters.flags.linkerFlags),
+        ]
+        for (settingName, buildFlags) in compilerAndLinkerFlags {
+            var rawFlags = buildFlags.filter {
+                switch $0.source {
+                case .commandLineOptions:
+                    // Flags specified by the user. These are generally the only ones that should be passed on. Match the native build system behavior of passing them to all compiles.
+                    return true
+                case .plugin:
+                    // Flags specified by a command plugin. Ideally these would match the behavior of flags passed on the command line, but for compatibility with the native build system we treat these as destination-only flags.
+                    return false
+                case .debugging:
+                    // Handled by the underlying build system.
+                    return false
+                case .toolset:
+                    // Swift Build loads toolset flags internally as part of loading Swift SDKs, or by passing the custom toolsets
+                    // via the SWIFT_SDK_TOOLSETS build setting, and may introspect them to override build settings.
+                    // Don't duplicate them here.
+                    return false
+                case .defaultSwiftTestingSearchPath:
+                    // Swift Build computes these internally. It's important not to add them a second time here
+                    // as it can break the intended search path ordering, for example, if the user is building
+                    // Swift Testing as a package dependency.
+                    return false
+                case .defaultWindowsSettings:
+                    // Swift Build computes these internally.
+                    return false
+                case .swiftSDK:
+                    // Swift Build loads Swift SDK flags internally, and may introspect them to override build
+                    // settings. Don't duplicate them here.
+                    return false
+                case nil:
+                    // Remaining flags are legacy build system specific (one occurrence only), or in tests.
+                    return false
+                }
+            }.map(\.value)
+            var rawDestinationOnlyFlags = buildFlags.filter {
+                switch $0.source {
+                case .plugin:
+                    // See comment in the switch above.
+                    return true
+                case .commandLineOptions, .debugging, .toolset, .defaultSwiftTestingSearchPath, .defaultWindowsSettings, .swiftSDK, nil:
+                    // Already included or excluded appropriately by the switch above.
+                    return false
+                }
+            }.map(\.value)
+            if settingName == "OTHER_LDFLAGS" {
+                rawFlags = rawFlags.asSwiftcLinkerFlags()
+                rawDestinationOnlyFlags = rawDestinationOnlyFlags.asSwiftcLinkerFlags()
+            }
+            settings[settingName] = (verbosityFlags + ["$(inherited)"] + rawFlags.map { $0.shellEscaped() }).joined(separator: " ")
+            settings["\(settingName)[__destination_platform=YES]"] = (["$(inherited)"] + rawDestinationOnlyFlags.map { $0.shellEscaped() }).joined(separator: " ")
+        }
+        settings["OTHER_LDFLAGS"] = (settings["OTHER_LDFLAGS"] ?? "$(inherited)") + " $(OTHER_LDFLAGS_SWIFTC_LINKER_DRIVER_$(LINKER_DRIVER))"
+
+        return settings
     }
 
     private static func constructDebuggingSettingsOverrides(from parameters: BuildParameters.Debugging) -> [String: String] {

--- a/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -14,6 +14,7 @@ import Basics
 import Foundation
 import PackageModel
 import _InternalTestSupport
+import SPMBuildCore
 import Testing
 
 import class Basics.AsyncProcess
@@ -147,6 +148,61 @@ private struct WebAssemblyIntegrationTests {
             let stdout = try result.utf8Output().trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(result.exitStatus == .terminated(code: 0), "wasmkit exited with non-zero status")
             #expect(stdout == "Hello from WebAssembly!", "Unexpected output: \(stdout)")
+        }
+    }
+
+    @Test(.requiresWebAssemblySwiftSDK, arguments: SupportedBuildSystemOnAllPlatforms)
+    func flagOverrides(buildSystem: BuildSystemProvider.Kind) async throws {
+        try await fixture(name: "Miscellaneous/FlagOverrides") { fixturePath in
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndWebAssemblySDKIDForTesting())
+
+            var env = Environment()
+            env["SWIFT_EXEC"] = compilerPath.pathString
+
+            let runOutput = try await executeSwiftRun(
+                fixturePath,
+                "FlagOverrides",
+                extraArgs: ["--swift-sdk", sdkID],
+                Xswiftc: ["-DONE"],
+                env: env,
+                buildSystem: buildSystem,
+            )
+
+            let lines = runOutput.stdout.split(separator: "\n").map(String.init)
+            #expect(lines.contains("Executable flag: ONE"))
+            #expect(lines.contains("Plugin tool flag: ONE"))
+        }
+    }
+
+    @Test(.requiresWebAssemblySwiftSDK, arguments: SupportedBuildSystemOnAllPlatforms)
+    func flagOverridesCommandPlugin(buildSystem: BuildSystemProvider.Kind) async throws {
+        try await fixture(name: "Miscellaneous/FlagOverrides") { fixturePath in
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndWebAssemblySDKIDForTesting())
+
+            var env = Environment()
+            env["SWIFT_EXEC"] = compilerPath.pathString
+
+            let pluginOutput = try await executeSwiftPackage(
+                fixturePath,
+                extraArgs: ["--swift-sdk", sdkID, "--allow-writing-to-package-directory", "build-and-run", "-DONE"],
+                env: env,
+                buildSystem: buildSystem,
+            )
+
+            let wasmBinary = try AbsolutePath(
+                validating: pluginOutput.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            #expect(localFileSystem.exists(wasmBinary), "Expected .wasm binary at \(wasmBinary)")
+
+            let wasmkitPath = try #require(try findWasmKit(sdkID: sdkID), "wasmkit not found in Swift SDK \(sdkID)")
+            let result = try await AsyncProcess.popen(
+                arguments: [wasmkitPath.pathString, "run", wasmBinary.pathString]
+            )
+            let stdout = try result.utf8Output().trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(result.exitStatus == .terminated(code: 0), "wasmkit exited with non-zero status")
+            let lines = stdout.split(separator: "\n").map(String.init)
+            #expect(lines.contains("Executable flag: ONE"))
+            #expect(lines.contains("Plugin tool flag: NONE"))
         }
     }
 }


### PR DESCRIPTION
While e.g. -Xswiftc flags are applied to all compiles, the equivalent flags passed via a command plugin were only applied to files compiled for the destination when building with the native build system. Match the behavior when using the new build system backend, update the PackagePlugin documentation to reflect the actual longstanding behavior, and add WebAssemblyIntegrationTests covering these behaviors so we are running some cross-compilation tests in CI which exercise this behavior.

Depends on https://github.com/swiftlang/swift-build/pull/1334