### PR TITLE
Update test to validate Swift 6.3+

### DIFF
--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -847,8 +847,12 @@ struct MiscellaneousTestCase {
             #expect(stdout.contains("Hello, async universe"), "stderr: \(stderr)")
         }
         } when: {
+            #if compiler(>=6.3)
+            false
+            #else
             // error: FileSystemError(kind: TSCBasic.FileSystemError.Kind.noEntry, path: Optional(<AbsolutePath:"C:\Users\ContainerAdministrator\AppData\Local\Temp\Miscellaneous_TestableAsyncExe.74Koc7\Miscellaneous_TestableAsyncExe\.build\out\Intermediates.noindex\TestableAsyncExe.build\Debug-windows\TestableAsyncExe4.build\Objects-normal\x86_64\TestableAsyncExe4.LinkFileList">))
             ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
+            #endif
         }
     }
 

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -316,16 +316,29 @@ struct SwiftBuildSystemTests {
                 case .off: "NO"
                 case .auto: nil
             }
-            let expectedPathValue: String? = switch indexStoreSettingUT {
-                case .on: buildParameters.indexStore.pathString
+            let expectedPathValue: AbsolutePath? = switch indexStoreSettingUT {
+                case .on: buildParameters.indexStore
                 case .off: nil
                 case .auto: nil
             }
 
             #expect(synthesizedArgs.table["SWIFT_INDEX_STORE_ENABLE"] == expectedSettingValue)
             #expect(synthesizedArgs.table["CLANG_INDEX_STORE_ENABLE"] == expectedSettingValue)
-            #expect(synthesizedArgs.table["SWIFT_INDEX_STORE_PATH"] == expectedPathValue)
-            #expect(synthesizedArgs.table["CLANG_INDEX_STORE_PATH"] == expectedPathValue)
+            if let expectedPathValue {
+                let swiftPath = try #require(
+                    synthesizedArgs.table["SWIFT_INDEX_STORE_PATH"],
+                    "SWIFT_INDEX_STORE_PATH is not set",
+                )
+                let clangPath = try #require(
+                    synthesizedArgs.table["CLANG_INDEX_STORE_PATH"],
+                    "CLANG_INDEX_STORE_PATH is not set",
+                )
+                #expect(AbsolutePath(swiftPath) == expectedPathValue)
+                #expect(AbsolutePath(clangPath) == expectedPathValue)
+            } else {
+                #expect(synthesizedArgs.table["SWIFT_INDEX_STORE_PATH"] == nil)
+                #expect(synthesizedArgs.table["CLANG_INDEX_STORE_PATH"] == nil)
+            }
         }
     }
 

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -151,10 +151,10 @@ final class PrebuiltsTests: XCTestCase {
         if usePrebuilt {
             let includes = try XCTUnwrap(target.buildSettings.assignments[.PREBUILT_INCLUDE_PATHS]).flatMap(\.values)
             XCTAssertEqual(includes.count, 2)
-            XCTAssertTrue(includes.contains("/tmp/ws/.build/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport/Modules".fixwin))
-            XCTAssertTrue(includes.contains("/tmp/ws/.build/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include".fixwin))
+            XCTAssertTrue(includes.contains(AbsolutePath("/tmp/ws/.build/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport/Modules").pathString))
+            XCTAssertTrue(includes.contains(AbsolutePath("/tmp/ws/.build/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include").pathString))
             let libPaths = try XCTUnwrap(target.buildSettings.assignments[.PREBUILT_LIBRARY_PATHS]).flatMap(\.values)
-            XCTAssertEqual(libPaths, ["/tmp/ws/.build/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport/lib".fixwin])
+            XCTAssertEqual(libPaths, [AbsolutePath("/tmp/ws/.build/prebuilts/swift-syntax/600.0.1/\(self.swiftVersion)-MacroSupport/lib").pathString])
             let lib = try XCTUnwrap(target.buildSettings.assignments[.PREBUILT_LIBRARIES]).flatMap(\.values)
             XCTAssertEqual(lib, ["MacroSupport"])
         } else {
@@ -523,7 +523,7 @@ final class PrebuiltsTests: XCTestCase {
 
         try await with(fileSystem: fs, artifact: artifact, swiftSyntaxVersion: "600.0.2") { _, rootCertPath, rootPackage, swiftSyntax in
             let secondFetch = SendableBox(false)
-            
+
             let httpClient = HTTPClient { request, progressHandler in
                 if request.url == "https://download.swift.org/prebuilts/swift-syntax/600.0.2/\(self.swiftVersion).json" {
                     let secondFetch = await secondFetch.value
@@ -534,12 +534,12 @@ final class PrebuiltsTests: XCTestCase {
                     return .notFound()
                 }
             }
-            
+
             let archiver = MockArchiver(handler: { _, archivePath, destination, completion in
                 XCTFail("Unexpected call to archiver")
                 completion(.success(()))
             })
-            
+
             let workspace = try await MockWorkspace(
                 sandbox: sandbox,
                 fileSystem: fs,
@@ -556,7 +556,7 @@ final class PrebuiltsTests: XCTestCase {
                     rootCertPath: rootCertPath
                 )
             )
-            
+
             try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
                 XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
                 let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
@@ -565,9 +565,9 @@ final class PrebuiltsTests: XCTestCase {
                 try checkSettings(rootPackage, "Foo", usePrebuilt: false)
                 try checkSettings(rootPackage, "FooClient", usePrebuilt: false)
             }
-            
+
             await secondFetch.set(true)
-            
+
             try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
                 XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
                 let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
@@ -938,7 +938,7 @@ final class PrebuiltsTests: XCTestCase {
                     swiftSyntax
                 ]
             )
-            
+
             try await workspace.checkPackageGraph(roots: ["Foo"]) { modulesGraph, diagnostics in
                 XCTAssertTrue(diagnostics.filter({ $0.severity == .error }).isEmpty)
                 let rootPackage = try XCTUnwrap(modulesGraph.rootPackages.first)
@@ -1452,12 +1452,3 @@ final class PrebuiltsTests: XCTestCase {
     }
 }
 
-extension String {
-    var fixwin: String {
-        #if os(Windows)
-        return self.replacingOccurrences(of: "/", with: "\\")
-        #else
-        return self
-        #endif
-    }
-}


### PR DESCRIPTION
The CI jobs executed mostly on Swift 6.3 for all platforms and on main-snapshot for Windows and Linux.  Now that the Windows self hosted pipeline is running Swift 6.3, some tests are failing.

Update the tests to have then be more flexible on platforms, and also to have the test provide expected behaviour on Swift 6.3+.

(cherry picked from commit 5b8cf7a44701eeb21a1028adffc5499f9a28127f)

Cherry-pick from #10035
