### PR TITLE
Updating wording based on DevPubs editor feedback

### DIFF
--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -44,7 +44,7 @@ struct APIDiff: AsyncSwiftCommand {
         abstract: "Diagnose API-breaking changes to Swift modules in a package.",
         discussion: """
         The diagnose-api-breaking-changes command can be used to compare the Swift API of \
-        a package to a baseline revision, diagnosing any breaking changes which have \
+        a package to a baseline revision, diagnosing any breaking changes that have \
         been introduced. By default, it compares every Swift module from the baseline \
         revision which is part of a library product. For packages with many targets, this \
         behavior may be undesirable as the comparison can be slow. \
@@ -58,9 +58,9 @@ struct APIDiff: AsyncSwiftCommand {
     var globalOptions: GlobalOptions
 
     @Option(help: """
-    The path to a text file containing breaking changes which should be ignored by the API comparison. \
+    The path to a text file containing breaking changes that the API comparison should ignore. \
     Each ignored breaking change in the file should appear on its own line and contain the exact message \
-    to be ignored (for example, 'API breakage: func foo() has been removed').
+    to ignore (for example, 'API breakage: func foo() has been removed').
     """)
     var breakageAllowlistPath: Basics.AbsolutePath?
 

--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -43,7 +43,7 @@ struct APIDiff: AsyncSwiftCommand {
         commandName: "diagnose-api-breaking-changes",
         abstract: "Diagnose API-breaking changes to Swift modules in a package.",
         discussion: """
-        The diagnose-api-breaking-changes command can be used to compare the Swift API of \
+        You can use the `diagnose-api-breaking-changes` command to compare the Swift API of \
         a package to a baseline revision, diagnosing any breaking changes that have \
         been introduced. By default, it compares every Swift module from the baseline \
         revision which is part of a library product. For packages with many targets, this \

--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -44,9 +44,9 @@ struct APIDiff: AsyncSwiftCommand {
         abstract: "Diagnose API-breaking changes to Swift modules in a package.",
         discussion: """
         You can use the `diagnose-api-breaking-changes` command to compare the Swift API of \
-        a package to a baseline revision, diagnosing any breaking changes that have \
-        been introduced. By default, it compares every Swift module from the baseline \
-        revision which is part of a library product. For packages with many targets, this \
+        a package to a baseline revision, diagnosing any breaking changes that were \
+        introduced. By default, it compares every Swift module from the baseline \
+        revision that is part of a library product. For packages with many targets, this \
         behavior may be undesirable as the comparison can be slow. \
         The `--products` and `--targets` options may be used to restrict the scope of \
         the comparison.

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -52,7 +52,7 @@ extension SwiftPackageCommand {
         @Option(name: .customLong("name"), help: "Provide a custom package name.")
         var packageName: String?
 
-        // This command supports creating the supplied --package-path if it isn't created.
+        // This command supports creating the supplied `--package-path` if it isn't created.
         var createPackagePath = true
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
@@ -63,8 +63,8 @@ extension SwiftPackageCommand {
             let packageName = self.packageName ?? cwd.basename
 
             // Testing is on by default, with XCTest only enabled explicitly.
-            // For macros this is reversed, since we don't support testing
-            // macros with Swift Testing yet.
+            // For macros, this is reversed because testing
+            // macros with Swift Testing isn't supported yet.
             var supportedTestingLibraries = Set<TestingLibrary>()
             if testLibraryOptions.isExplicitlyEnabled(.xctest, swiftCommandState: swiftCommandState) ||
                 (initMode == .macro && testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState)) {

--- a/Sources/Commands/PackageCommands/Init.swift
+++ b/Sources/Commands/PackageCommands/Init.swift
@@ -52,7 +52,7 @@ extension SwiftPackageCommand {
         @Option(name: .customLong("name"), help: "Provide a custom package name.")
         var packageName: String?
 
-        // This command should support creating the supplied --package-path if it isn't created.
+        // This command supports creating the supplied --package-path if it isn't created.
         var createPackagePath = true
 
         func run(_ swiftCommandState: SwiftCommandState) throws {

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -85,7 +85,7 @@ struct BuildCommandOptions: ParsableArguments {
           help: "Determines whether the build measures code coverage.")
     var enableCodeCoverage: Bool = false
 
-    /// If the binary output path should be printed.
+    /// Determines if you should print the binary output path.
     @Flag(name: .customLong("show-bin-path"), help: "Print the binary output path.")
     var shouldPrintBinPath: Bool = false
 
@@ -114,7 +114,7 @@ struct BuildCommandOptions: ParsableArguments {
     @OptionGroup(visibility: .private)
     var testLibraryOptions: TestLibraryOptions
 
-    /// If should link the Swift stdlib statically.
+    /// If it should link the Swift stdlib statically.
     @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Determines whether Swift stdlib links statically.")
     public var shouldLinkStaticSwiftStdlib: Bool = false
 

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -85,7 +85,7 @@ struct BuildCommandOptions: ParsableArguments {
           help: "Determines whether the build measures code coverage.")
     var enableCodeCoverage: Bool = false
 
-    /// Determines if you should print the binary output path.
+    /// Determines whether the build command prints the binary output path.
     @Flag(name: .customLong("show-bin-path"), help: "Print the binary output path.")
     var shouldPrintBinPath: Bool = false
 
@@ -114,7 +114,7 @@ struct BuildCommandOptions: ParsableArguments {
     @OptionGroup(visibility: .private)
     var testLibraryOptions: TestLibraryOptions
 
-    /// If it should link the Swift stdlib statically.
+    /// Determines whether the binary should statically link the Swift stdlib.
     @Flag(name: .customLong("static-swift-stdlib"), inversion: .prefixedNo, help: "Determines whether Swift stdlib links statically.")
     public var shouldLinkStaticSwiftStdlib: Bool = false
 

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1725,7 +1725,7 @@ private extension Basics.Diagnostic {
 
 /// The exit code returned to Swift Package Manager by Swift Testing when no
 /// tests matched the inputs specified by the developer (or, for the case of
-/// `swift test list`, when no tests were found.)
+/// `swift test list`, when no tests are found).
 ///
 /// Because Swift Package Manager does not directly link to the testing library,
 /// it duplicates the definition of this constant in its own source. Any changes

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -209,7 +209,7 @@ struct TestCommandOptions: ParsableArguments {
 
     /// The path where the test command generates the xUnit XML file.
     @Option(name: .customLong("xunit-output"),
-            help: "The path where the xUnit XML file generates.")
+            help: "The path where the test command generates the xUnit XML.")
     var xUnitOutput: AbsolutePath?
 
     @Flag(

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1724,7 +1724,7 @@ private extension Basics.Diagnostic {
 }
 
 /// The exit code returned to Swift Package Manager by Swift Testing when no
-/// tests matched the inputs specified by the developer (or, for the case of
+/// tests match the inputs specified by the developer (or, for the case of
 /// `swift test list`, when no tests are found).
 ///
 /// Because Swift Package Manager does not directly link to the testing library,

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -157,9 +157,9 @@ struct TestCommandOptions: ParsableArguments {
           help: "Determines whether tests run in parallel.")
     var shouldRunInParallel: Bool = false
 
-    /// Number of tests to execute in parallel
+    /// The number of tests to execute in parallel.
     @Option(name: .customLong("num-workers"),
-            help: "Number of tests to execute in parallel.")
+            help: "The number of tests to execute in parallel.")
     var numberOfWorkers: Int?
 
     /// Width of task group used by Swift Testing.
@@ -172,7 +172,7 @@ struct TestCommandOptions: ParsableArguments {
     @Option(help: .hidden)
     var experimentalMaximumRepetitions: Int?
 
-    /// The condition upon which to stop repeating (Swift Testing only).
+    /// The condition upon which repetition stops (Swift Testing only).
     @Option(help: .hidden)
     var experimentalRepeatUntil: String?
 
@@ -198,8 +198,8 @@ struct TestCommandOptions: ParsableArguments {
     var _testCaseSpecifier: String?
 
     @Option(help: """
-        Run test cases that match a regular expression. \
-        Format: <test-target>.<test-case> or <test-target>.<test-case>/<test>.
+        Run test cases that match a regular expression, for example, \
+        <test-target>.<test-case> or <test-target>.<test-case>/<test>.
         """)
     var filter: [String] = []
 
@@ -207,9 +207,9 @@ struct TestCommandOptions: ParsableArguments {
             help: "Skip test cases that match a regular expression. For example: '--skip PerformanceTests'.")
     var _testCaseSkip: [String] = []
 
-    /// Path where the xUnit xml file should be generated.
+    /// The path where the xUnit XML file generates.
     @Option(name: .customLong("xunit-output"),
-            help: "Path where the xUnit xml file should be generated.")
+            help: "The path where the xUnit XML file generates.")
     var xUnitOutput: AbsolutePath?
 
     @Flag(
@@ -231,7 +231,7 @@ struct TestCommandOptions: ParsableArguments {
           help: "Determines whether testing measures code coverage.")
     var enableCodeCoverage: Bool = false
 
-    /// Configure test output.
+    /// Configure the test output.
     @Option(help: ArgumentHelp("", visibility: .hidden))
     public var testOutput: TestOutput = .default
 

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -207,7 +207,7 @@ struct TestCommandOptions: ParsableArguments {
             help: "Skip test cases that match a regular expression. For example: '--skip PerformanceTests'.")
     var _testCaseSkip: [String] = []
 
-    /// The path where the xUnit XML file generates.
+    /// The path where the test command generates the xUnit XML file.
     @Option(name: .customLong("xunit-output"),
             help: "The path where the xUnit XML file generates.")
     var xUnitOutput: AbsolutePath?

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1727,7 +1727,7 @@ private extension Basics.Diagnostic {
 /// tests match the inputs specified by the developer (or, for the case of
 /// `swift test list`, when no tests are found).
 ///
-/// Because Swift Package Manager does not directly link to the testing library,
+/// Because Swift Package Manager doesn't directly link to the testing library,
 /// it duplicates the definition of this constant in its own source. Any changes
 /// to this constant in either package must be mirrored in the other.
 private var EXIT_NO_TESTS_FOUND: CInt {

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1686,7 +1686,7 @@ extension TestCommandOptions {
             : .skip(self._testCaseSkip)
     }
 
-    /// Returns the test case specifier if overridden in the env.
+    /// Returns the test case specifier if overridden in the environment. 
     private func skippedTestsOverride(fileSystem: FileSystem) -> TestCaseSpecifier? {
         guard let override = Environment.current["_SWIFTPM_SKIP_TESTS_LIST"] else {
             return nil

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -162,7 +162,7 @@ struct TestCommandOptions: ParsableArguments {
             help: "The number of tests to execute in parallel.")
     var numberOfWorkers: Int?
 
-    /// Width of task group used by Swift Testing.
+    /// The width of the task group used by Swift Testing.
     ///
     /// This argument is consumed by Swift Testing and is passed through verbatim by SwiftPM.
     @Option(help: .hidden)
@@ -240,18 +240,18 @@ struct TestCommandOptions: ParsableArguments {
     }
 }
 
-/// Tests filtering specifier, which is used to filter tests to run.
+/// Tests filtering the specifier, which is used to filter tests to run.
 public enum TestCaseSpecifier {
-    /// No filtering
+    /// No filtering.
     case none
 
-    /// Specify test with fully quantified name
+    /// Specify the test with a fully quantified name.
     case specific(String)
 
-    /// RegEx patterns for tests to run
+    /// The RegEx patterns for tests to run.
     case regex([String])
 
-    /// RegEx patterns for tests to skip
+    /// The RegEx patterns for tests to skip.
     case skip([String])
 }
 
@@ -319,9 +319,9 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         // Run XCTest.
         if options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
-            // Validate XCTest is available on Darwin-based systems. If it's not available and we're hitting this code
-            // path, that means the developer must have explicitly passed --enable-xctest (or the toolchain is
-            // corrupt, I suppose.)
+            // Validate XCTest is available on Darwin-based systems. If it's not available and you hit this code
+            // path, the developer explicitly passed `--enable-xctest` or the toolchain is
+            // corrupt.)
             let toolchain = try swiftCommandState.getTargetToolchain()
             if case let .unsupported(reason) = try swiftCommandState.getHostToolchain().swiftSDK.xctestSupport {
                 if let reason {
@@ -336,8 +336,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             if !self.options.shouldRunInParallel {
                 let (xctestArgs, testCount, testPaths) = try xctestArgs(for: testProducts, swiftCommandState: swiftCommandState)
 
-                // Tests have been filtered and/or skipped; assure that we only run test products
-                // of the tests we must run.
+                // Tests have been filtered or skipped; assure you only run test products
+                // of the tests you must run.
                 var filteredTestProducts = testProducts
                 if let testPaths, testProducts.count != testPaths.count {
                     filteredTestProducts = testProducts.filter({ testPaths.contains($0.bundlePath) })
@@ -413,11 +413,11 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
         }
 
-        // Run Swift Testing (parallel or not, it has a single entry point.)
+        // Run Swift Testing (parallel or not, it has a single entry point).
         if options.testLibraryOptions.isEnabled(.swiftTesting, swiftCommandState: swiftCommandState) {
             lazy var testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first
             if options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) || testEntryPointPath == nil {
-                // Filter test products to swift testing suites.
+                // Filter test products to Swift testing suites.
                 let testSuites = try TestingSupport.getSwiftTestingSuites(
                     in: testProducts,
                     swiftCommandState: swiftCommandState,
@@ -451,7 +451,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 }
 
             } else if let testEntryPointPath {
-                // Cannot run Swift Testing because an entry point file was used and the developer
+                // Can't run Swift Testing because an entry point file was used and the developer
                 // didn't explicitly enable Swift Testing.
                 swiftCommandState.observabilityScope.emit(
                     debug: "Skipping automatic Swift Testing invocation because a test entry point path is present: \(testEntryPointPath)"
@@ -489,12 +489,12 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
 
         case .regex, .specific, .skip:
-            // If old specifier `-s` option was used, emit deprecation notice.
+            // If the previous specifier `-s` option was used, emit the deprecation notice.
             if case .specific = options.testCaseSpecifier {
                 swiftCommandState.observabilityScope.emit(warning: "'--specifier' option is deprecated; use '--filter' instead")
             }
 
-            // Find the tests we need to run.
+            // Find the tests you need to run.
             let testSuites = try TestingSupport.getTestSuites(
                 in: testProducts,
                 swiftCommandState: swiftCommandState,
@@ -511,7 +511,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         }
     }
 
-    /// Generate xUnit file if requested.
+    /// Generate the xUnit file if requested.
     private func generateXUnitOutputIfRequested(
         for testResults: [ParallelTestRunner.TestResult],
         swiftCommandState: SwiftCommandState
@@ -534,7 +534,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
     public func run(_ swiftCommandState: SwiftCommandState) async throws {
         do {
-            // Validate commands arguments
+            // Validate commands arguments.
             try self.validateArguments(swiftCommandState: swiftCommandState)
         } catch {
             swiftCommandState.observabilityScope.emit(error)
@@ -544,7 +544,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         if self.options.shouldPrintCodeCovPath {
             try await printCodeCovPath(swiftCommandState)
         } else if self.options._deprecated_shouldListTests {
-            // backward compatibility 6/2022 for deprecation of flag into a subcommand
+            // Backward compatibility 6/2022 for deprecation of a flag into a subcommand.
             let command = try List.parse()
             try await command.run(swiftCommandState)
         } else {
@@ -559,7 +559,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
             try await run(swiftCommandState, buildParameters: productsBuildParameters, testProducts: testProducts)
 
-            // Process code coverage if requested. We do not process it if the test run failed.
+            // Process code coverage if requested. Don't process if the test run failed.
             // See https://github.com/swiftlang/swift-package-manager/pull/6894 for more info.
             if self.options.enableCodeCoverage, swiftCommandState.executionStatus != .failure {
                 try await processCodeCoverage(testProducts, swiftCommandState: swiftCommandState)
@@ -584,7 +584,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 if arg == "--xunit-output" || arg == "--experimental-maximum-repetitions" || arg == "--experimental-repeat-until" {
                     _ = originalCommandLineArguments.next()
                 } else if arg.hasPrefix("--xunit-output=") {
-                    // Drop the combined form so it is not passed through in addition to SPM's `--xunit-output`.
+                    // Drop the combined form so it isn't passed through in addition to SPM's `--xunit-output`.
                 } else {
                     commandLineArguments.append(arg)
                 }
@@ -593,8 +593,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
             if var xunitPath = options.xUnitOutput {
                 if options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
-                    // We are running Swift Testing, XCTest is also running in this session, and an xUnit path
-                    // was specified. Make sure we don't stomp on XCTest's XML output by having Swift Testing
+                    // You are running Swift Testing, XCTest is also running in this session, and an xUnit path
+                    // was specified. Make sure you don't stomp on XCTest's XML output by having Swift Testing
                     // write to a different path.
                     var xunitFileName = "\(xunitPath.basenameWithoutExt)-swift-testing"
                     if let ext = xunitPath.extension {
@@ -681,7 +681,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         print("\(unexpectedFailures.joined(separator: "\n"))")
     }
 
-    /// Processes the code coverage data and emits a json.
+    /// Processes the code coverage data and emits a JSON.
     private func processCodeCoverage(
         _ testProducts: [BuiltTestProduct],
         swiftCommandState: SwiftCommandState
@@ -711,7 +711,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         }
     }
 
-    /// Merges all profraw profiles in codecoverage directory into default.profdata file.
+    /// Merges all the profraw profiles in the `codecoverage` directory into the `default.profdata` file.
     private func mergeCodeCovRawDataFiles(swiftCommandState: SwiftCommandState) async throws {
         // Get the llvm-prof tool.
         let llvmProf = try swiftCommandState.getTargetToolchain().getLLVMProf()
@@ -778,14 +778,14 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         )
     }
 
-    /// Private function that validates the commands arguments
+    /// Private function that validates the commands arguments.
     ///
-    /// - Throws: if a command argument is invalid
+    /// - Throws: if a command argument is invalid.
     private func validateArguments(swiftCommandState: SwiftCommandState) throws {
-        // Validation for --num-workers.
+        // Validation for `--num-workers`.
         if let workers = options.numberOfWorkers {
-            // The --num-worker option should be called with --parallel. Since
-            // this option does not affect swift-testing at this time, we can
+            // The `--num-worker` option should be called with `--parallel`. Because
+            // this option doesn't affect `swift-testing` at this time, you can
             // effectively ignore that it defaults to enabling parallelization.
             guard options.shouldRunInParallel else {
                 throw StringError("--num-workers must be used with --parallel")
@@ -863,7 +863,7 @@ extension SwiftTestCommand {
         @OptionGroup()
         var sharedOptions: SharedOptions
 
-        /// Which testing libraries to use (and any related options.)
+        /// Which testing libraries to use (and any related options).
         @OptionGroup()
         var testLibraryOptions: TestLibraryOptions
 
@@ -871,7 +871,7 @@ extension SwiftTestCommand {
         @OptionGroup()
         var testEventStreamOptions: TestEventStreamOptions
 
-        // for deprecated passthrough from SwiftTestTool (parse will fail otherwise)
+        // For deprecated passthrough from `SwiftTestTool` (parse will fail otherwise).
         @Flag(name: [.customLong("list-tests"), .customShort("l")], help: .hidden)
         var _deprecated_passthrough: Bool = false
 
@@ -952,7 +952,7 @@ extension SwiftTestCommand {
                     })
                     if result == .failure {
                         swiftCommandState.executionStatus = .failure
-                        // If the runner reports failure do a check to ensure
+                        // If the runner reports failure, do a check to ensure
                         // all the binaries are present on the file system.
                         for path in testProducts.map(\.binaryPath) {
                             if !swiftCommandState.fileSystem.exists(path) {
@@ -961,7 +961,7 @@ extension SwiftTestCommand {
                         }
                     }
                 } else if let testEntryPointPath {
-                    // Cannot run Swift Testing because an entry point file was used and the developer
+                    // Can't run Swift Testing because an entry point file was used and the developer
                     // didn't explicitly enable Swift Testing.
                     swiftCommandState.observabilityScope.emit(
                         debug: "Skipping automatic Swift Testing invocation (list) because a test entry point path is present: \(testEntryPointPath)"
@@ -997,16 +997,16 @@ struct UnitTest {
     /// The name of the test case.
     let testCase: String
 
-    /// The specifier argument which can be passed to XCTest.
+    /// The specifier argument that can be passed to XCTest.
     var specifier: String {
         return testCase + "/" + name
     }
 }
 
-/// A class to run tests on a XCTest binary.
+/// A class to run tests on an XCTest binary.
 ///
-/// Note: Executes the XCTest with inherited environment as it is convenient to pass sensitive
-/// information like username, password etc to test cases via environment variables.
+/// Note: Executes the XCTest with the inherited environment because it's convenient to pass sensitive
+/// information like username and password to test cases via environment variables.
 final class TestRunner {
     /// The products containing tests to run.
     private let testProducts: [BuiltTestProduct]
@@ -1021,7 +1021,7 @@ final class TestRunner {
 
     private let testEnv: Environment
 
-    /// ObservabilityScope  to emit diagnostics.
+    /// The `ObservabilityScope`  to emit diagnostics.
     private let observabilityScope: ObservabilityScope
 
     /// Which testing library to use with this test run.
@@ -1046,8 +1046,8 @@ final class TestRunner {
     /// Creates an instance of TestRunner.
     ///
     /// - Parameters:
-    ///     - testPaths: Paths to valid XCTest binaries.
-    ///     - additionalArguments: Arguments to pass to the test runner process.
+    ///     - `testPaths`: Paths to valid XCTest binaries.
+    ///     - `additionalArguments`: Arguments to pass to the test runner process.
     init(
         testProducts: [BuiltTestProduct],
         additionalArguments: [String],
@@ -1076,12 +1076,12 @@ final class TestRunner {
 
         /// There were no matching tests to run.
         ///
-        /// XCTest does not report this result. It is used by Swift Testing only.
+        /// XCTest doesn't report this result. It's used by Swift Testing only.
         case noMatchingTests
     }
 
-    /// Executes and returns execution status. Prints test output on standard streams if requested
-    /// - Returns: Result of spawning and running the test process, and the output stream result
+    /// Executes and returns the execution status. Prints the test output on standard streams if requested.
+    /// - Returns: Result of spawning and running the test process, and the output stream result.
     func test(outputHandler: @escaping @Sendable (String) -> Void) -> Result {
         testPerProduct(outputHandler: outputHandler).map(\.result).reduce()
     }

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -120,14 +120,14 @@ public struct LocationOptions: ParsableArguments {
     @Option(name: .customLong("multiroot-data-file"), help: .hidden, completion: .directory)
     public var multirootPackageDataFile: AbsolutePath?
 
-    /// Path to the compilation destination describing JSON file.
+    /// The path to the compilation destination describing the JSON file.
     @Option(name: .customLong("destination"), help: .hidden, completion: .directory)
     public var customCompileDestination: AbsolutePath?
 
     @Option(name: .customLong("experimental-swift-sdks-path"), help: .hidden, completion: .directory)
     public var deprecatedSwiftSDKsDirectory: AbsolutePath?
 
-    /// Path to the directory containing installed Swift SDKs.
+    /// The path to the directory containing installed Swift SDKs.
     @Option(
         name: .customLong("swift-sdks-path"),
         help: "Path to the directory containing installed Swift SDKs.",
@@ -184,7 +184,7 @@ public struct CachingOptions: ParsableArguments {
     @Flag(name: .customLong("disable-package-manifest-caching"), help: .hidden)
     public var shouldDisableManifestCaching: Bool = false
 
-    /// Whether to enable llbuild manifest caching.
+    /// Whether to enable `llbuild` manifest caching.
     @Flag(name: .customLong("build-manifest-caching"), inversion: .prefixedEnableDisable)
     public var cacheBuildManifest: Bool = true
 
@@ -205,13 +205,13 @@ public struct CachingOptions: ParsableArguments {
         }
     }
 
-    /// Whether to use prebuilt swift-syntax libraries.
+    /// Whether to use prebuilt `swift-syntax` libraries.
     @Flag(name: .customLong("experimental-prebuilts"),
           inversion: .prefixedEnableDisable,
           help: "Determines whether macros use prebuilt swift-syntax libraries.")
     public var usePrebuilts: Bool = true
 
-    /// A hidden option to override the prebuilt's download location for testing.
+    /// A hidden option to override the prebuilts' download location for testing.
     @Option(
         name: .customLong("experimental-prebuilts-download-url"),
         help: .hidden
@@ -271,7 +271,7 @@ public struct SecurityOptions: ParsableArguments {
     )
     public var netrc: Bool = true
 
-    /// The path to the netrc file used when `netrc` is `true`.
+    /// The path to the .netrc file used when `netrc` is `true`.
     @Option(
         name: .customLong("netrc-file"),
         help: "Specify the netrc file path.",
@@ -315,7 +315,7 @@ public struct SecurityOptions: ParsableArguments {
 public struct ResolverOptions: ParsableArguments {
     public init() {}
 
-    /// Enable prefetching in resolver which will kick off parallel git cloning.
+    /// Enable prefetching in the resolver, which kicks off parallel git cloning.
     @Flag(name: .customLong("prefetching"), inversion: .prefixedEnableDisable)
     public var shouldEnableResolverPrefetching: Bool = true
 
@@ -335,7 +335,7 @@ public struct ResolverOptions: ParsableArguments {
         .disabled
 
     /// Enables pruning unused dependencies to omit redundant calculations during resolution, and each phase thereafter.
-    /// Hidden from the generated help text as this feature is only currently being considered for traits.
+    /// Hidden from the generated help text because this feature is currently only being considered for traits.
     @Flag(
         name: .customLong("experimental-prune-unused-dependencies"),
         help: ArgumentHelp(
@@ -466,11 +466,11 @@ public struct BuildOptions: ParsableArguments {
     @Option(name: .customLong("triple"), transform: Triple.init)
     public var customCompileTriple: Triple?
 
-    /// Path to the compilation destination’s SDK.
+    /// The path to the compilation destination’s SDK.
     @Option(name: .customLong("sdk"))
     public var customCompileSDK: AbsolutePath?
 
-    /// Path to the compilation destination’s toolchain.
+    /// The path to the compilation destination’s toolchain.
     @Option(name: .customLong("toolchain"))
     public var customCompileToolchain: AbsolutePath?
 
@@ -519,11 +519,11 @@ public struct BuildOptions: ParsableArguments {
     ///
     /// This is intended as a workaround if lazy type checking is causing compiler crashes.
     ///
-    /// Only applicable in conjunction with `--experimental-prepare-for-indexing`
+    /// Only applicable in conjunction with `--experimental-prepare-for-indexing`.
     @Flag(name: .customLong("experimental-prepare-for-indexing-no-lazy"), help: .hidden)
     var prepareForIndexingNoLazy: Bool = false
 
-    /// Hidden option to allow XCFrameworks on Linux
+    /// The hidden option to allow XCFrameworks on Linux.
     @Flag(
         name: .customLong("experimental-xcframeworks-on-linux"),
         help: .hidden
@@ -534,18 +534,18 @@ public struct BuildOptions: ParsableArguments {
     @Flag(name: .customLong("enable-parseable-module-interfaces"))
     public var shouldEnableParseableModuleInterfaces: Bool = false
 
-    /// The number of jobs for llbuild to start (aka the number of schedulerLanes)
+    /// The number of jobs for `llbuild` to start (aka the number of `schedulerLanes`).
     @Option(name: .shortAndLong, help: "The number of jobs to spawn in parallel during the build process.")
     public var jobs: UInt32 = UInt32(ProcessInfo.processInfo.activeProcessorCount)
 
     /// Whether to use the integrated Swift driver rather than shelling out
     /// to a separate process.
     @Flag()
-    /// This flag is deprecated but cannot indicate so in Swift Argument Parser until https://github.com/apple/swift-argument-parser/issues/656.
+    // This flag is deprecated but can't indicate so in the Swift Argument Parser until https://github.com/apple/swift-argument-parser/issues/656.
     public var useIntegratedSwiftDriver: Bool = false
 
     /// A flag that indicates this build should check whether targets only import
-    /// their explicitly-declared dependencies
+    /// their explicitly declared dependencies.
     @Option(help: "Check that targets only import their explicitly declared dependencies.")
     public var explicitTargetDependencyImportCheck: TargetDependencyImportCheckingMode = .none
 
@@ -574,16 +574,16 @@ public struct BuildOptions: ParsableArguments {
     @Flag(help: .hidden)
     public var enableTestDiscovery: Bool = false
 
-    /// Path of test entry point file to use, instead of synthesizing one or using `XCTMain.swift` in the package (if
+    /// The path of the test entry point file to use, instead of synthesizing one or using `XCTMain.swift` in the package (if
     /// present).
-    /// This implies `--enable-test-discovery`
+    /// This implies `--enable-test-discovery`.
     @Option(
         name: .customLong("experimental-test-entry-point-path"),
         help: .hidden
     )
     public var testEntryPointPath: AbsolutePath?
 
-    /// The lto mode to use if any.
+    /// The LTO mode to use, if any.
     @Option(
         name: .customLong("experimental-lto-mode"),
         help: .hidden
@@ -614,7 +614,7 @@ public struct BuildOptions: ParsableArguments {
     @Flag(name: .customLong("experimental-enable-codesize-profile"), help: "Generate SIL, LLVM IR, and optimization record files for code size profiling.")
     public var enableCodesizeProfile: Bool = false
 
-    /// Directory for code size profiling output files (SIL, IR, optimization records).
+    /// The directory for code size profiling output files (SIL, IR, optimization records).
     @Option(name: .customLong("experimental-codesize-profile-output-dir"), help: "Directory to store code size profiling output files.")
     public var codesizeProfileOutputDirectory: String?
 
@@ -662,35 +662,35 @@ public struct LinkerOptions: ParsableArguments {
     )
     public var linkerDeadStrip: Bool = true
 
-    /// Disables adding $ORIGIN/@loader_path to the rpath, useful when deploying
+    /// Disables adding `$ORIGIN/@loader_path` to the `rpath`, which is useful when deploying.
     @Flag(name: .customLong("disable-local-rpath"), help: "Disable adding $ORIGIN/@loader_path to the rpath by default.")
     public var shouldDisableLocalRpath: Bool = false
 }
 
-/// Which testing libraries to use (and any related options.)
+/// Which testing libraries to use (and any related options).
 @_spi(SwiftPMInternal)
 public struct TestLibraryOptions: ParsableArguments {
     public init() {}
 
-    /// Whether to enable support for XCTest (as explicitly specified by the user.)
+    /// Whether to enable support for XCTest (as explicitly specified by the user).
     ///
-    /// Callers will generally want to use ``enableXCTestSupport`` since it will
-    /// have the correct default value if the user didn't specify one.
+    /// Callers generally want to use ``enableXCTestSupport`` because it
+    /// has the correct default value if the user doesn't specify one.
     @Flag(name: .customLong("xctest"),
           inversion: .prefixedEnableDisable,
           help: "Determines whether the build includes XCTest support.")
     public var explicitlyEnableXCTestSupport: Bool?
 
-    /// Whether to enable support for Swift Testing (as explicitly specified by the user.)
+    /// Whether to enable support for Swift Testing (as explicitly specified by the user).
     ///
-    /// Callers will generally want to use ``enableSwiftTestingLibrarySupport`` since it will
-    /// have the correct default value if the user didn't specify one.
+    /// Callers generally want to use ``enableSwiftTestingLibrarySupport`` because it
+    /// has the correct default value if the user doesn't specify one.
     @Flag(name: .customLong("swift-testing"),
           inversion: .prefixedEnableDisable,
           help: "Determines whether the build includes Swift Testing support.")
     public var explicitlyEnableSwiftTestingLibrarySupport: Bool?
 
-    /// Legacy experimental equivalent of ``explicitlyEnableSwiftTestingLibrarySupport``.
+    /// The legacy experimental equivalent of ``explicitlyEnableSwiftTestingLibrarySupport``.
     ///
     /// This option will be removed in a future update.
     @Flag(name: .customLong("experimental-swift-testing"),
@@ -700,7 +700,7 @@ public struct TestLibraryOptions: ParsableArguments {
 
     /// The common implementation for `isEnabled()` and `isExplicitlyEnabled()`.
     ///
-    /// It is intentional that `isEnabled()` is not simply this function with a
+    /// It's intentional that `isEnabled()` isn't simply this function with a
     /// default value for the `default` argument. There's no "true" default
     /// value to use; it depends on the semantics the caller is interested in.
     private func isEnabled(_ library: TestingLibrary, `default`: Bool, swiftCommandState: SwiftCommandState) -> Bool {
@@ -801,7 +801,7 @@ public struct SBOMOptions: ParsableArguments {
     )
     package var _sbomFilter: SBOMModel.Filter? = nil
 
-    /// Whether to treat SBOM generation errors as warnings
+    /// Whether to treat SBOM generation errors as warnings.
     @Flag(
         name: .customLong("sbom-warning-only"),
         help: ArgumentHelp("Treat SBOM generation errors as warnings. Must be used with --sbom-spec. (default: false).")
@@ -810,7 +810,7 @@ public struct SBOMOptions: ParsableArguments {
 
     // MARK: - Computed properties with environment variable support
 
-    /// SBOM specifications with environment variable fallback. CLI flag takes precedence.
+    /// The SBOM specifications with environment variable fallback. The CLI flag takes precedence.
     /// Throws an error if the environment variable contains an invalid value.
     package var sbomSpecs: [SBOMModel.Spec] {
         get throws {
@@ -834,7 +834,7 @@ public struct SBOMOptions: ParsableArguments {
         }
     }
 
-    /// SBOM directory with environment variable fallback. CLI flag takes precedence.
+    /// The SBOM directory with environment variable fallback. The CLI flag takes precedence.
     package var sbomDirectory: AbsolutePath? {
         if let cmdLineDir = _sbomDirectory {
             return cmdLineDir
@@ -848,7 +848,7 @@ public struct SBOMOptions: ParsableArguments {
         return nil
     }
 
-    /// SBOM filter with environment variable fallback. CLI flag takes precedence.
+    /// The SBOM filter with environment variable fallback. The CLI flag takes precedence.
     /// Throws an error if the environment variable contains an invalid value.
     package var sbomFilter: SBOMModel.Filter {
         get throws {
@@ -865,7 +865,7 @@ public struct SBOMOptions: ParsableArguments {
         }
     }
 
-    /// SBOM warning-only mode with environment variable fallback. CLI flag takes precedence.
+    /// The SBOM warning-only mode with environment variable fallback. The CLI flag takes precedence.
     package var sbomWarningOnly: Bool {
         if _sbomWarningOnly {
             return true
@@ -929,7 +929,7 @@ extension Sanitizer {
         return nil
     }
 
-    /// All sanitizer options in a comma separated string
+    /// All the sanitizer options in a comma-separated string
     fileprivate static var formattedValues: String {
         Sanitizer.allCases.map(\.rawValue).joined(separator: ", ")
     }

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -205,13 +205,13 @@ public struct CachingOptions: ParsableArguments {
         }
     }
 
-    /// Whether to use macro prebuilts or not
+    /// Whether to use prebuilt swift-syntax libraries.
     @Flag(name: .customLong("experimental-prebuilts"),
           inversion: .prefixedEnableDisable,
           help: "Determines whether macros use prebuilt swift-syntax libraries.")
     public var usePrebuilts: Bool = true
 
-    /// Hidden option to override the prebuilts download location for testing
+    /// A hidden option to override the prebuilt's download location for testing.
     @Option(
         name: .customLong("experimental-prebuilts-download-url"),
         help: .hidden
@@ -245,7 +245,7 @@ public struct LoggingOptions: ParsableArguments {
           help:
             """
             Determines whether color diagnostics appear when printing to a TTY.
-            By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.
+            By default, the terminal enables color diagnostics when connected to a TTY and disables them otherwise.
             """)
     public var colorDiagnostics: Bool = ProcessInfo.processInfo.environment["NO_COLOR"] == nil
 }
@@ -253,15 +253,15 @@ public struct LoggingOptions: ParsableArguments {
 public struct SecurityOptions: ParsableArguments {
     public init() {}
 
-    /// Disables sandboxing when executing subprocesses.
+    /// Disables sandboxing when running subprocesses.
     @Flag(name: .customLong("disable-sandbox"), help: "Disable the sandbox when executing subprocesses.")
     public var shouldDisableSandbox: Bool = false
 
-    /// Force usage of the netrc file even in cases where it is not allowed.
+    /// Force usage of the .netrc file even in cases where other credential stores are preferred.
     @Flag(name: .customLong("netrc"), help: "Use netrc file even in cases where other credential stores are preferred.")
     public var forceNetrc: Bool = false
 
-    /// Whether to load netrc files for authenticating with remote servers
+    /// Whether to load .netrc files for authenticating with remote servers
     /// when downloading binary artifacts. This has no effects on registry
     /// communications.
     @Flag(
@@ -380,7 +380,7 @@ public struct ResolverOptions: ParsableArguments {
 public struct BuildOptions: ParsableArguments {
     public init() {}
 
-    /// Build configuration.
+    /// Build the configuration.
     @Option(name: .shortAndLong, help: "Build with the specified configuration.")
     public var configuration: BuildConfiguration?
 
@@ -541,7 +541,7 @@ public struct BuildOptions: ParsableArguments {
     /// Whether to use the integrated Swift driver rather than shelling out
     /// to a separate process.
     @Flag()
-    /// This flag is deprecated but cannot indicate so in Swift Argument Parser until https://github.com/apple/swift-argument-parser/issues/656
+    /// This flag is deprecated but cannot indicate so in Swift Argument Parser until https://github.com/apple/swift-argument-parser/issues/656.
     public var useIntegratedSwiftDriver: Bool = false
 
     /// A flag that indicates this build should check whether targets only import
@@ -658,7 +658,7 @@ public struct LinkerOptions: ParsableArguments {
     @Flag(
         name: .customLong("dead-strip"),
         inversion: .prefixedEnableDisable,
-        help: "Determines whether the linker strips dead code."
+        help: "Determines whether the linker strips unused code."
     )
     public var linkerDeadStrip: Bool = true
 
@@ -736,7 +736,7 @@ public struct TraitOptions: ParsableArguments {
     /// The traits to enable for the package.
     @Option(
         name: .customLong("traits"),
-        help: "Enable the specified traits of the package. Specify multiple traits as a comma-separated list, for example: `--traits Trait1,Trait2`. When enabling specific traits, the default traits must also be explicitly enabled by passing `defaults` to this option."
+        help: "Enable the specified traits of the package. Specify multiple traits as a comma-separated list, for example: `--traits Trait1,Trait2`. When enabling specific traits, you must also explicitly enable the default traits by passing `defaults` to this option."
     )
     package var _enabledTraits: String?
 
@@ -779,14 +779,14 @@ extension TraitConfiguration {
 public struct SBOMOptions: ParsableArguments {
     public init() {}
 
-    /// SBOM specification(s) to generate.
+    /// The SBOM specification(s) to generate.
     @Option(
         name: .customLong("sbom-spec"),
         help: ArgumentHelp("Set the SBOM specification and generate an SBOM.")
     )
     package var _sbomSpecs: [SBOMModel.Spec] = []
 
-    /// Directory path to generate SBOM(s) in.
+    /// The directory path to generate SBOM(s) in.
     @Option(
         name: .customLong("sbom-output-dir"),
         help: ArgumentHelp("The absolute or relative directory path to generate the SBOM(s) in. Must be used with --sbom-spec. (default: <scratch_path>/sboms)."),

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -119,9 +119,9 @@ extension PackageRegistryCommand {
         )
 
         static let maxPasswordLength = 512
-        // Define a larger buffer size so we read more than allowed, and
-        // this way we can tell if the entered password is over the length
-        // limit. One space is for \0, another is for the "overflowing" char.
+        // Define a larger buffer size so it reads more than allowed;
+        // this way, you can tell if the entered password is over the length
+        // limit. One space is for \0, and another is for the "overflowing" character.
         static let passwordBufferSize = Self.maxPasswordLength + 2
 
         @OptionGroup(visibility: .hidden)
@@ -155,8 +155,8 @@ extension PackageRegistryCommand {
         private static let PLACEHOLDER_TOKEN_USER = "token"
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
-            // We need to be able to read/write credentials
-            // Make sure credentials store is available before proceeding
+            // You need to be able to read/write credentials.
+            // Make sure the credentials store is available before proceeding.
             let authorizationProvider: AuthorizationProvider?
             do {
                 authorizationProvider = try swiftCommandState.getRegistryAuthorizationProvider()
@@ -168,10 +168,10 @@ extension PackageRegistryCommand {
                 throw ValidationError.unknownCredentialStore
             }
 
-            // Auth config is in user-level registries config only
+            // The authorization configuration is in the user-level registries configuration only.
             let configuration = try getRegistriesConfig(swiftCommandState, global: true)
 
-            // compute and validate registry URL
+            // Compute and validate the registry URL.
             guard let registryURL = self.registryURL ?? configuration.configuration.defaultRegistry?.url else {
                 throw ValidationError.unknownRegistry
             }
@@ -193,7 +193,7 @@ extension PackageRegistryCommand {
                 } else if let stored = authorizationProvider.authentication(for: registryURL),
                           stored.user == storeUsername
                 {
-                    // Password found in credential store
+                    // The password found in the credential store.
                     storePassword = stored.password
                     saveChanges = false
                 } else {
@@ -203,10 +203,10 @@ extension PackageRegistryCommand {
             } else {
                 authenticationType = .token
 
-                // All token auth accounts have the same placeholder value
+                // All token authentication accounts have the same placeholder value.
                 storeUsername = Self.PLACEHOLDER_TOKEN_USER
                 if let token {
-                    // User provided token
+                    // The user-provided token.
                     storePassword = token
                 } else if let tokenFilePath {
                     print("Reading access token from \(tokenFilePath).")
@@ -215,11 +215,11 @@ extension PackageRegistryCommand {
                 } else if let stored = authorizationProvider.authentication(for: registryURL),
                           stored.user == storeUsername
                 {
-                    // Token found in credential store
+                    // The token found in the credential store.
                     storePassword = stored.password
                     saveChanges = false
                 } else {
-                    // Prompt user for token
+                    // Prompt the user for the token.
                     storePassword = try readpassword("Enter access token: ")
                 }
             }
@@ -229,7 +229,7 @@ extension PackageRegistryCommand {
                 throw StringError("Credential store must be writable")
             }
 
-            // Save in cache so we can try the credentials and persist to storage only if login succeeds
+            // Save in the cache so you can try the credentials and persist to storage only if login succeeds.
             try await authorizationWriter?.addOrUpdate(
                 for: registryURL,
                 user: storeUsername,
@@ -237,7 +237,7 @@ extension PackageRegistryCommand {
                 persist: false
             )
 
-            // `url` can either be base URL of the registry, in which case the login API
+            // The `url` can either be the base URL of the registry, in which case the login API
             // is assumed to be at /login, or the full URL of the login API.
             var loginAPIPath: String?
             if !registryURL.path.isEmpty, registryURL.path != "/" {
@@ -247,11 +247,11 @@ extension PackageRegistryCommand {
             let loginURL = try Self.loginURL(from: registryURL, loginAPIPath: loginAPIPath)
 
 
-            // Build a RegistryConfiguration with the given authentication settings
+            // Build a `RegistryConfiguration` with the given authentication settings.
             var registryConfiguration = configuration.configuration
             try registryConfiguration.add(authentication: .init(type: authenticationType, loginAPIPath: loginAPIPath), for: registryURL)
 
-            // Build a RegistryClient to test login credentials (fingerprints don't matter in this case)
+            // Build a `RegistryClient` to test login credentials (fingerprints aren't applicable in this case).
             let registryClient = RegistryClient(
                 configuration: registryConfiguration,
                 fingerprintStorage: .none,
@@ -264,7 +264,7 @@ extension PackageRegistryCommand {
                 checksumAlgorithm: SHA256()
             )
 
-            // Try logging in
+            // Try logging in.
             try await registryClient.login(
                 loginURL: loginURL,
                 timeout: .seconds(5),
@@ -277,7 +277,7 @@ extension PackageRegistryCommand {
 
             let osStore = !(authorizationWriter is NetrcAuthorizationProvider)
 
-            // Prompt if writing to netrc file and --no-confirm is not set
+            // Prompt if writing to the netrc file and `--no-confirm` isn't set
             if saveChanges, !osStore, !self.noConfirm {
                 if self.globalOptions.security.forceNetrc {
                     print("""
@@ -314,7 +314,7 @@ extension PackageRegistryCommand {
                 }
             }
 
-            // Update user-level registry configuration file
+            // Update the user-level registry configuration file.
             let update: (inout RegistryConfiguration) throws -> Void = { configuration in
                 try configuration.add(authentication: .init(type: authenticationType, loginAPIPath: loginAPIPath), for: registryURL)
             }
@@ -340,17 +340,17 @@ extension PackageRegistryCommand {
         }
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
-            // Auth config is in user-level registries config only
+            // The authorization configuration is in the user-level registries configuration only.
             let configuration = try getRegistriesConfig(swiftCommandState, global: true)
 
-            // compute and validate registry URL
+            // Compute and validate the registry URL.
             guard let registryURL = self.registryURL ?? configuration.configuration.defaultRegistry?.url else {
                 throw ValidationError.unknownRegistry
             }
 
             try registryURL.validateRegistryURL()
 
-            // We need to be able to read/write credentials
+            // You need to be able to read/write credentials.
             guard let authorizationProvider = try swiftCommandState.getRegistryAuthorizationProvider() else {
                 throw ValidationError.unknownCredentialStore
             }
@@ -358,7 +358,7 @@ extension PackageRegistryCommand {
             let authorizationWriter = authorizationProvider as? AuthorizationWriter
             let osStore = !(authorizationWriter is NetrcAuthorizationProvider)
 
-            // Only OS credential store supports deletion
+            // Only OS credential store supports deletion.
             if osStore {
                 try await authorizationWriter?.remove(for: registryURL)
                 print("Credentials have been removed from operating system's secure credential store.")
@@ -366,7 +366,7 @@ extension PackageRegistryCommand {
                 print("netrc file not updated. Please remove credentials from the file manually.")
             }
 
-            // Update user-level registry configuration file
+            // Update the user-level registry configuration file.
             let update: (inout RegistryConfiguration) throws -> Void = { configuration in
                 configuration.removeAuthentication(for: registryURL)
             }

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -149,7 +149,7 @@ extension PackageRegistryCommand {
         )
         var tokenFilePath: AbsolutePath?
 
-        @Flag(help: "Write to the netrc file without asking for confirmation.")
+        @Flag(help: "Write to the .netrc file without asking for confirmation.")
         var noConfirm: Bool = false
 
         private static let PLACEHOLDER_TOKEN_USER = "token"

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -85,7 +85,7 @@ private func readpassword(_ prompt: String) throws -> String {
     #elseif canImport(Android)
     throw StringError("unable to read input - not implemented on this platform")
     #else
-    // GNU C implementation of getpass has no limit on the password length
+    // The GNU C implementation of `getpass` has no limit on the password length.
     // (https://man7.org/linux/man-pages/man3/getpass.3.html)
     password = String(cString: getpass(prompt))
     #endif
@@ -102,7 +102,7 @@ extension PackageRegistryCommand {
     struct Login: AsyncSwiftCommand {
 
         static func loginURL(from registryURL: URL, loginAPIPath: String?) throws -> URL {
-            // Login URL must be HTTPS
+            // The login URL must be HTTPS.
             var loginURLComponents = URLComponents(url: registryURL, resolvingAgainstBaseURL: true)
             loginURLComponents?.scheme = "https"
             loginURLComponents?.path = loginAPIPath ?? "/login"

--- a/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
@@ -41,7 +41,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
     @Option(
         parsing: .singleValue,
         help: """
-        A path to a directory containing headers. Multiple paths can be specified by providing this option multiple \
+        A path to a directory containing headers. You can specify multiple paths by providing this option multiple \
         times to the command.
         """
     )
@@ -50,7 +50,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
     @Option(
         parsing: .singleValue,
         help: """
-        A path to a directory containing libraries. Multiple paths can be specified by providing this option multiple \
+        A path to a directory containing libraries. You can specify multiple paths by providing this option multiple \
         times to the command.
         """
     )
@@ -59,7 +59,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
     @Option(
         parsing: .singleValue,
         help: """
-        A path to a toolset file. Multiple paths can be specified by providing this option multiple times to the command.
+        A path to a toolset file. You can specify multiple paths by providing this option multiple times to the command.
         """
     )
     var toolsetPath: [String] = []
@@ -67,8 +67,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
     @Flag(
         name: .customLong("reset"),
         help: """
-        Reset configuration properties currently applied to a given Swift SDK and target triple. If no specific \
-        property is specified, all of them are reset for the Swift SDK.
+        Reset configuration properties currently applied to a given Swift SDK and target triple. If you don't specify a property, the system resets all of them for the Swift SDK.
         """
     )
     var shouldReset: Bool = false

--- a/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/ConfigureSwiftSDK.swift
@@ -152,7 +152,7 @@ struct ConfigureSwiftSDK: AsyncParsableCommand {
             commandError = error
         }
 
-        // wait for all observability items to process
+        // Wait for all observability items to process.
         observabilityHandler.wait(timeout: .now() + 5)
 
         if let commandError {

--- a/Sources/SwiftSDKCommand/InstallSwiftSDK.swift
+++ b/Sources/SwiftSDKCommand/InstallSwiftSDK.swift
@@ -43,7 +43,7 @@ struct InstallSwiftSDK: SwiftSDKSubcommand {
         inversion: .prefixedNo,
         help: """
             Determines whether color diagnostics appear when printing to a TTY.
-            By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.
+            By default, the terminal enables color diagnostics when connected to a TTY and disables them otherwise.
             """
     )
     public var colorDiagnostics: Bool = ProcessInfo.processInfo.environment["NO_COLOR"] == nil


### PR DESCRIPTION
Editorial wording fixes to various CLI options

### Motivation:

Follow up to #9789 which was merged before editorial had a chance to review the changes.
This applies changes based on feedback, per rdar://171644260

### Modifications:

Mostly resolving usage of passive voice, better inclusive terms, some missing articles and punctuation, and refinement of usage around 'enabled'/'disabled' per Apple Style Guide.

