### PR TITLE
Do not launch XCTest for products that contain no XCTestCases - avoid "Executed 0 tests, with 0 failures" logs 

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -328,12 +328,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             if !self.options.shouldRunInParallel {
                 let (xctestArgs, testCount, testPaths) = try xctestArgs(for: testProducts, swiftCommandState: swiftCommandState)
 
-                // Tests have been filtered and/or skipped; assure that we only run test products
-                // of the tests we must run.
-                var filteredTestProducts = testProducts
-                if let testPaths, testProducts.count != testPaths.count {
-                    filteredTestProducts = testProducts.filter({ testPaths.contains($0.bundlePath) })
-                }
+                // Products with no XCTest cases are excluded by xctestArgs to avoid 'Executed 0 tests' logs.
+                let filteredTestProducts = testProducts.filter({ testPaths.contains($0.bundlePath) })
                 let productResults = try await runTestProducts(
                     filteredTestProducts,
                     additionalArguments: xctestArgs,
@@ -471,36 +467,25 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         }
     }
 
-    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState) throws -> (arguments: [String], testCount: Int?, testPaths: Set<AbsolutePath>?) {
-        switch options.testCaseSpecifier {
-        case .none:
-            if case .skip = options.skippedTests(fileSystem: swiftCommandState.fileSystem) {
-                fallthrough
-            } else {
-                return ([], nil, nil)
-            }
-
-        case .regex, .specific, .skip:
-            // If old specifier `-s` option was used, emit deprecation notice.
-            if case .specific = options.testCaseSpecifier {
-                swiftCommandState.observabilityScope.emit(warning: "'--specifier' option is deprecated; use '--filter' instead")
-            }
-
-            // Find the tests we need to run.
-            let testSuites = try TestingSupport.getTestSuites(
-                in: testProducts,
-                swiftCommandState: swiftCommandState,
-                enableCodeCoverage: options.enableCodeCoverage,
-                shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
-                experimentalTestOutput: options.enableExperimentalTestOutput,
-                sanitizers: globalOptions.build.sanitizers
-            )
-            let tests = try testSuites
-                .filteredTests(specifier: options.testCaseSpecifier)
-                .skippedTests(specifier: options.skippedTests(fileSystem: swiftCommandState.fileSystem))
-
-            return (TestRunner.xctestArguments(forTestSpecifiers: tests.map(\.specifier)), tests.count, Set(tests.map(\.testProduct.bundlePath)))
+    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState) throws -> (arguments: [String], testCount: Int, testPaths: Set<AbsolutePath>) {
+        // If old specifier `-s` option was used, emit deprecation notice.
+        if case .specific = options.testCaseSpecifier {
+            swiftCommandState.observabilityScope.emit(warning: "'--specifier' option is deprecated; use '--filter' instead")
         }
+
+        let testSuites = try TestingSupport.getTestSuites(
+            in: testProducts,
+            swiftCommandState: swiftCommandState,
+            enableCodeCoverage: options.enableCodeCoverage,
+            shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
+            experimentalTestOutput: options.enableExperimentalTestOutput,
+            sanitizers: globalOptions.build.sanitizers
+        )
+        let tests = try testSuites
+            .filteredTests(specifier: options.testCaseSpecifier)
+            .skippedTests(specifier: options.skippedTests(fileSystem: swiftCommandState.fileSystem))
+
+        return (TestRunner.xctestArguments(forTestSpecifiers: tests.map(\.specifier)), tests.count, Set(tests.map(\.testProduct.bundlePath)))
     }
 
     /// Generate xUnit file if requested.

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -123,7 +123,6 @@ struct TestDiscoveryTests {
         }
     }
 
-    // FIXME: eliminate extraneous warnings with --build-system swiftbuild
     @Test(
         .tags(
             .Feature.Command.Test,
@@ -135,18 +134,17 @@ struct TestDiscoveryTests {
         .bug("https://github.com/swiftlang/swift-build/issues/573"),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
-    func discovery_whenNoTests(_ buildSystem: BuildSystemProvider.Kind) async throws {
+    func testNoSpuriousEmptyTestExecLogs_whenPackageContainsNoTests(_ buildSystem: BuildSystemProvider.Kind) async throws {
             try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestDiscovery/NoTests") { fixturePath in
                 let (stdout, stderr) = try await executeSwiftTest(fixturePath, buildSystem: buildSystem)
                 // in "swift test" build output goes to stderr
                 #expect(stderr.contains("Build complete!"))
-                // we are expecting that no warning is produced
+                // we are expecting that a warning is produced that no test cases were run
                 let buidlSystemDeprecationDiag = Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem)
                 let filteredStderr = stderr.components(separatedBy: "\n").filter { !$0.contains(buidlSystemDeprecationDiag.message)}.joined(separator: "\n|")
-                #expect(!filteredStderr.contains("warning:"))
-                // in "swift test" test output goes to stdout
-                #expect(stdout.contains("Executed 0 tests"))
+                #expect(filteredStderr.contains("warning: No matching test cases were run"))
+                #expect(!stdout.contains("Executed 0 tests"))
             }
             } when: {
                 buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows


### PR DESCRIPTION
### Motivation:

When running tests in non-parallel mode we would emit many empty test log lines:

Test Suite 'All tests' started at 2026-04-23 14:38:40.828.
Test Suite 'All tests' passed at 2026-04-23 14:38:40.830.
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.003) seconds
Test Suite 'All tests' started at 2026-04-23 14:38:41.470.
Test Suite 'All tests' passed at 2026-04-23 14:38:41.471.
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
Test Suite 'All tests' started at 2026-04-23 14:38:42.041.
Test Suite 'All tests' passed at 2026-04-23 14:38:42.043.
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds

This change ensures we do not launch XCTest for products that contain no XCTestCases, avoiding the extra "Executed 0 tests, with 0 failures" logs 

### Modifications:

Always calls getTestSuites() regardless of whether a filter was specified.  The downside is we run XCTest to list tests lists for each product.  This is the same behaviour as the parallel mode.

### Result:

No longer launch XCTest for products that contain no XCTestCases
