### PR TITLE
[6.4] SwiftBuild: expose STRIP_INSTALLED_PRODUCT setting

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -407,6 +407,15 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             return result
         }
 
+        if let stripProduct = self.config.destinationBuildParameters.stripProducts {
+            self.observabilityScope.emit(
+                Basics.Diagnostic.unsupportedStripProductsConfigurationFlag(
+                    isEnabled: stripProduct,
+                    with: .native,
+                )
+            )
+        }
+
         let buildStartTime = DispatchTime.now()
 
         // Get the build description (either a cached one or newly created).

--- a/Sources/CoreCommands/CMakeLists.txt
+++ b/Sources/CoreCommands/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_library(CoreCommands
   BuildSystemSupport.swift
   SwiftCommandState.swift
+  SwiftCommandState.swift
   SwiftCommandObservabilityHandler.swift
   Options.swift)
 target_link_libraries(CoreCommands PUBLIC

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -650,6 +650,13 @@ public struct BuildOptions: ParsableArguments {
         /// See `BuildParameters.DebugInfoFormat.none` for details.
         case none
     }
+
+    @Flag(
+        name: .customLong("experimental-strip-products"),
+        inversion: .prefixedEnableDisable,
+        help: "Whether or not to strip debug symbols from the final binary.",
+    )
+    public var stripProducts: Bool?
 }
 
 public struct LinkerOptions: ParsableArguments {

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1063,7 +1063,8 @@ public final class SwiftCommandState {
                 forceTestDiscovery: self.options.build.enableTestDiscovery,
                 // backwards compatibility, remove with --enable-test-discovery
                 testEntryPointPath: self.options.build.testEntryPointPath
-            )
+            ),
+            stripProducts: self.options.build.stripProducts,
         )
     }
 

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -94,6 +94,9 @@ public struct BuildParameters: Encodable {
     /// Whether to create dylibs for dynamic library products.
     public var shouldCreateDylibForDynamicProducts: Bool
 
+    /// Whether to strip debug symbols from the final binary
+    public var stripProducts: Bool?
+
     /// The current build environment.
     public var buildEnvironment: BuildEnvironment {
         BuildEnvironment(platform: currentPlatform, configuration: configuration)
@@ -187,7 +190,8 @@ public struct BuildParameters: Encodable {
         linkingParameters: Linking = .init(),
         outputParameters: Output = .init(),
         testingParameters: Testing = .init(),
-        apiDigesterMode: APIDigesterMode? = nil
+        apiDigesterMode: APIDigesterMode? = nil,
+        stripProducts: Bool? = nil,
     ) throws {
         // Default to the unversioned triple if none is provided so that we defer to the package's requested deployment target, for Darwin platforms. For other platforms, continue to include the version since those don't have the concept of a package-specified version, and the version is meaningful for some platforms including Android and FreeBSD.
         let triple = try triple ?? {
@@ -253,6 +257,7 @@ public struct BuildParameters: Encodable {
         self.outputParameters = outputParameters
         self.testingParameters = testingParameters
         self.apiDigesterMode = apiDigesterMode
+        self.stripProducts = stripProducts
     }
 
     /// The path to the build directory (inside the data directory).

--- a/Sources/SPMBuildCore/CMakeLists.txt
+++ b/Sources/SPMBuildCore/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(SPMBuildCore
   BuildSystem/BuildSystemDelegate.swift
   BuildSystem/DiagnosticsCapturingBuildSystemDelegate.swift
   BuiltTestProduct.swift
+  Diagnostics+Extensions.swift
   Plugins/DefaultPluginScriptRunner.swift
   Plugins/PluginContextSerializer.swift
   Plugins/PluginInvocation.swift

--- a/Sources/SPMBuildCore/Diagnostics+Extensions.swift
+++ b/Sources/SPMBuildCore/Diagnostics+Extensions.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import struct Basics.Diagnostic
+import struct SPMBuildCore.BuildSystemProvider
+import enum PackageModel.BuildConfiguration
+
+extension Basics.Diagnostic {
+
+    package static func unsupportedStripProductsConfigurationFlag(
+        isEnabled: Bool,
+        with selectedBuildSystem: BuildSystemProvider.Kind,
+    ) -> Self {
+        return .error("Command line option '--\(isEnabled ? "enable": "--disable")--experimental-strip-products' is unsupported with build system '\(selectedBuildSystem)'.  Only use with '\(BuildSystemProvider.Kind.swiftbuild)' build system with configuration '\(BuildConfiguration.release)'")
+    }
+}

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -441,7 +441,7 @@ public final class PIFBuilder {
                 packageDisplayVersion: package.manifest.displayName,
                 pkgConfigDirectories: self.parameters.pkgConfigDirectories,
                 fileSystem: self.fileSystem,
-                observabilityScope: self.observabilityScope
+                observabilityScope: self.observabilityScope,
             )
 
             packagesAndBuilders.append((package, packagePIFBuilder, packagePIFBuilderDelegate))

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -12,6 +12,7 @@
 
 @_spi(SwiftPMInternal)
 import Basics
+import SPMBuildCore // for the Basics.Diagnostic extension
 import Dispatch
 import class Foundation.FileManager
 import class Foundation.JSONEncoder
@@ -427,6 +428,15 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         guard !buildParameters.shouldSkipBuilding else {
             result.serializedDiagnosticPathsByTargetName = .failure(StringError("Building was skipped"))
             return result
+        }
+
+        if let stripProdduct = self.buildParameters.stripProducts, self.buildParameters.configuration != .release {
+            self.observabilityScope.emit(
+                Basics.Diagnostic.unsupportedStripProductsConfigurationFlag(
+                    isEnabled: stripProdduct,
+                    with: .swiftbuild,
+                )
+            )
         }
 
         guard try await self.compilePlugins(in: subset) else {
@@ -867,6 +877,12 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 case .fuzzer:
                     settings["ENABLE_LIBFUZZER"] = "YES"
             }
+        }
+
+        settings["STRIP_INSTALLED_PRODUCT"] = if let stripInstalledProducts = self.buildParameters.stripProducts {
+            stripInstalledProducts ? "YES" : "NO"
+        } else {
+            "NO"
         }
 
         // FIXME: workaround for old Xcode installations such as what is in CI

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -13,6 +13,7 @@
 @_spi(SwiftPMInternal)
 import Basics
 import Dispatch
+import SPMBuildCore // for the Basics.Diagnostic extension
 import class Foundation.JSONEncoder
 import class Foundation.NSArray
 import class Foundation.NSDictionary
@@ -170,6 +171,15 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
 
         guard !buildParameters.shouldSkipBuilding else {
             return buildResult
+        }
+
+        if let stripProdduct = self.buildParameters.stripProducts {
+            self.observabilityScope.emit(
+                Basics.Diagnostic.unsupportedStripProductsConfigurationFlag(
+                    isEnabled: stripProdduct,
+                    with: .xcode,
+                )
+            )
         }
 
         let pifBuilder = try await getPIFBuilder()

--- a/Sources/_InternalTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalTestSupport/MockBuildTestHelper.swift
@@ -109,6 +109,7 @@ public func mockBuildParameters(
     prepareForIndexing: BuildParameters.PrepareForIndexingMode = .off,
     sanitizers: [Sanitizer] = [],
     numberOfWorkers: UInt32 = 3,
+    stripProducts: Bool? = nil,
 ) -> BuildParameters {
     try! BuildParameters(
         destination: destination,
@@ -140,6 +141,7 @@ public func mockBuildParameters(
             shouldDisableLocalRpath: shouldDisableLocalRpath,
             shouldLinkStaticSwiftStdlib: shouldLinkStaticSwiftStdlib
         ),
+        stripProducts: stripProducts,
     )
 }
 

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -33,7 +33,7 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
-    public static func requireCompiledWith6_3OrLater(_ comment: Comment? = nil) -> Self {
+    public static func requireCompiledWith6_3OrLater(because comment: Comment? = nil) -> Self {
         enabled(comment ?? "This needs to have been compiled with Swift 6.3 or later.") {
             #if compiler(>=6.3)
             true
@@ -41,6 +41,11 @@ extension Trait where Self == Testing.ConditionTrait {
             false
             #endif
         }
+    }
+
+    @available(*, deprecated, message: "use `requireCompiledWith6_3OrLater(because:) instead")
+    public static func requireCompiledWith6_3OrLater(_ comment: Comment? = nil) -> Self {
+        requireCompiledWith6_3OrLater(because: comment)
     }
 
     /// Enabled only if toolchain support swift concurrency

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -332,7 +332,8 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
                 ),
                 outputParameters: .init(
                     isVerbose: logLevel <= .info
-                )
+                ),
+                stripProducts: nil,
             )
         }
 

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -142,6 +142,102 @@ struct BuildCommandTestCases {
     }
 
     @Test(
+        arguments: [
+            BuildData(buildSystem: .swiftbuild, config: .release),
+        ], ["enable", "disable"],
+    )
+    func testStripProductsGeneratedDoesNotEmitErrorsWhenSupportedBuildSystemAndConfiguration(
+        buildData: BuildData,
+        action: String,
+    ) async throws {
+        let buildSystem = buildData.buildSystem
+        let config = buildData.config
+        let argumentUT = "--\(action)-experimental-strip-products"
+
+        try await fixture(name: "ValidLayouts/SingleModule/Library") { fixturePath in
+            let (stdout, stderr) = try await executeSwiftBuild(
+                fixturePath,
+                configuration: config,
+                extraArgs: [
+                    argumentUT,
+                    "--verbose",
+                ],
+                buildSystem: buildSystem,
+            )
+
+            let diag = Basics.Diagnostic.unsupportedStripProductsConfigurationFlag(
+                isEnabled: action.lowercased() == "enable",
+                with: buildSystem,
+            )
+
+            #expect(stdout.contains("Build complete!"))
+            #expect(!stderr.contains("\(diag.severity): \(diag.message)"))
+            #expect(!stdout.contains("\(diag.severity): \(diag.message)"))
+        }
+    }
+
+    @Test(
+        .requireHostOS(.macOS),
+        arguments: getBuildData(for: [.xcode]),  ["enable", "disable"],
+    )
+    func testStripProductsGeneratesErrorWhenUsedWithXcodeBuildSystemAndConfiguration(
+        buildData: BuildData,
+        action: String,
+    ) async throws {
+        try await __testImplementationStripProductsGeneratedErrorWhenUsedWithIncorrectBuildSystemAndConfiguration(
+            buildData: buildData,
+            action: action,
+        )
+    }
+
+    @Test(
+        arguments: getBuildData(for: [.native]) + [
+            BuildData(buildSystem: .swiftbuild, config: .debug),
+        ],  ["enable", "disable"],
+    )
+    func testStripProductsGeneratesErrorWhenUsedWithUnsupportedBuildSystemAndConfiguration(
+        buildData: BuildData,
+        action: String
+    ) async throws {
+        try await __testImplementationStripProductsGeneratedErrorWhenUsedWithIncorrectBuildSystemAndConfiguration(
+            buildData: buildData,
+            action: action,
+        )
+    }
+
+
+    private func __testImplementationStripProductsGeneratedErrorWhenUsedWithIncorrectBuildSystemAndConfiguration(
+        buildData: BuildData,
+        action: String,
+    ) async throws {
+        let buildSystem = buildData.buildSystem
+        let config = buildData.config
+
+        let argumentUT = "--\(action)-experimental-strip-products"
+
+        try await fixture(name: "ValidLayouts/SingleModule/Library") { fixturePath in
+
+            await expectThrowsCommandExecutionError(
+                try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: config,
+                    extraArgs: [
+                        argumentUT,
+                    ],
+                    buildSystem: buildSystem,
+                )
+            ) { error in
+                let diag = Basics.Diagnostic.unsupportedStripProductsConfigurationFlag(
+                    isEnabled: action.lowercased() == "enable",
+                    with: buildSystem,
+                )
+                #expect(error.stderr.contains("\(diag.severity): \(diag.message)"))
+            }
+        }
+    }
+
+
+    @Test(
         .tags(
             .Feature.CommandLineArguments.ShowBinPath,
         ),

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -137,7 +137,7 @@ extension PackageModel.Sanitizer {
     .tags(
         .TestSize.medium,
     ),
-    .requireCompiledWith6_3OrLater("https://github.com/swiftlang/swift-corelibs-foundation/pull/5269")
+    .requireCompiledWith6_3OrLater(because: "https://github.com/swiftlang/swift-corelibs-foundation/pull/5269")
 )
 struct SwiftBuildSystemTests {
 
@@ -342,6 +342,43 @@ struct SwiftBuildSystemTests {
         }
     }
 
+
+    @Test(
+        arguments: [
+            (stripProductsSettingUT: true, expectedValue: "YES"),
+            (stripProductsSettingUT: false, expectedValue: "NO"),
+            (stripProductsSettingUT: nil, expectedValue: "NO"),
+        ]
+    )
+    func validatestripProductsetting(
+        stripProductsSettingUT: Bool?,
+        expectedValue: String
+    ) async throws {
+        try await withInstantiatedSwiftBuildSystem(
+            fromFixture: "PIFBuilder/Simple",
+            buildParameters: mockBuildParameters(
+                destination: .host,
+                buildSystemKind: .swiftbuild,
+                stripProducts: stripProductsSettingUT,
+            ),
+        ) { swiftBuild, service, session, observabilityScope, buildParameters in
+
+            let buildSettings = try await swiftBuild.makeBuildParameters(
+                service: service,
+                session: session,
+                symbolGraphOptions: nil,
+                setToolchainSetting: false, // Set this to false as SwiftBuild checks the toolchain path
+            )
+
+            let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
+            let actual = synthesizedArgs.table["STRIP_INSTALLED_PRODUCT"]
+            #expect(
+                actual == expectedValue,
+                "strip install products: \(String(describing: stripProductsSettingUT)) >>> Actual: '\(actual)' expected: '\(expectedValue)'",
+            )
+       }
+    }
+
     @Test(
         .serialized,
         arguments: [
@@ -377,6 +414,7 @@ struct SwiftBuildSystemTests {
             )
        }
     }
+
 
     @Test(
         .issue("https://github.com/swiftlang/swift-package-manager/issues/9321", relationship: .verifies),
@@ -516,7 +554,6 @@ struct SwiftBuildSystemTests {
             }
         }
 
-        #if os(Windows)
         @Test
         func debugInfoFormatCodeViewOnWindows() async throws {
             // Test CodeView format separately as it's only supported on Windows
@@ -540,7 +577,6 @@ struct SwiftBuildSystemTests {
                 #expect(synthesizedArgs.table["DEBUG_INFORMATION_FORMAT"] == "codeview")
             }
         }
-        #endif
 
         @Test(
             arguments: [


### PR DESCRIPTION
Allow the STRIP_INSTALLED_PRODUCT build setting in the Swift Build settings to be configuration in SwiftPM.

Add an "enable/disable" build options that will sets the settings value accordingly.  When not set, the products are not stripped, matching the native build system.

Fixes: #10037
Issue: rdar://176554583

Depends on: https://github.com/swiftlang/swift-build/pull/1395