### PR TITLE
Fix .artifactbundleindex artifacts re-downloading on every resolve

### DIFF
--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -141,7 +141,9 @@ extension Workspace {
                                 packageRef: packageReference,
                                 targetName: target.name,
                                 url: url,
-                                checksum: checksum
+                                checksum: checksum,
+                                originalURL: nil,
+                                originalChecksum: nil
                             )
                         )
                     } else {
@@ -209,7 +211,9 @@ extension Workspace {
                                     targetName: indexFile.targetName,
                                     url: indexFile.url.deletingLastPathComponent()
                                         .appendingPathComponent(supportedArchive.fileName),
-                                    checksum: supportedArchive.checksum
+                                    checksum: supportedArchive.checksum,
+                                    originalURL: indexFile.url,
+                                    originalChecksum: indexFile.checksum
                                 )
                             } catch {
                                 errors.append(error)
@@ -385,8 +389,8 @@ extension Workspace {
                                     return ManagedArtifact.remote(
                                         packageRef: artifact.packageRef,
                                         targetName: artifact.targetName,
-                                        url: artifact.url.absoluteString,
-                                        checksum: artifact.checksum,
+                                        url: (artifact.originalURL ?? artifact.url).absoluteString,
+                                        checksum: artifact.originalChecksum ?? artifact.checksum,
                                         path: artifactPath,
                                         kind: artifactKind
                                     )
@@ -690,6 +694,8 @@ extension Workspace.BinaryArtifactsManager {
         let targetName: String
         let url: URL
         let checksum: String
+        let originalURL: URL?
+        let originalChecksum: String?
     }
 }
 
@@ -739,7 +745,7 @@ extension Workspace.BinaryArtifactsManager {
             return binaryArtifact
         } else if let binaryArtifact = binaryArtifacts.first {
             // single one
-            observabilityScope.emit(info: "found binary artifact: '\(binaryArtifact)'")
+            observabilityScope.emit(info: "found binary artifact: '\(binaryArtifact.0)'")
             return binaryArtifact
         } else {
             return .none
@@ -913,6 +919,7 @@ extension Workspace {
                 if case .remote(let existingURL, let existingChecksum) = existingArtifact.source {
                     // If we already have an artifact with the same checksum, we don't need to download it again.
                     if artifact.checksum == existingChecksum {
+                        observabilityScope.emit(debug: "binary artifact '\(artifact.targetName)' is up to date at \(existingArtifact.path)")
                         continue
                     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -9496,14 +9496,14 @@ final class WorkspaceTests: XCTestCase {
             "https://mirror.example.com/artifacts/a.zip",
         ])
 
-        // Verify managed artifacts store the mirrored archive URL
+        // Verify managed artifacts store the mirrored index URL and index checksum
         await workspace.checkManagedArtifacts { result in
             result.check(
                 packageIdentity: .plain("a"),
                 targetName: "A",
                 source: .remote(
-                    url: "https://mirror.example.com/artifacts/a.zip",
-                    checksum: "a1"
+                    url: "https://mirror.example.com/artifacts/index.artifactbundleindex",
+                    checksum: indexFileChecksum
                 ),
                 path: workspace.artifactsDir.appending(components: "a", "A", "A.xcframework")
             )
@@ -10036,8 +10036,8 @@ final class WorkspaceTests: XCTestCase {
                 packageIdentity: .plain("a"),
                 targetName: "A1",
                 source: .remote(
-                    url: "https://a.com/a1.zip",
-                    checksum: "a1"
+                    url: "https://a.com/a1.artifactbundleindex",
+                    checksum: ariFilesChecksums[0]
                 ),
                 path: workspace.artifactsDir.appending(components: "a", "A1", "A1.artifactbundle")
             )
@@ -10045,8 +10045,8 @@ final class WorkspaceTests: XCTestCase {
                 packageIdentity: .plain("a"),
                 targetName: "A2",
                 source: .remote(
-                    url: "https://a.com/a2/a2.zip",
-                    checksum: "a2"
+                    url: "https://a.com/a2.artifactbundleindex",
+                    checksum: ariFilesChecksums[1]
                 ),
                 path: workspace.artifactsDir.appending(components: "a", "A2", "A2.artifactbundle")
             )
@@ -10230,6 +10230,77 @@ final class WorkspaceTests: XCTestCase {
                     severity: .error
                 )
             }
+        }
+    }
+
+    func testDownloadArchiveIndexFileSkipsDownloadWhenChecksumMatches() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let httpClient = HTTPClient { request, _ in
+            throw StringError("unexpected network request: \(request.url)")
+        }
+
+        let checksumAlgorithm = MockHashAlgorithm()
+        let indexChecksum = "matching-checksum"
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: "https://a.com/a.artifactbundleindex",
+                            checksum: indexChecksum
+                        ),
+                    ]
+                ),
+            ],
+            binaryArtifactsManager: .init(
+                httpClient: httpClient,
+                archiver: MockArchiver(),
+                useCache: false
+            ),
+            checksumAlgorithm: checksumAlgorithm
+        )
+
+        let rootPath = try workspace.pathToRoot(withName: "Root")
+        let rootRef = PackageReference.root(identity: PackageIdentity(path: rootPath), path: rootPath)
+        let artifactPath = workspace.artifactsDir.appending(components: "root", "A", "A.xcframework")
+
+        try await workspace.set(
+            managedArtifacts: [
+                .init(
+                    packageRef: rootRef,
+                    targetName: "A",
+                    source: .remote(
+                        url: "https://a.com/a.artifactbundleindex",
+                        checksum: indexChecksum
+                    ),
+                    path: artifactPath,
+                    kind: .xcframework
+                ),
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+
+        await workspace.checkManagedArtifacts { result in
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A",
+                source: .remote(
+                    url: "https://a.com/a.artifactbundleindex",
+                    checksum: indexChecksum
+                ),
+                path: artifactPath
+            )
         }
     }
 


### PR DESCRIPTION
The ManagedArtifact for `.artifactbundleindex` targets was stored with the zip's URL and checksum, but compared against the index file's URL and checksum from `Package.swift`. Since these never match, the cache skip never triggered, causing a full re-download on every resolve.

Store the original index URL and checksum in the `ManagedArtifact` so the comparison matches on subsequent resolves.

Issue: #9976
