### PR TITLE
Fix `swift sdk configure --swift-static-resources-path` clobbering swiftResourcesPath

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -412,7 +412,7 @@ public struct SwiftSDK: Equatable {
             }
 
             if let swiftStaticResourcesPath = newConfiguration.swiftStaticResourcesPath {
-                self.swiftResourcesPath = try AbsolutePath(validating: swiftStaticResourcesPath, relativeTo: basePath)
+                self.swiftStaticResourcesPath = try AbsolutePath(validating: swiftStaticResourcesPath, relativeTo: basePath)
                 updatedProperties.append("swiftStaticResourcesPath")
             }
 

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -771,4 +771,68 @@ final class SwiftSDKBundleTests: XCTestCase {
             XCTAssertFalse(fileSystem.isFile(targetTripleConfigPath), "Reset configuration should clear configuration folder")
         }
     }
+
+    /// Regression test for `swift sdk configure --swift-static-resources-path X`
+    /// previously overwriting `swiftResourcesPath` (the dynamic-link path) instead of
+    /// `swiftStaticResourcesPath` due to a typo in `PathsConfiguration.merge(with:relativeTo:)`.
+    func testConfigureSwiftResourcesPaths() async throws {
+        let (fileSystem, bundles, swiftSDKsDirectory) = try generateTestFileSystem(
+            bundleArtifacts: [
+                .init(id: testArtifactID, supportedTriples: [arm64Triple]),
+            ]
+        )
+        let system = ObservabilitySystem.makeForTesting()
+        let store = SwiftSDKBundleStore(
+            swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: "/tmp",
+            fileSystem: fileSystem,
+            observabilityScope: system.topScope,
+            outputHandler: { _ in }
+        )
+
+        let archiver = MockArchiver()
+        for bundle in bundles {
+            try await store.install(bundlePathOrURL: bundle.path, archiver)
+        }
+
+        let hostTriple = try Triple("arm64-apple-macosx14.0")
+        let config = try SwiftSDKConfigurationStore(
+            hostTimeTriple: hostTriple,
+            swiftSDKBundleStore: store
+        )
+
+        #if os(Windows)
+        let dynamicResourcesPath = "C:\\some\\swift\\resources"
+        let staticResourcesPath = "C:\\some\\swift_static\\resources"
+        #else
+        let dynamicResourcesPath = "/some/swift/resources"
+        let staticResourcesPath = "/some/swift_static/resources"
+        #endif
+
+        var args = SwiftSDK.PathsConfiguration<String>()
+        args.swiftResourcesPath = dynamicResourcesPath
+        args.swiftStaticResourcesPath = staticResourcesPath
+        let configSuccess = try config.configure(
+            sdkID: testArtifactID,
+            targetTriple: targetTriple.tripleString,
+            showConfiguration: false,
+            resetConfiguration: false,
+            config: args
+        )
+        XCTAssertTrue(configSuccess)
+
+        let updatedConfig = try config.readConfiguration(
+            sdkID: testArtifactID,
+            targetTriple: targetTriple
+        )
+        XCTAssertEqual(
+            updatedConfig?.pathsConfiguration.swiftResourcesPath?.pathString,
+            dynamicResourcesPath,
+            "swiftResourcesPath should not be clobbered by swiftStaticResourcesPath"
+        )
+        XCTAssertEqual(
+            updatedConfig?.pathsConfiguration.swiftStaticResourcesPath?.pathString,
+            staticResourcesPath
+        )
+    }
 }


### PR DESCRIPTION
### Motivation:

`SwiftSDK.PathsConfiguration.merge(with:relativeTo:)` (the `String → AbsolutePath` overload used exclusively by the `swift sdk configure` command via `SwiftSDKConfigurationStore.configure`) had a one-character typo: when the new configuration carried a `swiftStaticResourcesPath`, the merge wrote it into `self.swiftResourcesPath` (the dynamic-link path) and recorded the change under the right name in `updatedProperties`.

Net behavior: `swift sdk configure <id> --swift-static-resources-path X` silently destroyed any previously-configured dynamic resource path and left `swiftStaticResourcesPath` unset. The in-memory `merge(with:)` overload immediately above it (line 373-397) targets the correct field, so this is purely the persistence path used by the configure subcommand.

### Modifications:

One-character fix in `Sources/PackageModel/SwiftSDKs/SwiftSDK.swift:415` — assign to `self.swiftStaticResourcesPath` instead of `self.swiftResourcesPath`.

Adds `testConfigureSwiftResourcesPaths` in `Tests/PackageModelTests/SwiftSDKBundleTests.swift` that round-trips both `swiftResourcesPath` and `swiftStaticResourcesPath` through `SwiftSDKConfigurationStore.configure(...)` + `readConfiguration(...)` and asserts both values survive intact. Verified the test fails with the typo present.

### Result:

`swift sdk configure --swift-static-resources-path X` now persists `X` to `swiftStaticResourcesPath` and leaves `swiftResourcesPath` untouched, matching the documented field semantics and the behavior of the in-memory `merge(with:)` overload.