### PR TITLE
Ensure test env is constructed correctly when listing Swift Testing tests

### DIFF
--- a/Fixtures/Miscellaneous/TestWithDynamicDep/MyDynDep/Package.swift
+++ b/Fixtures/Miscellaneous/TestWithDynamicDep/MyDynDep/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MyDynDep",
+    products: [
+        .library(name: "MyDynDep", type: .dynamic, targets: ["MyDynDep"]),
+    ],
+    targets: [
+        .target(name: "MyDynDep"),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestWithDynamicDep/MyDynDep/Sources/MyDynDep/MyDynDep.swift
+++ b/Fixtures/Miscellaneous/TestWithDynamicDep/MyDynDep/Sources/MyDynDep/MyDynDep.swift
@@ -1,0 +1,3 @@
+public func name() -> String {
+    "World"
+}

--- a/Fixtures/Miscellaneous/TestWithDynamicDep/Package.swift
+++ b/Fixtures/Miscellaneous/TestWithDynamicDep/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "TestWithDynamicDep",
+    dependencies: [
+        .package(path: "MyDynDep"),
+    ],
+    targets: [
+        .testTarget(
+            name: "MyDynDepTests",
+            dependencies: [.product(name: "MyDynDep", package: "MyDynDep")]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestWithDynamicDep/Tests/MyDynDepTests/MyDynDepTests.swift
+++ b/Fixtures/Miscellaneous/TestWithDynamicDep/Tests/MyDynDepTests/MyDynDepTests.swift
@@ -1,0 +1,6 @@
+import Testing
+import MyDynDep
+
+@Test func nameWorks() {
+    #expect(name() == "World")
+}

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -174,7 +174,7 @@ enum TestingSupport {
             .map {(
                 $0.binaryPath,
                 try Self.getSwiftTestingSuites(
-                    fromTestAt: $0.binaryPath,
+                    testProduct: $0,
                     swiftCommandState: swiftCommandState,
                     shouldSkipBuilding: shouldSkipBuilding,
                     sanitizers: sanitizers
@@ -188,13 +188,13 @@ enum TestingSupport {
     /// On Linux, the test binary handles `--list-tests` directly.
     ///
     /// - Parameters:
-    ///     - path: Path to the test binary.
+    ///     - testProduct: The test product.
     ///
     /// - Throws: TestError, SystemError, TSCUtility.Error
     ///
     /// - Returns: Array of test identifiers in the format "Module.Suite/testFunction()"
     static func getSwiftTestingSuites(
-        fromTestAt path: AbsolutePath,
+        testProduct: BuiltTestProduct,
         swiftCommandState: SwiftCommandState,
         shouldSkipBuilding: Bool,
         sanitizers: [Sanitizer]
@@ -212,24 +212,24 @@ enum TestingSupport {
             ).productsBuildParameters,
             sanitizers: sanitizers,
             library: .swiftTesting,
-            testProductPaths: [path],
+            testProductPaths: [testProduct.bundlePath],
             interopMode: nil // Interop not required when listing tests
         )
 
         var args: [String]
         #if os(macOS)
         let helper = try toolchain.getSwiftTestingHelper()
-        args = [helper.pathString, "--test-bundle-path", path.pathString,
+        args = [helper.pathString, "--test-bundle-path", testProduct.binaryPath.pathString,
                 "--list-tests", "--testing-library", "swift-testing",
-                path.pathString]
+                testProduct.binaryPath.pathString]
         #else
-        args = [path.pathString, "--list-tests", "--testing-library", "swift-testing"]
+        args = [testProduct.binaryPath.pathString, "--list-tests", "--testing-library", "swift-testing"]
         #endif
 
         let output: String
         do {
             output = try Self.runProcessWithExistenceCheck(
-                path: path,
+                path: testProduct.binaryPath,
                 fileSystem: swiftCommandState.fileSystem,
                 args: args,
                 env: env

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -1627,4 +1627,31 @@ struct TestCommandTests {
             }
          }
 
+    // Regression test for https://github.com/swiftlang/swift-package-manager/issues/9986. Ensure
+    // environment is computed correctly throughout the testing pipeline.
+    @Test(
+        .tags(
+            .Feature.TargetType.Test,
+            .Feature.ProductType.DynamicLibrary,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func testTargetWithDynamicLibraryProductDependency(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await withKnownIssue("Windows path issue", isIntermittent: true) {
+            try await fixture(name: "Miscellaneous/TestWithDynamicDep") { fixturePath in
+                _ = try await execute(
+                    [],
+                    packagePath: fixturePath,
+                    configuration: configuration,
+                    buildSystem: buildSystem,
+                    throwIfCommandFails: true
+                )
+            }
+        } when: {
+            .windows == ProcessInfo.hostOperatingSystem
+        }
+    }
 }


### PR DESCRIPTION
https://github.com/swiftlang/swift-package-manager/pull/9783 accidentally used the binaryPath instead of the bundlePath when constructing the environment used to list tests, which on macOS (where test targets are built as bundles) caused load failures for adjacent dylibs.