### PR TITLE
Fixup tests which mixed Swift Testing and XCTest asserts

### DIFF
--- a/Sources/_InternalTestSupport/Observability.swift
+++ b/Sources/_InternalTestSupport/Observability.swift
@@ -248,17 +248,27 @@ public class DiagnosticsTestResult {
         severity: Basics.Diagnostic.Severity,
         //metadata: ObservabilityMetadata? = .none,
         file: StaticString = #file,
-        line: UInt = #line
+        line: UInt = #line,
+        sourceLocation: SourceLocation = #_sourceLocation
     ) -> Basics.Diagnostic? {
         guard !self.uncheckedDiagnostics.isEmpty else {
-            XCTFail("No diagnostics left to check", file: file, line: line)
+            if Test.current != nil {
+                Issue.record("No diagnostics left to check", sourceLocation: sourceLocation)
+            } else {
+                XCTFail("No diagnostics left to check", file: file, line: line)
+            }
             return nil
         }
 
         let diagnostic: Basics.Diagnostic = self.uncheckedDiagnostics.removeFirst()
 
-        XCTAssertMatch(diagnostic.message, message, file: file, line: line)
-        XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
+        if Test.current != nil {
+            #expect(diagnostic.severity == severity, sourceLocation: sourceLocation)
+            #expect(message ~= diagnostic.message, sourceLocation: sourceLocation)
+        } else {
+            XCTAssertMatch(diagnostic.message, message, file: file, line: line)
+            XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
+        }
         // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed
         //XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
         //XCTAssertEqual(diagnostic.metadata?.droppingLegacyKeys(), metadata?.droppingLegacyKeys(), file: file, line: line)

--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -12,6 +12,7 @@
 
 @testable import Basics
 import _InternalTestSupport
+import Testing
 import XCTest
 
 import class Basics.AsyncProcess

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -178,7 +178,7 @@ struct ObservabilitySystemTest {
                 #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "debug", severity: .error))
+                let diagnostic = try #require(result.check(diagnostic: "debug", severity: .debug))
                 let diagnostic_metadata = try #require(diagnostic.metadata)
                 #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -14,6 +14,7 @@
 @testable import PackageLoading
 import PackageModel
 import _InternalTestSupport
+import Testing
 import XCTest
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -14,6 +14,7 @@ import Basics
 import PackageLoading
 import PackageModel
 import _InternalTestSupport
+import Testing
 import XCTest
 
 final class ModuleMapGeneration: XCTestCase {

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -14,6 +14,7 @@ import Basics
 import PackageLoading
 import PackageModel
 import _InternalTestSupport
+import Testing
 import XCTest
 
 final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -15,6 +15,7 @@ import Dispatch
 import PackageLoading
 import PackageModel
 import _InternalTestSupport
+import Testing
 import XCTest
 
 import enum TSCBasic.PathValidationError

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -14,6 +14,7 @@ import Basics
 import PackageLoading
 import PackageModel
 import _InternalTestSupport
+import Testing
 import XCTest
 
 import struct TSCBasic.ByteString

--- a/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
@@ -14,6 +14,7 @@ import Basics
 import PackageLoading
 import PackageModel
 import _InternalTestSupport
+import Testing
 import XCTest
 
 final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -14,6 +14,7 @@ import Basics
 import PackageModel
 import PackageLoading
 import _InternalTestSupport
+import Testing
 import XCTest
 
 import enum TSCBasic.PathValidationError

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -13,6 +13,7 @@
 import Basics
 @testable import PackageLoading
 import _InternalTestSupport
+import Testing
 import XCTest
 
 import struct TSCBasic.ByteString

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -15,6 +15,7 @@ import Foundation
 import PackageModel
 import PackageLoading
 import _InternalTestSupport
+import Testing
 import XCTest
 
 final class TargetSourcesBuilderTests: XCTestCase {

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -17,6 +17,7 @@ import Basics
 
 import _InternalTestSupport
 import func TSCBasic.withTemporaryFile
+import Testing
 import XCTest
 
 import struct TSCBasic.ByteString

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -17,6 +17,7 @@ import PackageModel
 @testable import PackageRegistry
 @testable import PackageSigning
 import _InternalTestSupport
+import Testing
 import XCTest
 
 import struct TSCUtility.Version

--- a/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
@@ -17,6 +17,7 @@ import PackageFingerprint
 import PackageModel
 @testable import PackageRegistry
 import _InternalTestSupport
+import Testing
 import XCTest
 
 import struct TSCUtility.Version

--- a/Tests/PackageRegistryTests/SignatureValidationTests.swift
+++ b/Tests/PackageRegistryTests/SignatureValidationTests.swift
@@ -17,6 +17,7 @@ import PackageModel
 import PackageSigning
 import _InternalTestSupport
 import X509 // FIXME: need this import or else SwiftSigningIdentity init crashes
+import Testing
 import XCTest
 
 import struct TSCUtility.Version

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -15,6 +15,7 @@ import _Concurrency
 import PackageModel
 import _InternalTestSupport
 @testable import SourceControl
+import Testing
 import XCTest
 
 final class RepositoryManagerTests: XCTestCase {

--- a/Tests/SwiftBuildSupportTests/FileSystemUtilsTests.swift
+++ b/Tests/SwiftBuildSupportTests/FileSystemUtilsTests.swift
@@ -127,11 +127,6 @@ struct CreateBuildSymbolicLinkFunction {
 
         testDiagnostics(observability.diagnostics) { result in
             result.check(
-                diagnostic: .contains("unable to delete"),
-                severity: .warning
-            )
-
-            result.check(
                 diagnostic: .contains("unable to create symbolic link"),
                 severity: .warning
             )

--- a/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
@@ -13,6 +13,7 @@
 import _InternalTestSupport
 import Basics
 import PackageModel
+import Testing
 import XCTest
 
 extension WorkspaceTests {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -21,6 +21,7 @@ import PackageSigning
 import SourceControl
 import SPMBuildCore
 @testable import Workspace
+import Testing
 import XCTest
 
 import struct TSCBasic.ByteString


### PR DESCRIPTION
I ran across a couple of tests which indirectly mixed test frameworks indirectly via the `check` helper, update its implementation to avoid this.