### PR TITLE
[6.4] Demote a PIF debug message from info -> debug so it doesn't appear in verbose output

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -458,7 +458,7 @@ public final class PackagePIFBuilder {
     @discardableResult
     public func build() throws -> [ModuleOrProduct] {
         self.log(
-            .info,
+            .debug,
             "Building PIF project for package '\(self.package.identity)' " +
             "(\(package.products.count) products, \(package.modules.count) modules)"
         )


### PR DESCRIPTION
PIF logging is primarily useful when debugging the build system, and most of it was already using the .debug severity so it only appears in --very-verbose output as opposed to regular --verbose. Fix the one remaining exception