### PR TITLE
Fix PIF MODULEMAP_PATH when a package has a hand-authored module map

### DIFF
--- a/Sources/Basics/FileSystem/RelativePath.swift
+++ b/Sources/Basics/FileSystem/RelativePath.swift
@@ -164,3 +164,9 @@ extension TSCRelativePath {
         self = path.underlying
     }
 }
+
+extension RelativePath {
+    package var escapedPathString: String {
+        self.pathString.replacing("\\", with: "\\\\")
+    }
+}

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -387,13 +387,12 @@ extension PackagePIFProjectBuilder {
         }
 
         // Generate a module map file, if needed.
-        var moduleMapFileContents = ""
-        let generatedModuleMapDir = "$(GENERATED_MODULEMAP_DIR)"
-        var generatedModuleMapPath = try RelativePath(validating:"\(generatedModuleMapDir)/\(sourceModule.name).modulemap").pathString
+        let moduleMapFileContents: String?
+        let moduleMapPath: String?
 
         if sourceModule.usesSwift && desiredModuleType != .macro {
             // Generate ObjC compatibility header for Swift library targets.
-            settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR] = generatedModuleMapDir
+            settings[.SWIFT_OBJC_INTERFACE_HEADER_DIR] = "$(GENERATED_MODULEMAP_DIR)"
             settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME] = "\(sourceModule.name)-Swift.h"
 
             moduleMapFileContents = """
@@ -402,6 +401,8 @@ extension PackagePIFProjectBuilder {
             export *
             }
             """
+            let generatedModuleMapPath = try RelativePath(validating:"$(GENERATED_MODULEMAP_DIR)/\(sourceModule.name).modulemap").pathString
+            moduleMapPath = generatedModuleMapPath
             // We only need to impart this to C clients.
             impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(generatedModuleMapPath)", "$(inherited)"]
         } else {
@@ -418,13 +419,18 @@ extension PackagePIFProjectBuilder {
                 // The modulemap was already generated, we should explicitly impart it on dependents,
                 impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(pluginGeneratedModuleMapPath)", "$(inherited)"]
                 impartedSettings[.OTHER_SWIFT_FLAGS] = ["-Xcc", "-fmodule-map-file=\(pluginGeneratedModuleMapPath)", "$(inherited)"]
-                generatedModuleMapPath = pluginGeneratedModuleMapPath.pathString
+                moduleMapFileContents = nil
+                moduleMapPath = pluginGeneratedModuleMapPath.pathString
             } else {
                 switch sourceModule.moduleMapType {
                 case nil, .some(.none):
                     // No modulemap, no action required.
+                    moduleMapFileContents = nil
+                    moduleMapPath = nil
                     break
                 case .custom(let customModuleMapPath):
+                    moduleMapFileContents = nil
+                    moduleMapPath = customModuleMapPath.pathString
                     // We don't need to generate a modulemap, but we should explicitly impart it on dependents,
                     // even if it will appear in search paths. See: https://github.com/swiftlang/swift-package-manager/issues/9290
                     impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(customModuleMapPath)", "$(inherited)"]
@@ -437,6 +443,8 @@ extension PackagePIFProjectBuilder {
                     export *
                     }
                     """
+                    let generatedModuleMapPath = try RelativePath(validating:"$(GENERATED_MODULEMAP_DIR)/\(sourceModule.name).modulemap").pathString
+                    moduleMapPath = generatedModuleMapPath
                     // Pass the path of the module map up to all direct and indirect clients.
                     impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(generatedModuleMapPath)", "$(inherited)"]
                     impartedSettings[.OTHER_SWIFT_FLAGS] = ["-Xcc", "-fmodule-map-file=\(generatedModuleMapPath)", "$(inherited)"]
@@ -448,6 +456,8 @@ extension PackagePIFProjectBuilder {
                     export *
                     }
                     """
+                    let generatedModuleMapPath = try RelativePath(validating:"$(GENERATED_MODULEMAP_DIR)/\(sourceModule.name).modulemap").pathString
+                    moduleMapPath = generatedModuleMapPath
                     // Pass the path of the module map up to all direct and indirect clients.
                     impartedSettings[.OTHER_CFLAGS] = ["-fmodule-map-file=\(generatedModuleMapPath)", "$(inherited)"]
                     impartedSettings[.OTHER_SWIFT_FLAGS] = ["-Xcc", "-fmodule-map-file=\(generatedModuleMapPath)", "$(inherited)"]
@@ -524,8 +534,12 @@ extension PackagePIFProjectBuilder {
         }
 
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "regular"
-        settings[.MODULEMAP_FILE_CONTENTS] = moduleMapFileContents
-        settings[.MODULEMAP_PATH] = generatedModuleMapPath
+        if let moduleMapFileContents {
+            settings[.MODULEMAP_FILE_CONTENTS] = moduleMapFileContents
+        }
+        if let moduleMapPath {
+            settings[.MODULEMAP_PATH] = moduleMapPath
+        }
         settings[.DEFINES_MODULE] = "YES"
 
         // Settings for text-based API.

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -679,6 +679,90 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test func moduleMapPathAndContents() async throws {
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/Library") { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+
+            let releaseConfig = try pif.workspace
+                .project(named: "Library")
+                .target(named: "Library")
+                .buildConfig(named: .release)
+
+            let expectedPath = try RelativePath(validating: "$(GENERATED_MODULEMAP_DIR)/Library.modulemap").pathString
+            #expect(releaseConfig.settings[.MODULEMAP_PATH] == expectedPath)
+            #expect(releaseConfig.settings[.MODULEMAP_FILE_CONTENTS] == """
+            module Library {
+            header "Library-Swift.h"
+            export *
+            }
+            """)
+        }
+
+        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+
+            let project = try pif.workspace.project(named: "ModuleMapGenerationCases")
+
+            do {
+                let releaseConfig = try project
+                    .target(named: "NoIncludeDir")
+                    .buildConfig(named: .release)
+
+                #expect(releaseConfig.settings[.MODULEMAP_PATH] == nil)
+                #expect(releaseConfig.settings[.MODULEMAP_FILE_CONTENTS] == nil)
+            }
+
+            do {
+                let releaseConfig = try project
+                    .target(named: "CustomModuleMap")
+                    .buildConfig(named: .release)
+
+                let path = try #require(releaseConfig.settings[.MODULEMAP_PATH])
+                #expect(path.hasSuffix(RelativePath("CustomModuleMap")
+                    .appending(components: ["include", "module.modulemap"]).pathString))
+                #expect(!path.contains("$(GENERATED_MODULEMAP_DIR)"))
+                #expect(releaseConfig.settings[.MODULEMAP_FILE_CONTENTS] == nil)
+            }
+
+            do {
+                let releaseConfig = try project
+                    .target(named: "UmbrellaHeader")
+                    .buildConfig(named: .release)
+
+                let expectedPath = try RelativePath(
+                    validating: "$(GENERATED_MODULEMAP_DIR)/UmbrellaHeader.modulemap"
+                ).pathString
+                #expect(releaseConfig.settings[.MODULEMAP_PATH] == expectedPath)
+
+                let contents = try #require(releaseConfig.settings[.MODULEMAP_FILE_CONTENTS])
+                #expect(contents.hasPrefix("module UmbrellaHeader {"))
+                #expect(contents.contains("umbrella header \""))
+                #expect(contents.contains(RelativePath("UmbrellaHeader")
+                    .appending(components: ["include", "UmbrellaHeader", "UmbrellaHeader.h"]).escapedPathString))
+                #expect(contents.contains("export *"))
+            }
+
+            do {
+                let releaseConfig = try project
+                    .target(named: "UmbrellaDirectoryInclude")
+                    .buildConfig(named: .release)
+
+                let expectedPath = try RelativePath(
+                    validating: "$(GENERATED_MODULEMAP_DIR)/UmbrellaDirectoryInclude.modulemap"
+                ).pathString
+                #expect(releaseConfig.settings[.MODULEMAP_PATH] == expectedPath)
+
+                let contents = try #require(releaseConfig.settings[.MODULEMAP_FILE_CONTENTS])
+                #expect(contents.hasPrefix("module UmbrellaDirectoryInclude {"))
+                #expect(contents.contains("umbrella \""))
+                #expect(!contents.contains("umbrella header"))
+                #expect(contents.contains(RelativePath("UmbrellaDirectoryInclude")
+                    .appending(component: "include").escapedPathString))
+                #expect(contents.contains("export *"))
+            }
+        }
+    }
+
     @Test func disablingLocalRpaths() async throws {
         try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple") { pif, observabilitySystem in
             #expect(observabilitySystem.diagnostics.filter {


### PR DESCRIPTION
When a target had a hand-authored module map, the PIF was correctly imparting the custom path to clients via OTHER_CFLAGS, but was incorrectly setting MODULEMAP_PATH to the path which would have been used if the build system had generated one. This doesn't impact compilation, but when symbol graph extraction was enabled it caused clang -extractapi to try to load the module map from the wrong path, failing the build.

This PR refactors the modulemap path computation so that it is explicitly assigned once along every path, fixing the original issue and hopefully making the code a bit clearer so it's easier to understand going forward.

rdar://173020089