### PR TITLE
Output "Found unhandled resource .." log line as warning (to stderr) to not corrupt json output during package describe

### DIFF
--- a/Fixtures/Miscellaneous/UnhandledResource/Package.swift
+++ b/Fixtures/Miscellaneous/UnhandledResource/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "UnhandledResource",
+    targets: [
+        .target(
+            name: "MyLib",
+            resources: [.process("missing.txt")]
+        )
+    ]
+)

--- a/Fixtures/Miscellaneous/UnhandledResource/Sources/MyLib/MyLib.swift
+++ b/Fixtures/Miscellaneous/UnhandledResource/Sources/MyLib/MyLib.swift
@@ -1,0 +1,1 @@
+public enum MyLib {}

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -197,7 +197,7 @@ public struct TargetSourcesBuilder {
                 if handledResources.contains(resource.path) {
                     return nil
                 } else {
-                    self.observabilityScope.emit(info: "Found unhandled resource at \(resource.path)")
+                    self.observabilityScope.emit(warning: "Found unhandled resource at \(resource.path)")
                     return self.resource(for: resource.path, with: .init(resource.rule))
                 }
             }

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1151,6 +1151,33 @@ struct PackageCommandTests {
 
     @Test(
         .tags(
+            .Feature.Command.Package.Describe,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func testDescribeJSONWithUnhandledResource_EnsureValidJSONOutput(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let config = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/UnhandledResource") { fixturePath in
+            let (jsonOutput, stderr) = try await execute(
+                ["describe", "--type=json"],
+                packagePath: fixturePath,
+                configuration: config,
+                buildSystem: buildSystem,
+            )
+
+            // Verify stdout contains valid JSON, not corrupted by diagnostic output.
+            let json = try JSON(bytes: ByteString(encodingAsUTF8: jsonOutput))
+            #expect(json["name"]?.string == "UnhandledResource")
+
+            // Verify the warning appears on stderr.
+            #expect(stderr.contains("Found unhandled resource"))
+        }
+    }
+
+    @Test(
+        .tags(
             .Feature.Command.Package.DumpPackage,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -341,10 +341,12 @@ struct ResourcesTests{
                 // Filter some unrelated output that could show up on stderr.
                 let buidlSystemDeprecationDiag = Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem)
                 let filteredStderr = stderr.components(separatedBy: "\n").filter { !$0.contains("[logging]") }
-                                                                        .filter { !$0.contains("Unable to locate libSwiftScan") }
-                                                                        .filter {
-                                                                            !$0.contains(Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem).message)
-                                                                        }.joined(separator: "\n")
+                    .filter { !$0.contains("Unable to locate libSwiftScan") }
+                    .filter {
+                        !$0.contains(Basics.Diagnostic.deprecatedBuildSystem(buildSystem: buildSystem).message)
+                    }
+                    .filter { !$0.contains("Found unhandled resource") }
+                    .joined(separator: "\n")
                 #expect(filteredStderr == "", "unexpectedly received error output: \(stderr)")
 
                 let builtProductsDir = try packageDir.appending(components: buildSystem.binPath(for: configuration))


### PR DESCRIPTION
Output "Found unhandled resource .." log line as warning (to stderr) to not corrupt json output during package describe

### Motivation:

When an unhandled resource was detected the message was printed to stdout, corrupting the json that is emitted.

### Modifications:

Move message to warning (stderr)

### Result:

Unhandled resource message is output to stderr
