### PR TITLE
Suppress warning about ignoring duplicate libraries in swiftbuild (parity with native/xcode)

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -562,6 +562,16 @@ extension PackagePIFProjectBuilder {
         )
         if enableDuplicateLinkageCulling {
             impartedSettings[.LD_WARN_DUPLICATE_LIBRARIES] = "NO"
+
+            for platform in ProjectModel.BuildSettings.Platform.allCases {
+                switch platform {
+                case .macOS, .macCatalyst, .iOS, .watchOS, .tvOS, .xrOS, .driverKit:
+                    let existing = impartedSettings[.OTHER_LDFLAGS, platform] ?? ["$(inherited)"]
+                    impartedSettings[.OTHER_LDFLAGS, platform] = ["-Xlinker", "-no_warn_duplicate_libraries"] + existing
+                case .android, .linux, .wasi, .openbsd, .freebsd, .windows, ._iOSDevice:
+                    break
+                }
+            }
         }
         if sourceModule.isCxx {
             for platform in ProjectModel.BuildSettings.Platform.allCases {


### PR DESCRIPTION
Suppress warning about ignoring duplicate libraries in swiftbuild (parity with native/xcode)

### Motivation:

The native (llbuild) and Xcode build systems suppressed this warning, retain that behaviour in swiftbuild.

### Modifications:

Explicitly pass -no_warn_duplicate_libraries

### Result:

Avoid warnings such as the following in dependent libraries:

ld: warning: ignoring duplicate libraries: '-lc++', '-lz'
