### PR TITLE
Ensure command-plugin-initiated builds use a consistent configuration

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CommandPluginBuildingBuildToolPlugin",
+    products: [
+        .library(name: "MyLibrary", targets: ["MyLibrary"]),
+    ],
+    targets: [
+        .target(
+            name: "MyLibrary",
+            plugins: [
+                "SourceGenPlugin",
+            ]
+        ),
+        .plugin(
+            name: "SourceGenPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                "SourceGenTool",
+            ]
+        ),
+        .executableTarget(
+            name: "SourceGenTool"
+        ),
+        .plugin(
+            name: "BuildInReleasePlugin",
+            capability: .command(
+                intent: .custom(verb: "build-release", description: "Build the package in release mode")
+            )
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Plugins/BuildInReleasePlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Plugins/BuildInReleasePlugin/plugin.swift
@@ -1,0 +1,15 @@
+import PackagePlugin
+
+@main
+struct BuildInReleasePlugin: CommandPlugin {
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        var parameters = PackageManager.BuildParameters()
+        parameters.configuration = .release
+        let result = try packageManager.build(.product("MyLibrary"), parameters: parameters)
+        guard result.succeeded else {
+            print("Build failed: \(result.logText)")
+            return
+        }
+        print("Built successfully")
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Plugins/SourceGenPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Plugins/SourceGenPlugin/plugin.swift
@@ -1,0 +1,21 @@
+import PackagePlugin
+import Foundation
+
+@main
+struct SourceGenPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        guard let target = target as? SourceModuleTarget else { return [] }
+        return try target.sourceFiles.compactMap { file -> Command? in
+            guard file.url.pathExtension == "dat" else { return nil }
+            let outputName = file.url.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
+            return .buildCommand(
+                displayName: "Generating \(outputName) from \(file.url.lastPathComponent)",
+                executable: try context.tool(named: "SourceGenTool").url,
+                arguments: [file.url.path, outputPath.path],
+                inputFiles: [file.url],
+                outputFiles: [outputPath]
+            )
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Sources/MyLibrary/MyLibrary.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Sources/MyLibrary/MyLibrary.swift
@@ -1,0 +1,3 @@
+public func getGreeting() -> String {
+    return greeting
+}

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Sources/MyLibrary/greeting.dat
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Sources/MyLibrary/greeting.dat
@@ -1,0 +1,1 @@
+Hello from generated source

--- a/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Sources/SourceGenTool/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin/Sources/SourceGenTool/main.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+if ProcessInfo.processInfo.arguments.count != 3 {
+    print("usage: SourceGenTool <input> <output>")
+    exit(1)
+}
+let inputFile = ProcessInfo.processInfo.arguments[1]
+let outputFile = ProcessInfo.processInfo.arguments[2]
+
+let variableName = URL(fileURLWithPath: inputFile).deletingPathExtension().lastPathComponent
+let inputData = FileManager.default.contents(atPath: inputFile) ?? Data()
+let inputString = String(data: inputData, encoding: .utf8) ?? ""
+let source = "public let \(variableName) = \"\(inputString.trimmingCharacters(in: .whitespacesAndNewlines))\"\n"
+FileManager.default.createFile(atPath: outputFile, contents: source.data(using: .utf8))

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -118,16 +118,21 @@ final class PluginDelegate: PluginInvocationDelegate {
     ) async throws -> PluginInvocationBuildResult {
         // Configure the build parameters.
         var buildParameters = try self.swiftCommandState.productsBuildParameters
+        var toolsBuildParameters = try swiftCommandState.toolsBuildParameters
         switch parameters.configuration {
         case .debug:
             buildParameters.configuration = .debug
+            toolsBuildParameters.configuration = .debug
         case .release:
             buildParameters.configuration = .release
+            toolsBuildParameters.configuration = .release
         case .inherit:
             // The top level argument parser set buildParameters.configuration according to the
             // --configuration command line parameter.   We don't need to do anything to inherit it.
             break
         }
+        // FIXME: Not applying these to the toolsBuildParameters is inconsistent with the handling of
+        // -Xcc, -Xswiftc, etc. However, resolving that is known to break some existing plugins.
         buildParameters.flags.cCompilerFlags.append(contentsOf: parameters.otherCFlags.constructBuildFlags(source: .plugin))
         buildParameters.flags.cxxCompilerFlags.append(contentsOf: parameters.otherCxxFlags.constructBuildFlags(source: .plugin))
         buildParameters.flags.swiftCompilerFlags.append(contentsOf: parameters.otherSwiftcFlags.constructBuildFlags(source: .plugin))
@@ -173,6 +178,7 @@ final class PluginDelegate: PluginInvocationDelegate {
             explicitProduct: explicitProduct,
             cacheBuildManifest: false,
             productsBuildParameters: buildParameters,
+            toolsBuildParameters: toolsBuildParameters,
             outputStream: outputStream,
             logLevel: logLevel
         )

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1682,4 +1682,25 @@ struct PluginTests {
             #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
+
+    @Test(
+        .IssueWindowsLongPath,
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func testCommandPluginBuildingPackageUsingBuildToolPlugin(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await withKnownIssue("Windows builds encounter long path handling issues", isIntermittent: true) {
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin") { fixturePath in
+                let (stdout, stderr) = try await executeSwiftPackage(
+                    fixturePath,
+                    extraArgs: ["plugin", "build-release"],
+                    buildSystem: buildSystem,
+                )
+                #expect(stdout.contains("Built successfully"))
+            }
+        } when: {
+            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
+        }
+    }
 }


### PR DESCRIPTION
Before this change, build configuration overrides from command plugins were not being applied to the tools build parameters, so when a command plugin initiated a release build the config of the host and destination parameters differed, unlike a build which passed --configuration on the command line. Currently, various parts of SwiftPM rely on the entire build using the same configuration, so this caused various issues, notably we would sometimes fail to properly lookup tools built from source when used by a build tool plugin.