### PR TITLE
Allow passing `--triple` alone to select a Swift SDK

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -463,7 +463,9 @@ public struct BuildOptions: ParsableArguments {
     }
 
     /// The compilation destination’s target triple.
-    @Option(name: .customLong("triple"), transform: Triple.init)
+    @Option(name: .customLong("triple"),
+            help: "Filter for selecting the target triple from a Swift SDK bundle to build with.",
+            transform: Triple.init)
     public var customCompileTriple: Triple?
 
     /// Path to the compilation destination’s SDK.

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -784,10 +784,16 @@ public struct SwiftSDK: Equatable {
                   let targetSwiftSDK = SwiftSDK.defaultSwiftSDK(for: targetTriple, hostSDK: hostSwiftSDK)
         {
             swiftSDK = targetSwiftSDK
-        } else if let swiftSDKSelector {
+        } else if swiftSDKSelector != nil || customCompileTriple != nil {
             do {
                 var ID: String
-                (ID, swiftSDK) = try store.selectBundle(matching: swiftSDKSelector, hostTriple: hostTriple, targetTriple: customCompileTriple)
+                if let swiftSDKSelector {
+                    (ID, swiftSDK) = try store.selectBundle(matching: swiftSDKSelector, hostTriple: hostTriple, targetTriple: customCompileTriple)
+                } else if let customCompileTriple {
+                    (ID, swiftSDK) = try store.selectBundle(matching: customCompileTriple.tripleString, hostTriple: hostTriple)
+                } else {
+                    fatalError("Neither an SDK nor a triple matched somehow.")
+                }
 
                 // Override with user's manual config
                 do {
@@ -806,7 +812,7 @@ public struct SwiftSDK: Equatable {
             } catch {
                 // If a user-installed bundle for the selector doesn't exist, check if the
                 // selector is recognized as a default SDK.
-                if let targetTriple = try? Triple(swiftSDKSelector),
+                if let targetTriple = try? customCompileTriple ?? Triple(swiftSDKSelector!),
                    let defaultSDK = SwiftSDK.defaultSwiftSDK(for: targetTriple, hostSDK: hostSwiftSDK) {
                     swiftSDK = defaultSDK
                 } else {


### PR DESCRIPTION
Simply aliases it to `--swift-sdk triple` and finally adds a help string for the flag, fixes #7330. I checked to make sure the `--swift-sdk` error strings still make sense and they do, because they use the generic word "query" anyway.

This passed all tests locally on macOS except for one:
```
Test Case '-[PackageModelTests.SwiftSDKBundleTests testTargetSDKDerivation]' started.
/Users/finagolfin/swift/swiftpm/Tests/PackageModelTests/SwiftSDKBundleTests.swift:537: error: -[PackageModelTests.SwiftSDKBundleTests testTargetSDKDerivation] : failed: caught error: "No Swift SDK found matching query `aarch64-unknown-linux-gnu` and host triple `arm64-apple-macosx14.0`. Use the `swift sdk list` command to see available Swift SDKs."
Test Case '-[PackageModelTests.SwiftSDKBundleTests testTargetSDKDerivation]' failed (0.121 seconds).
```
That test was added in #8034, in support of a strange config where you could use the host SDK but override the triple, ie ignoring the installed bundles. Supporting that is not going to work with selecting a triple from the installed bundles as requested in #7330, unless we check if no bundles are installed, and only then default to the host SDK override logic. That will be weird for the user, where the host SDK override is applied only _if_ no bundles happen to be installed.

Instead, I think we should just throw out that [host toolset override logic](https://github.com/swiftlang/swift-package-manager/pull/8034/changes#diff-a434883777befb0b6ef138f44a098a3d63d3b9dc59b521e16e2c5b3a6163117fR706), and [move this line](https://github.com/swiftlang/swift-package-manager/pull/8034/changes#diff-a434883777befb0b6ef138f44a098a3d63d3b9dc59b521e16e2c5b3a6163117fR704) to only apply to [the now somewhat-deprecated destination config files](https://github.com/swiftlang/swift-package-manager/blob/645158ee5da3319cfaf8b1ad03e4fff7c840a57e/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift#L766).

This `--triple` flag was introduced in #2604 to really [only apply to destination files at the time](https://github.com/swiftlang/swift-package-manager/pull/2604/changes#diff-8d396837a0426c26967e471b82d8f2eaf31f9a7ae2e03308300799edbac4bd18R809), and probably never worked well for the host destination it was also applied to then. It probably doesn't work very well for host SDK overrides today, unless you really know what you're doing.

Better to only apply this `--triple` flag to the old destination files, which it was first introduced for, and as a selector for Swift SDK bundles, as I do in this pull, throwing out the old host override logic and closing #8716 as unsupported. I think we have a free hand here, since this flag was never documented till now. I'll adjust that test and add a couple more depending on what's decided.

Let me know what you think, @jakepetroules, @kateinoigakukun, and @MaxDesiatov.