### PR TITLE
fuzzer test failure is nondeterministic on AL2

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1307,7 +1307,7 @@ struct MiscellaneousTestCase {
         .skipHostOS(.windows, "libFuzzer is not included in the Windows distribution"),
     )
     func libFuzzerSupport() async throws {
-        try await withKnownIssue {
+        try await withKnownIssue(isIntermittent: true) {
             let configuration = BuildConfiguration.debug
             try await fixture(name: "Miscellaneous/Fuzzer") { fixturePath in
                 let (stdout, stderr) = try await executeSwiftRun(


### PR DESCRIPTION
This test is occasionally passing depending on which linker version is on the CI machine: https://ci.swift.org/job/oss-swift-package-amazon-linux-2/5028/consoleText