### PR TITLE
Fix initializing `librarySearchPaths` in UserToolchain

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -877,7 +877,7 @@ public final class UserToolchain: Toolchain {
             xcbuildFlags: swiftSDK.toolset.knownTools[.xcbuild]?.extraCLIOptions ?? [])
 
         self.includeSearchPaths = swiftSDK.pathsConfiguration.includeSearchPaths ?? []
-        self.librarySearchPaths = swiftSDK.pathsConfiguration.includeSearchPaths ?? []
+        self.librarySearchPaths = swiftSDK.pathsConfiguration.librarySearchPaths ?? []
 
         self.librarianPath = try swiftSDK.toolset.knownTools[.librarian]?.path ?? UserToolchain.determineLibrarian(
             triple: triple,

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -5598,7 +5598,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
 
         // Link Product
         let exeLinkArguments = try result.buildProduct(for: "exe").linkArguments()
-        let exeLinkArgumentsPattern: [StringPattern] = ["-L", "\(sdkIncludeSearchPath)"]
+        let exeLinkArgumentsPattern: [StringPattern] = ["-L", "\(sdkLibrarySearchPath)"]
         XCTAssertMatch(exeLinkArguments, exeLinkArgumentsPattern)
     }
 


### PR DESCRIPTION
This was ignoring setting these link paths in all SDK bundles.
