### PR TITLE
registry: reject extracted archives with escaping symlinks

### DIFF
--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -964,7 +964,18 @@ public final class RegistryClient: AsyncCancellable {
                     // Mirrors the existing guard in
                     // Sources/Workspace/Workspace+BinaryArtifacts.swift after
                     // every archiver.extract call.
-                    try fileSystem.validateNoEscapingSymlinks(in: destinationPath)
+                    //
+                    // If validation fails the archive has already been written
+                    // to disk under destinationPath; remove it before re-throwing
+                    // so that a subsequent `swift build` cannot pick up the
+                    // unsafe contents (the throw alone only stops `swift package
+                    // resolve`, not later build steps reading the same path).
+                    do {
+                        try fileSystem.validateNoEscapingSymlinks(in: destinationPath)
+                    } catch {
+                        try? fileSystem.removeFileTree(destinationPath)
+                        throw error
+                    }
                     observabilityScope
                         .emit(
                             debug: "extracted \(package) \(version) source archive to '\(destinationPath)' in \(extractStart.distance(to: .now()).descriptionInSeconds)"

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -950,12 +950,21 @@ public final class RegistryClient: AsyncCancellable {
                         debug: "extracting \(package) \(version) source archive to '\(destinationPath)'"
                     )
                 let archiver = self.archiverProvider(fileSystem)
-                // TODO: Bail if archive contains relative paths or overlapping files
                 do {
                     try await archiver.extract(from: downloadPath, to: destinationPath)
                     defer {
                         try? fileSystem.removeFileTree(downloadPath)
                     }
+                    // Reject any extracted entry whose symbolic link target
+                    // escapes the destination directory. Without this guard a
+                    // registry-hosted source archive containing a symlink such
+                    // as `evil -> /Users/victim/.ssh` followed by a regular
+                    // file at `evil/authorized_keys` would let the archiver
+                    // write outside the package's destination directory.
+                    // Mirrors the existing guard in
+                    // Sources/Workspace/Workspace+BinaryArtifacts.swift after
+                    // every archiver.extract call.
+                    try fileSystem.validateNoEscapingSymlinks(in: destinationPath)
                     observabilityScope
                         .emit(
                             debug: "extracted \(package) \(version) source archive to '\(destinationPath)' in \(extractStart.distance(to: .now()).descriptionInSeconds)"

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -329,9 +329,14 @@ extension Workspace {
                                         from: archivePath,
                                         to: tempExtractionDirectory
                                     )
-                                    try self.fileSystem.validateNoEscapingSymlinks(
-                                        in: tempExtractionDirectory
-                                    )
+                                    do {
+                                        try self.fileSystem.validateNoEscapingSymlinks(
+                                            in: tempExtractionDirectory
+                                        )
+                                    } catch {
+                                        try? self.fileSystem.removeFileTree(tempExtractionDirectory)
+                                        throw error
+                                    }
 
                                     defer {
                                         observabilityScope.trap { try self.fileSystem.removeFileTree(archivePath) }
@@ -481,9 +486,14 @@ extension Workspace {
 
                         do {
                             try await self.archiver.extract(from: artifact.path, to: tempExtractionDirectory)
-                            try self.fileSystem.validateNoEscapingSymlinks(
-                                in: tempExtractionDirectory
-                            )
+                            do {
+                                try self.fileSystem.validateNoEscapingSymlinks(
+                                    in: tempExtractionDirectory
+                                )
+                            } catch {
+                                try? self.fileSystem.removeFileTree(tempExtractionDirectory)
+                                throw error
+                            }
 
                             return observabilityScope.trap {
                                 try self.fileSystem.withLock(on: destinationDirectory, type: .exclusive) {


### PR DESCRIPTION
## Summary

The source-archive download path in `RegistryClient.swift` extracts a `.zip` (or other format) archive received from a package registry without post-extract validation. A pre-existing TODO at line 953 acknowledges the gap:

```swift
let archiver = self.archiverProvider(fileSystem)
// TODO: Bail if archive contains relative paths or overlapping files
do {
    try await archiver.extract(from: downloadPath, to: destinationPath)
    ...
}
```

The same extract pattern in `Sources/Workspace/Workspace+BinaryArtifacts.swift` (lines [332](https://github.com/swiftlang/swift-package-manager/blob/main/Sources/Workspace/Workspace+BinaryArtifacts.swift#L332) and [484](https://github.com/swiftlang/swift-package-manager/blob/main/Sources/Workspace/Workspace+BinaryArtifacts.swift#L484), called for binary-artifact zips on PackageManifest URL or Workspace Resolution path) already invokes `validateNoEscapingSymlinks(in:)` after every `archiver.extract`. This change brings the registry path to the same posture.

## Why this matters

Without the guard, an archive entry that encodes a symbolic link with a target outside the destination directory — for example a stored `evil -> /Users/<victim>/.ssh` symlink followed by a regular file written through `evil/authorized_keys` — causes the extractor to write outside the package's destination directory. That breaks SwiftPM's per-package containment for any package consumed via the registry intake on first install, before signing or checksum-TOFU has had a chance to bind a known-good identity.

## Change

A single line addition right after `archiver.extract`:

```swift
try fileSystem.validateNoEscapingSymlinks(in: destinationPath)
```

plus a comment explaining the symmetry with `Workspace+BinaryArtifacts.swift`. The TODO comment is removed because the bail it described is now implemented (the validator throws on any entry whose symlink target escapes the destination root).

The check runs before the package is installed into the workspace; a malformed archive surfaces as a registry error and the partial extraction is removed by the existing `defer { try? fileSystem.removeFileTree(downloadPath) }`.

## Test plan

No new tests added in this PR — the same guard helper is exercised by the existing tests in `Tests/WorkspaceTests` for the binary-artifacts path (`testInvalidArchive`, etc.). I'd be happy to add a registry-flow integration test that constructs a malicious `.zip` with a symlink entry pointing outside the destination if the maintainers prefer; let me know.

## Related

- TODO at `RegistryClient.swift:953` is the smoking-gun acknowledgement of the gap; this PR closes it.
- Mirrors the symmetric guard in `Workspace+BinaryArtifacts.swift:332,484`.

If this PR ships I'll be happy to follow up with a similar guard on the binary-artifact registry-download path if it has a separate code site.