### PR TITLE
[Swift Build] Ensure failed build tool plugins terminate build planning

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -351,6 +351,11 @@ public final class PIFBuilder {
                         diagnosticsEmitter.emit(diag)
                     }
 
+                    guard result.succeeded else {
+                        observabilityScope.emit(error: "build planning stopped due to build-tool plugin failures")
+                        throw Diagnostics.fatalError
+                    }
+
                     prebuildCommands.append(contentsOf: result.prebuildCommands)
 
                     buildCommands.append(contentsOf: result.buildCommands.map( { buildCommand in

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4655,11 +4655,11 @@ struct PackageCommandTests {
                     #expect(error.stderr.contains("This is text from the plugin"))
                     #expect(error.stderr.contains("error: This is an error from the plugin"))
                     switch buildSystem {
-                        case .native:
+                    case .native, .swiftbuild:
                             #expect(
                                 error.stderr.contains("build planning stopped due to build-tool plugin failures")
                             )
-                        case .swiftbuild, .xcode:
+                        case .xcode:
                             break
                     }
                 }

--- a/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import Foundation
 import PackageLoading
+import SPMBuildCore
 import SwiftBuildSupport
 import Testing
 import _InternalTestSupport
@@ -366,10 +368,67 @@ struct PrebuiltsPIFTests {
             observabilityScope: observability.topScope
         )
 
+        struct MockPluginScriptRunner: PluginScriptRunner {
+            func compilePluginScript(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                toolsVersion: ToolsVersion,
+                workers: UInt32,
+                observabilityScope: ObservabilityScope,
+                callbackQueue: DispatchQueue,
+                delegate: any PluginScriptCompilerDelegate,
+                completion: @escaping (Result<PluginCompilationResult, any Error>) -> Void
+            ) {
+                callbackQueue.sync {
+                    completion(.failure(StringError("unimplemented")))
+                }
+            }
+
+            func buildCommandLine(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                toolsVersion: ToolsVersion,
+                workers: UInt32,
+                observabilityScope: ObservabilityScope?
+            ) -> (commandLine: [String], execName: String, execFilePath: AbsolutePath, diagFilePath: AbsolutePath) {
+                fatalError("Not implemented")
+            }
+
+            func runPluginScript(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                initialMessage: Data,
+                toolsVersion: ToolsVersion,
+                workingDirectory: AbsolutePath,
+                writableDirectories: [AbsolutePath],
+                readOnlyDirectories: [AbsolutePath],
+                allowNetworkConnections: [SandboxNetworkPermission],
+                workers: UInt32,
+                fileSystem: any FileSystem,
+                observabilityScope: ObservabilityScope,
+                callbackQueue: DispatchQueue,
+                delegate: any PluginScriptCompilerDelegate & PluginScriptRunnerDelegate,
+                completion: @escaping (Result<Int32, any Error>) -> Void
+            ) {
+                callbackQueue.sync {
+                    completion(.success(0))
+                }
+            }
+
+            var hostTriple: Triple {
+                get throws {
+                    return try UserToolchain.default.targetTriple
+                }
+            }
+        }
+
         let pifBuilder: PIFBuilder = PIFBuilder(
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
-                temporaryDirectory: AbsolutePath.root, addLocalRpaths: true),
+                temporaryDirectory: AbsolutePath.root,
+                addLocalRpaths: true,
+                pluginScriptRunner: MockPluginScriptRunner()
+            ),
             fileSystem: fs,
             observabilityScope: observability.topScope
         )


### PR DESCRIPTION
Add back the success check that got dropped accidentally in the build system transition.