### PR TITLE
swift package experimental-build-server should return DocC catalogs in sources responses

### DIFF
--- a/Fixtures/Miscellaneous/LibraryWithDocC/Package.swift
+++ b/Fixtures/Miscellaneous/LibraryWithDocC/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "LibraryWithDocC",
+    targets: [
+        .target(name: "MyLib"),
+    ]
+)

--- a/Fixtures/Miscellaneous/LibraryWithDocC/Sources/MyLib/Documentation.docc/MyLib.md
+++ b/Fixtures/Miscellaneous/LibraryWithDocC/Sources/MyLib/Documentation.docc/MyLib.md
@@ -1,0 +1,7 @@
+# ``MyLib``
+
+Introduction goes here
+
+## Overview
+
+This is the overview

--- a/Fixtures/Miscellaneous/LibraryWithDocC/Sources/MyLib/MyLib.swift
+++ b/Fixtures/Miscellaneous/LibraryWithDocC/Sources/MyLib/MyLib.swift
@@ -1,0 +1,3 @@
+public struct MyLib {
+    public static let greeting = "Hello, DocC!"
+}

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -92,6 +92,16 @@ extension PackageModel.Module {
     func pifTargetGUID(suffix: TargetSuffix?) -> GUID {
         PackagePIFBuilder.targetGUID(forModuleName: self.name, suffix: suffix)
     }
+
+    var doccCatalogPaths: Set<AbsolutePath> {
+        var result: Set<AbsolutePath> = []
+        for path in self.resources.map(\.path) + self.ignored + self.others {
+            if path.extension == "docc" {
+                result.insert(path)
+            }
+        }
+        return result
+    }
 }
 
 extension PackageGraph.ResolvedModule {

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -371,6 +371,7 @@ public final class PackagePIFBuilder {
 
         public var indexableFileURLs: [SourceControlURL]
         public var headerFiles: Set<AbsolutePath>
+        public var doccCatalogs: Set<AbsolutePath>
         /// Source files implementing the plugin represented by this target, which
         /// are compiled during build planning as opposed to participating in the
         /// build itself.
@@ -728,8 +729,9 @@ extension PackagePIFBuilder.ModuleOrProduct {
         moduleName: String?,
         pifTarget: ProjectModel.BaseTarget?,
         indexableFileURLs: [SourceControlURL] = [],
-        pluginScriptSourcePaths: [AbsolutePath] = [],
         headerFiles: Set<AbsolutePath> = [],
+        doccCatalogs: Set<AbsolutePath> = [],
+        pluginScriptSourcePaths: [AbsolutePath] = [],
         linkedPackageBinaries: [PackagePIFBuilder.LinkedPackageBinary] = [],
         swiftLanguageVersion: String? = nil,
         declaredPlatforms: [PackageModel.Platform]? = [],
@@ -743,6 +745,7 @@ extension PackagePIFBuilder.ModuleOrProduct {
         self.indexableFileURLs = indexableFileURLs
         self.pluginScriptSourcePaths = pluginScriptSourcePaths
         self.headerFiles = headerFiles
+        self.doccCatalogs = doccCatalogs
         self.linkedPackageBinaries = linkedPackageBinaries
         self.swiftLanguageVersion = swiftLanguageVersion
         self.declaredPlatforms = declaredPlatforms

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -635,6 +635,8 @@ extension PackagePIFProjectBuilder {
 
         let headerFiles = Set(sourceModule.headerFileAbsolutePaths)
 
+        let doccCatalogs = sourceModule.underlying.doccCatalogPaths
+
         // Add any additional source files emitted by custom build commands.
         for path in generatedFiles.sources {
             let sourceFileRef = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath].addFileReference { id in
@@ -876,6 +878,7 @@ extension PackagePIFProjectBuilder {
             pifTarget: .target(self.project[keyPath: sourceModuleTargetKeyPath]),
             indexableFileURLs: indexableFileURLs,
             headerFiles: headerFiles,
+            doccCatalogs: doccCatalogs,
             linkedPackageBinaries: linkedPackageBinaries,
             swiftLanguageVersion: sourceModule.packageSwiftLanguageVersion(manifest: packageManifest),
             declaredPlatforms: self.declaredPlatforms,

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -242,6 +242,8 @@ extension PackagePIFProjectBuilder {
 
         let headerFiles = Set(mainModule.headerFileAbsolutePaths)
 
+        let doccCatalogs = mainModule.underlying.doccCatalogPaths
+
         // Add any additional source files emitted by custom build commands.
         for path in generatedFiles.sources {
             let sourceFileRef = self.project.mainGroup[keyPath: mainTargetSourceFileGroupKeyPath]
@@ -537,6 +539,7 @@ extension PackagePIFProjectBuilder {
             pifTarget: .target(self.project[keyPath: mainModuleTargetKeyPath]),
             indexableFileURLs: indexableFileURLs,
             headerFiles: headerFiles,
+            doccCatalogs: doccCatalogs,
             linkedPackageBinaries: linkedPackageBinaries,
             swiftLanguageVersion: mainModule.packageSwiftLanguageVersion(manifest: packageManifest),
             declaredPlatforms: self.declaredPlatforms,
@@ -1038,8 +1041,8 @@ extension PackagePIFProjectBuilder {
             moduleName: pluginProduct.c99name,
             pifTarget: .aggregate(self.project[keyPath: pluginTargetKeyPath]),
             indexableFileURLs: [],
-            pluginScriptSourcePaths: pluginProduct.pluginModules?.only?.sources.paths ?? [],
             headerFiles: [],
+            pluginScriptSourcePaths: pluginProduct.pluginModules?.only?.sources.paths ?? [],
             linkedPackageBinaries: [],
             swiftLanguageVersion: nil,
             declaredPlatforms: self.declaredPlatforms,

--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -114,6 +114,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
     var state: ServerState = .waitingForInitializeRequest
 
     private var headersByTargetGUID: [String: Set<Basics.AbsolutePath>] = [:]
+    private var doccCatalogsByTargetGUID: [String: Set<Basics.AbsolutePath>] = [:]
 
     private struct PluginInfo {
         var name: String
@@ -259,6 +260,18 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                                 generated: false,
                                 dataKind: .sourceKit,
                                 data: SourceKitSourceItemData(kind: .header).encodeToLSPAny()
+                            )
+                        )
+                    }
+                    let doccCatalogs = self.doccCatalogsByTargetGUID[targetGUID] ?? []
+                    for doccCatalog in doccCatalogs {
+                        sourcesResponse.items[index].sources.append(
+                            SourceItem(
+                                uri: DocumentURI(doccCatalog.asURL),
+                                kind: .directory,
+                                generated: false,
+                                dataKind: .sourceKit,
+                                data: SourceKitSourceItemData(kind: .doccCatalog).encodeToLSPAny()
                             )
                         )
                     }
@@ -475,6 +488,18 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         self.headersByTargetGUID = headers
     }
 
+    private func rebuildDocCCatalogMapping(pifAccompanyingMetadata: [PackagePIFBuilder.ModuleOrProduct]) async {
+        var doccCatalogs: [String: Set<Basics.AbsolutePath>] = [:]
+        for moduleOrProduct in pifAccompanyingMetadata {
+            guard let pifTarget = moduleOrProduct.pifTarget else { continue }
+            let guid = pifTarget.id.value
+            if !moduleOrProduct.doccCatalogs.isEmpty {
+                doccCatalogs[guid] = moduleOrProduct.doccCatalogs
+            }
+        }
+        self.doccCatalogsByTargetGUID = doccCatalogs
+    }
+
     private func rebuildPluginMapping(pifAccompanyingMetadata: [PackagePIFBuilder.ModuleOrProduct]) {
         var plugins: [BuildTargetIdentifier: PluginInfo] = [:]
         for moduleOrProduct in pifAccompanyingMetadata {
@@ -536,6 +561,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                 let result = try await buildSystem.generatePIFAndAccompanyingMetadata(preserveStructure: false)
                 try localFileSystem.writeIfChanged(path: buildSystem.buildParameters.pifManifest, string: result.pif)
                 await self.rebuildHeaderMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
+                await self.rebuildDocCCatalogMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
                 self.rebuildPluginMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
                 self.connectionToUnderlyingBuildServer.send(OnWatchedFilesDidChangeNotification(changes: [
                     .init(uri: .init(buildSystem.buildParameters.pifManifest.asURL), type: .changed)

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -409,5 +409,23 @@ struct SwiftPMBuildServerTests {
             }
         }
     }
+
+    @Test
+    func doccCatalogSources() async throws {
+        try await withSwiftPMBSP(fixtureName: "Miscellaneous/LibraryWithDocC") { connection, _, _ in
+            let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            let myLibTarget = try #require(targetResponse.targets.first(where: { $0.displayName == "MyLib" }))
+            let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [myLibTarget.id]))
+            let sources = try #require(sourcesResponse.items.only?.sources)
+
+            let swiftSource = try #require(sources.first(where: { $0.uri.fileURL?.lastPathComponent == "MyLib.swift" }))
+            #expect(swiftSource.kind == .file)
+
+            let doccCatalog = try #require(sources.first(where: { $0.uri.fileURL?.pathExtension == "docc" }))
+            #expect(doccCatalog.kind == .directory)
+            #expect(doccCatalog.uri.fileURL?.lastPathComponent == "Documentation.docc")
+            #expect(doccCatalog.sourceKitData?.kind == .doccCatalog)
+        }
+    }
 }
 #endif


### PR DESCRIPTION
sourcekit-lsp/vscode-swift rely on these being reported by the build system in order to provide various DocC preview features. Inject them into responses at the SwiftPM layer, similar to the existing handling of header files