### PR TITLE
Bump Swift version to 6.5.0

### DIFF
--- a/Sources/Basics/SwiftVersion.swift
+++ b/Sources/Basics/SwiftVersion.swift
@@ -58,7 +58,7 @@ public struct SwiftVersion: Sendable {
 extension SwiftVersion {
     /// The current version of the package manager.
     public static let current = SwiftVersion(
-        version: (6, 4, 0),
+        version: (6, 5, 0),
         isDevelopment: true,
         buildIdentifier: getBuildIdentifier()
     )


### PR DESCRIPTION
Now that we have opened `release/6.4.x`, we need to be able to easily distinguish between toolchain builds produced from `main` vs the new release branch.

Bump the nominal Swift version to 6.5. Note that this is a provisional version number, serving as a technical placeholder that the project may decide to change. If that happens, then we can simply update these definitions as needed, similar to how Swift 5.11 got changed to Swift 6.0 during its development.