### PR TITLE
Add regression test for multi-triple Swift SDK bundle selection

### DIFF
--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -496,6 +496,128 @@ final class SwiftSDKBundleTests: XCTestCase {
         }
     }
 
+    /// Regression test for SR-Android-SDK-resource-dir / swiftlang/swift-package-manager#7973:
+    /// when `--swift-sdk <id>` and `--triple <triple>` are both supplied and the bundle's single
+    /// artifact ID maps to many target triples (the Android SDK's 3-arch × N-API-level shape),
+    /// `selectBundle` must filter by the supplied target triple and return the SwiftSDK whose
+    /// `swiftResourcesPath` matches that arch — not an arbitrary entry from the dictionary's
+    /// hash-randomized iteration order.
+    func testBundleSelectionByMultiTripleArtifact() async throws {
+        let bundlePath = "/android-sdk.artifactbundle"
+        let artifactID = "swift-android-sdk"
+        let variantPath = "swift-android"
+        let archs = ["aarch64", "x86_64", "armv7"]
+        let apiLevels = [30, 33]
+
+        var swiftSDKJSON = #"{ "schemaVersion": "4.0", "targetTriples": {"#
+        var first = true
+        for arch in archs {
+            for api in apiLevels {
+                let env = arch == "armv7" ? "androideabi" : "android"
+                let triple = "\(arch)-unknown-linux-\(env)\(api)"
+                if !first { swiftSDKJSON += "," }
+                first = false
+                swiftSDKJSON += """
+
+                    "\(triple)": {
+                        "sdkRootPath": "ndk-sysroot",
+                        "swiftResourcesPath": "swift-resources/usr/lib/swift-\(arch)",
+                        "swiftStaticResourcesPath": "swift-resources/usr/lib/swift_static-\(arch)"
+                    }
+                """
+            }
+        }
+        swiftSDKJSON += "} }"
+
+        let infoJSON = """
+        {
+            "schemaVersion": "1.0",
+            "artifacts": {
+                "\(artifactID)": {
+                    "type": "swiftSDK",
+                    "version": "0.0.1",
+                    "variants": [
+                        {
+                            "path": "\(variantPath)",
+                            "supportedTriples": ["arm64-apple-macosx13.0"]
+                        }
+                    ]
+                }
+            }
+        }
+        """
+
+        let fileSystem = try InMemoryFileSystem(files: [
+            "\(bundlePath)/info.json": ByteString(json: SerializedJSON(stringLiteral: infoJSON)),
+            "\(bundlePath)/\(variantPath)/swift-sdk.json": ByteString(json: SerializedJSON(stringLiteral: swiftSDKJSON)),
+        ])
+
+        let swiftSDKsDirectory = try AbsolutePath(validating: "/sdks")
+        try fileSystem.createDirectory(fileSystem.tempDirectory)
+        try fileSystem.createDirectory(swiftSDKsDirectory)
+
+        let system = ObservabilitySystem.makeForTesting()
+        let store = SwiftSDKBundleStore(
+            swiftSDKsDirectory: swiftSDKsDirectory,
+            hostToolchainBinDir: "/tmp",
+            fileSystem: fileSystem,
+            observabilityScope: system.topScope,
+            outputHandler: { _ in }
+        )
+
+        let archiver = MockArchiver()
+        try await store.install(bundlePathOrURL: bundlePath, archiver)
+
+        let hostTriple = try Triple("arm64-apple-macosx14.0")
+        let hostSwiftSDK = try SwiftSDK.hostSwiftSDK(environment: [:])
+
+        for arch in archs {
+            for api in apiLevels {
+                let env = arch == "armv7" ? "androideabi" : "android"
+                let triple = try Triple("\(arch)-unknown-linux-\(env)\(api)")
+                let expectedSwiftResources = "\(swiftSDKsDirectory.pathString)/android-sdk.artifactbundle/\(variantPath)/swift-resources/usr/lib/swift-\(arch)"
+                let expectedSwiftStaticResources = "\(swiftSDKsDirectory.pathString)/android-sdk.artifactbundle/\(variantPath)/swift-resources/usr/lib/swift_static-\(arch)"
+
+                let (id, sdk) = try store.selectBundle(
+                    matching: artifactID,
+                    hostTriple: hostTriple,
+                    targetTriple: triple
+                )
+
+                XCTAssertEqual(id, artifactID)
+                XCTAssertEqual(sdk.targetTriple?.tripleString, triple.tripleString)
+                XCTAssertEqual(
+                    sdk.pathsConfiguration.swiftResourcesPath?.pathString,
+                    expectedSwiftResources,
+                    "selectBundle returned wrong swiftResourcesPath for target \(triple.tripleString)"
+                )
+                XCTAssertEqual(
+                    sdk.pathsConfiguration.swiftStaticResourcesPath?.pathString,
+                    expectedSwiftStaticResources,
+                    "selectBundle returned wrong swiftStaticResourcesPath for target \(triple.tripleString)"
+                )
+
+                // End-to-end check via the same code path `swift build --swift-sdk X --triple Y` takes.
+                let derived = try SwiftSDK.deriveTargetSwiftSDK(
+                    hostSwiftSDK: hostSwiftSDK,
+                    hostTriple: hostTriple,
+                    customCompileTriple: triple,
+                    swiftSDKSelector: artifactID,
+                    store: store,
+                    observabilityScope: system.topScope,
+                    fileSystem: fileSystem
+                )
+
+                XCTAssertEqual(derived.targetTriple?.tripleString, triple.tripleString)
+                XCTAssertEqual(
+                    derived.pathsConfiguration.swiftResourcesPath?.pathString,
+                    expectedSwiftResources,
+                    "deriveTargetSwiftSDK returned wrong swiftResourcesPath for target \(triple.tripleString)"
+                )
+            }
+        }
+    }
+
     func testTargetSDKDerivation() async throws {
         let toolsetRootPath = AbsolutePath("/path/to/toolpath")
         let (fileSystem, bundles, swiftSDKsDirectory) = try generateTestFileSystem(

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -616,6 +616,19 @@ final class SwiftSDKBundleTests: XCTestCase {
                 )
             }
         }
+
+        XCTAssertThrowsError(try store.selectBundle(
+            matching: artifactID,
+            hostTriple: hostTriple
+        )) { error in
+            XCTAssertEqual(
+                "\(error)",
+                """
+                The query for `\(artifactID)` and host triple `\(hostTriple.tripleString)` \
+                has multiple target triples. Use the `--triple` flag to specify a triple.
+                """
+            )
+        }
     }
 
     func testTargetSDKDerivation() async throws {

--- a/Tests/PackageModelTests/SwiftSDKBundleTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKBundleTests.swift
@@ -559,7 +559,7 @@ final class SwiftSDKBundleTests: XCTestCase {
         let system = ObservabilitySystem.makeForTesting()
         let store = SwiftSDKBundleStore(
             swiftSDKsDirectory: swiftSDKsDirectory,
-            hostToolchainBinDir: "/tmp",
+            hostToolchainBinDir: AbsolutePath("/tmp"),
             fileSystem: fileSystem,
             observabilityScope: system.topScope,
             outputHandler: { _ in }
@@ -575,8 +575,8 @@ final class SwiftSDKBundleTests: XCTestCase {
             for api in apiLevels {
                 let env = arch == "armv7" ? "androideabi" : "android"
                 let triple = try Triple("\(arch)-unknown-linux-\(env)\(api)")
-                let expectedSwiftResources = "\(swiftSDKsDirectory.pathString)/android-sdk.artifactbundle/\(variantPath)/swift-resources/usr/lib/swift-\(arch)"
-                let expectedSwiftStaticResources = "\(swiftSDKsDirectory.pathString)/android-sdk.artifactbundle/\(variantPath)/swift-resources/usr/lib/swift_static-\(arch)"
+                let expectedSwiftResources = swiftSDKsDirectory.appending(components: "android-sdk.artifactbundle", "\(variantPath)", "swift-resources", "usr", "lib", "swift-\(arch)").pathString
+                let expectedSwiftStaticResources = swiftSDKsDirectory.appending(components: "android-sdk.artifactbundle", "\(variantPath)", "swift-resources", "usr", "lib", "swift_static-\(arch)").pathString
 
                 let (id, sdk) = try store.selectBundle(
                     matching: artifactID,


### PR DESCRIPTION
Tests-only follow-up for #9220 / #7973, fixed by 2f506071ad ("Fix searching for SDKs when a `--triple` is specified along with the SDK name"). Locks in that fix against the bundle shape that exposed it most reliably in the wild — one artifact ID containing many target triples (the official Swift Android SDK packs 27 entries this way).

### Motivation:

Before 2f506071ad, `SwiftSDK.deriveTargetSwiftSDK` did not forward `customCompileTriple` to `SwiftSDKBundleStore.selectBundle`. With no target triple to filter by, `selectBundle` fell into the artifact-ID match path and stored the first-iterated `SwiftSDK` from the bundle's `targetTriples` map. That map decodes as `[String: TripleProperties]`, whose iteration order is hash-randomized per process, so on bundles with many triples under one artifact ID the resulting `swiftResourcesPath` came out non-deterministic — sometimes for a different arch than the one the user asked for via `--triple`.

The official Swift Android SDK (`swift-6.3.1-RELEASE_android.artifactbundle`, produced by `swiftlang/swift-docker`'s `swift-ci/sdks/android/scripts/build.sh`) packs 27 entries (3 archs × 9 API levels) under one artifact ID, which exposed this bug at roughly 1-in-3 frequency. Existing `SwiftSDKBundleTests` only exercise bundles with one target triple per artifact, so the missing pass-through could re-regress without any test failing.

### Modifications:

Adds `testBundleSelectionByMultiTripleArtifact` to `Tests/PackageModelTests/SwiftSDKBundleTests.swift`. The test synthesizes an Android-shaped bundle (3 archs × 2 API levels = 6 entries under one artifact ID, each with arch-specific `swiftResourcesPath` / `swiftStaticResourcesPath`) entirely in `InMemoryFileSystem`, then asserts both:

1. `SwiftSDKBundleStore.selectBundle(matching:hostTriple:targetTriple:)` directly, and
2. The higher-level `SwiftSDK.deriveTargetSwiftSDK(...)` path that `swift build --swift-sdk X --triple Y` invokes,

return a `SwiftSDK` whose `pathsConfiguration.swiftResourcesPath` and `swiftStaticResourcesPath` match the requested target triple's arch for every (arch, api-level) combination.

Verified that reverting just `SwiftSDK.swift:789`'s `targetTriple: customCompileTriple` argument makes the test fail, so it catches the exact regression 2f506071ad fixed.

No production code changes.

### Result:

Bundles where one artifact ID maps to many target triples now have explicit test coverage. A future change that drops the `targetTriple` parameter pass-through (or weakens the predicate match in `selectSwiftSDK(id:hostTriple:targetTriple:)`) will fail this test rather than silently return the wrong arch's resources at build time.


Blocked by #10036