### PR TITLE
[6.4] Update Package branch-based dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1100,7 +1100,7 @@ func swiftSyntaxDependencies(_ names: [String]) -> [Target.Dependency] {
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-let relatedDependenciesBranch = "main"
+let relatedDependenciesBranch = "release/6.4.x"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
@@ -1130,7 +1130,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-system.git", revision: "1.5.0"),
         .package(url: "https://github.com/apple/swift-collections.git", revision: "1.1.6"),
         .package(url: "https://github.com/apple/swift-certificates.git", revision: "1.10.1"),
-        .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", revision: "1.0.7"),
+        .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite.git", revision: "1.0.9"),
         // Not in toolchain, used for use in previewing documentation
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
     ]


### PR DESCRIPTION
Update the Package.swift dependencies to have their branch dependency be `release/6.4.x`, to match the projects branch name.

Depends on: https://github.com/swiftlang/swift-build/pull/1370
Depends on: #10035 