### PR TITLE
[6.4] PIF: emit error when testTarget depends on testTarget

### DIFF
--- a/Fixtures/TestTargetDependOnTestTarget/Package.swift
+++ b/Fixtures/TestTargetDependOnTestTarget/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TestTargetDependOnTestTarget",
+    targets: [
+        .testTarget(
+            name: "leafTestTarget",
+        ),
+        .testTarget(
+            name: "myTestTarget",
+            dependencies: [
+                "leafTestTarget",
+            ],
+        ),
+        .testTarget(
+            name: "myOtherTestTarget",
+            dependencies: [
+                "leafTestTarget",
+                "myTestTarget",
+            ],
+        ),
+    ]
+)

--- a/Fixtures/TestTargetDependOnTestTarget/Tests/leafTestTarget/leafTestTarget.swift
+++ b/Fixtures/TestTargetDependOnTestTarget/Tests/leafTestTarget/leafTestTarget.swift
@@ -1,0 +1,9 @@
+import Testing
+
+@Suite
+struct LeafTestTargetTests {
+    @Test("LeafTestTarget tests")
+    func example() {
+        #expect(42 == 17 + 25)
+    }
+}

--- a/Fixtures/TestTargetDependOnTestTarget/Tests/myOtherTestTarget/myOtherTestTarget.swift
+++ b/Fixtures/TestTargetDependOnTestTarget/Tests/myOtherTestTarget/myOtherTestTarget.swift
@@ -1,0 +1,9 @@
+import Testing
+
+@Suite
+struct MyOTherTestTargetTests {
+    @Test("MyOTherTestTarget tests")
+    func example() {
+        #expect(42 == 17 + 25)
+    }
+}

--- a/Fixtures/TestTargetDependOnTestTarget/Tests/myTestTarget/myTestTarget.swift
+++ b/Fixtures/TestTargetDependOnTestTarget/Tests/myTestTarget/myTestTarget.swift
@@ -1,0 +1,9 @@
+import Testing
+
+@Suite
+struct MyTestTargetTests {
+    @Test("MyTestTarget tests")
+    func example() {
+        #expect(42 == 17 + 25)
+    }
+}

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -187,6 +187,10 @@ public final class PIFBuilder {
             throw PIFGenerationError.printedPIFManifestGraphviz
         }
 
+        if self.observabilityScope.errorsReported {
+            throw PIFGenerationError.errorDiagnosticsReported
+        }
+
         return PIFGenerationResult(pif: pifString, accompanyingMetadata: modulesAndProducts)
     }
 
@@ -814,6 +818,8 @@ public enum PIFGenerationError: Error {
 
     /// Early build termination when using `--print-pif-manifest-graph`.
     case printedPIFManifestGraphviz
+
+    case errorDiagnosticsReported
 }
 
 extension PIFGenerationError: CustomStringConvertible {
@@ -832,6 +838,9 @@ extension PIFGenerationError: CustomStringConvertible {
 
         case .printedPIFManifestGraphviz:
             "Printed PIF manifest as graphviz"
+
+        case .errorDiagnosticsReported:
+            "Errors reportes in PIF builder"
         }
     }
 }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -488,6 +488,12 @@ extension PackagePIFProjectBuilder {
                     }
 
                 case .library, .systemModule, .test:
+                    if moduleDependency.type == .test && product.type == .test {
+                        log(
+                            .error,
+                            "Test target '\(product.name)' cannot depend on another test target '\(moduleDependency.name)'",
+                        )
+                    }
                     let shouldLinkProduct = moduleDependency.type != .systemModule
                     let dependencyGUID = moduleDependency.pifTargetGUID
                     self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1015,6 +1015,22 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test
+    func errorEmittedWhenTestTargetDependsOnAnotherTestTarget() async throws {
+        try await withGeneratedPIF(fromFixture: "TestTargetDependOnTestTarget") { pif, observabilitySystem in
+            let expectedErrors = [
+                "PIF: Test target 'myOtherTestTarget' cannot depend on another test target 'leafTestTarget'",
+                "PIF: Test target 'myOtherTestTarget' cannot depend on another test target 'myTestTarget'",
+                "PIF: Test target 'myTestTarget' cannot depend on another test target 'leafTestTarget'",
+            ].sorted()
+            let actualDiags = observabilitySystem.diagnostics.filter { $0.severity == .error }
+            let diagMsgs = actualDiags.map { $0.message }.sorted()
+
+            #expect(actualDiags.count == expectedErrors.count)
+            #expect(diagMsgs == expectedErrors)
+        }
+    }
+
     @Test func mixedSourceTarget() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:


### PR DESCRIPTION
Swift Build does not suport testTarget that depend on another testTarget, and the error produced was not clear.

This change modifies the PIF Builder to emit an error diagnostics when it detects a testTarget depends on another testTarget.

Fixes: #10062
Issue: rdar://174431298