### PR TITLE
[6.3] Track scm URL for registry packages when using `--replace-scm-with-registry`

### DIFF
--- a/Sources/PackageGraph/ResolvedPackagesStore.swift
+++ b/Sources/PackageGraph/ResolvedPackagesStore.swift
@@ -39,9 +39,13 @@ public final class ResolvedPackagesStore {
         /// The resolved state.
         public let state: ResolutionState
 
-        public init(packageRef: PackageReference, state: ResolutionState) {
+        /// The original source control URL for a registry package that was mapped from a source control package.
+        public var originalScmUrl: SourceControlURL?
+
+        public init(packageRef: PackageReference, state: ResolutionState, originalScmUrl: SourceControlURL?) {
             self.packageRef = packageRef
             self.state = state
+            self.originalScmUrl = originalScmUrl
         }
     }
 
@@ -131,10 +135,11 @@ public final class ResolvedPackagesStore {
     /// - Parameters:
     ///   - packageRef: The package reference to track.
     ///   - state: The state to track with.
-    public func track(packageRef: PackageReference, state: ResolutionState) {
+    public func track(packageRef: PackageReference, state: ResolutionState, scm: SourceControlURL? = nil) {
         self.add(.init(
             packageRef: packageRef,
-            state: state
+            state: state,
+            originalScmUrl: scm
         ))
     }
 
@@ -439,6 +444,7 @@ private struct ResolvedPackagesStorage {
             let identity: PackageIdentity
             let kind: Kind
             let location: String
+            let originalLocation: String?
             let state: State
 
             init(_ pin: ResolvedPackagesStore.ResolvedPackage, mirrors: DependencyMirrors) throws {
@@ -463,6 +469,7 @@ private struct ResolvedPackagesStorage {
                 // rdar://52529014, rdar://52529011: pin file should store the original location but remap when loading
                 self.location = mirrors.original(for: location) ?? location
                 self.state = .init(pin.state)
+                self.originalLocation = pin.originalScmUrl?.absoluteString
             }
         }
 
@@ -534,7 +541,8 @@ extension ResolvedPackagesStore.ResolvedPackage {
         }
         self.init(
             packageRef: packageRef,
-            state: try .init(pin.state)
+            state: try .init(pin.state),
+            originalScmUrl: nil
         )
     }
 }
@@ -566,9 +574,15 @@ extension ResolvedPackagesStore.ResolvedPackage {
         case .registry:
             packageRef = .registry(identity: identity)
         }
+        let scm: SourceControlURL? = if let url = pin.originalLocation {
+            SourceControlURL(url)
+        } else {
+            nil
+        }
         self.init(
             packageRef: packageRef,
-            state: try .init(pin.state)
+            state: try .init(pin.state),
+            originalScmUrl: scm
         )
     }
 }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -99,7 +99,6 @@ enum ManifestJSONParser {
                 dependency: $0,
                 toolsVersion: toolsVersion,
                 parentPackagePath: packagePath,
-                identityResolver: identityResolver,
                 dependencyMapper: dependencyMapper,
                 fileSystem: fileSystem
             )
@@ -166,7 +165,6 @@ enum ManifestJSONParser {
         dependency: Serialization.PackageDependency,
         toolsVersion: ToolsVersion,
         parentPackagePath: AbsolutePath,
-        identityResolver: IdentityResolver,
         dependencyMapper: DependencyMapper,
         fileSystem: FileSystem
     ) throws -> PackageDependency {

--- a/Sources/PackageLoading/ToolsVersionParser.swift
+++ b/Sources/PackageLoading/ToolsVersionParser.swift
@@ -633,7 +633,6 @@ extension ManifestLoader {
                 return versionSpecificPath
             }
         }
-
         let contents: [String]
         do { contents = try fileSystem.getDirectoryContents(packagePath) } catch {
             throw ToolsVersionParser.Error.inaccessiblePackage(path: packagePath, reason: String(describing: error))

--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -149,7 +149,7 @@ public struct PackageReference {
     }
 
     public static func registry(identity: PackageIdentity) -> PackageReference {
-        PackageReference(identity: identity, kind: .registry(identity))
+        return PackageReference(identity: identity, kind: .registry(identity))
     }
 }
 

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -661,7 +661,6 @@ public final class RegistryClient: AsyncCancellable {
         observabilityScope: ObservabilityScope
     ) async throws -> String {
         let (registryIdentity, registry) = try self.unwrapRegistry(from: package)
-
         try await withAvailabilityCheck(
             registry: registry,
             observabilityScope: observabilityScope

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -33,7 +33,10 @@ extension Workspace {
             case sourceControlCheckout(CheckoutState)
 
             /// The dependency is downloaded from a registry.
-            case registryDownload(version: Version)
+            ///
+            /// If the scmUrl is non-nil, the dependency has been mapped from
+            /// a source control dependency.
+            case registryDownload(version: Version, scmUrl: SourceControlURL?)
 
             /// The dependency is in edited state.
             ///
@@ -50,8 +53,12 @@ extension Workspace {
                     return "fileSystem (\(path))"
                 case .sourceControlCheckout(let checkoutState):
                     return "sourceControlCheckout (\(checkoutState))"
-                case .registryDownload(let version):
-                    return "registryDownload (\(version))"
+                case .registryDownload(let version, let scm):
+                    var result = "registry download (\(version))"
+                    if let scm {
+                        result += " mapped from scm \(scm.absoluteString)"
+                    }
+                    return result
                 case .edited:
                     return "edited"
                 case .custom:
@@ -135,14 +142,15 @@ extension Workspace {
         public static func registryDownload(
             packageRef: PackageReference,
             version: Version,
-            subpath: Basics.RelativePath
+            subpath: Basics.RelativePath,
+            scmUrl: SourceControlURL? = nil
         ) throws -> ManagedDependency {
             guard case .registry = packageRef.kind else {
                 throw InternalError("invalid package type: \(packageRef.kind)")
             }
             return ManagedDependency(
                 packageRef: packageRef,
-                state: .registryDownload(version: version),
+                state: .registryDownload(version: version, scmUrl: scmUrl),
                 subpath: subpath
             )
         }

--- a/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
@@ -30,6 +30,7 @@ public class RegistryPackageContainer: PackageContainer {
     private let manifestLoader: ManifestLoaderProtocol
     private let currentToolsVersion: ToolsVersion
     private let observabilityScope: ObservabilityScope
+    private let identityLookupCache: Workspace.IdentityLookupCache
 
     private var knownVersionsCache = AsyncThrowingValueMemoizer<[Version]>()
     private var toolsVersionsCache = ThrowingAsyncKeyValueMemoizer<Version, ToolsVersion>()
@@ -44,7 +45,8 @@ public class RegistryPackageContainer: PackageContainer {
         registryClient: RegistryClient,
         manifestLoader: ManifestLoaderProtocol,
         currentToolsVersion: ToolsVersion,
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
+        identityLookupCache: Workspace.IdentityLookupCache
     ) {
         self.package = package
         self.identityResolver = identityResolver
@@ -55,6 +57,7 @@ public class RegistryPackageContainer: PackageContainer {
         self.observabilityScope = observabilityScope.makeChildScope(
             description: "RegistryPackageContainer",
             metadata: package.diagnosticsMetadata)
+        self.identityLookupCache = identityLookupCache
     }
 
     // MARK: - PackageContainer

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -72,6 +72,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     private var knownVersionsCache = ThreadSafeBox<[Version: String]?>()
     private var manifestsCache = ThrowingAsyncKeyValueMemoizer<String, Manifest>()
     private var toolsVersionsCache = ThreadSafeKeyValueStore<Version, ToolsVersion>()
+    private var identityLookupCache: Workspace.IdentityLookupCache
 
     /// This is used to remember if tools version of a particular version is
     /// valid or not.
@@ -87,7 +88,8 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         currentToolsVersion: ToolsVersion,
         fingerprintStorage: PackageFingerprintStorage?,
         fingerprintCheckingMode: FingerprintCheckingMode,
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
+        identityLookupCache: Workspace.IdentityLookupCache
     ) throws {
         self.package = package
         self.identityResolver = identityResolver
@@ -101,6 +103,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         self.observabilityScope = observabilityScope.makeChildScope(
             description: "SourceControlPackageContainer",
             metadata: package.diagnosticsMetadata)
+        self.identityLookupCache = identityLookupCache
     }
 
     // Compute the map of known versions.

--- a/Sources/Workspace/ResolverPrecomputationProvider.swift
+++ b/Sources/Workspace/ResolverPrecomputationProvider.swift
@@ -98,7 +98,7 @@ private struct LocalPackageContainer: PackageContainer {
         switch dependency?.state {
         case .sourceControlCheckout(.version(let version, revision: _)):
             return [version]
-        case .registryDownload(let version):
+        case .registryDownload(let version, _):
             return [version]
         default:
             return []
@@ -127,7 +127,7 @@ private struct LocalPackageContainer: PackageContainer {
         switch dependency?.state {
         case .sourceControlCheckout(.version(version, revision: _)):
             return try manifest.dependencyConstraints(productFilter: productFilter, enabledTraits)
-        case .registryDownload(version: version):
+        case .registryDownload(version: version, _):
             return try manifest.dependencyConstraints(productFilter: productFilter, enabledTraits)
         default:
             throw InternalError("expected version based state, but state was \(String(describing: dependency?.state))")

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -18,6 +18,7 @@ import class Basics.ObservabilityScope
 import func Basics.os_signpost
 import struct Basics.RelativePath
 import enum Basics.SignpostName
+import struct Basics.SourceControlURL
 import class Basics.ThreadSafeKeyValueStore
 import class Dispatch.DispatchGroup
 import struct Dispatch.DispatchTime
@@ -345,6 +346,19 @@ extension Workspace {
         // Ensure the cache path exists.
         self.createCacheDirectories(observabilityScope: observabilityScope)
 
+        // Populate the identity lookup cache via the Package.resolved.
+        // This will only ever be done if the user has passed in `--force-resolved-versions`
+        do {
+            self.identityLookupCache.deriveCache(
+                from: try self.resolvedPackagesStore.load().resolvedPackages,
+                self.configuration.sourceControlToRegistryDependencyTransformation
+            )
+        } catch {
+            // If we cannot load the resolved file, send log to user and
+            // continue.
+            observabilityScope.emit(debug: "Unable to prepopulate identity lookup cache", underlyingError: error)
+        }
+
         let rootManifests = try await self.loadRootManifests(
             packages: root.packages,
             observabilityScope: observabilityScope
@@ -423,7 +437,7 @@ extension Workspace {
             switch dependency.state {
             case .sourceControlCheckout(let checkoutState):
                 return !pin.state.equals(checkoutState)
-            case .registryDownload(let version):
+            case .registryDownload(let version, _):
                 return !pin.state.equals(version)
             case .edited, .fileSystem, .custom:
                 return true
@@ -1119,7 +1133,7 @@ extension Workspace {
             case .version(let version):
                 let stateChange: PackageStateChange
                 switch currentDependency?.state {
-                case .sourceControlCheckout(.version(version, _)), .registryDownload(version), .custom(version, _):
+                case .sourceControlCheckout(.version(version, _)), .registryDownload(version, _), .custom(version, _):
                     stateChange = .unchanged
                 case .edited, .fileSystem, .sourceControlCheckout, .registryDownload, .custom:
                     stateChange = .updated(.init(requirement: .version(version), products: binding.products))

--- a/Sources/Workspace/Workspace+Manifests.swift
+++ b/Sources/Workspace/Workspace+Manifests.swift
@@ -776,7 +776,7 @@ extension Workspace {
             default:
                 packageVersion = .none
             }
-        case .registryDownload(let downloadedVersion):
+        case .registryDownload(let downloadedVersion, _):
             packageKind = managedDependency.packageRef.kind
             packageVersion = downloadedVersion
         case .custom(let availableVersion, _):
@@ -943,7 +943,7 @@ extension Workspace {
                     observabilityScope
                         .emit(.checkedOutDependencyMissing(packageName: dependency.packageRef.identity.description))
 
-                case .registryDownload(let version):
+                case .registryDownload(let version, _):
                     // If some downloaded dependency has been removed, retrieve it again.
                     _ = try await self.downloadRegistryArchive(
                         package: dependency.packageRef,

--- a/Sources/Workspace/Workspace+PackageContainer.swift
+++ b/Sources/Workspace/Workspace+PackageContainer.swift
@@ -67,7 +67,8 @@ extension Workspace: PackageContainerProvider {
                 fingerprintStorage: self.fingerprints,
                 fingerprintCheckingMode: FingerprintCheckingMode
                     .map(self.configuration.fingerprintCheckingMode),
-                observabilityScope: observabilityScope
+                observabilityScope: observabilityScope,
+                identityLookupCache: self.identityLookupCache
             )
             return result
         // Resolve the container using the registry
@@ -79,7 +80,8 @@ extension Workspace: PackageContainerProvider {
                 registryClient: self.registryClient,
                 manifestLoader: self.manifestLoader,
                 currentToolsVersion: self.currentToolsVersion,
-                observabilityScope: observabilityScope
+                observabilityScope: observabilityScope,
+                identityLookupCache: identityLookupCache
             )
             return container
         }

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -56,21 +56,18 @@ extension Workspace {
         private let underlying: ManifestLoaderProtocol
         private let registryClient: RegistryClient
         private let transformationMode: TransformationMode
-
-        private let cacheTTL = DispatchTimeInterval.seconds(300) // 5m
-        private let identityLookupCache = ThreadSafeKeyValueStore<
-            SourceControlURL,
-            (result: Result<PackageIdentity?, Error>, expirationTime: DispatchTime)
-        >()
+        private let identityLookupCache: Workspace.IdentityLookupCache
 
         init(
             underlying: ManifestLoaderProtocol,
             registryClient: RegistryClient,
-            transformationMode: TransformationMode
+            transformationMode: TransformationMode,
+            identityLookupCache: Workspace.IdentityLookupCache
         ) {
             self.underlying = underlying
             self.registryClient = registryClient
             self.transformationMode = transformationMode
+            self.identityLookupCache = identityLookupCache
         }
 
         func load(
@@ -174,7 +171,7 @@ extension Workspace {
             for dependency in manifest.dependencies {
                 var modifiedDependency = dependency
                 if let registryIdentity = transformations[dependency] {
-                    guard case .sourceControl(let settings) = dependency, case .remote = settings.location else {
+                    guard case .sourceControl(let settings) = dependency, case .remote(let scmURL) = settings.location else {
                         // an implementation mistake
                         throw InternalError("unexpected non-source-control dependency: \(dependency)")
                     }
@@ -211,7 +208,7 @@ extension Workspace {
                                 identity: registryIdentity,
                                 requirement: requirement,
                                 productFilter: settings.productFilter,
-                                traits: settings.traits
+                                traits: settings.traits,
                             )
                         case .branch, .revision:
                             // branch and revision dependencies are not supported by the registry
@@ -332,10 +329,13 @@ extension Workspace {
             url: SourceControlURL,
             observabilityScope: ObservabilityScope
         ) async throws -> PackageIdentity? {
-            if let cached = self.identityLookupCache[url], cached.expirationTime > .now() {
+            if let cached = identityLookupCache[url], cached.expirationTime > .now() {
                 switch cached.result {
                 case .success(let identity):
-                    return identity;
+                    return identity
+                case .notApplicable:
+                    // scm package does not have a valid registry mapping
+                    return nil
                 case .failure:
                     // server error, do not try again
                     return nil
@@ -348,10 +348,10 @@ extension Workspace {
                     observabilityScope: observabilityScope
                 )
                 let identity = identities.sorted().first
-                self.identityLookupCache[url] = (result: .success(identity), expirationTime: .now() + self.cacheTTL)
+                identityLookupCache[storing: url] = .success(identity)
                 return identity
             } catch {
-                self.identityLookupCache[url] = (result: .failure(error), expirationTime: .now() + self.cacheTTL)
+                identityLookupCache[storing: url] = .failure(error)
                 throw error
             }
         }
@@ -406,11 +406,13 @@ extension Workspace {
             debug: "adding '\(package.identity)' (\(package.locationString)) to managed dependencies",
             metadata: package.diagnosticsMetadata
         )
+        let scm = self.identityLookupCache.scmURL(for: package.identity)
         try await self.state.add(
             dependency: .registryDownload(
                 packageRef: package,
                 version: version,
-                subpath: downloadPath.relative(to: self.location.registryDownloadDirectory)
+                subpath: downloadPath.relative(to: self.location.registryDownloadDirectory),
+                scmUrl: scm
             )
         )
         try await self.state.save()
@@ -445,5 +447,99 @@ extension Workspace {
 
         // remove the local copy
         try registryDownloadsManager.remove(package: dependency.packageRef.identity)
+    }
+}
+
+extension Workspace {
+    public class IdentityLookupCache {
+        public typealias Key = SourceControlURL
+        public typealias Value = CacheResult
+        public typealias CacheResult = (result: IdentityMapResult<PackageIdentity?, Error>, expirationTime: DispatchTime)
+
+
+        public enum IdentityMapResult<Success, Failure> {
+            /// Represents a successful mapping of a source control URL to its registry identity
+            case success(Success)
+            /// Represents a failure to retrieve an identity from the registry
+            case failure(Failure)
+            /// Represents a scenario wherein a scm package has no valid registry identity mapping
+            case notApplicable
+        }
+
+        /// Tracks the mapping of scm packages to their registry identities
+        private let cache = ThreadSafeKeyValueStore<SourceControlURL, CacheResult>()
+        private let cacheTTL = DispatchTimeInterval.seconds(300) // 5m
+
+        public var isEmpty: Bool {
+            return self.cache.isEmpty
+        }
+
+        public var description: String {
+            self.cache.get().description
+        }
+
+        public subscript(key: Key) -> CacheResult? {
+            get { self.cache[key] }
+            set { self.cache[key] = newValue }
+        }
+
+        public subscript(storing key: Key) -> IdentityMapResult<PackageIdentity?, Error>? {
+            get { self.cache[key]?.result }
+            set {
+                guard let newValue else {
+                    cache.removeValue(forKey: key)
+                    return
+                }
+                self.cache[key] = (
+                    result: newValue,
+                    expirationTime: .now() + self.cacheTTL
+                )
+            }
+        }
+
+        /// Derives an identity lookup cache from the Package.resolved file if applicable.
+        /// Asserts against the transformation mode set in the Workspace to determine how to store
+        /// source control packages and their identity mappings.
+        public func deriveCache(from resolvedPackages: ResolvedPackagesStore.ResolvedPackages, _ transformationMode: WorkspaceConfiguration.SourceControlToRegistryDependencyTransformation) {
+            guard transformationMode != .disabled else {
+                return
+            }
+
+            // First run, create a mapping between registry packages and their scm location, if applicable.
+            for resolvedPackage in resolvedPackages.values {
+                if case let .registry(id) = resolvedPackage.packageRef.kind,
+                   let url = resolvedPackage.originalScmUrl
+                {
+                    self[storing: url] = .success(id)
+                }
+            }
+
+            // Second pass;
+            // Track SCM packages that don't have a mapped registry equivalent,
+            // only if the transformation mode is `.swizzle`; this will avoid
+            // having to make any unnecessary calls to registry endpoints.
+            if transformationMode == .swizzle {
+                for resolvedPackage in resolvedPackages.values {
+                    if case .remoteSourceControl(let url) = resolvedPackage.packageRef.kind,
+                        self.cache[url] == nil {
+                        self[storing: url] = .notApplicable
+                    }
+                }
+            }
+        }
+
+        public func scmURL(for registryId: PackageIdentity) -> SourceControlURL? {
+            for (url, result) in self.cache.get() {
+                guard case .success(.some(let id)) = result.result else {
+                    continue
+                }
+
+                if id == registryId {
+                    return url
+                }
+            }
+
+            return nil
+        }
     }
 }

--- a/Sources/Workspace/Workspace+ResolvedPackages.swift
+++ b/Sources/Workspace/Workspace+ResolvedPackages.swift
@@ -128,22 +128,26 @@ extension ResolvedPackagesStore.ResolvedPackage {
         case .sourceControlCheckout(.version(let version, let revision)):
             self.init(
                 packageRef: dependency.packageRef,
-                state: .version(version, revision: revision.identifier)
+                state: .version(version, revision: revision.identifier),
+                originalScmUrl: nil
             )
         case .sourceControlCheckout(.branch(let branch, let revision)):
             self.init(
                 packageRef: dependency.packageRef,
-                state: .branch(name: branch, revision: revision.identifier)
+                state: .branch(name: branch, revision: revision.identifier),
+                originalScmUrl: nil
             )
         case .sourceControlCheckout(.revision(let revision)):
             self.init(
                 packageRef: dependency.packageRef,
-                state: .revision(revision.identifier)
+                state: .revision(revision.identifier),
+                originalScmUrl: nil
             )
-        case .registryDownload(let version):
+        case .registryDownload(let version, let scm):
             self.init(
                 packageRef: dependency.packageRef,
-                state: .version(version, revision: .none)
+                state: .version(version, revision: .none),
+                originalScmUrl: scm
             )
         case .edited, .fileSystem, .custom:
             // NOOP

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -293,8 +293,14 @@ extension WorkspaceStateStorage {
                         return try self.init(underlying: .sourceControlCheckout(.init(checkout)))
                     case "registryDownload":
                         let version = try container.decode(String.self, forKey: .version)
+                        let urlString = try container.decodeIfPresent(String.self, forKey: .scmUrl)
+                        let scm: SourceControlURL? = if let urlString {
+                            SourceControlURL(urlString)
+                        } else {
+                            nil
+                        }
                         return try self
-                            .init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
+                            .init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version), scmUrl: scm))
                     case "edited":
                         let path = try container.decode(Basics.AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(
@@ -322,9 +328,10 @@ extension WorkspaceStateStorage {
                     case .sourceControlCheckout(let state):
                         try container.encode("sourceControlCheckout", forKey: .name)
                         try container.encode(CheckoutInfo(state), forKey: .checkoutState)
-                    case .registryDownload(let version):
+                    case .registryDownload(let version, let scm):
                         try container.encode("registryDownload", forKey: .name)
                         try container.encode(version, forKey: .version)
+                        try container.encodeIfPresent(scm?.absoluteString, forKey: .scmUrl)
                     case .edited(_, let path):
                         try container.encode("edited", forKey: .name)
                         try container.encode(path, forKey: .path)
@@ -339,6 +346,7 @@ extension WorkspaceStateStorage {
                     case name
                     case path
                     case version
+                    case scmUrl
                     case checkoutState
                 }
 
@@ -692,7 +700,7 @@ extension WorkspaceStateStorage {
                     case "registryDownload":
                         let version = try container.decode(String.self, forKey: .version)
                         return try self
-                            .init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
+                            .init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version), scmUrl: nil))
                     case "edited":
                         let path = try container.decode(Basics.AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(
@@ -720,7 +728,7 @@ extension WorkspaceStateStorage {
                     case .sourceControlCheckout(let state):
                         try container.encode("sourceControlCheckout", forKey: .name)
                         try container.encode(CheckoutInfo(state), forKey: .checkoutState)
-                    case .registryDownload(let version):
+                    case .registryDownload(let version, _):
                         try container.encode("registryDownload", forKey: .name)
                         try container.encode(version, forKey: .version)
                     case .edited(_, let path):
@@ -1048,7 +1056,7 @@ extension WorkspaceStateStorage {
                     case "registryDownload":
                         let version = try container.decode(String.self, forKey: .version)
                         return try self
-                            .init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version)))
+                            .init(underlying: .registryDownload(version: TSCUtility.Version(versionString: version), scmUrl: nil))
                     case "edited":
                         let path = try container.decode(Basics.AbsolutePath?.self, forKey: .path)
                         return try self.init(underlying: .edited(
@@ -1076,7 +1084,7 @@ extension WorkspaceStateStorage {
                     case .sourceControlCheckout(let state):
                         try container.encode("sourceControlCheckout", forKey: .name)
                         try container.encode(CheckoutInfo(state), forKey: .checkoutState)
-                    case .registryDownload(let version):
+                    case .registryDownload(let version, _):
                         try container.encode("registryDownload", forKey: .name)
                         try container.encode(version, forKey: .version)
                     case .edited(_, let path):

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -125,6 +125,13 @@ public class Workspace {
     /// Utility to map dependencies
     let dependencyMapper: DependencyMapper
 
+    /// Utility to resolve scm packages who have been mapped to registry packages
+    /// through the use of `--replace-scm-with-registry`.
+    ///
+    /// This cache will be ignored if either `--disable-scm-to-registry-transformation`
+    /// or `--use-registry-identity-for-scm` are used.
+    let identityLookupCache: IdentityLookupCache
+
     /// The custom package container provider used by this workspace, if any.
     let customPackageContainerProvider: PackageContainerProvider?
 
@@ -552,13 +559,16 @@ public class Workspace {
         // register the registry dependencies downloader with the cancellation handler
         cancellator?.register(name: "registry downloads", handler: registryDownloadsManager)
 
+        let identityLookupCache: IdentityLookupCache = .init()
+
         if let transformationMode = RegistryAwareManifestLoader
             .TransformationMode(configuration.sourceControlToRegistryDependencyTransformation)
         {
             manifestLoader = RegistryAwareManifestLoader(
                 underlying: manifestLoader,
                 registryClient: registryClient,
-                transformationMode: transformationMode
+                transformationMode: transformationMode,
+                identityLookupCache: identityLookupCache,
             )
         }
 
@@ -641,7 +651,8 @@ public class Workspace {
             fingerprints: fingerprints,
             resolvedPackagesStore: resolvedPackagesStore,
             prebuiltsManager: prebuiltsManager,
-            state: state
+            state: state,
+            identityLookupCache: identityLookupCache
         )
     }
 
@@ -664,7 +675,8 @@ public class Workspace {
         fingerprints: PackageFingerprintStorage?,
         resolvedPackagesStore: LoadableResult<ResolvedPackagesStore>,
         prebuiltsManager: PrebuiltsManager?,
-        state: WorkspaceState
+        state: WorkspaceState,
+        identityLookupCache: IdentityLookupCache
     ) {
         self.fileSystem = fileSystem
         self.configuration = configuration
@@ -690,6 +702,8 @@ public class Workspace {
         self.prebuiltsManager = prebuiltsManager
 
         self.state = state
+
+        self.identityLookupCache = identityLookupCache
     }
 }
 
@@ -818,7 +832,7 @@ extension Workspace {
         switch dependency.state {
         case .sourceControlCheckout(let checkoutState):
             defaultRequirement = checkoutState.requirement
-        case .registryDownload(let version), .custom(let version, _):
+        case .registryDownload(let version, _), .custom(let version, _):
             defaultRequirement = .versionSet(.exact(version))
         case .fileSystem:
             throw StringError("local dependency '\(dependency.packageRef.identity)' can't be resolved")
@@ -1448,7 +1462,8 @@ extension Workspace {
             fingerprints: self.fingerprints,
             resolvedPackagesStore: self.resolvedPackagesStore,
             prebuiltsManager: prebuiltsManager,
-            state: self.state
+            state: self.state,
+            identityLookupCache: self.identityLookupCache
         )
     }
 }
@@ -1522,7 +1537,7 @@ extension Workspace {
                 case .unversioned:
                     result.append("unversioned")
                 }
-            case .registryDownload(let version)?, .custom(let version, _):
+            case .registryDownload(let version, _)?, .custom(let version, _):
                 result.append("resolved to '\(version)'")
             case .edited?:
                 result.append("edited")

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -743,7 +743,7 @@ public final class MockWorkspace {
         let resolvedPackagesStore = try workspace.resolvedPackagesStore.load()
 
         for (ref, state) in resolvedPackages {
-            resolvedPackagesStore.track(packageRef: ref, state: state)
+            resolvedPackagesStore.track(packageRef: ref, state: state, scm: nil)
         }
 
         for dependency in managedDependencies {
@@ -838,7 +838,7 @@ public final class MockWorkspace {
                     XCTAssertEqual(dependencyCheckoutState.branch, branch, file: file, line: line)
                 }
             case .registryDownload(let downloadVersion):
-                guard case .registryDownload(let dependencyVersion) = dependency.state else {
+                guard case .registryDownload(let dependencyVersion, _) = dependency.state else {
                     return XCTFail("invalid dependency state \(dependency.state)", file: file, line: line)
                 }
                 XCTAssertEqual(dependencyVersion, downloadVersion, file: file, line: line)

--- a/Tests/WorkspaceTests/ResolvedPackagesStoreTests.swift
+++ b/Tests/WorkspaceTests/ResolvedPackagesStoreTests.swift
@@ -509,4 +509,133 @@ final class ResolvedPackagesStoreTests: XCTestCase {
         }
     }
 
+    func testLoadingSchema3RegistryPinWithoutOriginalLocation() throws {
+        let fs = InMemoryFileSystem()
+        let packageResolvedFile = AbsolutePath("/Package.resolved")
+
+        try fs.writeFileContents(packageResolvedFile, string:
+            """
+            {
+                "version": 3,
+                "originHash": "abc123",
+                "pins": [
+                  {
+                    "identity": "scope.package",
+                    "kind": "registry",
+                    "location": "",
+                    "state": {
+                      "version": "1.0.0"
+                    }
+                  }
+                ]
+            }
+            """
+        )
+
+        let store = try ResolvedPackagesStore(packageResolvedFile: packageResolvedFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
+        let identity = PackageIdentity.plain("scope.package")
+        let resolution = try XCTUnwrap(store.resolvedPackages[identity])
+
+        // originalLocation absent in old file — should have nil SCM URL
+        XCTAssertNil(resolution.originalScmUrl)
+    }
+
+    func testLoadingSchema3RegistryPinWithOriginalLocation() throws {
+        let fs = InMemoryFileSystem()
+        let packageResolvedFile = AbsolutePath("/Package.resolved")
+        let scmURLString = "https://github.com/apple/swift-argument-parser.git"
+
+        try fs.writeFileContents(packageResolvedFile, string:
+            """
+            {
+                "version": 3,
+                "originHash": "abc123",
+                "pins": [
+                  {
+                    "identity": "apple.swift-argument-parser",
+                    "kind": "registry",
+                    "location": "",
+                    "originalLocation": "\(scmURLString)",
+                    "state": {
+                      "version": "1.7.0"
+                    }
+                  }
+                ]
+            }
+            """
+        )
+
+        let store = try ResolvedPackagesStore(packageResolvedFile: packageResolvedFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
+        let identity = PackageIdentity.plain("apple.swift-argument-parser")
+        let resolution = try XCTUnwrap(store.resolvedPackages[identity])
+
+        if let scmURL = resolution.originalScmUrl {
+            XCTAssertEqual(scmURL, SourceControlURL(scmURLString))
+        } else {
+            XCTFail("Expected .registry kind")
+        }
+    }
+
+    func testTrackRegistryPackageWithScmUrlRoundTrip() throws {
+        let fs = InMemoryFileSystem()
+        let packageResolvedFile = AbsolutePath("/Package.resolved")
+        let scmURL = SourceControlURL("https://github.com/apple/swift-argument-parser.git")
+        let identity = PackageIdentity.plain("apple.swift-argument-parser")
+
+        var store = try ResolvedPackagesStore(
+            packageResolvedFile: packageResolvedFile,
+            workingDirectory: .root,
+            fileSystem: fs,
+            mirrors: .init()
+        )
+        store.track(
+            packageRef: .registry(identity: identity),
+            state: .version("1.7.0", revision: .none),
+            scm: scmURL
+        )
+        try store.saveState(toolsVersion: .current, originHash: .none)
+
+        // Reload and verify originalScmUrl survived the round-trip
+        let store2 = try ResolvedPackagesStore(
+            packageResolvedFile: packageResolvedFile,
+            workingDirectory: .root,
+            fileSystem: fs,
+            mirrors: .init()
+        )
+        let resolution = try XCTUnwrap(store2.resolvedPackages[identity])
+        XCTAssertEqual(resolution.originalScmUrl, scmURL)
+
+        // Also verify the Package.resolved JSON contains the originalLocation field
+        let content: String = try fs.readFileContents(packageResolvedFile)
+        XCTAssertMatch(content, .contains("originalLocation"))
+        XCTAssertMatch(content, .contains(scmURL.absoluteString))
+    }
+
+    func testTrackRegistryPackageWithoutScmUrlProducesNilOriginalScmUrl() throws {
+        let fs = InMemoryFileSystem()
+        let packageResolvedFile = AbsolutePath("/Package.resolved")
+        let identity = PackageIdentity.plain("scope.package")
+
+        var store = try ResolvedPackagesStore(
+            packageResolvedFile: packageResolvedFile,
+            workingDirectory: .root,
+            fileSystem: fs,
+            mirrors: .init()
+        )
+        store.track(
+            packageRef: .registry(identity: identity),
+            state: .version("1.0.0", revision: .none)
+            // no scm: parameter
+        )
+        try store.saveState(toolsVersion: .current, originHash: .none)
+
+        let store2 = try ResolvedPackagesStore(
+            packageResolvedFile: packageResolvedFile,
+            workingDirectory: .root,
+            fileSystem: fs,
+            mirrors: .init()
+        )
+        let resolution = try XCTUnwrap(store2.resolvedPackages[identity])
+        XCTAssertNil(resolution.originalScmUrl)
+    }
 }

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5263,7 +5263,7 @@ final class WorkspaceTests: XCTestCase {
             let revision = try fooRepo.resolveRevision(tag: "1.0.0")
             let newState = ResolvedPackagesStore.ResolutionState.version("1.0.0", revision: revision.identifier)
 
-            resolvedPackagesStore.track(packageRef: fooPin.packageRef, state: newState)
+            resolvedPackagesStore.track(packageRef: fooPin.packageRef, state: newState, scm: nil)
             try resolvedPackagesStore.saveState(toolsVersion: ToolsVersion.current, originHash: .none)
         }
 
@@ -16386,6 +16386,339 @@ final class WorkspaceTests: XCTestCase {
         } catch {
             XCTFail("unexpected error: \(error)")
         }
+    }
+
+    // End-to-end — forceResolvedVersions + swizzle resolves correctly
+    // without making registry network requests on the second run.
+    func testForceResolvedWithReplaceScmWithRegistryResolvesCorrectly() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    path: "root",
+                    targets: [
+                        MockTarget(name: "RootTarget", dependencies: [
+                            .product(name: "FooProduct", package: "org.foo"),
+                        ]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    toolsVersion: .v5_6
+                ),
+            ],
+            packages: [
+                // org.foo is a registry package whose SCM URL maps to the registry identity
+                MockPackage(
+                    name: "FooPackage",
+                    identity: "org.foo",
+                    alternativeURLs: ["https://git/org/foo"],
+                    targets: [
+                        MockTarget(
+                            name: "FooTarget",
+                            dependencies: [
+                                .product(name: "Bar", package: "Bar")
+                            ]),
+                    ],
+                    products: [
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    versions: ["1.0.0", "1.1.0"]
+                ),
+                // Bar is a pure SCM dependency with no registry equivalent
+                MockPackage(
+                    name: "BarPackage",
+                    url: "https://git/org/bar",
+                    targets: [MockTarget(name: "BarTarget")],
+                    products: [MockProduct(name: "Bar", modules: ["BarTarget"])],
+                    versions: ["1.0.0", "1.1.0"]
+                ),
+            ]
+        )
+
+        // Run 1: initial resolve with swizzle — produces Package.resolved with
+        // registry pin for org.foo (with originalLocation) and SCM pin for bar.
+        workspace.sourceControlToRegistryDependencyTransformation = .swizzle
+        try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTesterXCTest(graph) { result in
+                result.check(packages: "org.foo", "bar", "Root")
+            }
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "org.foo", at: .registryDownload("1.1.0"))
+            result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
+        }
+
+        // Reset workspace state, keep Package.resolved.
+        try await workspace.closeWorkspace(resetState: true, resetResolvedFile: false)
+
+        // Run 2: force-resolved + swizzle — should resolve from Package.resolved
+        // without hitting the registry for identity lookups.
+        workspace.sourceControlToRegistryDependencyTransformation = .swizzle
+        try await workspace.checkPackageGraph(roots: ["root"], forceResolvedVersions: true) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTesterXCTest(graph) { result in
+                result.check(packages: "org.foo", "bar", "Root")
+            }
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "org.foo", at: .registryDownload("1.1.0"))
+            result.check(dependency: "bar", at: .checkout(.version("1.1.0")))
+        }
+    }
+
+    // identityLookupCache is pre-populated from Package.resolved entries
+    // (both positive registry mappings and nil mappings for SCM-only packages)
+    // when --force-resolved-versions is active.
+    func testIdentityLookupCachePrePopulatedFromResolvedFileOnForceResolved() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+        let fooSCMURL = SourceControlURL("https://git/org/foo")
+        let barSCMURL = SourceControlURL("https://git/org/bar")
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    path: "root",
+                    targets: [
+                        MockTarget(name: "RootTarget", dependencies: [
+                            .product(name: "FooProduct", package: "org.foo"),
+                        ]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    toolsVersion: .v5_6
+                ),
+            ],
+            packages: [
+                // org.foo is a registry package whose SCM URL maps to the registry identity
+                MockPackage(
+                    name: "FooPackage",
+                    identity: "org.foo",
+                    alternativeURLs: ["https://git/org/foo"],
+                    targets: [
+                        MockTarget(
+                            name: "FooTarget",
+                            dependencies: [
+                                .product(name: "Bar", package: "Bar")
+                            ]),
+                    ],
+                    products: [
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    versions: ["1.0.0", "1.1.0"]
+                ),
+                // Bar is a pure SCM dependency with no registry equivalent
+                MockPackage(
+                    name: "BarPackage",
+                    url: "https://git/org/bar",
+                    targets: [MockTarget(name: "BarTarget")],
+                    products: [MockProduct(name: "Bar", modules: ["BarTarget"])],
+                    versions: ["1.0.0", "1.1.0"]
+                ),
+            ]
+        )
+
+        // Run 1: produce Package.resolved.
+        workspace.sourceControlToRegistryDependencyTransformation = .swizzle
+        try await workspace.checkPackageGraph(roots: ["root"]) { _, _ in }
+
+        // Reset, keep Package.resolved.
+        try await workspace.closeWorkspace(resetState: true, resetResolvedFile: false)
+
+        // Run 2: forceResolvedVersions — pre-population should run.
+        workspace.sourceControlToRegistryDependencyTransformation = .swizzle
+        try await workspace.checkPackageGraph(roots: ["root"], forceResolvedVersions: true) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+
+        let ws = try workspace.getOrCreateWorkspace()
+
+        // org.foo was a registry pin with originalLocation — positive mapping expected.
+        let fooCacheEntry = try XCTUnwrap(ws.identityLookupCache[fooSCMURL], "Expected cache entry for foo SCM URL")
+        if case .success(let identity) = fooCacheEntry.result {
+            XCTAssertEqual(identity, PackageIdentity("org.foo"))
+        } else {
+            XCTFail("Expected .success(org.foo) in identityLookupCache for foo SCM URL")
+        }
+        // bar was a remoteSourceControl pin — nil mapping expected (second pass).
+        let barCacheEntry = try XCTUnwrap(ws.identityLookupCache[barSCMURL])
+
+        if case .notApplicable = barCacheEntry.result {
+            // expected — bar is SCM-only, no registry mapping
+        } else {
+            XCTFail("Expected .notApplicable for bar (SCM-only package)")
+        }                                                                                                                              }
+
+    // identityLookupCache is NOT pre-populated at workspace creation —
+    // pre-population only happens inside tryResolveBasedOnResolvedVersionsFile,
+    // which is only called when forceResolvedVersions is true.
+    func testIdentityLookupCacheNotPrePopulatedWithoutForceResolved() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+        let fooSCMURL = SourceControlURL("https://git/org/foo")
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    path: "root",
+                    targets: [
+                        MockTarget(name: "RootTarget", dependencies: [
+                            .product(name: "FooProduct", package: "org.foo"),
+                        ]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    toolsVersion: .v5_6
+                ),
+            ],
+            packages: [
+                // org.foo is a registry package whose SCM URL maps to the registry identity
+                MockPackage(
+                    name: "FooPackage",
+                    identity: "org.foo",
+                    alternativeURLs: ["https://git/org/foo"],
+                    targets: [
+                        MockTarget(
+                            name: "FooTarget",
+                            dependencies: [
+                                .product(name: "Bar", package: "Bar")
+                            ]),
+                    ],
+                    products: [
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/bar", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    versions: ["1.0.0", "1.1.0"]
+                ),
+                // Bar is a pure SCM dependency with no registry equivalent
+                MockPackage(
+                    name: "BarPackage",
+                    url: "https://git/org/bar",
+                    targets: [MockTarget(name: "BarTarget")],
+                    products: [MockProduct(name: "Bar", modules: ["BarTarget"])],
+                    versions: ["1.0.0", "1.1.0"]
+                ),
+            ]
+        )
+
+        // Run 1: produce Package.resolved.
+        workspace.sourceControlToRegistryDependencyTransformation = WorkspaceConfiguration
+            .SourceControlToRegistryDependencyTransformation.swizzle
+        try await workspace.checkPackageGraph(roots: ["root"]) { _, _ in }
+        try await workspace.closeWorkspace(resetState: true, resetResolvedFile: false)
+
+        // Create a fresh workspace instance — cache must be empty at creation time
+        // regardless of what Package.resolved contains.
+        let freshWS = try workspace.getOrCreateWorkspace()
+        XCTAssertTrue(
+            freshWS.identityLookupCache.isEmpty,
+            "Cache should be empty at workspace creation — pre-population only happens during forceResolvedVersions resolution"
+        )
+
+        // Resolve WITHOUT forceResolvedVersions — pre-population does NOT run.
+        workspace.sourceControlToRegistryDependencyTransformation = WorkspaceConfiguration
+            .SourceControlToRegistryDependencyTransformation.swizzle
+        try await workspace.checkPackageGraph(roots: ["root"], forceResolvedVersions: false) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+
+        // Cache may have been populated via registry HTTP calls during manifest loading,
+        // but the specific foo entry should have come from the registry, not Package.resolved.
+        // We can observe this is a different path by resetting again and confirming the
+        // cache is still empty before the forceResolved path populates it.
+        try await workspace.closeWorkspace(resetState: true, resetResolvedFile: false)
+        let freshWS2 = try workspace.getOrCreateWorkspace()
+        XCTAssertTrue(
+            freshWS2.identityLookupCache.isEmpty,
+            "Cache must be empty before forceResolvedVersions resolution runs pre-population"
+        )
+
+        workspace.sourceControlToRegistryDependencyTransformation = WorkspaceConfiguration
+            .SourceControlToRegistryDependencyTransformation.swizzle
+        try await workspace.checkPackageGraph(roots: ["root"], forceResolvedVersions: true) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+
+        // Now the cache should contain the entry, populated from Package.resolved.
+        XCTAssertTrue(
+            freshWS2.identityLookupCache[fooSCMURL] != nil,
+            "Cache should contain foo SCM URL after forceResolvedVersions run (pre-populated from Package.resolved)"
+        )
+    }
+
+    func testRegistryDownloadManagedDependencyHasScmUrlAfterSwizzle() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    path: "root",
+                    targets: [MockTarget(name: "RootTarget", dependencies: [
+                        .product(name: "FooProduct", package: "org.foo"),
+                    ])],
+                    products: [],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    toolsVersion: .v5_6
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "FooPackage",
+                    identity: "org.foo",
+                    alternativeURLs: ["https://git/org/foo"],
+                    targets: [MockTarget(name: "FooTarget")],
+                    products: [MockProduct(name: "FooProduct", modules: ["FooTarget"])],
+                    versions: ["1.0.0", "1.1.0"]
+                ),
+            ]
+        )
+
+        workspace.sourceControlToRegistryDependencyTransformation = .swizzle
+        try await workspace.checkPackageGraph(roots: ["root"]) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+
+        // The managed dependency for org.foo should carry the original SCM URL
+        let ws = try workspace.getOrCreateWorkspace()
+        let deps = await ws.state.dependencies
+        let fooDep = try XCTUnwrap(deps[PackageIdentity.plain("org.foo")])
+        guard case .registryDownload(_, let scmUrl) = fooDep.state else {
+            return XCTFail("Expected registryDownload state for org.foo")
+        }
+        XCTAssertEqual(scmUrl, SourceControlURL("https://git/org/foo"),
+            "registryDownload should carry the original SCM URL it was swizzled from")
     }
 
     func makeRegistryClient(


### PR DESCRIPTION
To track all packages that have been mapped from a source control URL, this change adds a parameter to the `ResolvedPackage` that tracks the scm URL when applicable; this has also been added to the `ManagedDependency.State.registryDownload` enum case as another associated value for further tracking. Upon startup, the Workspace can now derive an identity lookup cache that maps between the source control URL to the registry ID when applicable with the use of `--force-resolved-versions` so as to avoid making network requests and rely on the local state.

This will assure that if a user were to also rely on a lock-file behaviour from the Package.resolved, that SwiftPM can successfully resolve without needing to hit the registry endpoints.

(cherry picked from commit ec118c24e0f1b759f3699f68bdec51d3dca30b86)