### PR TITLE
[6.4] Query the underlying build system when determining the build products dir

### DIFF
--- a/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ClangModuleBuildDescription.swift
@@ -335,7 +335,7 @@ public final class ClangModuleBuildDescription {
 
         // Only add the build path to the framework search path if there are binary frameworks to link against.
         if !libraryBinaryPaths.isEmpty {
-            args += ["-F", buildParameters.buildPath.pathString]
+            args += ["-F", BuildOperation.buildProductsPath(for: buildParameters).pathString]
         }
 
         args += ["-I", clangTarget.includeDir.pathString]

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -67,10 +67,15 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
     /// Paths to tools shipped in binary dependencies
     var availableTools: [String: AbsolutePath] = [:]
 
+    /// Path to the build products directory.
+    public var productsPath: AbsolutePath {
+        BuildOperation.buildProductsPath(for: self.buildParameters)
+    }
+
     /// Path to the temporary directory for this product.
     var tempsPath: AbsolutePath {
         let suffix = buildParameters.suffix
-        return self.buildParameters.buildPath.appending(component: "\(self.product.name)\(suffix).product")
+        return self.productsPath.appending(component: "\(self.product.name)\(suffix).product")
     }
 
     /// Path to the link filelist file.
@@ -161,10 +166,10 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
 
         // Only add the build path to the framework search path if there are binary frameworks to link against.
         if !self.libraryBinaryPaths.isEmpty {
-            args += ["-F", self.buildParameters.buildPath.pathString]
+            args += ["-F", BuildOperation.buildProductsPath(for: self.buildParameters).pathString]
         }
 
-        args += ["-L", self.buildParameters.buildPath.pathString]
+        args += ["-L", BuildOperation.buildProductsPath(for: self.buildParameters).pathString]
         args += try ["-o", binaryPath.pathString]
         args += ["-module-name", self.product.name.spm_mangledToC99ExtendedIdentifier()]
         args += self.dylibs.map { "-l" + $0.product.name + $0.buildParameters.suffix }

--- a/Sources/Build/BuildDescription/ResolvedModule+BuildDescription.swift
+++ b/Sources/Build/BuildDescription/ResolvedModule+BuildDescription.swift
@@ -18,6 +18,6 @@ import SPMBuildCore
 extension ResolvedModule {
     func tempsPath(_ buildParameters: BuildParameters) -> AbsolutePath {
         let suffix = buildParameters.suffix
-        return buildParameters.buildPath.appending(component: "\(self.c99name)\(suffix).build")
+        return BuildOperation.buildProductsPath(for: buildParameters).appending(component: "\(self.c99name)\(suffix).build")
     }
 }

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -138,7 +138,7 @@ public final class SwiftModuleBuildDescription {
 
     var modulesPath: AbsolutePath {
         let suffix = self.buildParameters.suffix
-        return self.buildParameters.buildPath.appending(component: "Modules\(suffix)")
+        return BuildOperation.buildProductsPath(for: self.buildParameters).appending(component: "Modules\(suffix)")
     }
 
     /// The path to the swiftmodule file after compilation.
@@ -459,13 +459,13 @@ public final class SwiftModuleBuildDescription {
         try self.requiredMacros.forEach { macro in
             args += [
                 "-Xfrontend", "-load-plugin-library",
-                "-Xfrontend", macroBuildParameters.macroBinaryPath(macro).pathString
+                "-Xfrontend", BuildOperation.macroBinaryPath(for: macro, parameters: macroBuildParameters).pathString
             ]
         }
         #else
         let macroModules = try self.requiredMacros
         try macroModules.forEach { macro in
-            let executablePath = try macroBuildParameters.macroBinaryPath(macro).pathString
+            let executablePath = try BuildOperation.macroBinaryPath(for: macro, parameters: macroBuildParameters).pathString
             args += ["-Xfrontend", "-load-plugin-executable", "-Xfrontend", "\(executablePath)#\(macro.c99name)"]
         }
         #endif
@@ -563,7 +563,7 @@ public final class SwiftModuleBuildDescription {
 
         // Only add the build path to the framework search path if there are binary frameworks to link against.
         if !self.libraryBinaryPaths.isEmpty {
-            args += ["-F", self.buildParameters.buildPath.pathString]
+            args += ["-F", BuildOperation.buildProductsPath(for: self.buildParameters).pathString]
         }
 
         // Emit the ObjC compatibility header if enabled.

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder+Swift.swift
@@ -381,7 +381,7 @@ extension LLBuildManifestBuilder {
 
         // Otherwise, come up with a path for the new file and generate a command to populate it.
         let swiftCompilerPathHash = String(swiftCompilerPath.pathString.hash, radix: 16, uppercase: true)
-        let swiftVersionFilePath = buildParameters.buildPath.appending(component: "swift-version-\(swiftCompilerPathHash).txt")
+        let swiftVersionFilePath = BuildOperation.buildProductsPath(for: buildParameters).appending(component: "swift-version-\(swiftCompilerPathHash).txt")
         self.manifest.addSwiftGetVersionCommand(swiftCompilerPath: swiftCompilerPath, swiftVersionFilePath: swiftVersionFilePath)
         swiftGetVersionFiles[swiftCompilerPath] = swiftVersionFilePath
         return swiftVersionFilePath

--- a/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
+++ b/Sources/Build/BuildManifest/LLBuildManifestBuilder.swift
@@ -342,7 +342,7 @@ extension LLBuildManifestBuilder {
 
 extension BuildParameters {
     func destinationPath(forBinaryAt path: AbsolutePath) -> AbsolutePath {
-        self.buildPath.appending(component: path.basename)
+        BuildOperation.buildProductsPath(for: self).appending(component: path.basename)
     }
 
     var buildConfig: String { self.configuration.dirname }

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -193,7 +193,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
     public var hasIntegratedAPIDigesterSupport: Bool { false }
 
-    public func buildProductsPath(for parameters: BuildParameters) -> AbsolutePath {
+    public func buildProductsPath(for parameters: BuildParameters) async throws -> AbsolutePath {
         Self.buildProductsPath(for: parameters)
     }
 
@@ -555,7 +555,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         do {
             try self.fileSystem.createSymbolicLink(
                 oldBuildPath,
-                pointingAt: self.buildProductsPath(for: self.config.destinationBuildParameters),
+                pointingAt: Self.buildProductsPath(for: self.config.destinationBuildParameters),
                 relative: true
             )
         } catch {
@@ -1015,7 +1015,7 @@ extension BuildOperation {
         // `buildPackageStructure` to recognize the split.
         config.databasePath = config.scratchDirectory.appending("plugin-tools.db")
 
-        config.buildDescriptionPath = self.buildProductsPath(for: self.config.toolsBuildParameters).appending(
+        config.buildDescriptionPath = Self.buildProductsPath(for: self.config.toolsBuildParameters).appending(
             component: "plugin-tools-description.json"
         )
 
@@ -1065,7 +1065,7 @@ extension BuildOperation {
                     if let result = try await buildToolBuilder(name, path) {
                         return result
                     } else {
-                        return self.buildProductsPath(for: config.toolsBuildParameters).appending(path)
+                        return Self.buildProductsPath(for: config.toolsBuildParameters).appending(path)
                     }
                 }
 

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -74,7 +74,7 @@ package struct LLBuildSystemConfiguration {
         self.traitConfiguration = traitConfiguration
         self.manifestPath = manifestPath ?? destinationBuildParameters.llbuildManifest
         self.databasePath = databasePath ?? scratchDirectory.appending("build.db")
-        self.buildDescriptionPath = buildDescriptionPath ?? destinationBuildParameters.buildDescriptionPath
+        self.buildDescriptionPath = buildDescriptionPath ?? BuildOperation.buildDescriptionPath(for: destinationBuildParameters)
         self.fileSystem = fileSystem
         self.logLevel = logLevel
         self.outputStream = outputStream
@@ -109,13 +109,6 @@ package struct LLBuildSystemConfiguration {
         }
     }
 
-    func buildPath(for description: BuildParameters.Destination) -> AbsolutePath {
-        switch description {
-        case .host: self.toolsBuildParameters.buildPath
-        case .target: self.destinationBuildParameters.buildPath
-        }
-    }
-
     func dataPath(for description: BuildParameters.Destination) -> AbsolutePath {
         switch description {
         case .host: self.toolsBuildParameters.dataPath
@@ -125,8 +118,8 @@ package struct LLBuildSystemConfiguration {
 
     func buildDescriptionPath(for description: BuildParameters.Destination) -> AbsolutePath {
         switch description {
-        case .host: self.toolsBuildParameters.buildDescriptionPath
-        case .target: self.destinationBuildParameters.buildDescriptionPath
+        case .host: BuildOperation.buildDescriptionPath(for: self.toolsBuildParameters)
+        case .target: BuildOperation.buildDescriptionPath(for: self.destinationBuildParameters)
         }
     }
 
@@ -199,6 +192,44 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
     private let pkgConfigDirectories: [AbsolutePath]
 
     public var hasIntegratedAPIDigesterSupport: Bool { false }
+
+    public func buildProductsPath(for parameters: BuildParameters) -> AbsolutePath {
+        Self.buildProductsPath(for: parameters)
+    }
+
+    public static func buildProductsPath(for parameters: BuildParameters) -> AbsolutePath {
+        parameters.dataPath.appending(component: parameters.configuration.dirname)
+    }
+
+    /// The path to the index store directory for the given build parameters under the native build system.
+    public static func indexStore(for parameters: BuildParameters) -> AbsolutePath {
+        buildProductsPath(for: parameters).appending(components: "index", "store")
+    }
+
+    /// The path to the build description for the given build parameters under the native build system.
+    public static func buildDescriptionPath(for parameters: BuildParameters) -> AbsolutePath {
+        buildProductsPath(for: parameters).appending(components: "description.json")
+    }
+
+    /// The path to the test output file for the given build parameters under the native build system.
+    public static func testOutputPath(for parameters: BuildParameters) -> AbsolutePath {
+        buildProductsPath(for: parameters).appending(component: "testOutput.txt")
+    }
+
+    /// Returns the path to the binary of a product for the given build parameters under the native build system.
+    public static func binaryPath(for product: ResolvedProduct, parameters: BuildParameters) throws -> AbsolutePath {
+        try buildProductsPath(for: parameters).appending(parameters.binaryRelativePath(for: product))
+    }
+
+    /// Returns the path to the built binary for a macro module under the native build system.
+    public static func macroBinaryPath(for module: ResolvedModule, parameters: BuildParameters) throws -> AbsolutePath {
+        assert(module.type == .macro)
+        #if BUILD_MACROS_AS_DYLIBS
+        return try buildProductsPath(for: parameters).appending(parameters.dynamicLibraryPath(for: module.name))
+        #else
+        return try buildProductsPath(for: parameters).appending(parameters.executablePath(for: module.name))
+        #endif
+    }
 
     public convenience init(
         productsBuildParameters: BuildParameters,
@@ -524,7 +555,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         do {
             try self.fileSystem.createSymbolicLink(
                 oldBuildPath,
-                pointingAt: self.config.buildPath(for: .target),
+                pointingAt: self.buildProductsPath(for: self.config.destinationBuildParameters),
                 relative: true
             )
         } catch {
@@ -984,7 +1015,7 @@ extension BuildOperation {
         // `buildPackageStructure` to recognize the split.
         config.databasePath = config.scratchDirectory.appending("plugin-tools.db")
 
-        config.buildDescriptionPath = config.buildPath(for: .host).appending(
+        config.buildDescriptionPath = self.buildProductsPath(for: self.config.toolsBuildParameters).appending(
             component: "plugin-tools-description.json"
         )
 
@@ -1034,7 +1065,7 @@ extension BuildOperation {
                     if let result = try await buildToolBuilder(name, path) {
                         return result
                     } else {
-                        return config.buildPath(for: .host).appending(path)
+                        return self.buildProductsPath(for: config.toolsBuildParameters).appending(path)
                     }
                 }
 

--- a/Sources/Build/BuildPlan/BuildPlan+Test.swift
+++ b/Sources/Build/BuildPlan/BuildPlan+Test.swift
@@ -77,7 +77,7 @@ extension BuildPlan {
             /// Generates test discovery modules, which contain derived sources listing the discovered tests.
             func generateDiscoveryTargets() throws -> (target: SwiftModule, resolved: ResolvedModule, buildDescription: SwiftModuleBuildDescription) {
                 let discoveryTargetName = "\(package.manifest.displayName)PackageDiscoveredTests"
-                let discoveryDerivedDir = destinationBuildParameters.buildPath.appending(components: "\(discoveryTargetName).derived")
+                let discoveryDerivedDir = BuildOperation.buildProductsPath(for: destinationBuildParameters).appending(components: "\(discoveryTargetName).derived")
                 let discoveryMainFile = discoveryDerivedDir.appending(component: TestDiscoveryTool.mainFileName)
 
                 var discoveryPaths: [AbsolutePath] = []
@@ -136,7 +136,7 @@ extension BuildPlan {
                 swiftTargetDependencies: [Module.Dependency],
                 resolvedTargetDependencies: [ResolvedModule.Dependency]
             ) throws -> SwiftModuleBuildDescription {
-                let entryPointDerivedDir = destinationBuildParameters.buildPath.appending(components: "\(testProduct.name).derived")
+                let entryPointDerivedDir = BuildOperation.buildProductsPath(for: destinationBuildParameters).appending(components: "\(testProduct.name).derived")
                 let entryPointMainFileName = TestEntryPointTool.mainFileName
                 let entryPointMainFile = entryPointDerivedDir.appending(component: entryPointMainFileName)
                 let entryPointSources = Sources(paths: [entryPointMainFile], root: entryPointDerivedDir)

--- a/Sources/Build/BuildPlan/BuildPlan.swift
+++ b/Sources/Build/BuildPlan/BuildPlan.swift
@@ -45,7 +45,7 @@ extension BuildParameters {
             if let path = Environment.current["SWIFTPM_TESTS_MODULECACHE"] {
                 return try AbsolutePath(validating: path)
             }
-            return buildPath.appending("ModuleCache")
+            return BuildOperation.buildProductsPath(for: self).appending("ModuleCache")
         }
     }
 
@@ -69,7 +69,7 @@ extension BuildParameters {
         }
 
         if addIndexStoreArguments {
-            return ["-index-store-path", indexStore.pathString]
+            return ["-index-store-path", BuildOperation.indexStore(for: self).pathString]
         }
         return []
     }
@@ -588,7 +588,7 @@ public class BuildPlan: SPMBuildCore.BuildPlan {
     /// Creates arguments required to launch the Swift REPL that will allow
     /// importing the modules in the package graph.
     public func createREPLArguments() throws -> CLIArguments {
-        let buildPath = self.toolsBuildParameters.buildPath.pathString
+        let buildPath = BuildOperation.buildProductsPath(for: self.toolsBuildParameters).pathString
         var arguments = ["repl", "-I" + buildPath, "-L" + buildPath]
 
         // Link the special REPL product that contains all of the library targets.
@@ -1336,7 +1336,7 @@ extension Basics.Diagnostic {
 extension BuildParameters {
     /// Returns a named bundle's path inside the build directory.
     func bundlePath(named name: String) -> Basics.AbsolutePath {
-        self.buildPath.appending(component: name + self.triple.nsbundleExtension)
+        BuildOperation.buildProductsPath(for: self).appending(component: name + self.triple.nsbundleExtension)
     }
 }
 

--- a/Sources/Build/LLBuildCommands.swift
+++ b/Sources/Build/LLBuildCommands.swift
@@ -121,7 +121,7 @@ final class TestDiscoveryCommand: CustomLLBuildCommand, TestBuildCommand {
             return
         }
 
-        let index = self.context.productsBuildParameters.indexStore
+        let index = BuildOperation.indexStore(for: self.context.productsBuildParameters)
         let api = try self.context.indexStoreAPI.get()
         let store = try IndexStore.open(store: TSCAbsolutePath(index), api: api)
 

--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -31,7 +31,7 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
 
         extension SwiftPMXCTestObserver: XCTestObservation {
             var testOutputPath: String {
-                return "\(buildParameters.testOutputPath)"
+                return "\(BuildOperation.testOutputPath(for: buildParameters))"
             }
 
             private func write(record: any Encodable) {

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -86,7 +86,7 @@ struct DumpSymbolGraph: AsyncSwiftCommand {
 
         if let symbolGraph = buildResult.symbolGraph {
             // The build system produced symbol graphs for us, one for each target.
-            let buildPath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+            let buildPath = try await buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
 
             // Copy the symbol graphs from the target-specific locations to the single output directory
             for rootPackage in try await buildSystem.getPackageGraph().rootPackages {

--- a/Sources/Commands/PackageCommands/DumpCommands.swift
+++ b/Sources/Commands/PackageCommands/DumpCommands.swift
@@ -86,7 +86,7 @@ struct DumpSymbolGraph: AsyncSwiftCommand {
 
         if let symbolGraph = buildResult.symbolGraph {
             // The build system produced symbol graphs for us, one for each target.
-            let buildPath = try swiftCommandState.productsBuildParameters.buildPath
+            let buildPath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
 
             // Copy the symbol graphs from the target-specific locations to the single output directory
             for rootPackage in try await buildSystem.getPackageGraph().rootPackages {

--- a/Sources/Commands/PackageCommands/GenerateSBOM.swift
+++ b/Sources/Commands/PackageCommands/GenerateSBOM.swift
@@ -50,6 +50,7 @@ extension SwiftPackageCommand {
                 let resolvedPackagesStore = try workspace.resolvedPackagesStore.load()
 
                 let specs = try self.sbom.sbomSpecs
+                let buildSystem = try await swiftCommandState.createBuildSystem()
                 let input = SBOMInput(
                     modulesGraph: packageGraph,
                     dependencyGraph: nil,
@@ -57,7 +58,7 @@ extension SwiftPackageCommand {
                     filter: try self.sbom.sbomFilter,
                     product: self.product,
                     specs: specs.isEmpty ? Spec.allCases : specs,
-                    dir: await SBOMCreator.resolveSBOMDirectory(from: self.sbom.sbomDirectory, withDefault: try swiftCommandState.productsBuildParameters.buildPath),
+                    dir: await SBOMCreator.resolveSBOMDirectory(from: self.sbom.sbomDirectory, withDefault: try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)),
                     observabilityScope: swiftCommandState.observabilityScope
                 )
 

--- a/Sources/Commands/PackageCommands/GenerateSBOM.swift
+++ b/Sources/Commands/PackageCommands/GenerateSBOM.swift
@@ -58,7 +58,7 @@ extension SwiftPackageCommand {
                     filter: try self.sbom.sbomFilter,
                     product: self.product,
                     specs: specs.isEmpty ? Spec.allCases : specs,
-                    dir: await SBOMCreator.resolveSBOMDirectory(from: self.sbom.sbomDirectory, withDefault: try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)),
+                    dir: await SBOMCreator.resolveSBOMDirectory(from: self.sbom.sbomDirectory, withDefault: try await buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)),
                     observabilityScope: swiftCommandState.observabilityScope
                 )
 

--- a/Sources/Commands/PackageCommands/Install.swift
+++ b/Sources/Commands/PackageCommands/Install.swift
@@ -89,10 +89,11 @@ extension SwiftPackageCommand {
                 commandState.preferredBuildConfiguration = .release
             }
 
-            try await commandState.createBuildSystem(explicitProduct: productToInstall.name)
-                .build(subset: .product(productToInstall.name), buildOutputs: [])
+            let buildSystem = try await commandState.createBuildSystem(explicitProduct: productToInstall.name)
+            try await buildSystem.build(subset: .product(productToInstall.name), buildOutputs: [])
 
-            let binPath = try commandState.productsBuildParameters.buildPath.appending(component: productToInstall.name)
+            let binPath = try buildSystem.buildProductsPath(for: commandState.productsBuildParameters)
+                .appending(component: productToInstall.name)
             let finalBinPath = swiftpmBinDir.appending(component: binPath.basename)
             try commandState.fileSystem.copy(from: binPath, to: finalBinPath)
 

--- a/Sources/Commands/PackageCommands/Install.swift
+++ b/Sources/Commands/PackageCommands/Install.swift
@@ -92,7 +92,7 @@ extension SwiftPackageCommand {
             let buildSystem = try await commandState.createBuildSystem(explicitProduct: productToInstall.name)
             try await buildSystem.build(subset: .product(productToInstall.name), buildOutputs: [])
 
-            let binPath = try buildSystem.buildProductsPath(for: commandState.productsBuildParameters)
+            let binPath = try await buildSystem.buildProductsPath(for: commandState.productsBuildParameters)
                 .appending(component: productToInstall.name)
             let finalBinPath = swiftpmBinDir.appending(component: binPath.basename)
             try commandState.fileSystem.copy(from: binPath, to: finalBinPath)

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -359,7 +359,7 @@ struct PluginCommand: AsyncSwiftCommand {
                     return nil
                 }
             } else {
-                return buildParameters.buildPath.appending(path)
+                return buildSystem.buildProductsPath(for: buildParameters).appending(path)
             }
         }
 

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -359,7 +359,7 @@ struct PluginCommand: AsyncSwiftCommand {
                     return nil
                 }
             } else {
-                return buildSystem.buildProductsPath(for: buildParameters).appending(path)
+                return try await buildSystem.buildProductsPath(for: buildParameters).appending(path)
             }
         }
 

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -114,7 +114,7 @@ struct SnippetCard: Card {
         print("Building '\(snippet.path)'\n")
         let buildSystem = try await swiftCommandState.createBuildSystem(explicitProduct: snippet.name)
         try await buildSystem.build(subset: .product(snippet.name), buildOutputs: [])
-        let executablePath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+        let executablePath = try await buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
             .appending(component: snippet.name)
         if let exampleTarget = try await buildSystem.getPackageGraph().module(for: snippet.name) {
             try ProcessEnv.chdir(exampleTarget.sources.paths[0].parentDirectory)

--- a/Sources/Commands/Snippets/Cards/SnippetCard.swift
+++ b/Sources/Commands/Snippets/Cards/SnippetCard.swift
@@ -114,7 +114,8 @@ struct SnippetCard: Card {
         print("Building '\(snippet.path)'\n")
         let buildSystem = try await swiftCommandState.createBuildSystem(explicitProduct: snippet.name)
         try await buildSystem.build(subset: .product(snippet.name), buildOutputs: [])
-        let executablePath = try swiftCommandState.productsBuildParameters.buildPath.appending(component: snippet.name)
+        let executablePath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+            .appending(component: snippet.name)
         if let exampleTarget = try await buildSystem.getPackageGraph().module(for: snippet.name) {
             try ProcessEnv.chdir(exampleTarget.sources.paths[0].parentDirectory)
         }

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -140,7 +140,8 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
 
     public func run(_ swiftCommandState: SwiftCommandState) async throws {
         if options.shouldPrintBinPath {
-            return try print(swiftCommandState.productsBuildParameters.buildPath.description)
+            let buildSystem = try await swiftCommandState.createBuildSystem()
+            return try print(buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters).description)
         }
 
         if options.printManifestGraphviz {
@@ -256,7 +257,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
                 filter: try self.options.sbom.sbomFilter,
                 product: options.product,
                 specs: try self.options.sbom.sbomSpecs,
-                dir: await SBOMCreator.resolveSBOMDirectory(from: self.options.sbom.sbomDirectory, withDefault: try swiftCommandState.productsBuildParameters.buildPath),
+                dir: await SBOMCreator.resolveSBOMDirectory(from: self.options.sbom.sbomDirectory, withDefault: try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)),
                 observabilityScope: swiftCommandState.observabilityScope
             )
 

--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -141,7 +141,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
     public func run(_ swiftCommandState: SwiftCommandState) async throws {
         if options.shouldPrintBinPath {
             let buildSystem = try await swiftCommandState.createBuildSystem()
-            return try print(buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters).description)
+            return try await print(buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters).description)
         }
 
         if options.printManifestGraphviz {
@@ -257,7 +257,7 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
                 filter: try self.options.sbom.sbomFilter,
                 product: options.product,
                 specs: try self.options.sbom.sbomSpecs,
-                dir: await SBOMCreator.resolveSBOMDirectory(from: self.options.sbom.sbomDirectory, withDefault: try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)),
+                dir: await SBOMCreator.resolveSBOMDirectory(from: self.options.sbom.sbomDirectory, withDefault: try await buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)),
                 observabilityScope: swiftCommandState.observabilityScope
             )
 

--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -169,7 +169,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                 }
 
                 let productRelativePath = try swiftCommandState.productsBuildParameters.executablePath(for: productName)
-                let productAbsolutePath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+                let productAbsolutePath = try await buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
                     .appending(productRelativePath)
 
                 // Make sure we are running from the original working directory.
@@ -225,11 +225,11 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                     try await buildSystem.build(subset: .product(productName), buildOutputs: [])
                 }
 
-                let executablePath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+                let executablePath = try await buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
                     .appending(component: productName)
 
                 let productRelativePath = try swiftCommandState.productsBuildParameters.executablePath(for: productName)
-                let productAbsolutePath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+                let productAbsolutePath = try await buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
                     .appending(productRelativePath)
 
                 let runnerPath: AbsolutePath

--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -169,7 +169,8 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                 }
 
                 let productRelativePath = try swiftCommandState.productsBuildParameters.executablePath(for: productName)
-                let productAbsolutePath = try swiftCommandState.productsBuildParameters.buildPath.appending(productRelativePath)
+                let productAbsolutePath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+                    .appending(productRelativePath)
 
                 // Make sure we are running from the original working directory.
                 let cwd: AbsolutePath? = swiftCommandState.fileSystem.currentWorkingDirectory
@@ -224,10 +225,12 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                     try await buildSystem.build(subset: .product(productName), buildOutputs: [])
                 }
 
-                let executablePath = try swiftCommandState.productsBuildParameters.buildPath.appending(component: productName)
+                let executablePath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+                    .appending(component: productName)
 
                 let productRelativePath = try swiftCommandState.productsBuildParameters.executablePath(for: productName)
-                let productAbsolutePath = try swiftCommandState.productsBuildParameters.buildPath.appending(productRelativePath)
+                let productAbsolutePath = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+                    .appending(productRelativePath)
 
                 let runnerPath: AbsolutePath
                 let arguments: [String]

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -309,10 +309,10 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         return note
     }
 
-    private func run(_ swiftCommandState: SwiftCommandState, buildParameters: BuildParameters, testProducts: [BuiltTestProduct]) async throws {
+    private func run(_ swiftCommandState: SwiftCommandState, buildParameters: BuildParameters, testProducts: [BuiltTestProduct], buildSystem: any BuildSystem) async throws {
         // Remove test output from prior runs and validate priors.
         if self.options.enableExperimentalTestOutput && buildParameters.triple.supportsTestSummary {
-            _ = try? localFileSystem.removeFileTree(buildParameters.testOutputPath)
+            _ = try? localFileSystem.removeFileTree(buildSystem.testOutputPath(for: buildParameters))
         }
 
         var results = [TestProductResult]()
@@ -334,7 +334,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
 
             if !self.options.shouldRunInParallel {
-                let (xctestArgs, testCount, testPaths) = try xctestArgs(for: testProducts, swiftCommandState: swiftCommandState)
+                let (xctestArgs, testCount, testPaths) = try xctestArgs(for: testProducts, swiftCommandState: swiftCommandState, buildSystem: buildSystem)
 
                 // Tests have been filtered and/or skipped; assure that we only run test products
                 // of the tests we must run.
@@ -347,7 +347,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     additionalArguments: xctestArgs,
                     productsBuildParameters: buildParameters,
                     swiftCommandState: swiftCommandState,
-                    library: .xctest
+                    library: .xctest,
+                    buildSystem: buildSystem
                 )
                 if productResults.map(\.result).reduce() == .success, testCount == 0 {
                     results.append(contentsOf: productResults.map {
@@ -363,7 +364,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     enableCodeCoverage: options.enableCodeCoverage,
                     shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
                     experimentalTestOutput: options.enableExperimentalTestOutput,
-                    sanitizers: globalOptions.build.sanitizers
+                    sanitizers: globalOptions.build.sanitizers,
+                    buildSystem: buildSystem
                 )
                 let tests = try testSuites
                     .filteredTests(specifier: options.testCaseSpecifier)
@@ -392,7 +394,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                         productsBuildParameters: buildParameters,
                         toolsVersion: toolsVersion,
                         shouldOutputSuccess: swiftCommandState.logLevel <= .info,
-                        observabilityScope: swiftCommandState.observabilityScope
+                        observabilityScope: swiftCommandState.observabilityScope,
+                        buildSystem: buildSystem
                     )
 
                     testResults = try runner.run(tests)
@@ -422,7 +425,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     in: testProducts,
                     swiftCommandState: swiftCommandState,
                     shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
-                    sanitizers: globalOptions.build.sanitizers
+                    sanitizers: globalOptions.build.sanitizers,
+                    buildSystem: buildSystem
                 )
 
                 // Filter test cases based on specifiers.
@@ -439,7 +443,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                             additionalArguments: [],
                             productsBuildParameters: buildParameters,
                             swiftCommandState: swiftCommandState,
-                            library: .swiftTesting
+                            library: .swiftTesting,
+                            buildSystem: buildSystem
                         )
                     )
                 } else {
@@ -472,14 +477,14 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         case .failure:
             swiftCommandState.executionStatus = .failure
             if self.options.enableExperimentalTestOutput {
-                try Self.handleTestOutput(productsBuildParameters: buildParameters, packagePath: testProducts[0].packagePath)
+                try Self.handleTestOutput(productsBuildParameters: buildParameters, packagePath: testProducts[0].packagePath, buildSystem: buildSystem)
             }
         case .noMatchingTests:
             swiftCommandState.observabilityScope.emit(.noMatchingTests)
         }
     }
 
-    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState) throws -> (arguments: [String], testCount: Int?, testPaths: Set<AbsolutePath>?) {
+    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState, buildSystem: any BuildSystem) throws -> (arguments: [String], testCount: Int?, testPaths: Set<AbsolutePath>?) {
         switch options.testCaseSpecifier {
         case .none:
             if case .skip = options.skippedTests(fileSystem: swiftCommandState.fileSystem) {
@@ -501,7 +506,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 enableCodeCoverage: options.enableCodeCoverage,
                 shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
                 experimentalTestOutput: options.enableExperimentalTestOutput,
-                sanitizers: globalOptions.build.sanitizers
+                sanitizers: globalOptions.build.sanitizers,
+                buildSystem: buildSystem
             )
             let tests = try testSuites
                 .filteredTests(specifier: options.testCaseSpecifier)
@@ -549,20 +555,20 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             try await command.run(swiftCommandState)
         } else {
             let (productsBuildParameters, _) = try swiftCommandState.buildParametersForTest(options: self.options)
-            let testProducts = try await buildTestsIfNeeded(swiftCommandState: swiftCommandState)
+            let (buildSystem, testProducts) = try await buildTestsIfNeeded(swiftCommandState: swiftCommandState)
 
             // Clean out the code coverage directory that may contain stale
             // profraw files from a previous run of the code coverage tool.
             if self.options.enableCodeCoverage {
-                try swiftCommandState.fileSystem.removeFileTree(productsBuildParameters.codeCovPath)
+                try swiftCommandState.fileSystem.removeFileTree(buildSystem.codeCovPath(for: productsBuildParameters))
             }
 
-            try await run(swiftCommandState, buildParameters: productsBuildParameters, testProducts: testProducts)
+            try await run(swiftCommandState, buildParameters: productsBuildParameters, testProducts: testProducts, buildSystem: buildSystem)
 
             // Process code coverage if requested. We do not process it if the test run failed.
             // See https://github.com/swiftlang/swift-package-manager/pull/6894 for more info.
             if self.options.enableCodeCoverage, swiftCommandState.executionStatus != .failure {
-                try await processCodeCoverage(testProducts, swiftCommandState: swiftCommandState)
+                try await processCodeCoverage(testProducts, swiftCommandState: swiftCommandState, buildSystem: buildSystem)
             }
         }
     }
@@ -572,7 +578,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         additionalArguments: [String],
         productsBuildParameters: BuildParameters,
         swiftCommandState: SwiftCommandState,
-        library: TestingLibrary
+        library: TestingLibrary,
+        buildSystem: any BuildSystem
     ) async throws -> [TestProductResult] {
         // Pass through all arguments from the command line to Swift Testing.
         var additionalArguments = additionalArguments
@@ -629,7 +636,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             sanitizers: globalOptions.build.sanitizers,
             library: library,
             testProductPaths: testProducts.map(\.bundlePath),
-            interopMode: toolsVersion?.defaultInteropMode
+            interopMode: toolsVersion?.defaultInteropMode,
+            buildSystem: buildSystem
         )
 
         let runner = TestRunner(
@@ -650,13 +658,13 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         })
     }
 
-    private static func handleTestOutput(productsBuildParameters: BuildParameters, packagePath: AbsolutePath) throws {
-        guard localFileSystem.exists(productsBuildParameters.testOutputPath) else {
+    private static func handleTestOutput(productsBuildParameters: BuildParameters, packagePath: AbsolutePath, buildSystem: any BuildSystem) throws {
+        guard localFileSystem.exists(buildSystem.testOutputPath(for: productsBuildParameters)) else {
             print("No existing test output found.")
             return
         }
 
-        let lines = try String(contentsOfFile: productsBuildParameters.testOutputPath.pathString).components(separatedBy: "\n")
+        let lines = try String(contentsOfFile: buildSystem.testOutputPath(for: productsBuildParameters).pathString).components(separatedBy: "\n")
         let events = try lines.map { try JSONDecoder().decode(TestEventRecord.self, from: $0) }
 
         let caseEvents = events.compactMap { $0.caseEvent }
@@ -684,7 +692,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     /// Processes the code coverage data and emits a json.
     private func processCodeCoverage(
         _ testProducts: [BuiltTestProduct],
-        swiftCommandState: SwiftCommandState
+        swiftCommandState: SwiftCommandState,
+        buildSystem: any BuildSystem
     ) async throws {
         let workspace = try swiftCommandState.getActiveWorkspace()
         let root = try swiftCommandState.getWorkspaceRoot()
@@ -697,38 +706,40 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         }
 
         // Merge all the profraw files to produce a single profdata file.
-        try await mergeCodeCovRawDataFiles(swiftCommandState: swiftCommandState)
+        try await mergeCodeCovRawDataFiles(swiftCommandState: swiftCommandState, buildSystem: buildSystem)
 
         let (productsBuildParameters, _) = try swiftCommandState.buildParametersForTest(options: self.options)
         for product in testProducts {
             // Export the codecov data as JSON.
-            let jsonPath = productsBuildParameters.codeCovAsJSONPath(packageName: rootManifest.displayName)
+            let jsonPath = buildSystem.codeCovPath(for: productsBuildParameters).appending(component: rootManifest.displayName + ".json")
             try await exportCodeCovAsJSON(
                 to: jsonPath,
                 testBinary: product.coverageBinaryPath,
                 swiftCommandState: swiftCommandState,
+                buildSystem: buildSystem
             )
         }
     }
 
     /// Merges all profraw profiles in codecoverage directory into default.profdata file.
-    private func mergeCodeCovRawDataFiles(swiftCommandState: SwiftCommandState) async throws {
+    private func mergeCodeCovRawDataFiles(swiftCommandState: SwiftCommandState, buildSystem: any BuildSystem) async throws {
         // Get the llvm-prof tool.
         let llvmProf = try swiftCommandState.getTargetToolchain().getLLVMProf()
 
         // Get the profraw files.
         let (productsBuildParameters, _) = try swiftCommandState.buildParametersForTest(options: self.options)
-        let codeCovFiles = try swiftCommandState.fileSystem.getDirectoryContents(productsBuildParameters.codeCovPath)
+        let codeCovPath = buildSystem.codeCovPath(for: productsBuildParameters)
+        let codeCovFiles = try swiftCommandState.fileSystem.getDirectoryContents(codeCovPath)
 
         // Construct arguments for invoking the llvm-prof tool.
         var args = [llvmProf.pathString, "merge", "-sparse"]
         for file in codeCovFiles {
-            let filePath = productsBuildParameters.codeCovPath.appending(component: file)
+            let filePath = codeCovPath.appending(component: file)
             if filePath.extension == "profraw" {
                 args.append(filePath.pathString)
             }
         }
-        args += ["-o", productsBuildParameters.codeCovDataFile.pathString]
+        args += ["-o", buildSystem.codeCovDataFile(for: productsBuildParameters).pathString]
         try await AsyncProcess.checkNonZeroExit(arguments: args)
     }
 
@@ -736,7 +747,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     private func exportCodeCovAsJSON(
         to path: AbsolutePath,
         testBinary: AbsolutePath,
-        swiftCommandState: SwiftCommandState
+        swiftCommandState: SwiftCommandState,
+        buildSystem: any BuildSystem
     ) async throws {
         // Export using the llvm-cov tool.
         let llvmCov = try swiftCommandState.getTargetToolchain().getLLVMCov()
@@ -749,7 +761,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         let args = [
             llvmCov.pathString,
             "export",
-            "-instr-profile=\(productsBuildParameters.codeCovDataFile)",
+            "-instr-profile=\(buildSystem.codeCovDataFile(for: productsBuildParameters))",
         ] + archArgs + [
             testBinary.pathString,
         ]
@@ -767,7 +779,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     /// - Returns: The paths to the build test products.
     private func buildTestsIfNeeded(
         swiftCommandState: SwiftCommandState
-    ) async throws -> [BuiltTestProduct] {
+    ) async throws -> (buildSystem: any BuildSystem, testProducts: [BuiltTestProduct]) {
         let (productsBuildParameters, toolsBuildParameters) = try swiftCommandState.buildParametersForTest(options: self.options)
         return try await Commands.buildTestsIfNeeded(
             swiftCommandState: swiftCommandState,
@@ -820,7 +832,8 @@ extension SwiftTestCommand {
             throw StringError("invalid manifests at \(root.packages)")
         }
         let (productsBuildParameters, _) = try swiftCommandState.buildParametersForTest(enableCodeCoverage: true)
-        print(productsBuildParameters.codeCovAsJSONPath(packageName: rootManifest.displayName))
+        let buildSystem = try await swiftCommandState.createBuildSystem()
+        print(buildSystem.codeCovPath(for: productsBuildParameters).appending(component: rootManifest.displayName + ".json"))
     }
 }
 
@@ -840,14 +853,16 @@ fileprivate extension Triple {
 }
 
 extension SwiftTestCommand {
-    struct Last: SwiftCommand {
+    struct Last: AsyncSwiftCommand {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        func run(_ swiftCommandState: SwiftCommandState) throws {
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
+            let buildSystem = try await swiftCommandState.createBuildSystem()
             try SwiftTestCommand.handleTestOutput(
                 productsBuildParameters: try swiftCommandState.productsBuildParameters,
-                packagePath: localFileSystem.currentWorkingDirectory ?? .root // by definition runs in the current working directory
+                packagePath: localFileSystem.currentWorkingDirectory ?? .root, // by definition runs in the current working directory
+                buildSystem: buildSystem
             )
         }
     }
@@ -897,7 +912,7 @@ extension SwiftTestCommand {
                 enableCodeCoverage: false,
                 shouldSkipBuilding: sharedOptions.shouldSkipBuilding
             )
-            let testProducts = try await buildTestsIfNeeded(
+            let (buildSystem, testProducts) = try await buildTestsIfNeeded(
                 swiftCommandState: swiftCommandState,
                 productsBuildParameters: productsBuildParameters,
                 toolsBuildParameters: toolsBuildParameters
@@ -911,7 +926,8 @@ extension SwiftTestCommand {
                 sanitizers: globalOptions.build.sanitizers,
                 library: .swiftTesting,
                 testProductPaths: testProducts.map(\.bundlePath),
-                interopMode: toolsVersion?.defaultInteropMode
+                interopMode: toolsVersion?.defaultInteropMode,
+                buildSystem: buildSystem
             )
 
             if testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
@@ -921,7 +937,8 @@ extension SwiftTestCommand {
                     enableCodeCoverage: false,
                     shouldSkipBuilding: sharedOptions.shouldSkipBuilding,
                     experimentalTestOutput: false,
-                    sanitizers: globalOptions.build.sanitizers
+                    sanitizers: globalOptions.build.sanitizers,
+                    buildSystem: buildSystem
                 )
 
                 // Print the tests.
@@ -974,7 +991,7 @@ extension SwiftTestCommand {
             swiftCommandState: SwiftCommandState,
             productsBuildParameters: BuildParameters,
             toolsBuildParameters: BuildParameters
-        ) async throws -> [BuiltTestProduct] {
+        ) async throws -> (buildSystem: any BuildSystem, testProducts: [BuiltTestProduct]) {
             return try await Commands.buildTestsIfNeeded(
                 swiftCommandState: swiftCommandState,
                 productsBuildParameters: productsBuildParameters,
@@ -1244,6 +1261,8 @@ final class ParallelTestRunner {
     /// ObservabilityScope to emit diagnostics.
     private let observabilityScope: ObservabilityScope
 
+    private let buildSystem: any BuildSystem
+
     init(
         bundlePaths: [AbsolutePath],
         cancellator: Cancellator,
@@ -1253,7 +1272,8 @@ final class ParallelTestRunner {
         productsBuildParameters: BuildParameters,
         toolsVersion: ToolsVersion?,
         shouldOutputSuccess: Bool,
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
+        buildSystem: any BuildSystem
     ) {
         self.bundlePaths = bundlePaths
         self.cancellator = cancellator
@@ -1262,6 +1282,7 @@ final class ParallelTestRunner {
         self.toolsVersion = toolsVersion
         self.shouldOutputSuccess = shouldOutputSuccess
         self.observabilityScope = observabilityScope.makeChildScope(description: "Parallel Test Runner")
+        self.buildSystem = buildSystem
 
         // command's result output goes on stdout
         // ie "swift test" should output to stdout
@@ -1314,7 +1335,8 @@ final class ParallelTestRunner {
             sanitizers: self.buildOptions.sanitizers,
             library: .xctest, // swift-testing does not use ParallelTestRunner
             testProductPaths: bundlePaths,
-            interopMode: self.toolsVersion?.defaultInteropMode
+            interopMode: self.toolsVersion?.defaultInteropMode,
+            buildSystem: self.buildSystem
         )
 
         // Enqueue all the tests.
@@ -1711,12 +1733,6 @@ extension TestCommandOptions {
     }
 }
 
-extension BuildParameters {
-    fileprivate func codeCovAsJSONPath(packageName: String) -> AbsolutePath {
-        return self.codeCovPath.appending(component: packageName + ".json")
-    }
-}
-
 private extension Basics.Diagnostic {
     static var noMatchingTests: Self {
         .warning("No matching test cases were run")
@@ -1750,7 +1766,7 @@ private func buildTestsIfNeeded(
     toolsBuildParameters: BuildParameters,
     testProduct: String?,
     traitConfiguration: TraitConfiguration
-) async throws -> [BuiltTestProduct] {
+) async throws -> (buildSystem: any BuildSystem, testProducts: [BuiltTestProduct]) {
     let buildSystem = try await swiftCommandState.createBuildSystem(
         productsBuildParameters: productsBuildParameters,
         toolsBuildParameters: toolsBuildParameters
@@ -1776,16 +1792,16 @@ private func buildTestsIfNeeded(
 
     if let testProductName = testProduct {
         if let selectedTestProduct = testProducts.first(where: { $0.productName == testProductName }) {
-            return [selectedTestProduct]
+            return (buildSystem, [selectedTestProduct])
         }
 
         let selectedTestProducts = testProducts.filter({ $0.umbrellaProductName == testProductName })
         if !selectedTestProducts.isEmpty {
-            return selectedTestProducts
+            return (buildSystem, selectedTestProducts)
         }
 
         throw TestError.testProductNotFound(productName: testProductName)
     } else {
-        return testProducts
+        return (buildSystem, testProducts)
     }
 }

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -312,7 +312,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     private func run(_ swiftCommandState: SwiftCommandState, buildParameters: BuildParameters, testProducts: [BuiltTestProduct], buildSystem: any BuildSystem) async throws {
         // Remove test output from prior runs and validate priors.
         if self.options.enableExperimentalTestOutput && buildParameters.triple.supportsTestSummary {
-            _ = try? localFileSystem.removeFileTree(buildSystem.testOutputPath(for: buildParameters))
+            let testOutputPath = try await buildSystem.testOutputPath(for: buildParameters)
+            _ = try? localFileSystem.removeFileTree(testOutputPath)
         }
 
         var results = [TestProductResult]()
@@ -334,7 +335,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
 
             if !self.options.shouldRunInParallel {
-                let (xctestArgs, testCount, testPaths) = try xctestArgs(for: testProducts, swiftCommandState: swiftCommandState, buildSystem: buildSystem)
+                let (xctestArgs, testCount, testPaths) = try await xctestArgs(for: testProducts, swiftCommandState: swiftCommandState, buildSystem: buildSystem)
 
                 // Tests have been filtered and/or skipped; assure that we only run test products
                 // of the tests we must run.
@@ -358,7 +359,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     results.append(contentsOf: productResults)
                 }
             } else {
-                let testSuites = try TestingSupport.getTestSuites(
+                let testSuites = try await TestingSupport.getTestSuites(
                     in: testProducts,
                     swiftCommandState: swiftCommandState,
                     enableCodeCoverage: options.enableCodeCoverage,
@@ -398,7 +399,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                         buildSystem: buildSystem
                     )
 
-                    testResults = try runner.run(tests)
+                    testResults = try await runner.run(tests)
 
                     // Report a result for each product that had tests run.
                     let failedTestProducts = Set(testResults.filter({ !$0.success }).map(\.unitTest.testProduct))
@@ -421,7 +422,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             lazy var testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first
             if options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) || testEntryPointPath == nil {
                 // Filter test products to swift testing suites.
-                let testSuites = try TestingSupport.getSwiftTestingSuites(
+                let testSuites = try await TestingSupport.getSwiftTestingSuites(
                     in: testProducts,
                     swiftCommandState: swiftCommandState,
                     shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
@@ -477,14 +478,14 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         case .failure:
             swiftCommandState.executionStatus = .failure
             if self.options.enableExperimentalTestOutput {
-                try Self.handleTestOutput(productsBuildParameters: buildParameters, packagePath: testProducts[0].packagePath, buildSystem: buildSystem)
+                try await Self.handleTestOutput(productsBuildParameters: buildParameters, packagePath: testProducts[0].packagePath, buildSystem: buildSystem)
             }
         case .noMatchingTests:
             swiftCommandState.observabilityScope.emit(.noMatchingTests)
         }
     }
 
-    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState, buildSystem: any BuildSystem) throws -> (arguments: [String], testCount: Int?, testPaths: Set<AbsolutePath>?) {
+    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState, buildSystem: any BuildSystem) async throws -> (arguments: [String], testCount: Int?, testPaths: Set<AbsolutePath>?) {
         switch options.testCaseSpecifier {
         case .none:
             if case .skip = options.skippedTests(fileSystem: swiftCommandState.fileSystem) {
@@ -500,7 +501,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
 
             // Find the tests we need to run.
-            let testSuites = try TestingSupport.getTestSuites(
+            let testSuites = try await TestingSupport.getTestSuites(
                 in: testProducts,
                 swiftCommandState: swiftCommandState,
                 enableCodeCoverage: options.enableCodeCoverage,
@@ -560,7 +561,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             // Clean out the code coverage directory that may contain stale
             // profraw files from a previous run of the code coverage tool.
             if self.options.enableCodeCoverage {
-                try swiftCommandState.fileSystem.removeFileTree(buildSystem.codeCovPath(for: productsBuildParameters))
+                try swiftCommandState.fileSystem.removeFileTree(try await buildSystem.codeCovPath(for: productsBuildParameters))
             }
 
             try await run(swiftCommandState, buildParameters: productsBuildParameters, testProducts: testProducts, buildSystem: buildSystem)
@@ -630,7 +631,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         let toolchain = try swiftCommandState.getTargetToolchain()
         let toolsVersion = try await swiftCommandState.getToolsVersion()
-        let testEnv = try TestingSupport.constructTestEnvironment(
+        let testEnv = try await TestingSupport.constructTestEnvironment(
             toolchain: toolchain,
             destinationBuildParameters: productsBuildParameters,
             sanitizers: globalOptions.build.sanitizers,
@@ -658,13 +659,14 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         })
     }
 
-    private static func handleTestOutput(productsBuildParameters: BuildParameters, packagePath: AbsolutePath, buildSystem: any BuildSystem) throws {
-        guard localFileSystem.exists(buildSystem.testOutputPath(for: productsBuildParameters)) else {
+    private static func handleTestOutput(productsBuildParameters: BuildParameters, packagePath: AbsolutePath, buildSystem: any BuildSystem) async throws {
+        let testOutputPath = try await buildSystem.testOutputPath(for: productsBuildParameters)
+        guard localFileSystem.exists(testOutputPath) else {
             print("No existing test output found.")
             return
         }
 
-        let lines = try String(contentsOfFile: buildSystem.testOutputPath(for: productsBuildParameters).pathString).components(separatedBy: "\n")
+        let lines = try String(contentsOfFile: testOutputPath.pathString).components(separatedBy: "\n")
         let events = try lines.map { try JSONDecoder().decode(TestEventRecord.self, from: $0) }
 
         let caseEvents = events.compactMap { $0.caseEvent }
@@ -711,7 +713,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         let (productsBuildParameters, _) = try swiftCommandState.buildParametersForTest(options: self.options)
         for product in testProducts {
             // Export the codecov data as JSON.
-            let jsonPath = buildSystem.codeCovPath(for: productsBuildParameters).appending(component: rootManifest.displayName + ".json")
+            let jsonPath = try await buildSystem.codeCovPath(for: productsBuildParameters).appending(component: rootManifest.displayName + ".json")
             try await exportCodeCovAsJSON(
                 to: jsonPath,
                 testBinary: product.coverageBinaryPath,
@@ -728,7 +730,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         // Get the profraw files.
         let (productsBuildParameters, _) = try swiftCommandState.buildParametersForTest(options: self.options)
-        let codeCovPath = buildSystem.codeCovPath(for: productsBuildParameters)
+        let codeCovPath = try await buildSystem.codeCovPath(for: productsBuildParameters)
         let codeCovFiles = try swiftCommandState.fileSystem.getDirectoryContents(codeCovPath)
 
         // Construct arguments for invoking the llvm-prof tool.
@@ -739,7 +741,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 args.append(filePath.pathString)
             }
         }
-        args += ["-o", buildSystem.codeCovDataFile(for: productsBuildParameters).pathString]
+        args += ["-o", try await buildSystem.codeCovDataFile(for: productsBuildParameters).pathString]
         try await AsyncProcess.checkNonZeroExit(arguments: args)
     }
 
@@ -761,7 +763,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         let args = [
             llvmCov.pathString,
             "export",
-            "-instr-profile=\(buildSystem.codeCovDataFile(for: productsBuildParameters))",
+            "-instr-profile=\(try await buildSystem.codeCovDataFile(for: productsBuildParameters))",
         ] + archArgs + [
             testBinary.pathString,
         ]
@@ -833,7 +835,7 @@ extension SwiftTestCommand {
         }
         let (productsBuildParameters, _) = try swiftCommandState.buildParametersForTest(enableCodeCoverage: true)
         let buildSystem = try await swiftCommandState.createBuildSystem()
-        print(buildSystem.codeCovPath(for: productsBuildParameters).appending(component: rootManifest.displayName + ".json"))
+        print(try await buildSystem.codeCovPath(for: productsBuildParameters).appending(component: rootManifest.displayName + ".json"))
     }
 }
 
@@ -859,7 +861,7 @@ extension SwiftTestCommand {
 
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             let buildSystem = try await swiftCommandState.createBuildSystem()
-            try SwiftTestCommand.handleTestOutput(
+            try await SwiftTestCommand.handleTestOutput(
                 productsBuildParameters: try swiftCommandState.productsBuildParameters,
                 packagePath: localFileSystem.currentWorkingDirectory ?? .root, // by definition runs in the current working directory
                 buildSystem: buildSystem
@@ -920,7 +922,7 @@ extension SwiftTestCommand {
 
             let toolchain = try swiftCommandState.getTargetToolchain()
             let toolsVersion = try await swiftCommandState.getToolsVersion()
-            let testEnv = try TestingSupport.constructTestEnvironment(
+            let testEnv = try await TestingSupport.constructTestEnvironment(
                 toolchain: toolchain,
                 destinationBuildParameters: productsBuildParameters,
                 sanitizers: globalOptions.build.sanitizers,
@@ -931,7 +933,7 @@ extension SwiftTestCommand {
             )
 
             if testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
-                let testSuites = try TestingSupport.getTestSuites(
+                let testSuites = try await TestingSupport.getTestSuites(
                     in: testProducts,
                     swiftCommandState: swiftCommandState,
                     enableCodeCoverage: false,
@@ -1326,10 +1328,10 @@ final class ParallelTestRunner {
     }
 
     /// Executes the tests spawning parallel workers. Blocks calling thread until all workers are finished.
-    func run(_ tests: [UnitTest]) throws -> [TestResult] {
+    func run(_ tests: [UnitTest]) async throws -> [TestResult] {
         assert(!tests.isEmpty, "There should be at least one test to execute.")
 
-        let testEnv = try TestingSupport.constructTestEnvironment(
+        let testEnv = try await TestingSupport.constructTestEnvironment(
             toolchain: self.toolchain,
             destinationBuildParameters: self.productsBuildParameters,
             sanitizers: self.buildOptions.sanitizers,

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -239,7 +239,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Clean out the code coverage directory that may contain stale `profraw` files from a previous run of
         // the code coverage tool.
         if parameters.enableCodeCoverage {
-            try swiftCommandState.fileSystem.removeFileTree(toolsBuildParameters.codeCovPath)
+            try swiftCommandState.fileSystem.removeFileTree(buildSystem.codeCovPath(for: toolsBuildParameters))
         }
 
         // Construct the environment we'll pass down to the tests.
@@ -250,7 +250,8 @@ final class PluginDelegate: PluginInvocationDelegate {
             sanitizers: swiftCommandState.options.build.sanitizers,
             library: .xctest, // FIXME: support both libraries
             testProductPaths: buildSystem.builtTestProducts.map(\.bundlePath),
-            interopMode: toolsVersion?.defaultInteropMode
+            interopMode: toolsVersion?.defaultInteropMode,
+            buildSystem: buildSystem
         )
 
         // Iterate over the tests and run those that match the filter.
@@ -264,7 +265,8 @@ final class PluginDelegate: PluginInvocationDelegate {
                 enableCodeCoverage: parameters.enableCodeCoverage,
                 shouldSkipBuilding: false,
                 experimentalTestOutput: false,
-                sanitizers: swiftCommandState.options.build.sanitizers
+                sanitizers: swiftCommandState.options.build.sanitizers,
+                buildSystem: buildSystem
             )
             for testSuite in testSuites {
                 // Each test suite is just a container for test cases (confusingly called "tests",
@@ -334,12 +336,12 @@ final class PluginDelegate: PluginInvocationDelegate {
         let codeCoverageDataFile: AbsolutePath?
         if parameters.enableCodeCoverage {
             // Use `llvm-prof` to merge all the `.profraw` files into a single `.profdata` file.
-            let mergedCovFile = toolsBuildParameters.codeCovDataFile
-            let codeCovFileNames = try swiftCommandState.fileSystem.getDirectoryContents(toolsBuildParameters.codeCovPath)
+            let mergedCovFile = buildSystem.codeCovDataFile(for: toolsBuildParameters)
+            let codeCovFileNames = try swiftCommandState.fileSystem.getDirectoryContents(buildSystem.codeCovPath(for: toolsBuildParameters))
             var llvmProfCommand = [try toolchain.getLLVMProf().pathString]
             llvmProfCommand += ["merge", "-sparse"]
             for fileName in codeCovFileNames where fileName.hasSuffix(".profraw") {
-                let filePath = toolsBuildParameters.codeCovPath.appending(component: fileName)
+                let filePath = buildSystem.codeCovPath(for: toolsBuildParameters).appending(component: fileName)
                 llvmProfCommand.append(filePath.pathString)
             }
             llvmProfCommand += ["-o", mergedCovFile.pathString]
@@ -354,8 +356,8 @@ final class PluginDelegate: PluginInvocationDelegate {
             }
             // We get the output on stdout, and have to write it to a JSON ourselves.
             let jsonOutput = try await AsyncProcess.checkNonZeroExit(arguments: llvmCovCommand)
-            let jsonCovFile = toolsBuildParameters.codeCovDataFile.parentDirectory.appending(
-                component: toolsBuildParameters.codeCovDataFile.basenameWithoutExt + ".json"
+            let jsonCovFile = mergedCovFile.parentDirectory.appending(
+                component: mergedCovFile.basenameWithoutExt + ".json"
             )
             try swiftCommandState.fileSystem.writeFileContents(jsonCovFile, string: jsonOutput)
 
@@ -406,7 +408,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         let buildResult = try await buildSystem.build(subset: .target(targetName), buildOutputs: [.symbolGraph(options), .buildPlan])
 
         if let symbolGraph = buildResult.symbolGraph {
-            let path = (try swiftCommandState.productsBuildParameters.buildPath)
+            let path = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
             return PluginInvocationSymbolGraphResult(directoryPath: "\(path)/\(symbolGraph.outputLocationForTarget(targetName, try swiftCommandState.productsBuildParameters).joined(separator:"/"))")
         } else if let buildPlan = buildResult.buildPlan {
             func lookupDescription(

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -239,7 +239,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         // Clean out the code coverage directory that may contain stale `profraw` files from a previous run of
         // the code coverage tool.
         if parameters.enableCodeCoverage {
-            try swiftCommandState.fileSystem.removeFileTree(buildSystem.codeCovPath(for: toolsBuildParameters))
+            try swiftCommandState.fileSystem.removeFileTree(try await buildSystem.codeCovPath(for: toolsBuildParameters))
         }
 
         // Construct the environment we'll pass down to the tests.
@@ -259,7 +259,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         var numFailedTests = 0
         for testProduct in await buildSystem.builtTestProducts {
             // Get the test suites in the bundle. Each is just a container for test cases.
-            let testSuites = try TestingSupport.getTestSuites(
+            let testSuites = try await TestingSupport.getTestSuites(
                 fromTestAt: testProduct.bundlePath,
                 swiftCommandState: swiftCommandState,
                 enableCodeCoverage: parameters.enableCodeCoverage,
@@ -336,12 +336,13 @@ final class PluginDelegate: PluginInvocationDelegate {
         let codeCoverageDataFile: AbsolutePath?
         if parameters.enableCodeCoverage {
             // Use `llvm-prof` to merge all the `.profraw` files into a single `.profdata` file.
-            let mergedCovFile = buildSystem.codeCovDataFile(for: toolsBuildParameters)
-            let codeCovFileNames = try swiftCommandState.fileSystem.getDirectoryContents(buildSystem.codeCovPath(for: toolsBuildParameters))
+            let mergedCovFile = try await buildSystem.codeCovDataFile(for: toolsBuildParameters)
+            let codeCovPath = try await buildSystem.codeCovPath(for: toolsBuildParameters)
+            let codeCovFileNames = try swiftCommandState.fileSystem.getDirectoryContents(codeCovPath)
             var llvmProfCommand = [try toolchain.getLLVMProf().pathString]
             llvmProfCommand += ["merge", "-sparse"]
             for fileName in codeCovFileNames where fileName.hasSuffix(".profraw") {
-                let filePath = buildSystem.codeCovPath(for: toolsBuildParameters).appending(component: fileName)
+                let filePath = codeCovPath.appending(component: fileName)
                 llvmProfCommand.append(filePath.pathString)
             }
             llvmProfCommand += ["-o", mergedCovFile.pathString]
@@ -408,7 +409,7 @@ final class PluginDelegate: PluginInvocationDelegate {
         let buildResult = try await buildSystem.build(subset: .target(targetName), buildOutputs: [.symbolGraph(options), .buildPlan])
 
         if let symbolGraph = buildResult.symbolGraph {
-            let path = try buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
+            let path = try await buildSystem.buildProductsPath(for: swiftCommandState.productsBuildParameters)
             return PluginInvocationSymbolGraphResult(directoryPath: "\(path)/\(symbolGraph.outputLocationForTarget(targetName, try swiftCommandState.productsBuildParameters).joined(separator:"/"))")
         } else if let buildPlan = buildResult.buildPlan {
             func lookupDescription(

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -78,7 +78,8 @@ enum TestingSupport {
         enableCodeCoverage: Bool,
         shouldSkipBuilding: Bool,
         experimentalTestOutput: Bool,
-        sanitizers: [Sanitizer]
+        sanitizers: [Sanitizer],
+        buildSystem: any BuildSystem
     ) throws -> [BuiltTestProduct: [TestSuite]] {
         let testSuitesByProduct = try testProducts
             .map {(
@@ -89,7 +90,8 @@ enum TestingSupport {
                     enableCodeCoverage: enableCodeCoverage,
                     shouldSkipBuilding: shouldSkipBuilding,
                     experimentalTestOutput: experimentalTestOutput,
-                    sanitizers: sanitizers
+                    sanitizers: sanitizers,
+                    buildSystem: buildSystem
                 )
             )}
         return try Dictionary(throwingUniqueKeysWithValues: testSuitesByProduct)
@@ -111,7 +113,8 @@ enum TestingSupport {
         enableCodeCoverage: Bool,
         shouldSkipBuilding: Bool,
         experimentalTestOutput: Bool,
-        sanitizers: [Sanitizer]
+        sanitizers: [Sanitizer],
+        buildSystem: any BuildSystem
     ) throws -> [TestSuite] {
         // Run the correct tool.
         var args = [String]()
@@ -128,7 +131,8 @@ enum TestingSupport {
                 sanitizers: sanitizers,
                 library: .xctest,
                 testProductPaths: [path],
-                interopMode: nil // Interop not required when listing tests
+                interopMode: nil, // Interop not required when listing tests
+                buildSystem: buildSystem
             )
             try Self.runProcessWithExistenceCheck(
                 path: path,
@@ -150,7 +154,8 @@ enum TestingSupport {
             sanitizers: sanitizers,
             library: .xctest,
             testProductPaths: [path],
-            interopMode: nil // Interop not required when listing tests
+            interopMode: nil, // Interop not required when listing tests
+            buildSystem: buildSystem
         )
         args = [path.description, "--dump-tests-json"]
         let data = try Self.runProcessWithExistenceCheck(
@@ -168,7 +173,8 @@ enum TestingSupport {
         in testProducts: [BuiltTestProduct],
         swiftCommandState: SwiftCommandState,
         shouldSkipBuilding: Bool,
-        sanitizers: [Sanitizer]
+        sanitizers: [Sanitizer],
+        buildSystem: any BuildSystem
     ) throws -> [AbsolutePath: [String]] {
         let suitesByProduct = try testProducts
             .map {(
@@ -177,7 +183,8 @@ enum TestingSupport {
                     testProduct: $0,
                     swiftCommandState: swiftCommandState,
                     shouldSkipBuilding: shouldSkipBuilding,
-                    sanitizers: sanitizers
+                    sanitizers: sanitizers,
+                    buildSystem: buildSystem
                 )
             )}
         return try Dictionary(throwingUniqueKeysWithValues: suitesByProduct)
@@ -197,7 +204,8 @@ enum TestingSupport {
         testProduct: BuiltTestProduct,
         swiftCommandState: SwiftCommandState,
         shouldSkipBuilding: Bool,
-        sanitizers: [Sanitizer]
+        sanitizers: [Sanitizer],
+        buildSystem: any BuildSystem
     ) throws -> [String] {
         let toolchain = try swiftCommandState.getTargetToolchain()
         let env = try Self.constructTestEnvironment(
@@ -213,7 +221,8 @@ enum TestingSupport {
             sanitizers: sanitizers,
             library: .swiftTesting,
             testProductPaths: [testProduct.bundlePath],
-            interopMode: nil // Interop not required when listing tests
+            interopMode: nil, // Interop not required when listing tests
+            buildSystem: buildSystem
         )
 
         var args: [String]
@@ -300,7 +309,8 @@ enum TestingSupport {
         sanitizers: [Sanitizer],
         library: TestingLibrary,
         testProductPaths: [AbsolutePath],
-        interopMode: String?
+        interopMode: String?,
+        buildSystem: any BuildSystem
     ) throws -> Environment {
         var env = Environment.current
 
@@ -341,7 +351,7 @@ enum TestingSupport {
             //
             // These are all merged using `llvm-profdata merge` once the outer test command has
             // completed.
-            let codecovProfile = buildParameters.buildPath.appending(components: "codecov", "\(library)%m.%p.profraw")
+            let codecovProfile = buildSystem.buildProductsPath(for: buildParameters).appending(components: "codecov", "\(library)%m.%p.profraw")
             env["LLVM_PROFILE_FILE"] = codecovProfile.pathString
         }
 

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -80,21 +80,21 @@ enum TestingSupport {
         experimentalTestOutput: Bool,
         sanitizers: [Sanitizer],
         buildSystem: any BuildSystem
-    ) throws -> [BuiltTestProduct: [TestSuite]] {
-        let testSuitesByProduct = try testProducts
-            .map {(
-                $0,
-                try Self.getTestSuites(
-                    fromTestAt: $0.bundlePath,
-                    swiftCommandState: swiftCommandState,
-                    enableCodeCoverage: enableCodeCoverage,
-                    shouldSkipBuilding: shouldSkipBuilding,
-                    experimentalTestOutput: experimentalTestOutput,
-                    sanitizers: sanitizers,
-                    buildSystem: buildSystem
-                )
-            )}
-        return try Dictionary(throwingUniqueKeysWithValues: testSuitesByProduct)
+    ) async throws -> [BuiltTestProduct: [TestSuite]] {
+        var result: [(BuiltTestProduct, [TestSuite])] = []
+        for product in testProducts {
+            let suites = try await Self.getTestSuites(
+                fromTestAt: product.bundlePath,
+                swiftCommandState: swiftCommandState,
+                enableCodeCoverage: enableCodeCoverage,
+                shouldSkipBuilding: shouldSkipBuilding,
+                experimentalTestOutput: experimentalTestOutput,
+                sanitizers: sanitizers,
+                buildSystem: buildSystem
+            )
+            result.append((product, suites))
+        }
+        return try Dictionary(throwingUniqueKeysWithValues: result)
     }
 
     /// Runs the corresponding tool to get tests JSON and create TestSuite array.
@@ -115,25 +115,26 @@ enum TestingSupport {
         experimentalTestOutput: Bool,
         sanitizers: [Sanitizer],
         buildSystem: any BuildSystem
-    ) throws -> [TestSuite] {
+    ) async throws -> [TestSuite] {
         // Run the correct tool.
         var args = [String]()
         #if os(macOS)
+        let env = try await Self.constructTestEnvironment(
+            toolchain: try swiftCommandState.getTargetToolchain(),
+            destinationBuildParameters: swiftCommandState.buildParametersForTest(
+                enableCodeCoverage: enableCodeCoverage,
+                shouldSkipBuilding: shouldSkipBuilding,
+                experimentalTestOutput: experimentalTestOutput
+            ).productsBuildParameters,
+            sanitizers: sanitizers,
+            library: .xctest,
+            testProductPaths: [path],
+            interopMode: nil, // Interop not required when listing tests
+            buildSystem: buildSystem
+        )
+        let helperPath = try Self.xctestHelperPath(swiftCommandState: swiftCommandState).pathString
         let data: String = try withTemporaryFile { tempFile in
-            args = [try Self.xctestHelperPath(swiftCommandState: swiftCommandState).pathString, path.pathString, tempFile.path.pathString]
-            let env = try Self.constructTestEnvironment(
-                toolchain: try swiftCommandState.getTargetToolchain(),
-                destinationBuildParameters: swiftCommandState.buildParametersForTest(
-                    enableCodeCoverage: enableCodeCoverage,
-                    shouldSkipBuilding: shouldSkipBuilding,
-                    experimentalTestOutput: experimentalTestOutput
-                ).productsBuildParameters,
-                sanitizers: sanitizers,
-                library: .xctest,
-                testProductPaths: [path],
-                interopMode: nil, // Interop not required when listing tests
-                buildSystem: buildSystem
-            )
+            args = [helperPath, path.pathString, tempFile.path.pathString]
             try Self.runProcessWithExistenceCheck(
                 path: path,
                 fileSystem: swiftCommandState.fileSystem,
@@ -145,7 +146,7 @@ enum TestingSupport {
             return try swiftCommandState.fileSystem.readFileContents(AbsolutePath(tempFile.path))
         }
         #else
-        let env = try Self.constructTestEnvironment(
+        let env = try await Self.constructTestEnvironment(
             toolchain: try swiftCommandState.getTargetToolchain(),
             destinationBuildParameters: swiftCommandState.buildParametersForTest(
                 enableCodeCoverage: enableCodeCoverage,
@@ -175,19 +176,19 @@ enum TestingSupport {
         shouldSkipBuilding: Bool,
         sanitizers: [Sanitizer],
         buildSystem: any BuildSystem
-    ) throws -> [AbsolutePath: [String]] {
-        let suitesByProduct = try testProducts
-            .map {(
-                $0.binaryPath,
-                try Self.getSwiftTestingSuites(
-                    testProduct: $0,
-                    swiftCommandState: swiftCommandState,
-                    shouldSkipBuilding: shouldSkipBuilding,
-                    sanitizers: sanitizers,
-                    buildSystem: buildSystem
-                )
-            )}
-        return try Dictionary(throwingUniqueKeysWithValues: suitesByProduct)
+    ) async throws -> [AbsolutePath: [String]] {
+        var result: [(AbsolutePath, [String])] = []
+        for product in testProducts {
+            let suites = try await Self.getSwiftTestingSuites(
+                testProduct: product,
+                swiftCommandState: swiftCommandState,
+                shouldSkipBuilding: shouldSkipBuilding,
+                sanitizers: sanitizers,
+                buildSystem: buildSystem
+            )
+            result.append((product.binaryPath, suites))
+        }
+        return try Dictionary(throwingUniqueKeysWithValues: result)
     }
 
     /// Runs the test binary to list Swift Testing tests and returns their identifiers.
@@ -206,9 +207,9 @@ enum TestingSupport {
         shouldSkipBuilding: Bool,
         sanitizers: [Sanitizer],
         buildSystem: any BuildSystem
-    ) throws -> [String] {
+    ) async throws -> [String] {
         let toolchain = try swiftCommandState.getTargetToolchain()
-        let env = try Self.constructTestEnvironment(
+        let env = try await Self.constructTestEnvironment(
             toolchain: toolchain,
             destinationBuildParameters: swiftCommandState.buildParametersForTest(
                 // Unlike the XCTest helper tool, the Swift Testing runtime initialises LLVM
@@ -311,7 +312,7 @@ enum TestingSupport {
         testProductPaths: [AbsolutePath],
         interopMode: String?,
         buildSystem: any BuildSystem
-    ) throws -> Environment {
+    ) async throws -> Environment {
         var env = Environment.current
 
         // If the standard output or error stream is NOT a TTY, set the NO_COLOR
@@ -351,7 +352,7 @@ enum TestingSupport {
             //
             // These are all merged using `llvm-profdata merge` once the outer test command has
             // completed.
-            let codecovProfile = buildSystem.buildProductsPath(for: buildParameters).appending(components: "codecov", "\(library)%m.%p.profraw")
+            let codecovProfile = try await buildSystem.buildProductsPath(for: buildParameters).appending(components: "codecov", "\(library)%m.%p.profraw")
             env["LLVM_PROFILE_FILE"] = codecovProfile.pathString
         }
 

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -42,7 +42,9 @@ private struct NativeBuildSystemFactory: BuildSystemFactory {
         _ = try await swiftCommandState.getRootPackageInformation(enableAllTraits)
         let testEntryPointPath = productsBuildParameters?.testProductStyle.explicitlySpecifiedEntryPointPath
         let cacheBuildManifest = if cacheBuildManifest {
-            try await self.swiftCommandState.canUseCachedBuildManifest()
+            try await self.swiftCommandState.canUseCachedBuildManifest(
+                buildDescriptionPath: BuildOperation.buildDescriptionPath(for: try productsBuildParameters ?? self.swiftCommandState.productsBuildParameters)
+            )
         } else {
             false
         }

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -902,7 +902,7 @@ public final class SwiftCommandState {
         try self._manifestLoader.get()
     }
 
-    public func canUseCachedBuildManifest(_ traitConfiguration: TraitConfiguration = .default) async throws -> Bool {
+    public func canUseCachedBuildManifest(_ traitConfiguration: TraitConfiguration = .default, buildDescriptionPath: AbsolutePath) async throws -> Bool {
         if !self.options.caching.cacheBuildManifest {
             return false
         }
@@ -910,7 +910,7 @@ public final class SwiftCommandState {
         let buildParameters = try self.productsBuildParameters
         let haveBuildManifestAndDescription =
             self.fileSystem.exists(buildParameters.llbuildManifest) &&
-            self.fileSystem.exists(buildParameters.buildDescriptionPath)
+            self.fileSystem.exists(buildDescriptionPath)
 
         if !haveBuildManifestAndDescription {
             return false

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -255,6 +255,35 @@ public struct BuildParameters: Encodable {
         self.apiDigesterMode = apiDigesterMode
     }
 
+    /// The path to the build directory (inside the data directory).
+    @available(*, deprecated, message: "Use BuildSystem.buildProductsPath(for:) instead. This is preserved temporarily to support sourcekit-lsp")
+    public var buildPath: Basics.AbsolutePath {
+        // TODO: query the build system for this.
+        switch buildSystemKind {
+        case .xcode, .swiftbuild:
+            var configDir: String = configuration.dirname.capitalized
+            if self.triple.isMacOSX {
+                // no suffix
+            } else if self.triple.isAndroid() {
+                configDir += "-android"
+            } else if self.triple.isWasm {
+                configDir += "-webassembly"
+            } else {
+                configDir += "-" + (self.triple.darwinPlatform?.platformName ?? self.triple.osNameUnversioned)
+            }
+            return dataPath.appending(components: "Products", configDir)
+        case .native:
+            return dataPath.appending(component: configuration.dirname)
+        }
+    }
+
+    /// The path to the index store directory.
+    @available(*, deprecated, message: "Use BuildSystem.indexStore(for:) instead. This is preserved temporarily to support sourcekit-lsp")
+    public var indexStore: Basics.AbsolutePath {
+        assert(indexStoreMode != .off, "index store is disabled")
+        return buildPath.appending(components: "index", "store")
+    }
+
     public var llbuildManifest: Basics.AbsolutePath {
         // FIXME: this path isn't specific to `BuildParameters` due to its use of `..`
         // FIXME: it should be calculated in a different place

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -255,43 +255,6 @@ public struct BuildParameters: Encodable {
         self.apiDigesterMode = apiDigesterMode
     }
 
-    /// The path to the build directory (inside the data directory).
-    public var buildPath: Basics.AbsolutePath {
-        // TODO: query the build system for this.
-        switch buildSystemKind {
-        case .xcode, .swiftbuild:
-            var configDir: String = configuration.dirname.capitalized
-            if self.triple.isMacOSX {
-                // no suffix
-            } else if self.triple.isAndroid() {
-                configDir += "-android"
-            } else if self.triple.isWasm {
-                configDir += "-webassembly"
-            } else {
-                configDir += "-" + (self.triple.darwinPlatform?.platformName ?? self.triple.osNameUnversioned)
-            }
-            return dataPath.appending(components: "Products", configDir)
-        case .native:
-            return dataPath.appending(component: configuration.dirname)
-        }
-    }
-
-    /// The path to the index store directory.
-    public var indexStore: Basics.AbsolutePath {
-        assert(indexStoreMode != .off, "index store is disabled")
-        return buildPath.appending(components: "index", "store")
-    }
-
-    /// The path to the code coverage directory.
-    public var codeCovPath: Basics.AbsolutePath {
-        return buildPath.appending("codecov")
-    }
-
-    /// The path to the code coverage profdata file.
-    public var codeCovDataFile: Basics.AbsolutePath {
-        return codeCovPath.appending("default.profdata")
-    }
-
     public var llbuildManifest: Basics.AbsolutePath {
         // FIXME: this path isn't specific to `BuildParameters` due to its use of `..`
         // FIXME: it should be calculated in a different place
@@ -304,30 +267,8 @@ public struct BuildParameters: Encodable {
         return dataPath.appending(components: "..", "manifest.pif")
     }
 
-    public var buildDescriptionPath: Basics.AbsolutePath {
-        // FIXME: this path isn't specific to `BuildParameters`, should be moved one directory level higher
-        return buildPath.appending(components: "description.json")
-    }
-
-    public var testOutputPath: Basics.AbsolutePath {
-        return buildPath.appending(component: "testOutput.txt")
-    }
-    /// Returns the path to the binary of a product for the current build parameters.
-    public func binaryPath(for product: ResolvedProduct) throws -> Basics.AbsolutePath {
-        return try buildPath.appending(binaryRelativePath(for: product))
-    }
-
-    public func macroBinaryPath(_ module: ResolvedModule) throws -> Basics.AbsolutePath {
-        assert(module.type == .macro)
-        #if BUILD_MACROS_AS_DYLIBS
-        return buildPath.appending(try dynamicLibraryPath(for: module.name))
-        #else
-        return buildPath.appending(try executablePath(for: module.name))
-        #endif
-    }
-
     /// Returns the path to the dynamic library of a product for the current build parameters.
-    private func dynamicLibraryPath(for name: String) throws -> Basics.RelativePath {
+    package func dynamicLibraryPath(for name: String) throws -> Basics.RelativePath {
         try RelativePath(validating: "\(self.triple.dynamicLibraryPrefix)\(name)\(self.suffix)\(self.triple.dynamicLibraryExtension)")
     }
 

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -99,7 +99,7 @@ public protocol BuildSystem: Cancellable {
     func generatePIF(preserveStructure: Bool) async throws -> String
 
     /// The path to the build directory for the given build parameters.
-    func buildProductsPath(for parameters: BuildParameters) -> AbsolutePath
+    func buildProductsPath(for parameters: BuildParameters) async throws -> AbsolutePath
 }
 
 extension BuildSystem {
@@ -110,29 +110,29 @@ extension BuildSystem {
     }
 
     /// The path to the index store directory for the given build parameters.
-    public func indexStore(for parameters: BuildParameters) -> AbsolutePath {
+    public func indexStore(for parameters: BuildParameters) async throws -> AbsolutePath {
         assert(parameters.indexStoreMode != .off, "index store is disabled")
-        return buildProductsPath(for: parameters).appending(components: "index", "store")
+        return try await buildProductsPath(for: parameters).appending(components: "index", "store")
     }
 
     /// The path to the code coverage directory for the given build parameters.
-    public func codeCovPath(for parameters: BuildParameters) -> AbsolutePath {
-        buildProductsPath(for: parameters).appending("codecov")
+    public func codeCovPath(for parameters: BuildParameters) async throws -> AbsolutePath {
+        try await buildProductsPath(for: parameters).appending("codecov")
     }
 
     /// The path to the code coverage profdata file for the given build parameters.
-    public func codeCovDataFile(for parameters: BuildParameters) -> AbsolutePath {
-        codeCovPath(for: parameters).appending("default.profdata")
+    public func codeCovDataFile(for parameters: BuildParameters) async throws -> AbsolutePath {
+        try await codeCovPath(for: parameters).appending("default.profdata")
     }
 
     /// The path to the test output file for the given build parameters.
-    public func testOutputPath(for parameters: BuildParameters) -> AbsolutePath {
-        buildProductsPath(for: parameters).appending(component: "testOutput.txt")
+    public func testOutputPath(for parameters: BuildParameters) async throws -> AbsolutePath {
+        try await buildProductsPath(for: parameters).appending(component: "testOutput.txt")
     }
 
     /// Returns the path to the binary of a product for the given build parameters.
-    public func binaryPath(for product: ResolvedProduct, parameters: BuildParameters) throws -> AbsolutePath {
-        try buildProductsPath(for: parameters).appending(parameters.binaryRelativePath(for: product))
+    public func binaryPath(for product: ResolvedProduct, parameters: BuildParameters) async throws -> AbsolutePath {
+        try await buildProductsPath(for: parameters).appending(parameters.binaryRelativePath(for: product))
     }
 }
 

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -97,6 +97,9 @@ public protocol BuildSystem: Cancellable {
     var hasIntegratedAPIDigesterSupport: Bool { get }
 
     func generatePIF(preserveStructure: Bool) async throws -> String
+
+    /// The path to the build directory for the given build parameters.
+    func buildProductsPath(for parameters: BuildParameters) -> AbsolutePath
 }
 
 extension BuildSystem {
@@ -104,6 +107,32 @@ extension BuildSystem {
     @discardableResult
     public func build() async throws -> BuildResult {
         try await build(subset: .allExcludingTests, buildOutputs: [])
+    }
+
+    /// The path to the index store directory for the given build parameters.
+    public func indexStore(for parameters: BuildParameters) -> AbsolutePath {
+        assert(parameters.indexStoreMode != .off, "index store is disabled")
+        return buildProductsPath(for: parameters).appending(components: "index", "store")
+    }
+
+    /// The path to the code coverage directory for the given build parameters.
+    public func codeCovPath(for parameters: BuildParameters) -> AbsolutePath {
+        buildProductsPath(for: parameters).appending("codecov")
+    }
+
+    /// The path to the code coverage profdata file for the given build parameters.
+    public func codeCovDataFile(for parameters: BuildParameters) -> AbsolutePath {
+        codeCovPath(for: parameters).appending("default.profdata")
+    }
+
+    /// The path to the test output file for the given build parameters.
+    public func testOutputPath(for parameters: BuildParameters) -> AbsolutePath {
+        buildProductsPath(for: parameters).appending(component: "testOutput.txt")
+    }
+
+    /// Returns the path to the binary of a product for the given build parameters.
+    public func binaryPath(for product: ResolvedProduct, parameters: BuildParameters) throws -> AbsolutePath {
+        try buildProductsPath(for: parameters).appending(parameters.binaryRelativePath(for: product))
     }
 }
 
@@ -156,13 +185,17 @@ public protocol ProductBuildDescription {
 
     /// The build parameters.
     var buildParameters: BuildParameters { get }
+
+    /// The build products directory — the path under which built binaries, libraries, and other
+    /// products are placed for the corresponding build system/parameters.
+    var productsPath: AbsolutePath { get }
 }
 
 extension ProductBuildDescription {
     /// The path to the product binary produced.
     public var binaryPath: AbsolutePath {
         get throws {
-            try self.buildParameters.binaryPath(for: product)
+            try self.productsPath.appending(self.buildParameters.binaryRelativePath(for: product))
         }
     }
 }

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -83,7 +83,11 @@ package struct PIFBuilderParameters {
     /// the build products to a different location.
     let addLocalRpaths: Bool
 
-    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRPaths: Bool) {
+    /// The directory in which host-destination build products (e.g. plugin tools) are placed, as
+    /// reported by the build system for the host `BuildParameters`.
+    let hostBuildProductsPath: AbsolutePath
+
+    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRPaths: Bool, hostBuildProductsPath: AbsolutePath) {
         self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
         self.enableTestability = enableTestability
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
@@ -97,6 +101,7 @@ package struct PIFBuilderParameters {
         self.pluginWorkingDirectory = pluginWorkingDirectory
         self.additionalFileRules = additionalFileRules
         self.addLocalRpaths = addLocalRPaths
+        self.hostBuildProductsPath = hostBuildProductsPath
     }
 }
 
@@ -156,8 +161,7 @@ public final class PIFBuilder {
         prettyPrint: Bool = true,
         preservePIFModelStructure: Bool = false,
         printPIFManifestGraphviz: Bool = false,
-        buildParameters: BuildParameters,
-        hostBuildParameters: BuildParameters
+        buildParameters: BuildParameters
     ) async throws -> PIFGenerationResult {
         let encoder = prettyPrint ? JSONEncoder.makeWithDefaults() : JSONEncoder()
 
@@ -165,7 +169,7 @@ public final class PIFBuilder {
             encoder.userInfo[.encodeForSwiftBuild] = true
         }
 
-        let (topLevelObject, modulesAndProducts) = try await self.constructPIF(buildParameters: buildParameters, hostBuildParameters: hostBuildParameters)
+        let (topLevelObject, modulesAndProducts) = try await self.constructPIF(buildParameters: buildParameters)
 
         // Sign the PIF objects before encoding it for Swift Build.
         try PIF.sign(workspace: topLevelObject.workspace)
@@ -192,7 +196,6 @@ public final class PIFBuilder {
     private func availableBuildPluginTools(
         graph: ModulesGraph,
         buildParameters: BuildParameters,
-        hostBuildParameters: BuildParameters,
         pluginsPerModule: [ResolvedModule.ID: [ResolvedModule]],
         hostTriple: Basics.Triple
     ) async throws -> [ResolvedModule.ID: [String: PluginTool]] {
@@ -207,7 +210,7 @@ public final class PIFBuilder {
                     environment: buildParameters.buildEnvironment,
                     for: hostTriple
                 ) { name, path in
-                    return hostBuildParameters.buildPath.appending(path)
+                    return self.parameters.hostBuildProductsPath.appending(path)
                 }
 
                 accessibleToolsPerPlugin[plugin.id] = accessibleTools
@@ -220,8 +223,7 @@ public final class PIFBuilder {
     /// Constructs all `PackagePIFBuilder` objects used by the `constructPIF` function.
     /// In particular, this is useful for unit testing the complex `PIFBuilder` class.
     func makePIFBuilders(
-        buildParameters: BuildParameters,
-        hostBuildParameters: BuildParameters
+        buildParameters: BuildParameters
     ) async throws -> [(ResolvedPackage, PackagePIFBuilder, any PackagePIFBuilder.BuildDelegate)] {
         let pluginScriptRunner = self.parameters.pluginScriptRunner
         let outputDir = self.parameters.pluginWorkingDirectory.appending("outputs")
@@ -233,7 +235,6 @@ public final class PIFBuilder {
         let availablePluginTools = try await availableBuildPluginTools(
             graph: graph,
             buildParameters: buildParameters,
-            hostBuildParameters: hostBuildParameters,
             pluginsPerModule: pluginsPerModule,
             hostTriple: try pluginScriptRunner.hostTriple
         )
@@ -452,8 +453,7 @@ public final class PIFBuilder {
 
     /// Constructs a `PIF.TopLevelObject` representing the package graph.
     package func constructPIF(
-        buildParameters: BuildParameters,
-        hostBuildParameters: BuildParameters
+        buildParameters: BuildParameters
     ) async throws -> (PIF.TopLevelObject, [PackagePIFBuilder.ModuleOrProduct]) {
         return try await memoize(to: &self.cachedPIF) {
             let rootPackages = self.graph.rootPackages
@@ -461,7 +461,7 @@ public final class PIFBuilder {
                 throw PIFGenerationError.rootPackageNotFound
             }
 
-            let packagesAndPIFBuilders = try await makePIFBuilders(buildParameters: buildParameters, hostBuildParameters: hostBuildParameters)
+            let packagesAndPIFBuilders = try await makePIFBuilders(buildParameters: buildParameters)
 
             var modulesAndProducts: [PackagePIFBuilder.ModuleOrProduct] = []
             let packagesAndPIFProjects = try packagesAndPIFBuilders.map { (package, pifBuilder, _) in
@@ -554,7 +554,6 @@ public final class PIFBuilder {
     // Convenience method for generating PIF.
     public static func generatePIF(
         buildParameters: BuildParameters,
-        hostBuildParameters: BuildParameters,
         packageGraph: ModulesGraph,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
@@ -566,7 +565,8 @@ public final class PIFBuilder {
         additionalFileRules: [FileRuleDescription],
         addLocalRpaths: Bool,
         materializeStaticArchiveProductsForRootPackages: Bool,
-        createDynamicVariantsForLibraryProducts: Bool
+        createDynamicVariantsForLibraryProducts: Bool,
+        hostBuildProductsPath: AbsolutePath
     ) async throws -> PIFGenerationResult {
         let parameters = PIFBuilderParameters(
             buildParameters,
@@ -577,8 +577,8 @@ public final class PIFBuilder {
             additionalFileRules: additionalFileRules,
             addLocalRpaths: addLocalRpaths,
             materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
-            createDynamicVariantsForLibraryProducts: createDynamicVariantsForLibraryProducts
-
+            createDynamicVariantsForLibraryProducts: createDynamicVariantsForLibraryProducts,
+            hostBuildProductsPath: hostBuildProductsPath
         )
         let builder = Self(
             graph: packageGraph,
@@ -586,7 +586,7 @@ public final class PIFBuilder {
             fileSystem: fileSystem,
             observabilityScope: observabilityScope
         )
-        return try await builder.generatePIF(preservePIFModelStructure: preservePIFModelStructure, buildParameters: buildParameters, hostBuildParameters: hostBuildParameters)
+        return try await builder.generatePIF(preservePIFModelStructure: preservePIFModelStructure, buildParameters: buildParameters)
     }
 }
 
@@ -848,7 +848,8 @@ extension PIFBuilderParameters {
         additionalFileRules: [FileRuleDescription],
         addLocalRpaths: Bool,
         materializeStaticArchiveProductsForRootPackages: Bool,
-        createDynamicVariantsForLibraryProducts: Bool
+        createDynamicVariantsForLibraryProducts: Bool,
+        hostBuildProductsPath: AbsolutePath
     ) {
         self.init(
             isPackageAccessModifierSupported: buildParameters.driverParameters.isPackageAccessModifierSupported,
@@ -864,6 +865,7 @@ extension PIFBuilderParameters {
             pluginWorkingDirectory: pluginWorkingDirectory,
             additionalFileRules: additionalFileRules,
             addLocalRPaths: addLocalRpaths,
+            hostBuildProductsPath: hostBuildProductsPath
         )
     }
 }

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -37,8 +37,7 @@ import Foundation
 import SWBBuildService
 import SwiftBuild
 import enum SWBCore.SwiftAPIDigesterMode
-import struct SWBUtil.XcodeVersionInfo
-import struct SWBUtil.Path
+import SWBUtil
 
 struct SessionFailedError: Error {
     var error: Error
@@ -250,6 +249,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
     private let logLevel: Basics.Diagnostic.Severity
     private var packageGraph: AsyncThrowingValueMemoizer<ModulesGraph> = .init()
     private var pifBuilder: AsyncThrowingValueMemoizer<PIFBuilder> = .init()
+    private let buildProductsDirectorySuffixCache = AsyncCache<String, String>()
     private let fileSystem: FileSystem
     private let observabilityScope: ObservabilityScope
 
@@ -274,8 +274,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
                 for package in graph.rootPackages {
                     for product in package.products where product.type == .test {
-                        let binaryPath = try self.binaryPath(for: product, parameters: buildParameters)
-                        let coverageBinaryPath = try self.buildProductsPath(for: buildParameters).appending(
+                        let binaryPath = try await self.binaryPath(for: product, parameters: buildParameters)
+                        let coverageBinaryPath = try await self.buildProductsPath(for: buildParameters).appending(
                             buildParameters.testCoverageBinaryRelativePath(forTestProductName: product.name)
                         )
                         builtProducts.append(
@@ -307,17 +307,21 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
     public var hasIntegratedAPIDigesterSupport: Bool { true }
 
-    public func buildProductsPath(for parameters: BuildParameters) -> Basics.AbsolutePath {
-        var configDir: String = parameters.configuration.dirname.capitalized
-        if parameters.triple.isMacOSX {
-            // no suffix
-        } else if parameters.triple.isAndroid() {
-            configDir += "-android"
-        } else if parameters.triple.isWasm {
-            configDir += "-webassembly"
-        } else {
-            configDir += "-" + (parameters.triple.darwinPlatform?.platformName ?? parameters.triple.osNameUnversioned)
+    public func buildProductsPath(for parameters: BuildParameters) async throws -> Basics.AbsolutePath {
+        let suffix = try await buildProductsDirectorySuffixCache.value(forKey: parameters.triple.tripleString) {
+            try await withService(connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint)) { service in
+                var suffix: String?
+                try await withSession(service: service, name: "swiftpm-build-products-path", toolchain: parameters.toolchain, packageManagerResourcesDirectory: self.packageManagerResourcesDirectory) { session, _ in
+                    let info = try await session.buildTargetInfo(triple: parameters.triple.tripleString)
+                    suffix = info.buildProductsDirectorySuffix
+                }
+                guard let suffix else {
+                    throw StringError("Failed to query build system for build products path suffix")
+                }
+                return suffix
+            }
         }
+        let configDir = parameters.configuration.dirname.capitalized + suffix
         return parameters.dataPath.appending(components: "Products", configDir)
     }
 
@@ -427,11 +431,12 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             replArguments: nil,
         )
 
+        let productsPath = try await self.buildProductsPath(for: self.buildParameters)
         defer {
-            if self.fileSystem.exists(self.buildProductsPath(for: self.buildParameters), followSymlink: true) {
+            if self.fileSystem.exists(productsPath, followSymlink: true) {
                 createBuildSymbolicLinks(
                     self.scratchDirectory.appending(component: self.buildParameters.configuration.dirname),
-                    pointingAt: self.buildProductsPath(for: self.buildParameters),
+                    pointingAt: productsPath,
                     fileSystem: self.fileSystem,
                     observabilityScope: self.observabilityScope,
                 )
@@ -996,7 +1001,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         case .on:
             for setting in indexStoreSettingNames {
                 settings[setting.enableVariableName] = "YES"
-                settings[setting.pathVariable] = self.indexStore(for: self.buildParameters).pathStringWithPosixSlashes
+                settings[setting.pathVariable] = try await self.indexStore(for: self.buildParameters).pathStringWithPosixSlashes
             }
         case .off:
             for setting in indexStoreSettingNames {
@@ -1317,7 +1322,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     addLocalRpaths: !self.buildParameters.linkingParameters.shouldDisableLocalRpath,
                     materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
                     createDynamicVariantsForLibraryProducts: false,
-                    hostBuildProductsPath: self.buildProductsPath(for: self.hostBuildParameters)
+                    hostBuildProductsPath: try await self.buildProductsPath(for: self.hostBuildParameters)
                 ),
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -274,8 +274,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
                 for package in graph.rootPackages {
                     for product in package.products where product.type == .test {
-                        let binaryPath = try buildParameters.binaryPath(for: product)
-                        let coverageBinaryPath = try buildParameters.buildPath.appending(
+                        let binaryPath = try self.binaryPath(for: product, parameters: buildParameters)
+                        let coverageBinaryPath = try self.buildProductsPath(for: buildParameters).appending(
                             buildParameters.testCoverageBinaryRelativePath(forTestProductName: product.name)
                         )
                         builtProducts.append(
@@ -306,6 +306,20 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
     }
 
     public var hasIntegratedAPIDigesterSupport: Bool { true }
+
+    public func buildProductsPath(for parameters: BuildParameters) -> Basics.AbsolutePath {
+        var configDir: String = parameters.configuration.dirname.capitalized
+        if parameters.triple.isMacOSX {
+            // no suffix
+        } else if parameters.triple.isAndroid() {
+            configDir += "-android"
+        } else if parameters.triple.isWasm {
+            configDir += "-webassembly"
+        } else {
+            configDir += "-" + (parameters.triple.darwinPlatform?.platformName ?? parameters.triple.osNameUnversioned)
+        }
+        return parameters.dataPath.appending(components: "Products", configDir)
+    }
 
     public var enableTaskBacktraces: Bool {
         self.buildParameters.outputParameters.enableTaskBacktraces
@@ -414,10 +428,10 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         )
 
         defer {
-            if self.fileSystem.exists(self.buildParameters.buildPath, followSymlink: true) {
+            if self.fileSystem.exists(self.buildProductsPath(for: self.buildParameters), followSymlink: true) {
                 createBuildSymbolicLinks(
                     self.scratchDirectory.appending(component: self.buildParameters.configuration.dirname),
-                    pointingAt: self.buildParameters.buildPath,
+                    pointingAt: self.buildProductsPath(for: self.buildParameters),
                     fileSystem: self.fileSystem,
                     observabilityScope: self.observabilityScope,
                 )
@@ -982,7 +996,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         case .on:
             for setting in indexStoreSettingNames {
                 settings[setting.enableVariableName] = "YES"
-                settings[setting.pathVariable] = self.buildParameters.indexStore.pathStringWithPosixSlashes
+                settings[setting.pathVariable] = self.indexStore(for: self.buildParameters).pathStringWithPosixSlashes
             }
         case .off:
             for setting in indexStoreSettingNames {
@@ -1303,6 +1317,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     addLocalRpaths: !self.buildParameters.linkingParameters.shouldDisableLocalRpath,
                     materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
                     createDynamicVariantsForLibraryProducts: false,
+                    hostBuildProductsPath: self.buildProductsPath(for: self.hostBuildParameters)
                 ),
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,
@@ -1318,8 +1333,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         return try await pifBuilder.generatePIF(
             preservePIFModelStructure: preserveStructure,
             printPIFManifestGraphviz: buildParameters.printPIFManifestGraphviz,
-            buildParameters: buildParameters,
-            hostBuildParameters: hostBuildParameters
+            buildParameters: buildParameters
         )
     }
 

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -54,7 +54,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
 
                 for package in graph.rootPackages {
                     for product in package.products where product.type == .test {
-                        let binaryPath = try buildParameters.binaryPath(for: product)
+                        let binaryPath = try self.binaryPath(for: product, parameters: buildParameters)
                         builtProducts.append(
                             BuiltTestProduct(
                                 productName: product.name,
@@ -82,6 +82,20 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
     }
 
     public var hasIntegratedAPIDigesterSupport: Bool { false }
+
+    public func buildProductsPath(for parameters: BuildParameters) -> AbsolutePath {
+        var configDir: String = parameters.configuration.dirname.capitalized
+        if parameters.triple.isMacOSX {
+            // no suffix
+        } else if parameters.triple.isAndroid() {
+            configDir += "-android"
+        } else if parameters.triple.isWasm {
+            configDir += "-webassembly"
+        } else {
+            configDir += "-" + (parameters.triple.darwinPlatform?.platformName ?? parameters.triple.osNameUnversioned)
+        }
+        return parameters.dataPath.appending(components: "Products", configDir)
+    }
 
     public init(
         buildParameters: BuildParameters,

--- a/Sources/XCBuildSupport/XcodeBuildSystem.swift
+++ b/Sources/XCBuildSupport/XcodeBuildSystem.swift
@@ -54,7 +54,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
 
                 for package in graph.rootPackages {
                     for product in package.products where product.type == .test {
-                        let binaryPath = try self.binaryPath(for: product, parameters: buildParameters)
+                        let binaryPath = try await self.binaryPath(for: product, parameters: buildParameters)
                         builtProducts.append(
                             BuiltTestProduct(
                                 productName: product.name,
@@ -83,7 +83,7 @@ public final class XcodeBuildSystem: SPMBuildCore.BuildSystem {
 
     public var hasIntegratedAPIDigesterSupport: Bool { false }
 
-    public func buildProductsPath(for parameters: BuildParameters) -> AbsolutePath {
+    public func buildProductsPath(for parameters: BuildParameters) async throws -> AbsolutePath {
         var configDir: String = parameters.configuration.dirname.capitalized
         if parameters.triple.isMacOSX {
             // no suffix

--- a/Sources/_InternalBuildTestSupport/MockBuildTestHelper.swift
+++ b/Sources/_InternalBuildTestSupport/MockBuildTestHelper.swift
@@ -156,7 +156,7 @@ package func mockPluginTools(
             environment: buildParameters.buildEnvironment,
             for: hostTriple
         ) { name, path in
-            buildParameters.buildPath.appending(path)
+            BuildOperation.buildProductsPath(for: buildParameters).appending(path)
         }
 
         accessibleToolsPerPlugin[plugin.id] = accessibleTools

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -219,7 +219,20 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
                     shouldDisableLocalRpath: self.shouldDisableLocalRpath,
                     logLevel: self.logLevel
                 )
-                return print(parameters.buildPath.description)
+                let buildSystem = try builder.createBuildSystem(
+                    packagePath: packagePath,
+                    scratchDirectory: scratchDirectory,
+                    buildSystem: self.buildSystem,
+                    configuration: self.configuration,
+                    architectures: self.architectures,
+                    buildFlags: self.buildFlags,
+                    manifestBuildFlags: self.manifestFlags,
+                    useIntegratedSwiftDriver: self.useIntegratedSwiftDriver,
+                    explicitTargetDependencyImportCheck: self.explicitTargetDependencyImportCheck,
+                    shouldDisableLocalRpath: self.shouldDisableLocalRpath,
+                    logLevel: self.logLevel
+                )
+                return print(buildSystem.buildProductsPath(for: parameters).description)
             }
 
             try await builder.build(

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -232,7 +232,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
                     shouldDisableLocalRpath: self.shouldDisableLocalRpath,
                     logLevel: self.logLevel
                 )
-                return print(buildSystem.buildProductsPath(for: parameters).description)
+                return try await print(buildSystem.buildProductsPath(for: parameters).description)
             }
 
             try await builder.build(

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -3867,7 +3867,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
             ))
 
             let lib = try result.moduleBuildDescription(for: "lib").clang()
-            let path = StringPattern.equal(result.plan.destinationBuildParameters.indexStore.pathString)
+            let path = StringPattern.equal(BuildOperation.indexStore(for: result.plan.destinationBuildParameters).pathString)
 
             XCTAssertMatch(
                 try lib.basicArguments(isCXX: false),

--- a/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
@@ -204,10 +204,6 @@ import SwiftBuild
             buildParameters: mockBuildParameters(
                 destination: .host,
                 buildSystemKind: .swiftbuild,
-            ),
-            hostBuildParameters: mockBuildParameters(
-                destination: .host,
-                buildSystemKind: .swiftbuild,
             )
         ).0
     }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -30,7 +30,8 @@ extension PIFBuilderParameters {
         temporaryDirectory: Basics.AbsolutePath,
         addLocalRpaths: Bool,
         shouldCreateDylibForDynamicProducts: Bool = false,
-        pluginScriptRunner: PluginScriptRunner? = nil
+        pluginScriptRunner: PluginScriptRunner? = nil,
+        hostBuildProductsPath: Basics.AbsolutePath? = nil
     ) throws -> Self {
         try self.init(
             isPackageAccessModifierSupported: true,
@@ -49,7 +50,8 @@ extension PIFBuilderParameters {
             disableSandbox: false,
             pluginWorkingDirectory: temporaryDirectory.appending(component: "plugin-working-dir"),
             additionalFileRules: [],
-            addLocalRPaths: addLocalRpaths
+            addLocalRPaths: addLocalRpaths,
+            hostBuildProductsPath: hostBuildProductsPath ?? temporaryDirectory.appending(component: "host-build-products")
         )
     }
 }
@@ -59,16 +61,11 @@ fileprivate func withGeneratedPIF(
     addLocalRpaths: Bool = true,
     shouldCreateDylibForDynamicProducts: Bool = true,
     buildParameters: BuildParameters? = nil,
-    hostBuildParameters: BuildParameters? = nil,
+    hostBuildProductsPath: AbsolutePath? = nil,
     do doIt: (SwiftBuildSupport.PIF.TopLevelObject, TestingObservability) async throws -> ()
 ) async throws {
     let buildParameters = if let buildParameters {
         buildParameters
-    } else {
-        mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
-    }
-    let hostBuildParameters = if let hostBuildParameters {
-        hostBuildParameters
     } else {
         mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
     }
@@ -94,14 +91,14 @@ fileprivate func withGeneratedPIF(
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: fixturePath,
                 addLocalRpaths: addLocalRpaths,
-                shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts
+                shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts,
+                hostBuildProductsPath: hostBuildProductsPath
             ),
             fileSystem: localFileSystem,
             observabilityScope: observabilitySystem.topScope
         )
         let (pif, _) = try await builder.constructPIF(
-            buildParameters: buildParameters,
-            hostBuildParameters: hostBuildParameters
+            buildParameters: buildParameters
         )
         try await doIt(pif, observabilitySystem)
     }
@@ -392,8 +389,7 @@ struct PIFBuilderTests {
 
         // Act
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
-            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         // Assert
@@ -511,11 +507,6 @@ struct PIFBuilderTests {
     @Test func buildToolPluginCommandLineUsesHostBuildPath() async throws {
         let hostBuildPath = AbsolutePath("/path/to/host/build")
         let destBuildPath = AbsolutePath("/path/to/dest/build")
-        let hostBuildParams = mockBuildParameters(
-            destination: .host,
-            buildPath: hostBuildPath,
-            buildSystemKind: .swiftbuild
-        )
         let destBuildParams = mockBuildParameters(
             destination: .host,
             buildPath: destBuildPath,
@@ -525,7 +516,7 @@ struct PIFBuilderTests {
         try await withGeneratedPIF(
             fromFixture: "Miscellaneous/Plugins/MySourceGenPlugin",
             buildParameters: destBuildParams,
-            hostBuildParameters: hostBuildParams
+            hostBuildProductsPath: hostBuildPath
         ) { pif, observabilitySystem in
             let project = try pif.workspace.project(named: "MySourceGenPlugin")
             let target = try project.target(named: "MyLocalTool-product")
@@ -827,8 +818,7 @@ struct PIFBuilderTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
-            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let remoteProject = try pif.workspace.project(named: "remote-pkg")
@@ -966,8 +956,7 @@ struct PIFBuilderTests {
         )
 
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
-            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let project = try pif.workspace.project(named: "Root")
@@ -1060,8 +1049,7 @@ struct PIFBuilderTests {
         )
 
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
-            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let project = try pif.workspace.project(named: "Pkg")

--- a/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
@@ -176,8 +176,7 @@ struct PrebuiltsPIFTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
-            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let hostTargets = Set([
@@ -433,8 +432,7 @@ struct PrebuiltsPIFTests {
             observabilityScope: observability.topScope
         )
         let (pif, _) = try await pifBuilder.constructPIF(
-            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild),
-            hostBuildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
         )
 
         let targets = pif.workspace.projects.flatMap({ $0.underlying.targets })

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -317,7 +317,7 @@ struct SwiftBuildSystemTests {
                 case .auto: nil
             }
             let expectedPathValue: AbsolutePath? = switch indexStoreSettingUT {
-                case .on: swiftBuild.indexStore(for: buildParameters)
+                case .on: try await swiftBuild.indexStore(for: buildParameters)
                 case .off: nil
                 case .auto: nil
             }

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -37,13 +37,13 @@ func withInstantiatedSwiftBuildSystem(
 
     try await fixture(name: fixtureName) { fixturePath  in
         try await withTemporaryDirectory  { tmpDir in
+            let toolchain = try UserToolchain.default
             let buildParameters = if let buildParameters {
                 buildParameters
             } else {
-                mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+                mockBuildParameters(destination: .host, toolchain: toolchain, buildSystemKind: .swiftbuild)
             }
             let observabilitySystem: TestingObservability = ObservabilitySystem.makeForTesting()
-            let toolchain = try UserToolchain.default
             let workspace = try Workspace(
                 fileSystem: fileSystem,
                 forRootPackage: fixturePath,
@@ -299,6 +299,7 @@ struct SwiftBuildSystemTests {
             fromFixture: "PIFBuilder/Simple",
             buildParameters: mockBuildParameters(
                 destination: .host,
+                toolchain: try UserToolchain.default,
                 buildSystemKind: .swiftbuild,
                 indexStoreMode: indexStoreSettingUT,
             ),

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -317,7 +317,7 @@ struct SwiftBuildSystemTests {
                 case .auto: nil
             }
             let expectedPathValue: AbsolutePath? = switch indexStoreSettingUT {
-                case .on: buildParameters.indexStore
+                case .on: swiftBuild.indexStore(for: buildParameters)
                 case .off: nil
                 case .auto: nil
             }


### PR DESCRIPTION
Step 2 of ensuring the build products for the same platform but different architectures do not collide when targeting a platform which does not support universal binaries (https://github.com/swiftlang/swift-build/issues/1363).

The first commit deleted BuildParameters.buildPath in favor of a new protocol requirement on BuildSystem, and updates all of the callers. This ensures each build system backend is responsible for computing its own products directory path. Then, the second commit updates SwiftBuildSystem to query the underlying build engine for the correct products directory suffix for a given platform instead of having BuildParameters.buildPath attempt to replicate the same logic.

Once this change lands, Swift Build can update the products dir to include an architecture component on platforms where it's needed to disambiguate