### PR TITLE
Fix warnings with unhandled files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -613,6 +613,9 @@ let package = Package(
                 "PackageCollections",
                 "PackageModel",
             ],
+            exclude: [
+                "CMakeLists.txt",
+            ],
             swiftSettings: commonExperimentalFeatures
         ),
 
@@ -705,7 +708,10 @@ let package = Package(
         .executableTarget(
             /** Interacts with package collections */
             name: "swift-package-collection",
-            dependencies: ["PackageCollectionsCommand"]
+            dependencies: ["PackageCollectionsCommand"],
+            exclude: [
+                "CMakeLists.txt",
+            ],
         ),
         .executableTarget(
             /** Multi-command entry point for SwiftPM. */
@@ -722,7 +728,10 @@ let package = Package(
         .executableTarget(
             /** Interact with package registry */
             name: "swift-package-registry",
-            dependencies: ["PackageRegistryCommand"]
+            dependencies: ["PackageRegistryCommand"],
+            exclude: [
+                "CMakeLists.txt",
+            ],
         ),
         .executableTarget(
             /** Utility to produce the artifacts for prebuilts */


### PR DESCRIPTION
Recent changes to the Package.swift reported some warning of unhandled files similar to the following

    warning: 'swift-package-manager': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
        <path/to/file>/CMakeLists.txt

Update the Package.swift to exclude the `CMakeLists.txt` file from the respective target, thus addressing the "warning."
