### PR TITLE
Fix typo in `.github/workflows/pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -89,7 +89,7 @@ jobs:
       yamllint_check_enabled: true
 
   wasm-integration-tests:
-    name: WASM Integration Tests
+    name: Wasm Integration Tests
     needs: [soundness]
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:


### PR DESCRIPTION
Per [the Wasm spec](https://webassembly.github.io/spec/core/intro/introduction.html), "Wasm" is not capitalized:
> A contraction of “WebAssembly”, not an acronym, hence not using all-caps.
