### PR TITLE
Update platform versions in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -135,9 +135,9 @@ if shouldUseSwiftBuildFramework {
 let package = Package(
     name: "SwiftPM",
     platforms: [
-        .macOS(.v14),
-        .iOS(.v17),
-        .macCatalyst(.v17),
+        .macOS(.v15),
+        .iOS(.v18),
+        .macCatalyst(.v18),
     ],
     products:
     autoProducts.flatMap {


### PR DESCRIPTION
We need to raise the minimum deployment target so that Swift Tools Protocols and Swift Build are unblocked from doing so.

This follows the sourcekit-lsp update in swiftlang/sourcekit-lsp#2636