### PR TITLE
Add static linux Swift SDK integration tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -101,3 +101,17 @@ jobs:
       wasm_sdk_pre_build_command: ./.github/scripts/prebuild.sh
       # This is a hack - replace the build command with a test command and drop the --swift-sdk arg the workflow appends.
       wasm_sdk_build_command: "swift test --filter WebAssemblyIntegrationTests #"
+
+  static-linux-integration-tests:
+    name: Static Linux Integration Tests
+    needs: [soundness]
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    with:
+      enable_linux_checks: false
+      enable_windows_checks: false
+      enable_macos_checks: false
+      enable_linux_static_sdk_build: true
+      linux_static_sdk_versions: '["nightly-main"]'
+      linux_static_sdk_pre_build_command: ./.github/scripts/prebuild.sh
+      # This is a hack - replace the build command with a test command and drop the --swift-sdk arg the workflow appends.
+      linux_static_sdk_build_command: "swift test --filter StaticLinuxIntegrationTests #"

--- a/Package.swift
+++ b/Package.swift
@@ -993,6 +993,14 @@ let package = Package(
                 "PackageModel",
             ]
         ),
+        .testTarget(
+            name: "SwiftPMStaticLinuxIntegrationTests",
+            dependencies: [
+                "_InternalTestSupport",
+                "Basics",
+                "PackageModel",
+            ]
+        ),
         // Examples (These are built to ensure they stay up to date with the API.)
         .executableTarget(
             name: "package-info",

--- a/Sources/_InternalTestSupport/SwiftSDKLookup.swift
+++ b/Sources/_InternalTestSupport/SwiftSDKLookup.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import PackageModel
+
+import class Basics.AsyncProcess
+
+/// Returns the compiler tag reported by `swiftc -print-target-info`, used as the prefix of
+/// installed Swift SDK artifact IDs (e.g. `swift-6.2-DEVELOPMENT-SNAPSHOT-2025-XX-XX-a`).
+package func swiftCompilerTag(compilerPath: AbsolutePath) async -> String? {
+    guard let result = try? await AsyncProcess.popen(args: compilerPath.pathString, "-print-target-info") else {
+        return nil
+    }
+    guard result.exitStatus == .terminated(code: 0) else {
+        return nil
+    }
+    struct SwiftPrintTargetInfo: Decodable {
+        var swiftCompilerTag: String
+    }
+    return try? JSONDecoder().decode(SwiftPrintTargetInfo.self, from: result.utf8Output()).swiftCompilerTag
+}
+
+/// Returns the path to the single toolchain installed under `/github/home/.swift-toolchains`
+/// when running inside the standard Swift GitHub Actions runner, or nil otherwise.
+package func githubActionsToolchain() -> AbsolutePath? {
+    let userToolchainsDir = AbsolutePath("/github/home/.swift-toolchains")
+    let userToolchains = try? FileManager.default.contentsOfDirectory(atPath: userToolchainsDir.pathString)
+    guard let userToolchains, userToolchains.count == 1 else {
+        return nil
+    }
+    return userToolchainsDir.appending(component: userToolchains[0])
+}
+
+/// Looks up an installed Swift SDK by running `swift sdk list` and returning the first artifact ID
+/// whose suffix (following the compiler tag prefix) satisfies `predicate`.
+package func findSwiftSDK(
+    compilerPath: AbsolutePath,
+    where predicate: (_ suffix: String) -> Bool
+) async -> String? {
+    guard let compilerTag = await swiftCompilerTag(compilerPath: compilerPath) else {
+        return nil
+    }
+    let prefix = "\(compilerTag)_"
+    guard let result = try? await SwiftPM.sdk.execute(["list"]) else {
+        return nil
+    }
+    let sdks = result.stdout.components(separatedBy: "\n")
+        .map { $0.spm_chomp() }
+        .filter { !$0.isEmpty }
+    return sdks.first { sdk in
+        guard sdk.hasPrefix(prefix) else { return false }
+        return predicate(String(sdk.dropFirst(prefix.count)))
+    }
+}
+
+package func findCompilerAndSDKIDForTesting(
+    where predicate: (_ suffix: String) -> Bool
+) async throws -> (AbsolutePath, String)? {
+    let compilerPath: AbsolutePath
+    if let githubActionsToolchain = githubActionsToolchain() {
+        compilerPath = githubActionsToolchain.appending(components: ["usr", "bin", "swiftc\(ProcessInfo.exeSuffix)"])
+    } else {
+        compilerPath = try UserToolchain(swiftSDK: SwiftSDK.hostSwiftSDK()).swiftCompilerPath
+    }
+
+    guard let sdkID = await findSwiftSDK(compilerPath: compilerPath, where: predicate) else {
+        return nil
+    }
+
+    return (compilerPath, sdkID)
+}
+
+package func findCompilerAndStaticLinuxSDKIDForTesting() async throws -> (AbsolutePath, String)? {
+    try await findCompilerAndSDKIDForTesting { $0.hasPrefix("static-linux") }
+}

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -195,6 +195,12 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    public static var requiresStaticLinuxSwiftSDK: Self {
+        enabled("Static Linux Swift SDK is not installed") {
+            try await findCompilerAndStaticLinuxSDKIDForTesting() != nil
+        }
+    }
+
     /// Skip test if built by XCode.
     public static func skipIfXcodeBuilt() -> Self {
         disabled("Tests built by Xcode") {

--- a/Tests/SwiftPMStaticLinuxIntegrationTests/StaticLinuxIntegrationTests.swift
+++ b/Tests/SwiftPMStaticLinuxIntegrationTests/StaticLinuxIntegrationTests.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import PackageModel
+import _InternalTestSupport
+import SPMBuildCore
+import Testing
+
+import class Basics.AsyncProcess
+
+@Suite(
+    .tags(
+        Tag.Feature.Command.Build,
+    )
+)
+private struct StaticLinuxIntegrationTests {
+    @Test(.requiresStaticLinuxSwiftSDK, arguments: SupportedBuildSystemOnAllPlatforms)
+    func basicSwiftExecutable(buildSystem: BuildSystemProvider.Kind) async throws {
+        try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndStaticLinuxSDKIDForTesting())
+
+            var env = Environment()
+            env["SWIFT_EXEC"] = compilerPath.pathString
+
+            let arch: String
+            #if os(Linux)
+            #if arch(x86_64)
+            arch = "x86_64"
+            #elseif arch(aarch64)
+            arch = "aarch64"
+            #else
+            arch = "x86_64"
+            #endif
+            #else
+            arch = "x86_64"
+            #endif
+
+            let buildOutput = try await executeSwiftBuild(
+                fixturePath,
+                extraArgs: ["--swift-sdk", sdkID, "--triple", "\(arch)-swift-linux-musl"],
+                env: env,
+                buildSystem: buildSystem,
+            )
+            #expect(buildOutput.stdout.contains("Build complete"))
+
+            let binPathOutput = try await executeSwiftBuild(
+                fixturePath,
+                extraArgs: ["--swift-sdk", sdkID, "--triple", "\(arch)-swift-linux-musl", "--show-bin-path"],
+                env: env,
+                buildSystem: buildSystem,
+            )
+            let binPath = binPathOutput.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            let binary = try AbsolutePath(validating: binPath).appending(component: "ExecutableNew")
+            #expect(localFileSystem.exists(binary), "Expected binary at \(binary)")
+
+            #if os(Linux)
+            // Static-linux binaries are standalone ELFs that can run directly on a Linux host of the same arch.
+            let result = try await AsyncProcess.popen(arguments: [binary.pathString])
+            let stdout = try result.utf8Output().trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(result.exitStatus == .terminated(code: 0), "binary exited with non-zero status")
+            #expect(stdout == "Hello, world!", "Unexpected output: \(stdout)")
+            #endif
+        }
+    }
+}

--- a/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -19,47 +19,6 @@ import Testing
 
 import class Basics.AsyncProcess
 
-package func swiftCompilerTag(compilerPath: AbsolutePath) async -> String? {
-    guard let result = try? await AsyncProcess.popen(args: compilerPath.pathString, "-print-target-info") else {
-        return nil
-    }
-    guard result.exitStatus == .terminated(code: 0) else {
-        return nil
-    }
-    struct SwiftPrintTargetInfo: Decodable {
-        var swiftCompilerTag: String
-    }
-    return try? JSONDecoder().decode(SwiftPrintTargetInfo.self, from: result.utf8Output()).swiftCompilerTag
-}
-
-package func findSwiftSDK(compilerPath: AbsolutePath, _ name: String) async -> String? {
-    guard let compilerTag = await swiftCompilerTag(compilerPath: compilerPath) else {
-        return nil
-    }
-    let prefix = "\(compilerTag)_"
-    guard let result = try? await SwiftPM.sdk.execute(["list"]) else {
-        return nil
-    }
-    let sdks = result.stdout.components(separatedBy: "\n")
-        .map { $0.spm_chomp() }
-        .filter { !$0.isEmpty }
-    let matchingSDKs = sdks.filter { sdk in
-        guard sdk.hasPrefix(prefix) else { return false }
-        let suffix = String(sdk.dropFirst(prefix.count))
-        return name == suffix
-    }
-    return matchingSDKs.count == 1 ? matchingSDKs[0] : nil
-}
-
-private func githubActionsToolchain() -> AbsolutePath? {
-    let userToolchainsDir = AbsolutePath("/github/home/.swift-toolchains")
-    let userToolchains = try? FileManager.default.contentsOfDirectory(atPath: userToolchainsDir.pathString)
-    guard let userToolchains, userToolchains.count == 1 else {
-        return nil
-    }
-    return userToolchainsDir.appending(component: userToolchains[0])
-}
-
 private func findWasmKit(sdkID: String) throws -> AbsolutePath? {
     let observability = ObservabilitySystem { _, _ in }
     let hostSDK = try SwiftSDK.hostSwiftSDK()
@@ -85,21 +44,9 @@ private func findWasmKit(sdkID: String) throws -> AbsolutePath? {
     return swiftSDK.toolset.knownTools[.debugger]?.path
 }
 
-func findCompilerAndWebAssemblySDKIDForTesting() async throws -> (AbsolutePath, String)? {
-    let compilerPath: AbsolutePath
-    if let githubActionsToolchain = githubActionsToolchain() {
-        compilerPath = githubActionsToolchain.appending(components: ["usr", "bin", "swiftc\(ProcessInfo.exeSuffix)"])
-    } else {
-        compilerPath = try UserToolchain(swiftSDK: SwiftSDK.hostSwiftSDK()).swiftCompilerPath
-    }
-
-    guard let sdkID = await findSwiftSDK(compilerPath: compilerPath, "wasm") else {
-        return nil
-    }
-
-    return (compilerPath, sdkID)
+private func findCompilerAndWebAssemblySDKIDForTesting() async throws -> (AbsolutePath, String)? {
+    try await findCompilerAndSDKIDForTesting { $0 == "wasm" }
 }
-
 
 extension Trait where Self == Testing.ConditionTrait {
     static var requiresWebAssemblySwiftSDK: Self {


### PR DESCRIPTION
Reuse some of the infrastructure from the WebAssemblyIntegrationTests target to setup some scaffolding for a set of integration tests using the static linux swift sdk