### PR TITLE
Use the toolset paths from `sdk configure` to override an SDK bundle's toolset paths

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -761,6 +761,7 @@ public struct SwiftSDK: Equatable {
     ) throws -> SwiftSDK {
         var swiftSDK: SwiftSDK
         var isBasedOnHostSDK: Bool = false
+        var loadedToolsetPaths: Bool = false
 
         // Create custom toolchain if present.
         if let customDestination = customCompileDestination {
@@ -795,7 +796,9 @@ public struct SwiftSDK: Equatable {
                         hostTimeTriple: hostTriple,
                         swiftSDKBundleStore: store
                     )
+                    let bundleToolsetPaths = swiftSDK.pathsConfiguration.toolsetPaths ?? []
                     try configurationStore.readConfiguration(sdkID: ID, sdk: &swiftSDK)
+                    loadedToolsetPaths = !bundleToolsetPaths.elementsEqual(swiftSDK.pathsConfiguration.toolsetPaths ?? [])
                 } catch {
                     // Do nothing to override if a custom SDK config is not found.
                     observabilityScope.emit(
@@ -817,6 +820,28 @@ public struct SwiftSDK: Equatable {
             // Otherwise use the host toolchain.
             swiftSDK = hostSwiftSDK
             isBasedOnHostSDK = true
+        }
+
+        // Override the current toolset in the SDK with a custom config.
+        if loadedToolsetPaths, let toolpaths = swiftSDK.pathsConfiguration.toolsetPaths {
+            let wasmKitProperties = Toolset.ToolProperties(
+                path: store.hostToolchainBinDir.appending("wasmkit"),
+                extraCLIOptions: ["run", "--dir", "."]
+            )
+            let defaultTools: [Toolset.KnownTool: Toolset.ToolProperties] = if swiftSDK.targetTriple!.isWasm {
+                [.debugger: wasmKitProperties, .testRunner: wasmKitProperties]
+            } else {
+                [:]
+            }
+            swiftSDK.toolset = try toolpaths.reduce(into: Toolset(knownTools: defaultTools, rootPaths: [])) {
+                try $0.merge(
+                    with: Toolset(
+                        from: $1,
+                        at: fileSystem,
+                        observabilityScope
+                    )
+                )
+            }
         }
 
         if !customToolsets.isEmpty {


### PR DESCRIPTION
#9229 finally got `swift sdk configure` working to apply local config overrides to target triples in SDK bundles when compiling with the native build system, but I noticed when working on that that the configured toolset paths are not applied. This is a better version of the commit I had added there, but more deliberation is still needed.

Right now, this will do the same as [when the `--toolset` flag is added on the command-line](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md#toolsetjson-files), ie merge any newly configured toolset flags into the toolset _from_ the original SDK bundle. However, unlike the `--toolset` flag, those using `sdk configure` probably expect to override the original toolset in the SDK bundle altogether, as they do with the other paths.

That will require more changes wiping the original toolset that is probably [decoded from the SDK bundle and separately initialized](https://github.com/swiftlang/swift-package-manager/blob/main/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift#L991).

Since this `swift sdk configure` feature never affected compilation until now, we have a free hand here to decide how it should work for toolsets for the first time.

@owenv, you will have to decide this for your similar swift-build pull, #10013, let me know what you're doing there.

@MaxDesiatov and @jakepetroules, let me know what you think this should do for user-configured toolset paths.