### PR TITLE
Include task backtraces in trace event files

### DIFF
--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -505,10 +505,11 @@ public final class SwiftCommandState {
         }
 
         if options.build.enableTaskBacktraces {
-            // Task backtraces require at least verbose output to be logged
-            if !options.logging.verbose && !options.logging.veryVerbose {
+            // Task backtraces require at least verbose output to be logged, unless
+            // they're being captured in an event trace file.
+            if !options.logging.verbose && !options.logging.veryVerbose && options.build.traceEventsFilePath == nil {
                 observabilityScope.emit(
-                    warning: "'--experimental-task-backtraces' requires '--verbose' or '--very-verbose'"
+                    warning: "'--experimental-task-backtraces' requires '--verbose', '--very-verbose', or '--experimental-trace-events-file'"
                 )
             }
 

--- a/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
@@ -127,10 +127,23 @@ public final class SwiftBuildSystemMessageHandler {
         self.tasksEmitted.insert(info)
     }
 
+    private func renderTaskBacktrace(
+        for startedInfo: SwiftBuildMessage.TaskStartedInfo
+    ) -> String? {
+        guard
+            let id = SWBBuildOperationBacktraceFrame.Identifier(taskSignatureData: Data(startedInfo.taskSignature.utf8)),
+            let backtrace = SWBTaskBacktrace(from: id, collectedFrames: buildState.collectedBacktraceFrames)
+        else {
+            return nil
+        }
+        let rendered = backtrace.renderTextualRepresentation()
+        return rendered.isEmpty ? nil : rendered
+    }
+
     private func handleTaskOutput(
         _ info: SwiftBuildMessage.TaskCompleteInfo,
         _ startedInfo: SwiftBuildMessage.TaskStartedInfo,
-        _ enableTaskBacktraces: Bool
+        _ renderedBacktrace: String?
     ) throws {
         // Begin by emitting the text received by the task started event.
         if let started = self.buildState.startedInfo(for: startedInfo) {
@@ -163,14 +176,8 @@ public final class SwiftBuildSystemMessageHandler {
         }
 
         // Handle task backtraces, if applicable.
-        if enableTaskBacktraces {
-            if let id = SWBBuildOperationBacktraceFrame.Identifier(taskSignatureData: Data(startedInfo.taskSignature.utf8)),
-               let backtrace = SWBTaskBacktrace(from: id, collectedFrames: buildState.collectedBacktraceFrames) {
-                let formattedBacktrace = backtrace.renderTextualRepresentation()
-                if !formattedBacktrace.isEmpty {
-                    self.observabilityScope.emit(info: "Task backtrace:\n\(formattedBacktrace)")
-                }
-            }
+        if let renderedBacktrace, !renderedBacktrace.isEmpty {
+            self.observabilityScope.emit(info: "Task backtrace:\n\(renderedBacktrace)")
         }
     }
 
@@ -278,13 +285,18 @@ public final class SwiftBuildSystemMessageHandler {
         case .taskComplete(let info):
             let startedInfo = try buildState.completed(task: info)
 
+            let renderedBacktrace = self.enableBacktraces
+                ? self.renderTaskBacktrace(for: startedInfo)
+                : nil
+
             traceEventsWriter?.taskCompleted(
                 info,
                 startedInfo: startedInfo,
+                backtrace: renderedBacktrace
             )
 
             // Handler for task output, handling failures if applicable.
-            try self.handleTaskOutput(info, startedInfo, self.enableBacktraces)
+            try self.handleTaskOutput(info, startedInfo, renderedBacktrace)
 
             let targetInfo = try buildState.target(for: startedInfo)
             callback = { [weak self] buildSystem in

--- a/Sources/SwiftBuildSupport/TraceEventsWriter.swift
+++ b/Sources/SwiftBuildSupport/TraceEventsWriter.swift
@@ -147,6 +147,7 @@ package final class TraceEventsWriter {
     package func taskCompleted(
         _ info: SwiftBuildMessage.TaskCompleteInfo,
         startedInfo: SwiftBuildMessage.TaskStartedInfo,
+        backtrace: String? = nil
     ) {
         let taskID = TaskID(info.taskID)
         let endInstant = ContinuousClock.now
@@ -166,6 +167,9 @@ package final class TraceEventsWriter {
         args["description"] = .string(startedInfo.executionDescription)
         if let cmdLine = startedInfo.commandLineDisplayString {
             args["commandLine"] = .string(cmdLine)
+        }
+        if let backtrace, !backtrace.isEmpty {
+            args["backtrace"] = .string(backtrace)
         }
         args["result"] = .string("\(info.result)")
         appendEvent(TraceEvent(

--- a/Tests/FunctionalTests/TaskBacktracesTests.swift
+++ b/Tests/FunctionalTests/TaskBacktracesTests.swift
@@ -72,7 +72,26 @@ struct TaskBacktraceTests {
                 buildSystem: .swiftbuild,
                 throwIfCommandFails: false
             )
-            #expect(stderr.contains("'--experimental-task-backtraces' requires '--verbose' or '--very-verbose'"))
+            #expect(stderr.contains("'--experimental-task-backtraces' requires '--verbose', '--very-verbose', or '--experimental-trace-events-file'"))
+        }
+    }
+
+    @Test(
+        .tags(.TestSize.large, .Feature.TaskBacktraces)
+    )
+    func taskBacktracesDoesNotWarnWhenTraceEventsFileProvided() async throws {
+        try await fixture(name: "Miscellaneous/Simple") { fixturePath in
+            let traceFile = fixturePath.appending("trace.json")
+            let (_, stderr) = try await executeSwiftBuild(
+                fixturePath,
+                extraArgs: [
+                    "--experimental-task-backtraces",
+                    "--experimental-trace-events-file", traceFile.pathString,
+                ],
+                buildSystem: .swiftbuild,
+                throwIfCommandFails: false
+            )
+            #expect(!stderr.contains("'--experimental-task-backtraces' requires"))
         }
     }
 


### PR DESCRIPTION
Exposing these in the trace events file makes it easier to debug incremental builds where some tasks unexpectedly re-ran.