### PR TITLE
Add support for symbol graph generation for clang targets

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -638,7 +638,15 @@ fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelega
     }
 
     func configureSourceModuleBuildSettings(sourceModule: ResolvedModule, settings: inout ProjectModel.BuildSettings) {
-        settings[.SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR] = "$(TARGET_BUILD_DIR)/$(CURRENT_ARCH)/\(sourceModule.name).symbolgraphs"
+        let symbolGraphOutputDir = "$(TARGET_BUILD_DIR)/$(CURRENT_ARCH)/\(sourceModule.name).symbolgraphs"
+        settings[.SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR] = symbolGraphOutputDir
+        // C/ObjC symbol graphs default to $(SYMBOL_GRAPH_EXTRACTOR_OUTPUT_BASE)/clang/$(triple) — a different
+        // base var — so override to match the Swift output directory.
+        settings[.TAPI_EXTRACT_API_OUTPUT_DIR] = symbolGraphOutputDir
+        // We currently put the C/ObjC headers under project documentation for the sole purpose of symbol graph generation.
+        // So, we instruct the documentation compiler to extract the project documentation for this purpose until such time
+        // that the public headers can be listed as public in the PIF.
+        settings[.DOCC_EXTRACT_PROJECT_HEADERS_DOCUMENTATION] = "YES"
     }
 
     func customInstallPath(product: PackageModel.Product) -> String? {

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -635,6 +635,24 @@ extension PackagePIFProjectBuilder {
 
         let headerFiles = Set(sourceModule.headerFileAbsolutePaths)
 
+        // Add the header files with project visibility for the purpose of exposing them
+        // for symbol graph generation. For non-swift API that will be done using TAPI and
+        // a build setting to instruct it to use project visible header files. In the future
+        // it may be possible to add public header files with public header visibility.
+        for headerPath in headerFiles {
+            let headerFileRef = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath]
+                .addFileReference { id in
+                    FileReference(id: id, path: headerPath.pathString, pathBase: .absolute)
+                }
+
+            self.project[keyPath: sourceModuleTargetKeyPath].common.withHeadersBuildPhase { phase in
+                phase.common.addBuildFile { id in
+                    BuildFile(id: id, fileRef: headerFileRef)
+                    // headerVisibility: nil (omitted) = "project" visibility
+                }
+            }
+        }
+
         let doccCatalogs = sourceModule.underlying.doccCatalogPaths
 
         // Add any additional source files emitted by custom build commands.

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1115,47 +1115,53 @@ struct PIFBuilderTests {
             let project = try pif.workspace.project(named: "ModuleMapGenerationCases")
 
             // UmbrellaHeader has include/UmbrellaHeader/UmbrellaHeader.h — expect a headers build phase
-            let umbrellaTarget = try project.target(named: "UmbrellaHeader")
-            let umbrellaHeadersPhase: ProjectModel.HeadersBuildPhase = try #require(
-                umbrellaTarget.common.buildPhases.compactMap({
-                    guard case let .headers(phase) = $0 else { return nil }
-                    return phase
-                }).only,
-                "Expected exactly one headers build phase for UmbrellaHeader"
-            )
+            do {
+                let umbrellaTarget = try project.target(named: "UmbrellaHeader")
+                let umbrellaHeadersPhase: ProjectModel.HeadersBuildPhase = try #require(
+                    umbrellaTarget.common.buildPhases.compactMap({
+                        guard case let .headers(phase) = $0 else { return nil }
+                        return phase
+                    }).only,
+                    "Expected exactly one headers build phase for UmbrellaHeader"
+                )
 
-            let umbrellaHeaderPaths: [AbsolutePath] = umbrellaHeadersPhase.files.compactMap {
-                guard case .reference(id: let refId) = $0.ref else { return nil }
-                return try? project.underlying.mainGroup.findSource(ref: refId)
-            }.sorted()
-            #expect(umbrellaHeaderPaths.contains { $0.basename == "UmbrellaHeader.h" })
-            // nil headerVisibility means "project" visibility — what we set for symbol graph extraction
-            #expect(umbrellaHeadersPhase.files.allSatisfy { $0.headerVisibility == nil })
+                let umbrellaHeaderPaths: [AbsolutePath] = umbrellaHeadersPhase.files.compactMap {
+                    guard case .reference(id: let refId) = $0.ref else { return nil }
+                    return try? project.underlying.mainGroup.findSource(ref: refId)
+                }.sorted()
+                #expect(umbrellaHeaderPaths.contains { $0.basename == "UmbrellaHeader.h" })
+                // nil headerVisibility means "project" visibility — what we set for symbol graph extraction
+                #expect(umbrellaHeadersPhase.files.allSatisfy { $0.headerVisibility == nil })
+            }
 
             // FlatInclude has include/FlatIncludeHeader.h — expect a headers build phase
-            let flatIncludeTarget = try project.target(named: "FlatInclude")
-            let flatIncludeHeadersPhase: ProjectModel.HeadersBuildPhase = try #require(
-                flatIncludeTarget.common.buildPhases.compactMap({
-                    guard case let .headers(phase) = $0 else { return nil }
-                    return phase
-                }).only,
-                "Expected exactly one headers build phase for FlatInclude"
-            )
+            do {
+                let flatIncludeTarget = try project.target(named: "FlatInclude")
+                let flatIncludeHeadersPhase: ProjectModel.HeadersBuildPhase = try #require(
+                    flatIncludeTarget.common.buildPhases.compactMap({
+                        guard case let .headers(phase) = $0 else { return nil }
+                        return phase
+                    }).only,
+                    "Expected exactly one headers build phase for FlatInclude"
+                )
 
-            let flatIncludeHeaderPaths: [AbsolutePath] = flatIncludeHeadersPhase.files.compactMap {
-                guard case .reference(id: let refId) = $0.ref else { return nil }
-                return try? project.underlying.mainGroup.findSource(ref: refId)
-            }.sorted()
-            #expect(flatIncludeHeaderPaths.contains { $0.basename == "FlatIncludeHeader.h" })
-            #expect(flatIncludeHeadersPhase.files.allSatisfy { $0.headerVisibility == nil })
+                let flatIncludeHeaderPaths: [AbsolutePath] = flatIncludeHeadersPhase.files.compactMap {
+                    guard case .reference(id: let refId) = $0.ref else { return nil }
+                    return try? project.underlying.mainGroup.findSource(ref: refId)
+                }.sorted()
+                #expect(flatIncludeHeaderPaths.contains { $0.basename == "FlatIncludeHeader.h" })
+                #expect(flatIncludeHeadersPhase.files.allSatisfy { $0.headerVisibility == nil })
+            }
 
             // NoIncludeDir has no header files — should have no headers build phase
-            let noIncludeDirTarget = try project.target(named: "NoIncludeDir")
-            let noHeadersPhases = noIncludeDirTarget.common.buildPhases.filter {
-                guard case .headers = $0 else { return false }
-                return true
+            do {
+                let noIncludeDirTarget = try project.target(named: "NoIncludeDir")
+                let noHeadersPhases = noIncludeDirTarget.common.buildPhases.filter {
+                    guard case .headers = $0 else { return false }
+                    return true
+                }
+                #expect(noHeadersPhases.isEmpty)
             }
-            #expect(noHeadersPhases.isEmpty)
         }
     }
 }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1088,6 +1088,19 @@ struct PIFBuilderTests {
         #expect(sources == expected)
      }
 
+    @Test func noHeaderMaps() async throws {
+        try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple") { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+            let project = try pif.workspace.project(named: "Foo")
+            for configName in [BuildConfiguration.debug, .release] {
+                #expect(
+                    try project.buildConfig(named: configName).settings[.USE_HEADERMAP] == "NO",
+                    "config: \(configName)"
+                )
+            }
+        }
+    }
+
     @Test func symbolGraphExtractorBuildSettings() async throws {
         try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1092,27 +1092,19 @@ struct PIFBuilderTests {
         try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
 
-            // C target: all three symbol graph settings should be present
-            let cConfig = try pif.workspace
-                .project(named: "ModuleMapGenerationCases")
-                .target(named: "UmbrellaHeader")
-                .buildConfig(named: .release)
+            // configureSourceModuleBuildSettings is called for every source module via the same
+            // delegate path, so verifying on representative C targets is sufficient coverage.
+            for targetName in ["UmbrellaHeader", "FlatInclude"] {
+                let config = try pif.workspace
+                    .project(named: "ModuleMapGenerationCases")
+                    .target(named: targetName)
+                    .buildConfig(named: .release)
 
-            let expectedCDir = "$(TARGET_BUILD_DIR)/$(CURRENT_ARCH)/UmbrellaHeader.symbolgraphs"
-            #expect(cConfig.settings[.SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR] == expectedCDir)
-            #expect(cConfig.settings[.TAPI_EXTRACT_API_OUTPUT_DIR] == expectedCDir)
-            #expect(cConfig.settings[.DOCC_EXTRACT_PROJECT_HEADERS_DOCUMENTATION] == "YES")
-
-            // Swift executable target: settings should also be present
-            let swiftConfig = try pif.workspace
-                .project(named: "ModuleMapGenerationCases")
-                .target(named: "Baz")
-                .buildConfig(named: .release)
-
-            let expectedSwiftDir = "$(TARGET_BUILD_DIR)/$(CURRENT_ARCH)/Baz.symbolgraphs"
-            #expect(swiftConfig.settings[.SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR] == expectedSwiftDir)
-            #expect(swiftConfig.settings[.TAPI_EXTRACT_API_OUTPUT_DIR] == expectedSwiftDir)
-            #expect(swiftConfig.settings[.DOCC_EXTRACT_PROJECT_HEADERS_DOCUMENTATION] == "YES")
+                let expectedDir = "$(TARGET_BUILD_DIR)/$(CURRENT_ARCH)/\(targetName).symbolgraphs"
+                #expect(config.settings[.SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR] == expectedDir, "target: \(targetName)")
+                #expect(config.settings[.TAPI_EXTRACT_API_OUTPUT_DIR] == expectedDir, "target: \(targetName)")
+                #expect(config.settings[.DOCC_EXTRACT_PROJECT_HEADERS_DOCUMENTATION] == "YES", "target: \(targetName)")
+            }
         }
     }
 

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1087,6 +1087,85 @@ struct PIFBuilderTests {
         ]
         #expect(sources == expected)
      }
+
+    @Test func symbolGraphExtractorBuildSettings() async throws {
+        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+
+            // C target: all three symbol graph settings should be present
+            let cConfig = try pif.workspace
+                .project(named: "ModuleMapGenerationCases")
+                .target(named: "UmbrellaHeader")
+                .buildConfig(named: .release)
+
+            let expectedCDir = "$(TARGET_BUILD_DIR)/$(CURRENT_ARCH)/UmbrellaHeader.symbolgraphs"
+            #expect(cConfig.settings[.SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR] == expectedCDir)
+            #expect(cConfig.settings[.TAPI_EXTRACT_API_OUTPUT_DIR] == expectedCDir)
+            #expect(cConfig.settings[.DOCC_EXTRACT_PROJECT_HEADERS_DOCUMENTATION] == "YES")
+
+            // Swift executable target: settings should also be present
+            let swiftConfig = try pif.workspace
+                .project(named: "ModuleMapGenerationCases")
+                .target(named: "Baz")
+                .buildConfig(named: .release)
+
+            let expectedSwiftDir = "$(TARGET_BUILD_DIR)/$(CURRENT_ARCH)/Baz.symbolgraphs"
+            #expect(swiftConfig.settings[.SYMBOL_GRAPH_EXTRACTOR_OUTPUT_DIR] == expectedSwiftDir)
+            #expect(swiftConfig.settings[.TAPI_EXTRACT_API_OUTPUT_DIR] == expectedSwiftDir)
+            #expect(swiftConfig.settings[.DOCC_EXTRACT_PROJECT_HEADERS_DOCUMENTATION] == "YES")
+        }
+    }
+
+    @Test func cFamilyHeadersAddedToHeadersBuildPhase() async throws {
+        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+
+            let project = try pif.workspace.project(named: "ModuleMapGenerationCases")
+
+            // UmbrellaHeader has include/UmbrellaHeader/UmbrellaHeader.h — expect a headers build phase
+            let umbrellaTarget = try project.target(named: "UmbrellaHeader")
+            let umbrellaHeadersPhase: ProjectModel.HeadersBuildPhase = try #require(
+                umbrellaTarget.common.buildPhases.compactMap({
+                    guard case let .headers(phase) = $0 else { return nil }
+                    return phase
+                }).only,
+                "Expected exactly one headers build phase for UmbrellaHeader"
+            )
+
+            let umbrellaHeaderPaths: [AbsolutePath] = umbrellaHeadersPhase.files.compactMap {
+                guard case .reference(id: let refId) = $0.ref else { return nil }
+                return try? project.underlying.mainGroup.findSource(ref: refId)
+            }.sorted()
+            #expect(umbrellaHeaderPaths.contains { $0.basename == "UmbrellaHeader.h" })
+            // nil headerVisibility means "project" visibility — what we set for symbol graph extraction
+            #expect(umbrellaHeadersPhase.files.allSatisfy { $0.headerVisibility == nil })
+
+            // FlatInclude has include/FlatIncludeHeader.h — expect a headers build phase
+            let flatIncludeTarget = try project.target(named: "FlatInclude")
+            let flatIncludeHeadersPhase: ProjectModel.HeadersBuildPhase = try #require(
+                flatIncludeTarget.common.buildPhases.compactMap({
+                    guard case let .headers(phase) = $0 else { return nil }
+                    return phase
+                }).only,
+                "Expected exactly one headers build phase for FlatInclude"
+            )
+
+            let flatIncludeHeaderPaths: [AbsolutePath] = flatIncludeHeadersPhase.files.compactMap {
+                guard case .reference(id: let refId) = $0.ref else { return nil }
+                return try? project.underlying.mainGroup.findSource(ref: refId)
+            }.sorted()
+            #expect(flatIncludeHeaderPaths.contains { $0.basename == "FlatIncludeHeader.h" })
+            #expect(flatIncludeHeadersPhase.files.allSatisfy { $0.headerVisibility == nil })
+
+            // NoIncludeDir has no header files — should have no headers build phase
+            let noIncludeDirTarget = try project.target(named: "NoIncludeDir")
+            let noHeadersPhases = noIncludeDirTarget.common.buildPhases.filter {
+                guard case .headers = $0 else { return false }
+                return true
+            }
+            #expect(noHeadersPhases.isEmpty)
+        }
+    }
 }
 
 extension ProjectModel.Group {


### PR DESCRIPTION
Add support for symbol graph generation for clang targets:
* Add header files to the PIF with "project" visibility
* Set TAPI symbol graph output directory to the same location as used for Swift
* Set TAPI to use the project headers as input to the symbol graph generation