### PR TITLE
Make addLocalRpaths an enum to support different build configurations

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -81,17 +81,13 @@ package struct PIFBuilderParameters {
     /// Add rpaths which allow loading libraries adjacent to the current image at runtime. This is desirable
     /// when launching build products from the build directory, but should often be disabled when deploying
     /// the build products to a different location.
-    let addLocalRpaths: Bool
-
-    /// Allow for turning off local rpaths in the release builds. Defaults to `true` but can be set to
-    /// to `false` to prevent ld warnings and issues with performance, security and library relocation.
-    let addLocalRpathsInReleaseConfiguration: Bool
+    let addLocalRpaths: PackagePIFBuilder.AddLocalRpaths
 
     /// The directory in which host-destination build products (e.g. plugin tools) are placed, as
     /// reported by the build system for the host `BuildParameters`.
     let hostBuildProductsPath: AbsolutePath
 
-    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRPaths: Bool, addLocalRpathsInReleaseConfiguration: Bool = true, hostBuildProductsPath: AbsolutePath) {
+    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRpaths: PackagePIFBuilder.AddLocalRpaths, hostBuildProductsPath: AbsolutePath) {
         self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
         self.enableTestability = enableTestability
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
@@ -104,8 +100,7 @@ package struct PIFBuilderParameters {
         self.disableSandbox = disableSandbox
         self.pluginWorkingDirectory = pluginWorkingDirectory
         self.additionalFileRules = additionalFileRules
-        self.addLocalRpaths = addLocalRPaths
-        self.addLocalRpathsInReleaseConfiguration = addLocalRpathsInReleaseConfiguration
+        self.addLocalRpaths = addLocalRpaths
         self.hostBuildProductsPath = hostBuildProductsPath
     }
 }
@@ -448,7 +443,6 @@ public final class PIFBuilder {
                 materializeStaticArchiveProductsForRootPackages: self.parameters.materializeStaticArchiveProductsForRootPackages,
                 createDynamicVariantsForLibraryProducts: self.parameters.createDynamicVariantsForLibraryProducts,
                 addLocalRpaths: self.parameters.addLocalRpaths,
-                addLocalRpathsInReleaseConfiguration: self.parameters.addLocalRpathsInReleaseConfiguration,
                 packageDisplayVersion: package.manifest.displayName,
                 pkgConfigDirectories: self.parameters.pkgConfigDirectories,
                 fileSystem: self.fileSystem,
@@ -573,8 +567,7 @@ public final class PIFBuilder {
         pluginWorkingDirectory: AbsolutePath,
         pkgConfigDirectories: [Basics.AbsolutePath],
         additionalFileRules: [FileRuleDescription],
-        addLocalRpaths: Bool,
-        addLocalRpathsInReleaseConfiguration: Bool = true,
+        addLocalRpaths: PackagePIFBuilder.AddLocalRpaths,
         materializeStaticArchiveProductsForRootPackages: Bool,
         createDynamicVariantsForLibraryProducts: Bool,
         hostBuildProductsPath: AbsolutePath
@@ -587,7 +580,6 @@ public final class PIFBuilder {
             pluginWorkingDirectory: pluginWorkingDirectory,
             additionalFileRules: additionalFileRules,
             addLocalRpaths: addLocalRpaths,
-            addLocalRpathsInReleaseConfiguration: addLocalRpathsInReleaseConfiguration,
             materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
             createDynamicVariantsForLibraryProducts: createDynamicVariantsForLibraryProducts,
             hostBuildProductsPath: hostBuildProductsPath
@@ -872,8 +864,7 @@ extension PIFBuilderParameters {
         disableSandbox: Bool,
         pluginWorkingDirectory: AbsolutePath,
         additionalFileRules: [FileRuleDescription],
-        addLocalRpaths: Bool,
-        addLocalRpathsInReleaseConfiguration: Bool = true,
+        addLocalRpaths: PackagePIFBuilder.AddLocalRpaths,
         materializeStaticArchiveProductsForRootPackages: Bool,
         createDynamicVariantsForLibraryProducts: Bool,
         hostBuildProductsPath: AbsolutePath
@@ -891,8 +882,7 @@ extension PIFBuilderParameters {
             disableSandbox: disableSandbox,
             pluginWorkingDirectory: pluginWorkingDirectory,
             additionalFileRules: additionalFileRules,
-            addLocalRPaths: addLocalRpaths,
-            addLocalRpathsInReleaseConfiguration: addLocalRpathsInReleaseConfiguration,
+            addLocalRpaths: addLocalRpaths,
             hostBuildProductsPath: hostBuildProductsPath
         )
     }

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -83,11 +83,15 @@ package struct PIFBuilderParameters {
     /// the build products to a different location.
     let addLocalRpaths: Bool
 
+    /// Allow for turning off local rpaths in the release builds. Defaults to `true` but can be set to
+    /// to `false` to prevent ld warnings and issues with performance, security and library relocation.
+    let addLocalRpathsInReleaseConfiguration: Bool
+
     /// The directory in which host-destination build products (e.g. plugin tools) are placed, as
     /// reported by the build system for the host `BuildParameters`.
     let hostBuildProductsPath: AbsolutePath
 
-    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRPaths: Bool, hostBuildProductsPath: AbsolutePath) {
+    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRPaths: Bool, addLocalRpathsInReleaseConfiguration: Bool = true, hostBuildProductsPath: AbsolutePath) {
         self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
         self.enableTestability = enableTestability
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
@@ -101,6 +105,7 @@ package struct PIFBuilderParameters {
         self.pluginWorkingDirectory = pluginWorkingDirectory
         self.additionalFileRules = additionalFileRules
         self.addLocalRpaths = addLocalRPaths
+        self.addLocalRpathsInReleaseConfiguration = addLocalRpathsInReleaseConfiguration
         self.hostBuildProductsPath = hostBuildProductsPath
     }
 }
@@ -443,6 +448,7 @@ public final class PIFBuilder {
                 materializeStaticArchiveProductsForRootPackages: self.parameters.materializeStaticArchiveProductsForRootPackages,
                 createDynamicVariantsForLibraryProducts: self.parameters.createDynamicVariantsForLibraryProducts,
                 addLocalRpaths: self.parameters.addLocalRpaths,
+                addLocalRpathsInReleaseConfiguration: self.parameters.addLocalRpathsInReleaseConfiguration,
                 packageDisplayVersion: package.manifest.displayName,
                 pkgConfigDirectories: self.parameters.pkgConfigDirectories,
                 fileSystem: self.fileSystem,
@@ -568,6 +574,7 @@ public final class PIFBuilder {
         pkgConfigDirectories: [Basics.AbsolutePath],
         additionalFileRules: [FileRuleDescription],
         addLocalRpaths: Bool,
+        addLocalRpathsInReleaseConfiguration: Bool = true,
         materializeStaticArchiveProductsForRootPackages: Bool,
         createDynamicVariantsForLibraryProducts: Bool,
         hostBuildProductsPath: AbsolutePath
@@ -580,6 +587,7 @@ public final class PIFBuilder {
             pluginWorkingDirectory: pluginWorkingDirectory,
             additionalFileRules: additionalFileRules,
             addLocalRpaths: addLocalRpaths,
+            addLocalRpathsInReleaseConfiguration: addLocalRpathsInReleaseConfiguration,
             materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
             createDynamicVariantsForLibraryProducts: createDynamicVariantsForLibraryProducts,
             hostBuildProductsPath: hostBuildProductsPath
@@ -865,6 +873,7 @@ extension PIFBuilderParameters {
         pluginWorkingDirectory: AbsolutePath,
         additionalFileRules: [FileRuleDescription],
         addLocalRpaths: Bool,
+        addLocalRpathsInReleaseConfiguration: Bool = true,
         materializeStaticArchiveProductsForRootPackages: Bool,
         createDynamicVariantsForLibraryProducts: Bool,
         hostBuildProductsPath: AbsolutePath
@@ -883,6 +892,7 @@ extension PIFBuilderParameters {
             pluginWorkingDirectory: pluginWorkingDirectory,
             additionalFileRules: additionalFileRules,
             addLocalRPaths: addLocalRpaths,
+            addLocalRpathsInReleaseConfiguration: addLocalRpathsInReleaseConfiguration,
             hostBuildProductsPath: hostBuildProductsPath
         )
     }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -187,15 +187,20 @@ public final class PackagePIFBuilder {
     /// Create dynamic library variants for automatic library products, for use by development-time features such as Previews and Swift Playgrounds.
     let createDynamicVariantsForLibraryProducts: Bool
 
+    /// Controls whether local rpaths are imparted to package consumers and in which configurations.
+    public enum AddLocalRpaths: Sendable {
+        /// Do not add local rpaths.
+        case never
+        /// Add rpaths only in the Debug configuration.
+        case debugOnly
+        /// Add rpaths in both Debug and Release configurations.
+        case always
+    }
+
     /// Add rpaths which allow loading libraries adjacent to the current image at runtime. This is desirable
     /// when launching build products from the build directory, but should often be disabled when deploying
-    /// the build products to a different location.
-    let addLocalRpaths: Bool
-
-    /// Whether to also impart local rpaths in the Release configuration. Defaults to `true` for
-    /// native-build-system parity. Hosts that may produce OS dylibs (`install_name` under
-    /// `/System/Library` or `/usr/lib`) should set this to `false`; ld rejects rpaths there.
-    let addLocalRpathsInReleaseConfiguration: Bool
+    /// the build products to a different location or building the release configuration.
+    let addLocalRpaths: AddLocalRpaths
 
     /// Package display version, if any (i.e., it can be a version, branch or a git ref).
     let packageDisplayVersion: String?
@@ -228,8 +233,7 @@ public final class PackagePIFBuilder {
         createDylibForDynamicProducts: Bool = false,
         materializeStaticArchiveProductsForRootPackages: Bool = false,
         createDynamicVariantsForLibraryProducts: Bool = true,
-        addLocalRpaths: Bool = true,
-        addLocalRpathsInReleaseConfiguration: Bool = true,
+        addLocalRpaths: AddLocalRpaths = .always,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
         fileSystem: FileSystem,
@@ -248,7 +252,6 @@ public final class PackagePIFBuilder {
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.addLocalRpaths = addLocalRpaths
-        self.addLocalRpathsInReleaseConfiguration = addLocalRpathsInReleaseConfiguration
     }
 
     public init(
@@ -260,8 +263,7 @@ public final class PackagePIFBuilder {
         createDylibForDynamicProducts: Bool = false,
         materializeStaticArchiveProductsForRootPackages: Bool = false,
         createDynamicVariantsForLibraryProducts: Bool = true,
-        addLocalRpaths: Bool = true,
-        addLocalRpathsInReleaseConfiguration: Bool = true,
+        addLocalRpaths: AddLocalRpaths = .always,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
         fileSystem: FileSystem,
@@ -276,7 +278,6 @@ public final class PackagePIFBuilder {
         self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
         self.createDynamicVariantsForLibraryProducts = createDynamicVariantsForLibraryProducts
         self.addLocalRpaths = addLocalRpaths
-        self.addLocalRpathsInReleaseConfiguration = addLocalRpathsInReleaseConfiguration
         self.packageDisplayVersion = packageDisplayVersion
         self.pkgConfigDirectories = pkgConfigDirectories
         self.fileSystem = fileSystem

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -192,6 +192,11 @@ public final class PackagePIFBuilder {
     /// the build products to a different location.
     let addLocalRpaths: Bool
 
+    /// Whether to also impart local rpaths in the Release configuration. Defaults to `true` for
+    /// native-build-system parity. Hosts that may produce OS dylibs (`install_name` under
+    /// `/System/Library` or `/usr/lib`) should set this to `false`; ld rejects rpaths there.
+    let addLocalRpathsInReleaseConfiguration: Bool
+
     /// Package display version, if any (i.e., it can be a version, branch or a git ref).
     let packageDisplayVersion: String?
 
@@ -224,6 +229,7 @@ public final class PackagePIFBuilder {
         materializeStaticArchiveProductsForRootPackages: Bool = false,
         createDynamicVariantsForLibraryProducts: Bool = true,
         addLocalRpaths: Bool = true,
+        addLocalRpathsInReleaseConfiguration: Bool = true,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
         fileSystem: FileSystem,
@@ -242,6 +248,7 @@ public final class PackagePIFBuilder {
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.addLocalRpaths = addLocalRpaths
+        self.addLocalRpathsInReleaseConfiguration = addLocalRpathsInReleaseConfiguration
     }
 
     public init(
@@ -254,6 +261,7 @@ public final class PackagePIFBuilder {
         materializeStaticArchiveProductsForRootPackages: Bool = false,
         createDynamicVariantsForLibraryProducts: Bool = true,
         addLocalRpaths: Bool = true,
+        addLocalRpathsInReleaseConfiguration: Bool = true,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
         fileSystem: FileSystem,
@@ -268,6 +276,7 @@ public final class PackagePIFBuilder {
         self.materializeStaticArchiveProductsForRootPackages = materializeStaticArchiveProductsForRootPackages
         self.createDynamicVariantsForLibraryProducts = createDynamicVariantsForLibraryProducts
         self.addLocalRpaths = addLocalRpaths
+        self.addLocalRpathsInReleaseConfiguration = addLocalRpathsInReleaseConfiguration
         self.packageDisplayVersion = packageDisplayVersion
         self.pkgConfigDirectories = pkgConfigDirectories
         self.fileSystem = fileSystem

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -858,15 +858,15 @@ extension PackagePIFProjectBuilder {
         // An imparted build setting on C will propagate back to both B and A.
         // FIXME: -rpath should not be given if -static is
         var rpaths: [String] = impartedSettings[.LD_RUNPATH_SEARCH_PATHS] ?? []
-        if pifBuilder.addLocalRpaths {
+        if pifBuilder.addLocalRpaths != .never {
             rpaths.append("$(RPATH_ORIGIN)")
-            if pifBuilder.addLocalRpathsInReleaseConfiguration {
+            if pifBuilder.addLocalRpaths == .always {
                 impartedSettings[.LD_RUNPATH_SEARCH_PATHS] = rpaths + ["$(inherited)"]
             }
         }
 
         var impartedDebugSettings = impartedSettings
-        if pifBuilder.addLocalRpaths {
+        if pifBuilder.addLocalRpaths != .never {
             // FIXME: Why is this rpath only added to the debug config? We should investigate reworking this.
             rpaths.append("$(BUILT_PRODUCTS_DIR)/PackageFrameworks")
             impartedDebugSettings[.LD_RUNPATH_SEARCH_PATHS] = rpaths + ["$(inherited)"]

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -825,20 +825,15 @@ extension PackagePIFProjectBuilder {
         //
         // An imparted build setting on C will propagate back to both B and A.
         // FIXME: -rpath should not be given if -static is
-        var rpaths: [String] = []
-        if let existingRpaths = impartedSettings[.LD_RUNPATH_SEARCH_PATHS] {
-            rpaths.append(contentsOf: existingRpaths)
-        }
-        if pifBuilder.addLocalRpaths {
-            rpaths.append("$(RPATH_ORIGIN)")
-            impartedSettings[.LD_RUNPATH_SEARCH_PATHS] = rpaths + ["$(inherited)"]
-        }
-
+        // Only add LD_RUNPATH_SEARCH_PATHS to the debug config. rpaths should
+        // not be added when building for release configs, particulary for OS dylibs
+        // as it could create ambiguity, security, performance and relocation issues
         var impartedDebugSettings = impartedSettings
         if pifBuilder.addLocalRpaths {
-            // FIXME: Why is this rpath only added to the debug config? We should investigate reworking this.
-            rpaths.append("$(BUILT_PRODUCTS_DIR)/PackageFrameworks")
-            impartedDebugSettings[.LD_RUNPATH_SEARCH_PATHS] = rpaths + ["$(inherited)"]
+            var debugRpaths = impartedSettings[.LD_RUNPATH_SEARCH_PATHS] ?? []
+            debugRpaths.append("$(RPATH_ORIGIN)")
+            debugRpaths.append("$(BUILT_PRODUCTS_DIR)/PackageFrameworks")
+            impartedDebugSettings[.LD_RUNPATH_SEARCH_PATHS] = debugRpaths + ["$(inherited)"]
         }
 
         self.project[keyPath: sourceModuleTargetKeyPath].common.addBuildConfig { id in

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -857,15 +857,19 @@ extension PackagePIFProjectBuilder {
         //
         // An imparted build setting on C will propagate back to both B and A.
         // FIXME: -rpath should not be given if -static is
-        // Only add LD_RUNPATH_SEARCH_PATHS to the debug config. rpaths should
-        // not be added when building for release configs, particulary for OS dylibs
-        // as it could create ambiguity, security, performance and relocation issues
+        var rpaths: [String] = impartedSettings[.LD_RUNPATH_SEARCH_PATHS] ?? []
+        if pifBuilder.addLocalRpaths {
+            rpaths.append("$(RPATH_ORIGIN)")
+            if pifBuilder.addLocalRpathsInReleaseConfiguration {
+                impartedSettings[.LD_RUNPATH_SEARCH_PATHS] = rpaths + ["$(inherited)"]
+            }
+        }
+
         var impartedDebugSettings = impartedSettings
         if pifBuilder.addLocalRpaths {
-            var debugRpaths = impartedSettings[.LD_RUNPATH_SEARCH_PATHS] ?? []
-            debugRpaths.append("$(RPATH_ORIGIN)")
-            debugRpaths.append("$(BUILT_PRODUCTS_DIR)/PackageFrameworks")
-            impartedDebugSettings[.LD_RUNPATH_SEARCH_PATHS] = debugRpaths + ["$(inherited)"]
+            // FIXME: Why is this rpath only added to the debug config? We should investigate reworking this.
+            rpaths.append("$(BUILT_PRODUCTS_DIR)/PackageFrameworks")
+            impartedDebugSettings[.LD_RUNPATH_SEARCH_PATHS] = rpaths + ["$(inherited)"]
         }
 
         self.project[keyPath: sourceModuleTargetKeyPath].common.addBuildConfig { id in

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -857,20 +857,15 @@ extension PackagePIFProjectBuilder {
         //
         // An imparted build setting on C will propagate back to both B and A.
         // FIXME: -rpath should not be given if -static is
-        var rpaths: [String] = []
-        if let existingRpaths = impartedSettings[.LD_RUNPATH_SEARCH_PATHS] {
-            rpaths.append(contentsOf: existingRpaths)
-        }
-        if pifBuilder.addLocalRpaths {
-            rpaths.append("$(RPATH_ORIGIN)")
-            impartedSettings[.LD_RUNPATH_SEARCH_PATHS] = rpaths + ["$(inherited)"]
-        }
-
+        // Only add LD_RUNPATH_SEARCH_PATHS to the debug config. rpaths should
+        // not be added when building for release configs, particulary for OS dylibs
+        // as it could create ambiguity, security, performance and relocation issues
         var impartedDebugSettings = impartedSettings
         if pifBuilder.addLocalRpaths {
-            // FIXME: Why is this rpath only added to the debug config? We should investigate reworking this.
-            rpaths.append("$(BUILT_PRODUCTS_DIR)/PackageFrameworks")
-            impartedDebugSettings[.LD_RUNPATH_SEARCH_PATHS] = rpaths + ["$(inherited)"]
+            var debugRpaths = impartedSettings[.LD_RUNPATH_SEARCH_PATHS] ?? []
+            debugRpaths.append("$(RPATH_ORIGIN)")
+            debugRpaths.append("$(BUILT_PRODUCTS_DIR)/PackageFrameworks")
+            impartedDebugSettings[.LD_RUNPATH_SEARCH_PATHS] = debugRpaths + ["$(inherited)"]
         }
 
         self.project[keyPath: sourceModuleTargetKeyPath].common.addBuildConfig { id in

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -135,7 +135,7 @@ extension PackagePIFProjectBuilder {
             settings[.BUILD_SERVER_PROTOCOL_TARGET_TAGS, default: ["$(inherited)"]].append("test")
 
             // FIXME: we shouldn't always include both the deep and shallow bundle paths here, but for that we'll need rdar://31867023
-            if pifBuilder.addLocalRpaths {
+            if pifBuilder.addLocalRpaths != .never {
                 settings[.LD_RUNPATH_SEARCH_PATHS] = [
                     "$(RPATH_ORIGIN)/Frameworks",
                     "$(RPATH_ORIGIN)/../Frameworks",
@@ -1108,7 +1108,7 @@ extension PackagePIFProjectBuilder {
 
         // A test-runner should always be adjacent to the dynamic library containing the tests,
         // so add the appropriate rpaths.
-        if pifBuilder.addLocalRpaths {
+        if pifBuilder.addLocalRpaths != .never {
             settings[.LD_RUNPATH_SEARCH_PATHS] = [
                 "$(inherited)",
                 "$(RPATH_ORIGIN)"

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1349,7 +1349,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                     disableSandbox: self.pluginConfiguration.disableSandbox,
                     pluginWorkingDirectory: self.pluginConfiguration.workDirectory,
                     additionalFileRules: additionalFileRules,
-                    addLocalRpaths: !self.buildParameters.linkingParameters.shouldDisableLocalRpath,
+                    addLocalRpaths: self.buildParameters.linkingParameters.shouldDisableLocalRpath ? .never : .always,
                     materializeStaticArchiveProductsForRootPackages: materializeStaticArchiveProductsForRootPackages,
                     createDynamicVariantsForLibraryProducts: false,
                     hostBuildProductsPath: try await self.buildProductsPath(for: self.hostBuildParameters)

--- a/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
@@ -193,7 +193,7 @@ import SwiftBuild
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: AbsolutePath.root,
-                addLocalRpaths: true,
+                addLocalRpaths: .always,
                 pluginScriptRunner: pluginScriptRunner
             ),
             fileSystem: fs,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -695,12 +695,23 @@ struct PIFBuilderTests {
             }.isEmpty)
 
             do {
+                let debugConfig = try pif.workspace
+                    .project(named: "Foo")
+                    .target(named: "Foo")
+                    .buildConfig(named: .debug)
+
+                #expect(debugConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == ["$(RPATH_ORIGIN)", "$(BUILT_PRODUCTS_DIR)/PackageFrameworks", "$(inherited)"])
+            }
+
+            do {
                 let releaseConfig = try pif.workspace
                     .project(named: "Foo")
                     .target(named: "Foo")
                     .buildConfig(named: .release)
 
-                #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == ["$(RPATH_ORIGIN)", "$(inherited)"])
+                // Release configuration should not inherit rpaths to prevent ambiguity, security, performance
+                // and relocation issues
+                #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
             }
         }
 
@@ -708,6 +719,15 @@ struct PIFBuilderTests {
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .error
             }.isEmpty)
+
+            do {
+                let debugConfig = try pif.workspace
+                    .project(named: "Foo")
+                    .target(named: "Foo")
+                    .buildConfig(named: .debug)
+
+                #expect(debugConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
+            }
 
             do {
                 let releaseConfig = try pif.workspace

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -28,8 +28,7 @@ import Workspace
 extension PIFBuilderParameters {
     static func constructDefaultParametersForTesting(
         temporaryDirectory: Basics.AbsolutePath,
-        addLocalRpaths: Bool,
-        addLocalRpathsInReleaseConfiguration: Bool = true,
+        addLocalRpaths: PackagePIFBuilder.AddLocalRpaths,
         shouldCreateDylibForDynamicProducts: Bool = false,
         pluginScriptRunner: PluginScriptRunner? = nil,
         hostBuildProductsPath: Basics.AbsolutePath? = nil
@@ -51,8 +50,7 @@ extension PIFBuilderParameters {
             disableSandbox: false,
             pluginWorkingDirectory: temporaryDirectory.appending(component: "plugin-working-dir"),
             additionalFileRules: [],
-            addLocalRPaths: addLocalRpaths,
-            addLocalRpathsInReleaseConfiguration: addLocalRpathsInReleaseConfiguration,
+            addLocalRpaths: addLocalRpaths,
             hostBuildProductsPath: hostBuildProductsPath ?? temporaryDirectory.appending(component: "host-build-products")
         )
     }
@@ -60,8 +58,7 @@ extension PIFBuilderParameters {
 
 fileprivate func withGeneratedPIF(
     fromFixture fixtureName: String,
-    addLocalRpaths: Bool = true,
-    addLocalRpathsInReleaseConfiguration: Bool = true,
+    addLocalRpaths: PackagePIFBuilder.AddLocalRpaths = .always,
     shouldCreateDylibForDynamicProducts: Bool = true,
     buildParameters: BuildParameters? = nil,
     hostBuildProductsPath: AbsolutePath? = nil,
@@ -94,7 +91,6 @@ fileprivate func withGeneratedPIF(
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: fixturePath,
                 addLocalRpaths: addLocalRpaths,
-                addLocalRpathsInReleaseConfiguration: addLocalRpathsInReleaseConfiguration,
                 shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts,
                 hostBuildProductsPath: hostBuildProductsPath
             ),
@@ -385,7 +381,7 @@ struct PIFBuilderTests {
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: AbsolutePath.root.appending("tmp"),
-                addLocalRpaths: true,
+                addLocalRpaths: .always,
             ),
             fileSystem: fs,
             observabilityScope: observabilityScope.topScope,
@@ -792,7 +788,7 @@ struct PIFBuilderTests {
             }
         }
 
-        try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple", addLocalRpaths: false) { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple", addLocalRpaths: .never) { pif, observabilitySystem in
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .error
             }.isEmpty)
@@ -817,10 +813,10 @@ struct PIFBuilderTests {
         }
     }
 
-    @Test func disablingLocalRpathsInReleaseConfiguration() async throws {
+    @Test func debugOnlyLocalRpaths() async throws {
         try await withGeneratedPIF(
             fromFixture: "Miscellaneous/Simple",
-            addLocalRpathsInReleaseConfiguration: false
+            addLocalRpaths: .debugOnly
         ) { pif, observabilitySystem in
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .error
@@ -833,34 +829,6 @@ struct PIFBuilderTests {
                     .buildConfig(named: .debug)
 
                 #expect(debugConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == ["$(RPATH_ORIGIN)", "$(BUILT_PRODUCTS_DIR)/PackageFrameworks", "$(inherited)"])
-            }
-
-            do {
-                let releaseConfig = try pif.workspace
-                    .project(named: "Foo")
-                    .target(named: "Foo")
-                    .buildConfig(named: .release)
-
-                #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
-            }
-        }
-
-        try await withGeneratedPIF(
-            fromFixture: "Miscellaneous/Simple",
-            addLocalRpaths: false,
-            addLocalRpathsInReleaseConfiguration: false
-        ) { pif, observabilitySystem in
-            #expect(observabilitySystem.diagnostics.filter {
-                $0.severity == .error
-            }.isEmpty)
-
-            do {
-                let debugConfig = try pif.workspace
-                    .project(named: "Foo")
-                    .target(named: "Foo")
-                    .buildConfig(named: .debug)
-
-                #expect(debugConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
             }
 
             do {
@@ -975,7 +943,7 @@ struct PIFBuilderTests {
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: AbsolutePath.root,
-                addLocalRpaths: true
+                addLocalRpaths: .always
             ),
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -1112,7 +1080,7 @@ struct PIFBuilderTests {
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: AbsolutePath.root.appending("tmp"),
-                addLocalRpaths: true
+                addLocalRpaths: .always
             ),
             fileSystem: fs,
             observabilityScope: observability.topScope
@@ -1222,7 +1190,7 @@ struct PIFBuilderTests {
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: AbsolutePath.root.appending("tmp"),
-                addLocalRpaths: true
+                addLocalRpaths: .always
             ),
             fileSystem: fs,
             observabilityScope: observability.topScope

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -29,6 +29,7 @@ extension PIFBuilderParameters {
     static func constructDefaultParametersForTesting(
         temporaryDirectory: Basics.AbsolutePath,
         addLocalRpaths: Bool,
+        addLocalRpathsInReleaseConfiguration: Bool = true,
         shouldCreateDylibForDynamicProducts: Bool = false,
         pluginScriptRunner: PluginScriptRunner? = nil,
         hostBuildProductsPath: Basics.AbsolutePath? = nil
@@ -51,6 +52,7 @@ extension PIFBuilderParameters {
             pluginWorkingDirectory: temporaryDirectory.appending(component: "plugin-working-dir"),
             additionalFileRules: [],
             addLocalRPaths: addLocalRpaths,
+            addLocalRpathsInReleaseConfiguration: addLocalRpathsInReleaseConfiguration,
             hostBuildProductsPath: hostBuildProductsPath ?? temporaryDirectory.appending(component: "host-build-products")
         )
     }
@@ -59,6 +61,7 @@ extension PIFBuilderParameters {
 fileprivate func withGeneratedPIF(
     fromFixture fixtureName: String,
     addLocalRpaths: Bool = true,
+    addLocalRpathsInReleaseConfiguration: Bool = true,
     shouldCreateDylibForDynamicProducts: Bool = true,
     buildParameters: BuildParameters? = nil,
     hostBuildProductsPath: AbsolutePath? = nil,
@@ -91,6 +94,7 @@ fileprivate func withGeneratedPIF(
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: fixturePath,
                 addLocalRpaths: addLocalRpaths,
+                addLocalRpathsInReleaseConfiguration: addLocalRpathsInReleaseConfiguration,
                 shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts,
                 hostBuildProductsPath: hostBuildProductsPath
             ),
@@ -784,13 +788,68 @@ struct PIFBuilderTests {
                     .target(named: "Foo")
                     .buildConfig(named: .release)
 
-                // Release configuration should not inherit rpaths to prevent ambiguity, security, performance
-                // and relocation issues
-                #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
+                #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == ["$(RPATH_ORIGIN)", "$(inherited)"])
             }
         }
 
         try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple", addLocalRpaths: false) { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter {
+                $0.severity == .error
+            }.isEmpty)
+
+            do {
+                let debugConfig = try pif.workspace
+                    .project(named: "Foo")
+                    .target(named: "Foo")
+                    .buildConfig(named: .debug)
+
+                #expect(debugConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
+            }
+
+            do {
+                let releaseConfig = try pif.workspace
+                    .project(named: "Foo")
+                    .target(named: "Foo")
+                    .buildConfig(named: .release)
+
+                #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
+            }
+        }
+    }
+
+    @Test func disablingLocalRpathsInReleaseConfiguration() async throws {
+        try await withGeneratedPIF(
+            fromFixture: "Miscellaneous/Simple",
+            addLocalRpathsInReleaseConfiguration: false
+        ) { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter {
+                $0.severity == .error
+            }.isEmpty)
+
+            do {
+                let debugConfig = try pif.workspace
+                    .project(named: "Foo")
+                    .target(named: "Foo")
+                    .buildConfig(named: .debug)
+
+                #expect(debugConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == ["$(RPATH_ORIGIN)", "$(BUILT_PRODUCTS_DIR)/PackageFrameworks", "$(inherited)"])
+            }
+
+            do {
+                let releaseConfig = try pif.workspace
+                    .project(named: "Foo")
+                    .target(named: "Foo")
+                    .buildConfig(named: .release)
+
+                #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
+            }
+        }
+
+        try await withGeneratedPIF(
+            fromFixture: "Miscellaneous/Simple",
+            addLocalRpaths: false,
+            addLocalRpathsInReleaseConfiguration: false
+        ) { pif, observabilitySystem in
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .error
             }.isEmpty)

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -770,12 +770,23 @@ struct PIFBuilderTests {
             }.isEmpty)
 
             do {
+                let debugConfig = try pif.workspace
+                    .project(named: "Foo")
+                    .target(named: "Foo")
+                    .buildConfig(named: .debug)
+
+                #expect(debugConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == ["$(RPATH_ORIGIN)", "$(BUILT_PRODUCTS_DIR)/PackageFrameworks", "$(inherited)"])
+            }
+
+            do {
                 let releaseConfig = try pif.workspace
                     .project(named: "Foo")
                     .target(named: "Foo")
                     .buildConfig(named: .release)
 
-                #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == ["$(RPATH_ORIGIN)", "$(inherited)"])
+                // Release configuration should not inherit rpaths to prevent ambiguity, security, performance
+                // and relocation issues
+                #expect(releaseConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
             }
         }
 
@@ -783,6 +794,15 @@ struct PIFBuilderTests {
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .error
             }.isEmpty)
+
+            do {
+                let debugConfig = try pif.workspace
+                    .project(named: "Foo")
+                    .target(named: "Foo")
+                    .buildConfig(named: .debug)
+
+                #expect(debugConfig.impartedBuildProperties.settings[.LD_RUNPATH_SEARCH_PATHS] == nil)
+            }
 
             do {
                 let releaseConfig = try pif.workspace

--- a/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
@@ -171,7 +171,7 @@ struct PrebuiltsPIFTests {
         let pifBuilder: PIFBuilder = PIFBuilder(
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
-                temporaryDirectory: AbsolutePath.root, addLocalRpaths: true),
+                temporaryDirectory: AbsolutePath.root, addLocalRpaths: .always),
             fileSystem: fs,
             observabilityScope: observability.topScope
         )
@@ -425,7 +425,7 @@ struct PrebuiltsPIFTests {
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: AbsolutePath.root,
-                addLocalRpaths: true,
+                addLocalRpaths: .always,
                 pluginScriptRunner: MockPluginScriptRunner()
             ),
             fileSystem: fs,


### PR DESCRIPTION
Allow for `addLocalRpaths` to be called with one of: `.never`, .`debugOnly` or `.always` to allow for selectively adding rpaths based on build requirements.

### Motivation:

In the release configuration adding local rpaths can cause linker warnings and issues with location, relocation, performance and security. Instead of always adding rpaths, the `.debugOnly` option can be used to ensure that release configs do not get an rpath. 

### Modifications:

`addLocalRpaths` was converted to an enum to allow for `.never`, .`debugOnly` or `.always` options. Tests and comments were updated accordingly.

### Result:

Users of PIFBuilder can now turn off rpaths for the release configuration but keep rpaths on for debug configurations to assist with debugging. The previous functionality of turning off rpaths completely is still available with the `.never` option.

Related: rdar://173020084

