### PR TITLE
PackagePIFProjectBuilder+Modules.swift: Add missing `.emscripten`

### DIFF
--- a/Sources/Basics/Vendor/Triple+Platforms.swift
+++ b/Sources/Basics/Vendor/Triple+Platforms.swift
@@ -18,6 +18,12 @@
 // Changes:
 // - Replaced usage of `\(_:or:)` string interpolation.
 // - Replaced usage of `self.isDarwin` with `self.os?.isDarwin ?? false`.
+// - Added `.emscripten` case to `platformName(conflatingDarwin:)` so
+//   `BuildParameters.buildPath` can derive the Products-dir suffix
+//   from the triple without hardcoding the platform name. Swift Build
+//   depends on the returned "emscripten" string matching its
+//   `EFFECTIVE_PLATFORM_NAME`. Re-vendor from swift-driver once the
+//   upstream file adopts the same case.
 //
 //===----------------------------------------------------------------------===//
 
@@ -329,6 +335,8 @@ extension Triple {
       return "haiku"
     case .wasi:
       return "wasi"
+    case .emscripten:
+      return "emscripten"
     case .noneOS:
       return nil
 
@@ -336,7 +344,7 @@ extension Triple {
     // Triple updates
     case .ananas, .cloudABI, .dragonFly, .fuchsia, .kfreebsd, .lv2, .netbsd,
          .solaris, .minix, .rtems, .nacl, .cnk, .aix, .cuda, .nvcl, .amdhsa,
-         .elfiamcu, .mesa3d, .contiki, .amdpal, .hermitcore, .hurd, .emscripten:
+         .elfiamcu, .mesa3d, .contiki, .amdpal, .hermitcore, .hurd:
       return nil
     }
   }

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -265,7 +265,11 @@ public struct BuildParameters: Encodable {
                 // no suffix
             } else if self.triple.isAndroid() {
                 configDir += "-android"
-            } else if self.triple.isWasm {
+            } else if self.triple.isWasm && self.triple.isNoneOS() {
+                // Legacy suffix for bare-metal wasm (wasm32-unknown-none-wasm).
+                // All other wasm triples (wasi*, emscripten) fall through
+                // to `osNameUnversioned` below, which must match swift-build's
+                // `WebAssemblyPlatformExtension.platformName(triple:)` output.
                 configDir += "-webassembly"
             } else {
                 configDir += "-" + (self.triple.darwinPlatform?.platformName ?? self.triple.osNameUnversioned)

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -567,9 +567,9 @@ extension PackagePIFProjectBuilder {
             for platform in ProjectModel.BuildSettings.Platform.allCases {
                 // darwin & freebsd
                 switch platform {
-                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd, .emscripten:
+                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd, .emscripten, .wasi:
                         impartedSettings[.OTHER_LDFLAGS, platform] = ["-lc++", "$(inherited)"]
-                    case .android, .linux, .wasi, .openbsd:
+                    case .android, .linux, .openbsd:
                         impartedSettings[.OTHER_LDFLAGS, platform] = ["-lstdc++", "$(inherited)"]
                     case .windows, ._iOSDevice:
                         break

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -567,7 +567,7 @@ extension PackagePIFProjectBuilder {
             for platform in ProjectModel.BuildSettings.Platform.allCases {
                 // darwin & freebsd
                 switch platform {
-                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
+                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd, .emscripten:
                         impartedSettings[.OTHER_LDFLAGS, platform] = ["-lc++", "$(inherited)"]
                     case .android, .linux, .wasi, .openbsd:
                         impartedSettings[.OTHER_LDFLAGS, platform] = ["-lstdc++", "$(inherited)"]

--- a/Tests/SPMBuildCoreTests/BuildParametersTests.swift
+++ b/Tests/SPMBuildCoreTests/BuildParametersTests.swift
@@ -13,6 +13,7 @@
 @testable import SPMBuildCore
 import Basics
 import struct PackageModel.BuildEnvironment
+import enum PackageModel.BuildConfiguration
 import struct PackageModel.Platform
 import _InternalTestSupport
 import Testing
@@ -28,6 +29,51 @@ struct BuildParametersTests {
         #expect(parameters.enableTestability)
         parameters.configuration = .release
         #expect(!parameters.enableTestability)
+    }
+
+    @Test(arguments: [
+        (triple: "wasm32-unknown-wasi", suffix: "-wasi"),
+        (triple: "wasm32-unknown-wasip1", suffix: "-wasi"),
+        (triple: "wasm32-unknown-wasip1-threads", suffix: "-wasi"),
+        (triple: "wasm32-unknown-wasip2", suffix: "-wasi"),
+        (triple: "wasm64-unknown-wasi", suffix: "-wasi"),
+        (triple: "wasm32-unknown-emscripten", suffix: "-emscripten"),
+        (triple: "wasm32-unknown-none-wasm", suffix: "-webassembly"),
+    ] as [(triple: String, suffix: String)],
+    [
+        (config: BuildConfiguration.debug, buildSystem: BuildSystemProvider.Kind.swiftbuild),
+        (config: .debug, buildSystem: .xcode),
+        (config: .release, buildSystem: .swiftbuild),
+        (config: .release, buildSystem: .xcode),
+    ] as [(config: BuildConfiguration, buildSystem: BuildSystemProvider.Kind)])
+    func productsDirSuffixIsDerivedFromTriple(
+        tripleAndSuffix: (triple: String, suffix: String),
+        configAndBuildSystem: (config: BuildConfiguration, buildSystem: BuildSystemProvider.Kind),
+    ) throws {
+        // The expected-suffix column must stay byte-exact with swift-build's
+        // `WebAssemblyPlatformExtension.platformName(triple:)` (wasi, emscripten)
+        // and with swift-build's pre-#1335 legacy "webassembly" platform name
+        // (bare-metal wasm). A mismatch breaks `swift build --show-bin-path` /
+        // `swift run` path resolution under `.swiftbuild` — the exact regression
+        // that caused PR #1335 to be reverted.
+        let parsedTriple = try Basics.Triple(tripleAndSuffix.triple)
+        let parameters = mockBuildParameters(
+            destination: .target,
+            config: configAndBuildSystem.config,
+            buildSystemKind: configAndBuildSystem.buildSystem,
+            triple: parsedTriple,
+        )
+        let configDir = parameters.buildPath.basename
+        let expectedConfigPrefix = configAndBuildSystem.config.dirname.capitalized
+        #expect(
+            configDir == expectedConfigPrefix + tripleAndSuffix.suffix,
+            """
+            triple \(tripleAndSuffix.triple) / config \(configAndBuildSystem.config) / \
+            buildSystem \(configAndBuildSystem.buildSystem) must yield \
+            Products/\(expectedConfigPrefix)\(tripleAndSuffix.suffix) \
+            (got \"\(configDir)\")
+            """,
+        )
     }
 
     /// Covers the path that `llvm-cov export` must be given so that it can read the

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -418,7 +418,7 @@ struct PIFBuilderTests {
             for platform in ProjectModel.BuildSettings.Platform.allCases {
                 let search_paths = releaseConfig.impartedBuildProperties.settings[.LIBRARY_SEARCH_PATHS, platform]
                 switch platform {
-                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd, .android, .linux, .wasi, .openbsd, ._iOSDevice:
+                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd, .android, .linux, .emscripten, .wasi, .openbsd, ._iOSDevice:
                          #expect(search_paths == nil, "for platform \(platform)")
                     case .windows:
                         #expect(search_paths == ["$(inherited)", "$(TARGET_BUILD_DIR)/ExecutableModules"], "for platform \(platform)")

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -456,9 +456,9 @@ struct PIFBuilderTests {
             for platform in ProjectModel.BuildSettings.Platform.allCases {
                 let ld_flags = releaseConfig.impartedBuildProperties.settings[.OTHER_LDFLAGS, platform]
                 switch platform {
-                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
+                    case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd, .emscripten, .wasi:
                          #expect(ld_flags == ["-lc++", "$(inherited)"], "for platform \(platform)")
-                    case .android, .linux, .wasi, .openbsd:
+                    case .android, .linux, .openbsd:
                         #expect(ld_flags == ["-lstdc++", "$(inherited)"], "for platform \(platform)")
                     case .windows, ._iOSDevice:
                         #expect(ld_flags == nil, "for platform \(platform)")


### PR DESCRIPTION
```
14:09:47  /Users/ec2-user/jenkins/workspace/swift-package-manager-with-xcode-self-hosted-PR-osx-release-toolchain/branch-main/swiftpm/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift:569:17: error: switch must be exhaustive
14:09:47  567 |             for platform in ProjectModel.BuildSettings.Platform.allCases {
14:09:47  568 |                 // darwin & freebsd
14:09:47  569 |                 switch platform {
14:09:47      |                 |- error: switch must be exhaustive
14:09:47      |                 `- note: add missing case: '.emscripten'
14:09:47  570 |                     case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit, .freebsd:
14:09:47  571 |                         impartedSettings[.OTHER_LDFLAGS, platform] = ["-lc++", "$(inherited)"]
```