### PR TITLE
Reject binary artifact archives containing symlinks that escape the extraction directory

### DIFF
--- a/Sources/Basics/FileSystem/FileSystem+Extensions.swift
+++ b/Sources/Basics/FileSystem/FileSystem+Extensions.swift
@@ -624,6 +624,35 @@ extension FileSystem {
 
         try self.removeFileTree(tempDirectory)
     }
+
+    package func validateNoEscapingSymlinks(
+        in directory: AbsolutePath,
+        resolveSymlinks resolve: @escaping (AbsolutePath) throws -> AbsolutePath = { try resolveSymlinks($0) }
+    ) throws {
+        let resolvedRoot = try resolve(directory)
+        try self.validateNoEscapingSymlinks(in: directory, root: resolvedRoot, resolveSymlinks: resolve)
+    }
+
+    private func validateNoEscapingSymlinks(
+        in directory: AbsolutePath,
+        root: AbsolutePath,
+        resolveSymlinks resolve: (AbsolutePath) throws -> AbsolutePath
+    ) throws {
+        let contents = try self.getDirectoryContents(directory)
+        for entry in contents {
+            let entryPath = directory.appending(component: entry)
+            if self.isSymlink(entryPath) {
+                let resolvedPath = try resolve(entryPath)
+                guard resolvedPath.isDescendantOfOrEqual(to: root) else {
+                    throw StringError(
+                        "symlink '\(entry)' points to '\(resolvedPath)' which is outside '\(root)'"
+                    )
+                }
+            } else if self.isDirectory(entryPath) {
+                try self.validateNoEscapingSymlinks(in: entryPath, root: root, resolveSymlinks: resolve)
+            }
+        }
+    }
 }
 
 // MARK: - Locking

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -186,6 +186,16 @@ struct BinaryArtifactsManagerError: Error, CustomStringConvertible {
         .init(description: "local binary target '\(targetName)' at '\(artifactPath)' does not contain a binary artifact.")
     }
 
+    static func artifactContainsEscapingSymlink(
+        targetName: String,
+        symlinkPath: AbsolutePath,
+        destination: String
+    ) -> Self {
+        .init(
+            description: "archive of binary target '\(targetName)' contains a symlink at '\(symlinkPath.basename)' that points to '\(destination)' outside the archive directory"
+        )
+    }
+
     static func exhaustedAttempts(missing: [PackageReference]) -> Self {
         let missing = missing.sorted(by: { $0.identity < $1.identity }).map {
             switch $0.kind {

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -203,6 +203,11 @@ extension Workspace {
                                         "No supported archive was found for '\(self.hostToolchain.targetTriple.tripleString)'"
                                     )
                                 }
+                                guard !supportedArchive.fileName.contains("..") else {
+                                    throw StringError(
+                                        "invalid archive fileName '\(supportedArchive.fileName)'"
+                                    )
+                                }
                                 // add relevant archive
                                 return RemoteArtifact(
                                     packageRef: indexFile.packageRef,
@@ -319,6 +324,9 @@ extension Workspace {
                                     try await self.archiver.extract(
                                         from: archivePath,
                                         to: tempExtractionDirectory
+                                    )
+                                    try self.fileSystem.validateNoEscapingSymlinks(
+                                        in: tempExtractionDirectory
                                     )
 
                                     defer {
@@ -469,6 +477,9 @@ extension Workspace {
 
                         do {
                             try await self.archiver.extract(from: artifact.path, to: tempExtractionDirectory)
+                            try self.fileSystem.validateNoEscapingSymlinks(
+                                in: tempExtractionDirectory
+                            )
 
                             return observabilityScope.trap {
                                 try self.fileSystem.withLock(on: destinationDirectory, type: .exclusive) {

--- a/Tests/BasicsTests/FileSystem/FileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/FileSystemTests.swift
@@ -100,4 +100,88 @@ struct FileSystemTests {
             }
         }
     }
+
+    @Test
+    func validateNoEscapingSymlinksAllowsInternalSymlinks() throws {
+        try withTemporaryDirectory { tmpDir in
+            let dir = tmpDir.appending("extraction")
+            try localFileSystem.createDirectory(dir, recursive: true)
+            let subdir = dir.appending("sub")
+            try localFileSystem.createDirectory(subdir)
+            try localFileSystem.writeFileContents(subdir.appending("file.txt"), string: "content")
+            try localFileSystem.createSymbolicLink(
+                dir.appending("link"),
+                pointingAt: subdir.appending("file.txt"),
+                relative: true
+            )
+
+            #expect(throws: Never.self) {
+                try localFileSystem.validateNoEscapingSymlinks(in: dir)
+            }
+        }
+    }
+
+    @Test
+    func validateNoEscapingSymlinksRejectsEscapingAbsoluteSymlink() throws {
+        try withTemporaryDirectory { tmpDir in
+            let dir = tmpDir.appending("extraction")
+            try localFileSystem.createDirectory(dir, recursive: true)
+            try localFileSystem.createSymbolicLink(
+                dir.appending("escape"),
+                pointingAt: tmpDir,
+                relative: false
+            )
+
+            #expect(throws: StringError.self) {
+                try localFileSystem.validateNoEscapingSymlinks(in: dir)
+            }
+        }
+    }
+
+    @Test
+    func validateNoEscapingSymlinksRejectsEscapingRelativeSymlink() throws {
+        try withTemporaryDirectory { tmpDir in
+            let dir = tmpDir.appending("extraction")
+            try localFileSystem.createDirectory(dir, recursive: true)
+            try localFileSystem.createSymbolicLink(
+                dir.appending("escape"),
+                pointingAt: tmpDir,
+                relative: true
+            )
+
+            #expect(throws: StringError.self) {
+                try localFileSystem.validateNoEscapingSymlinks(in: dir)
+            }
+        }
+    }
+
+    @Test
+    func validateNoEscapingSymlinksRejectsNestedEscapingSymlink() throws {
+        try withTemporaryDirectory { tmpDir in
+            let dir = tmpDir.appending("extraction")
+            let nested = dir.appending(components: "a", "b")
+            try localFileSystem.createDirectory(nested, recursive: true)
+            try localFileSystem.createSymbolicLink(
+                nested.appending("escape"),
+                pointingAt: tmpDir,
+                relative: true
+            )
+
+            #expect(throws: StringError.self) {
+                try localFileSystem.validateNoEscapingSymlinks(in: dir)
+            }
+        }
+    }
+
+    @Test
+    func validateNoEscapingSymlinksEmptyDirectorySucceeds() throws {
+        try withTemporaryDirectory { tmpDir in
+            let dir = tmpDir.appending("extraction")
+            try localFileSystem.createDirectory(dir, recursive: true)
+
+            #expect(throws: Never.self) {
+                try localFileSystem.validateNoEscapingSymlinks(in: dir)
+            }
+        }
+    }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -10412,6 +10412,72 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testDownloadArchiveIndexFileRejectsPathTraversalFileName() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+        try fs.createMockToolchain()
+        let hostToolchain = try UserToolchain.mockHostToolchain(fs)
+
+        let ari = """
+        {
+            "schemaVersion": "1.0",
+            "archives": [
+                {
+                    "fileName": "../../evil.zip",
+                    "checksum": "a",
+                    "supportedTriples": ["\(hostToolchain.targetTriple.tripleString)"]
+                }
+            ]
+        }
+        """
+        let checksumAlgorithm = MockHashAlgorithm()
+        let ariChecksum = checksumAlgorithm.hash(ari).hexadecimalRepresentation
+
+        let httpClient = HTTPClient { request, _ in
+            switch request.kind {
+            case .generic:
+                switch request.url.lastPathComponent {
+                case "a.artifactbundleindex":
+                    return .okay(body: ari)
+                default:
+                    throw StringError("unexpected url \(request.url)")
+                }
+            case .download:
+                throw StringError("should not download")
+            }
+        }
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: "https://a.com/a.artifactbundleindex",
+                            checksum: ariChecksum
+                        ),
+                    ]
+                ),
+            ],
+            binaryArtifactsManager: .init(
+                httpClient: httpClient
+            )
+        )
+
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: .contains("invalid archive fileName '../../evil.zip'"),
+                    severity: .error
+                )
+            }
+        }
+    }
+
     func testDownloadArchiveIndexTripleNotFound() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
When a binary artifact is extracted symbolic links are preserved. After extraction, the contents are copied to the artifacts directory via `FileManager.copyItem`, which also preserves symlinks rather than dereferencing them.

A malicious binary artifact archive could include a symlink pointing outside the extraction directory (e.g. `myFile -> ../../../.ssh/`). After extraction and copy, anything that reads through the artifact directory would follow the symlink and traverse attacker-chosen paths.

On its own this is not a critical vulnerability since something would then have to read this symlink and print its contents. This patch acts is general hardening against this class of path travesal attack.

Add `validateNoEscapingSymlinks(in:)` to `FileSystem`, called immediately after each `archiver.extract` call site. The function recursively walks the extraction directory, resolves each symlink via `realpath`, and throws if the resolved target falls outside the root. The resolver is injectable via closure parameter for future testability with `InMemoryFileSystem`.

Also fix a potential path traversal  when reading the supported archive filename, which does a path concatination with a user provided path from the manifest.
