### PR TITLE
Use INDEX_ENABLE_DATA_STORE to control index operation while building

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -678,7 +678,7 @@ public final class PackagePIFBuilder {
         debugSettings[.ENABLE_TESTABILITY] = "YES"
         debugSettings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS, default: []].append(contentsOf: ["DEBUG"])
         debugSettings[.GCC_PREPROCESSOR_DEFINITIONS, default: ["$(inherited)"]].append(contentsOf: ["DEBUG=1"])
-        debugSettings[.SWIFT_INDEX_STORE_ENABLE] = "YES"
+        debugSettings[.INDEX_ENABLE_DATA_STORE] = "YES"
         builder.project.addBuildConfig { id in BuildConfig(id: id, name: "Debug", settings: debugSettings) }
 
         // Add the build settings that are specific to release builds, and set those as the "Release" configuration.

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -146,7 +146,7 @@ extension PackagePIFProjectBuilder {
             settings[.SKIP_INSTALL] = "NO"
             settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS].lazilyInitialize { ["$(inherited)"] }
             // Enable index-while building for Swift compilations to facilitate discovery of XCTest tests.
-            settings[.SWIFT_INDEX_STORE_ENABLE] = "YES"
+            settings[.INDEX_ENABLE_DATA_STORE] = "YES"
 
             if mainModule.platformConstraint == .host {
                 // This is a macro test using prebuilts

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -902,13 +902,13 @@ struct PIFBuilderTests {
                     .buildConfig(named: configuration)
                 switch indexStoreSettingUT {
                     case .on, .off:
-                        #expect(targetConfig.settings[.SWIFT_INDEX_STORE_ENABLE] == nil)
+                        #expect(targetConfig.settings[.INDEX_ENABLE_DATA_STORE] == nil)
                     case .auto:
                         let expectedSwiftIndexStoreEnableValue: String? = switch configuration {
                             case .debug: "YES"
                             case .release: nil
                         }
-                        #expect(targetConfig.settings[.SWIFT_INDEX_STORE_ENABLE] == expectedSwiftIndexStoreEnableValue)
+                        #expect(targetConfig.settings[.INDEX_ENABLE_DATA_STORE] == expectedSwiftIndexStoreEnableValue)
                 }
 
                 let testTargetConfig = try pif.workspace
@@ -917,9 +917,9 @@ struct PIFBuilderTests {
                     .buildConfig(named: configuration)
                 switch indexStoreSettingUT {
                     case .on, .off:
-                        #expect(testTargetConfig.settings[.SWIFT_INDEX_STORE_ENABLE] == nil)
+                        #expect(testTargetConfig.settings[.INDEX_ENABLE_DATA_STORE] == nil)
                     case .auto:
-                        #expect(testTargetConfig.settings[.SWIFT_INDEX_STORE_ENABLE] == "YES")
+                        #expect(testTargetConfig.settings[.INDEX_ENABLE_DATA_STORE] == "YES")
                 }
             }
         }


### PR DESCRIPTION
INDEX_ENABLE_DATA_STORE is used with xcodebuild command line overrides this allow that to be overridden where before SWIFT_INDEX_STORE_ENABLE was being used prevent the override

rdar://174859173
