### PR TITLE
Fix debug format override

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -558,7 +558,7 @@ public struct BuildOptions: ParsableArguments {
 
     /// The Debug Information Format to use.
     @Option(name: .customLong("debug-info-format", withSingleDash: true), help: "The Debug Information Format to use.")
-    public var debugInfoFormat: DebugInfoFormat = .dwarf
+    public var debugInfoFormat: DebugInfoFormat? = nil
 
     public var buildSystem: BuildSystemProvider.Kind {
         switch self._buildSystem {

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1020,7 +1020,7 @@ public final class SwiftCommandState {
             prepareForIndexing: prepareForIndexingMode,
             enableXCFrameworksOnLinux: options.build.enableXCFrameworksOnLinux,
             debuggingParameters: .init(
-                debugInfoFormat: self.options.build.debugInfoFormat.buildParameter,
+                debugInfoFormat: self.options.build.debugInfoFormat?.buildParameter,
                 triple: triple,
                 shouldEnableDebuggingEntitlement:
                 self.options.build
@@ -1484,4 +1484,3 @@ extension Basics.Diagnostic {
         )
     }
 }
-

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -670,6 +670,7 @@ public final class PackagePIFBuilder {
         // Add the build settings that are specific to debug builds, and set those as the "Debug" configuration.
         var debugSettings = settings
         debugSettings[.COPY_PHASE_STRIP] = "NO"
+        //TODO would be nice to have this defaulted by the build systems as we may want different default based on platform (ie codeview for windows)
         debugSettings[.DEBUG_INFORMATION_FORMAT] = "dwarf"
         debugSettings[.ENABLE_NS_ASSERTIONS] = "YES"
         debugSettings[.GCC_OPTIMIZATION_LEVEL] = "0"
@@ -684,6 +685,7 @@ public final class PackagePIFBuilder {
         // Add the build settings that are specific to release builds, and set those as the "Release" configuration.
         var releaseSettings = settings
         releaseSettings[.COPY_PHASE_STRIP] = "YES"
+        //TODO would be nice to have this defaulted by the build systems as we may want different default based on platform (ie codeview for windows)
         releaseSettings[.DEBUG_INFORMATION_FORMAT] = "dwarf-with-dsym"
         releaseSettings[.GCC_OPTIMIZATION_LEVEL] = "s"
         releaseSettings[.SWIFT_OPTIMIZATION_LEVEL] = "-Owholemodule"

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -997,7 +997,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         settings["ADD_TOOLCHAIN_CONCURRENCY_BACK_DEPLOY_RPATH"] = "YES"
         settings["ADD_TOOLCHAIN_SPAN_BACK_DEPLOY_RPATH"] = "YES"
 
-        try settings.merge(Self.constructDebuggingSettingsOverrides(from: buildParameters.debuggingParameters), uniquingKeysWith: reportConflict)
+        try settings.merge(Self.constructDebuggingSettingsOverrides(from: buildParameters.debuggingParameters, for: buildParameters.configuration), uniquingKeysWith: reportConflict)
         try settings.merge(Self.constructDriverSettingsOverrides(from: buildParameters.driverParameters), uniquingKeysWith: reportConflict)
         try settings.merge(self.constructLinkerSettingsOverrides(from: buildParameters.linkingParameters, triple: buildParameters.triple), uniquingKeysWith: reportConflict)
         try settings.merge(Self.constructTestingSettingsOverrides(from: buildParameters.testingParameters), uniquingKeysWith: reportConflict)
@@ -1159,7 +1159,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         return settings
     }
 
-    private static func constructDebuggingSettingsOverrides(from parameters: BuildParameters.Debugging) -> [String: String] {
+    private static func constructDebuggingSettingsOverrides(from parameters: BuildParameters.Debugging, for configuration: BuildConfiguration) -> [String: String] {
         var settings: [String: String] = [:]
         if parameters.shouldEnableDebuggingEntitlement {
             settings["DEPLOYMENT_POSTPROCESSING"] = "NO"
@@ -1167,7 +1167,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         // Set DEBUG_INFORMATION_FORMAT based on debugInfoFormat
         switch parameters.debugInfoFormat {
         case .dwarf:
-            settings["DEBUG_INFORMATION_FORMAT"] = "dwarf"
+            settings["DEBUG_INFORMATION_FORMAT"] =  configuration == .debug ? "dwarf" : "dwarf-with-dsym"
         case .codeview:
             settings["DEBUG_INFORMATION_FORMAT"] = "codeview"
         case .none?:


### PR DESCRIPTION
- use dwarf or dwarf-with-dsym based on build config in setting override
- update options to not explicitly set the debug type to dwarf so that we may move this down to the build system someday to handle different formats on different platforms.

