### PR TITLE
Tests: Augment `internalExecAsDep` to run against all build configurations

### DIFF
--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -61,27 +61,24 @@ struct DependencyResolutionTests {
     }
 
     @Test(
-        .issue("https://github.com/swiftlang/swift-package-manager/issues/8984", relationship: .defect),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/8984", relationship: .verifies),
         .tags(
             Tag.Feature.Command.Build,
         ),
-        arguments: SupportedBuildSystemOnAllPlatforms,
+        arguments: getBuildData(for: SupportedBuildSystemOnAllPlatforms),
     )
     func internalExecAsDep(
-        buildSystem: BuildSystemProvider.Kind,
+        buildData: BuildData,
     ) async throws {
-        let configuration = BuildConfiguration.debug
+        let buildSystem = buildData.buildSystem
+        let configuration = buildData.config
         try await fixture(name: "DependencyResolution/Internal/InternalExecutableAsDependency") { fixturePath in
-            await withKnownIssue(isIntermittent: true) {
-                await #expect(throws: (any Error).self) {
-                    try await executeSwiftBuild(
-                        fixturePath,
-                        configuration: configuration,
-                        buildSystem: buildSystem,
-                    )
-                }
-            } when: {
-                configuration == .release && buildSystem == .swiftbuild // an error is not raised.
+            await #expect(throws: (any Error).self) {
+                try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: configuration,
+                    buildSystem: buildSystem,
+                )
             }
         }
     }


### PR DESCRIPTION
Theh `internalExecAsDep` was expected to fail when build against all build configurations.  While bringing up SwiftPM on SwiftBuild, this a build failure was not occurring with the `release` configuration.

This has since been fixed, so update the test by ensuring we run against all build configurations to ensure we don't regress in this area.

Fixes: #8984
Issue: rdar://157238199