### PR TITLE
[Swift Build] Address libFuzzer support TODO

### DIFF
--- a/Fixtures/Miscellaneous/Fuzzer/Package.swift
+++ b/Fixtures/Miscellaneous/Fuzzer/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "Fuzzer",
+    targets: [
+        .executableTarget(
+            name: "Fuzzer",
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Fuzzer/Sources/Fuzzer/Fuzzer.swift
+++ b/Fixtures/Miscellaneous/Fuzzer/Sources/Fuzzer/Fuzzer.swift
@@ -1,0 +1,13 @@
+@_cdecl("LLVMFuzzerTestOneInput")
+public func test(_ start: UnsafeRawPointer, _ count: Int) -> CInt {
+    let bytes = UnsafeRawBufferPointer(start: start, count: count)
+    _ = bytes.first
+    return 0
+}
+
+@main
+struct Fuzzer {
+    static func main() {
+        print("regular main called")
+    }
+}

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -167,6 +167,13 @@ extension PackagePIFProjectBuilder {
                 settings[.INSTALL_PATH] = "/usr/local/bin"
                 settings[.LD_RUNPATH_SEARCH_PATHS] = ["$(inherited)", "@executable_path/../lib"]
             }
+
+            // When the fuzzing is enabled via build request overrides, rename the entry point of executables
+            // so that we use the libFuzzer entrypoint.
+            settings[.OTHER_SWIFT_FLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                $0.append("$(OTHER_SWIFT_FLAGS_ENABLE_LIBFUZZER_$(ENABLE_LIBFUZZER))")
+            }
+            settings[multiple: "OTHER_SWIFT_FLAGS_ENABLE_LIBFUZZER_YES"] = ["-Xfrontend", "-entry-point-function-name", "-Xfrontend", "\(mainModule.c99name)_main"]
         }
 
         mainModule.addParseAsLibrarySettings(to: &settings, toolsVersion: package.manifest.toolsVersion, fileSystem: pifBuilder.fileSystem)

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -832,7 +832,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 case .scudo:
                     settings["ENABLE_SCUDO_SANITIZER"] = "YES"
                 case .fuzzer:
-                    throw StringError("\(sanitizer) is not currently supported with this build system.")
+                    settings["ENABLE_LIBFUZZER"] = "YES"
             }
         }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1299,6 +1299,31 @@ struct MiscellaneousTestCase {
             ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
         }
     }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
+        .skipHostOS(.windows, "libFuzzer is not included in the Windows distribution"),
+    )
+    func libFuzzerSupport() async throws {
+        try await withKnownIssue {
+            let configuration = BuildConfiguration.debug
+            try await fixture(name: "Miscellaneous/Fuzzer") { fixturePath in
+                let (stdout, stderr) = try await executeSwiftRun(
+                    fixturePath,
+                    nil,
+                    configuration: configuration,
+                    extraArgs: ["--sanitize", "fuzzer", "Fuzzer", "--", "-runs=10"],
+                    buildSystem: .swiftbuild
+                )
+                #expect(stderr.contains("Done 10 runs"))
+                #expect(!stdout.contains("regular main called"))
+            }
+        } when: {
+            ProcessInfo.isHostAmazonLinux2() // libFuzzer link issues occur on AL2
+        }
+    }
 }
 
 @Suite

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -116,8 +116,7 @@ func withInstantiatedSwiftBuildSystem(
 extension PackageModel.Sanitizer {
     var hasSwiftBuildSupport: Bool {
         switch self {
-            case .address, .thread, .undefined, .scudo: true
-            case .fuzzer: false
+            case .address, .thread, .undefined, .scudo, .fuzzer: true
         }
     }
 
@@ -127,7 +126,7 @@ extension PackageModel.Sanitizer {
             case .thread: "ENABLE_THREAD_SANITIZER"
             case .undefined: "ENABLE_UNDEFINED_BEHAVIOR_SANITIZER"
             case .scudo: "ENABLE_SCUDO_SANITIZER"
-            case .fuzzer: nil
+            case .fuzzer: "ENABLE_LIBFUZZER"
         }
 
     }


### PR DESCRIPTION
Depends on https://github.com/swiftlang/swift-build/pull/1355

1. Forward the appropriate build request override when passed --sanitize=fuzzer
2. Rename the entrypoint of executables so they can be replaced by the fuzzing implementation

Fixes: #9858 