### PR TITLE
Filter gitignored files when building the publish archive

### DIFF
--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -19,6 +19,7 @@ import PackageModel
 import PackageFingerprint
 import PackageRegistry
 import PackageSigning
+import SourceControl
 import Workspace
 
 #if USE_IMPL_ONLY_IMPORTS
@@ -472,17 +473,26 @@ enum PackageArchiver {
     ) async throws -> AbsolutePath {
         let archivePath = workingDirectory.appending("\(packageIdentity)-\(packageVersion).zip")
 
-        // create temp location for sources
         let sourceDirectory = workingDirectory.appending(components: "source", "\(packageIdentity)")
         try localFileSystem.createDirectory(sourceDirectory, recursive: true)
 
-        // TODO: filter other unnecessary files, and/or .swiftpmignore file
-        let ignoredContent = [".build", ".git", ".gitignore", ".swiftpm"]
-        let packageContent = try localFileSystem.getDirectoryContents(packageDirectory)
-        for item in (packageContent.filter { !ignoredContent.contains($0) }) {
-            try localFileSystem.copy(
-                from: packageDirectory.appending(component: item),
-                to: sourceDirectory.appending(component: item)
+        let gitRepositoryProvider = GitRepositoryProvider()
+        let isGitRepository = (try? gitRepositoryProvider.isValidDirectory(packageDirectory)) == true
+
+        if isGitRepository {
+            try await Self.populateFromGitHead(
+                packageDirectory: packageDirectory,
+                sourceDirectory: sourceDirectory,
+                workingDirectory: workingDirectory,
+                cancellator: cancellator
+            )
+        } else {
+            observabilityScope.emit(
+                warning: "publishing from a non-git package directory uses a best-effort filter; consider initializing a git repository or using '.gitattributes export-ignore' for deterministic filtering"
+            )
+            try Self.copyFilteringSensitiveFiles(
+                from: packageDirectory,
+                to: sourceDirectory
             )
         }
 
@@ -504,5 +514,76 @@ enum PackageArchiver {
         )
 
         return archivePath
+    }
+
+    private static func populateFromGitHead(
+        packageDirectory: AbsolutePath,
+        sourceDirectory: AbsolutePath,
+        workingDirectory: AbsolutePath,
+        cancellator: Cancellator?
+    ) async throws {
+        let intermediateArchive = workingDirectory.appending("git-source.zip")
+        if localFileSystem.exists(intermediateArchive) {
+            try localFileSystem.removeFileTree(intermediateArchive)
+        }
+
+        let repository = GitRepository(path: packageDirectory, cancellator: cancellator)
+        try repository.archive(to: intermediateArchive)
+
+        let archiver = UniversalArchiver(localFileSystem, cancellator)
+        try await archiver.extract(from: intermediateArchive, to: sourceDirectory)
+        try localFileSystem.stripFirstLevel(of: sourceDirectory)
+        try localFileSystem.removeFileTree(intermediateArchive)
+    }
+
+    private static let ignoredDirectoryNames: Set<String> = [
+        ".build", ".git", ".hg", ".svn", ".swiftpm", "node_modules",
+    ]
+
+    private static let ignoredExactFilenames: Set<String> = [
+        ".ds_store",
+        ".gitignore",
+        ".netrc",
+        ".npmrc",
+        "credentials",
+        "credentials.json",
+        "id_ecdsa",
+        "id_ecdsa.pub",
+        "id_ed25519",
+        "id_ed25519.pub",
+        "id_rsa",
+        "id_rsa.pub",
+        "secrets.json",
+    ]
+
+    private static let ignoredFileExtensions: [String] = [
+        ".key", ".p12", ".pem", ".pfx",
+    ]
+
+    private static func isSensitiveFilename(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        if self.ignoredExactFilenames.contains(lower) { return true }
+        if lower == ".env" || lower.hasPrefix(".env.") { return true }
+        return self.ignoredFileExtensions.contains { lower.hasSuffix($0) }
+    }
+
+    private static func copyFilteringSensitiveFiles(
+        from source: AbsolutePath,
+        to destination: AbsolutePath
+    ) throws {
+        let entries = try localFileSystem.getDirectoryContents(source)
+        for entry in entries {
+            let sourceEntry = source.appending(component: entry)
+            let destinationEntry = destination.appending(component: entry)
+
+            if localFileSystem.isDirectory(sourceEntry) && !localFileSystem.isSymlink(sourceEntry) {
+                if self.ignoredDirectoryNames.contains(entry) { continue }
+                try localFileSystem.createDirectory(destinationEntry, recursive: false)
+                try self.copyFilteringSensitiveFiles(from: sourceEntry, to: destinationEntry)
+            } else {
+                if self.isSensitiveFilename(entry) { continue }
+                try localFileSystem.copy(from: sourceEntry, to: destinationEntry)
+            }
+        }
     }
 }

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -19,6 +19,7 @@ import PackageRegistry
 @testable import PackageRegistryCommand
 import struct SPMBuildCore.BuildSystemProvider
 import PackageSigning
+import SourceControl
 import _InternalTestSupport
 import TSCclibc // for SPM_posix_spawn_file_actions_addchdir_np_supported
 import Workspace
@@ -580,6 +581,139 @@ struct PackageRegistryCommandTests {
 
             let extractedPath = try await validatePackageArchive(at: archivePath)
             expectFileExists(at: extractedPath.appending(component: metadataFilename))
+        }
+
+        // git repo: untracked secrets must not end up in the published archive
+        try await withTemporaryDirectory { temporaryDirectory in
+            let packageDirectory = temporaryDirectory.appending("MyPackage")
+            try localFileSystem.createDirectory(packageDirectory)
+
+            let initPackage = try InitPackage(
+                name: "MyPackage",
+                packageType: .executable,
+                destinationPath: packageDirectory,
+                fileSystem: localFileSystem
+            )
+            try initPackage.writePackageStructure()
+            initGitRepo(packageDirectory)
+
+            let secretFiles = [".env", "id_rsa", "credentials.json", ".netrc"]
+            for name in secretFiles {
+                try localFileSystem.writeFileContents(
+                    packageDirectory.appending(component: name),
+                    bytes: "SECRET=leak"
+                )
+            }
+            try localFileSystem.writeFileContents(
+                packageDirectory.appending(components: "Sources", "api.key"),
+                bytes: "SECRET=leak"
+            )
+
+            let workingDirectory = temporaryDirectory.appending(component: UUID().uuidString)
+
+            let archivePath = try await PackageArchiver.archive(
+                packageIdentity: packageIdentity,
+                packageVersion: "2.0.0",
+                packageDirectory: packageDirectory,
+                workingDirectory: workingDirectory,
+                workingFilesToCopy: [],
+                cancellator: .none,
+                observabilityScope: observability.topScope
+            )
+
+            let extractedPath = try await validatePackageArchive(at: archivePath)
+            for name in secretFiles {
+                expectFileDoesNotExists(at: extractedPath.appending(component: name))
+            }
+            expectFileDoesNotExists(at: extractedPath.appending(components: "Sources", "api.key"))
+        }
+
+        // git repo: .gitattributes export-ignore must be honored
+        try await withTemporaryDirectory { temporaryDirectory in
+            let packageDirectory = temporaryDirectory.appending("MyPackage")
+            try localFileSystem.createDirectory(packageDirectory)
+
+            let initPackage = try InitPackage(
+                name: "MyPackage",
+                packageType: .executable,
+                destinationPath: packageDirectory,
+                fileSystem: localFileSystem
+            )
+            try initPackage.writePackageStructure()
+            initGitRepo(packageDirectory)
+
+            try localFileSystem.writeFileContents(
+                packageDirectory.appending(component: ".gitattributes"),
+                bytes: "secret/** export-ignore\n"
+            )
+            try localFileSystem.createDirectory(packageDirectory.appending(component: "secret"))
+            try localFileSystem.writeFileContents(
+                packageDirectory.appending(components: "secret", "data.txt"),
+                bytes: "SECRET=leak"
+            )
+            let repo = GitRepository(path: packageDirectory)
+            try repo.stageEverything()
+            try repo.commit(message: "add secret dir with export-ignore")
+
+            let workingDirectory = temporaryDirectory.appending(component: UUID().uuidString)
+
+            let archivePath = try await PackageArchiver.archive(
+                packageIdentity: packageIdentity,
+                packageVersion: "2.1.0",
+                packageDirectory: packageDirectory,
+                workingDirectory: workingDirectory,
+                workingFilesToCopy: [],
+                cancellator: .none,
+                observabilityScope: observability.topScope
+            )
+
+            let extractedPath = try await validatePackageArchive(at: archivePath)
+            expectFileDoesNotExists(at: extractedPath.appending(components: "secret", "data.txt"))
+            expectFileDoesNotExists(at: extractedPath.appending(component: "secret"))
+        }
+
+        // non-git package: common secret filenames must be filtered (top-level + nested)
+        try await withTemporaryDirectory { temporaryDirectory in
+            let packageDirectory = temporaryDirectory.appending("MyPackage")
+            try localFileSystem.createDirectory(packageDirectory)
+
+            let initPackage = try InitPackage(
+                name: "MyPackage",
+                packageType: .executable,
+                destinationPath: packageDirectory,
+                fileSystem: localFileSystem
+            )
+            try initPackage.writePackageStructure()
+
+            let secretFiles = [".env", "id_rsa", "credentials.json", ".netrc"]
+            for name in secretFiles {
+                try localFileSystem.writeFileContents(
+                    packageDirectory.appending(component: name),
+                    bytes: "SECRET=leak"
+                )
+            }
+            try localFileSystem.writeFileContents(
+                packageDirectory.appending(components: "Sources", "api.key"),
+                bytes: "SECRET=leak"
+            )
+
+            let workingDirectory = temporaryDirectory.appending(component: UUID().uuidString)
+
+            let archivePath = try await PackageArchiver.archive(
+                packageIdentity: packageIdentity,
+                packageVersion: "2.2.0",
+                packageDirectory: packageDirectory,
+                workingDirectory: workingDirectory,
+                workingFilesToCopy: [],
+                cancellator: .none,
+                observabilityScope: observability.topScope
+            )
+
+            let extractedPath = try await validatePackageArchive(at: archivePath)
+            for name in secretFiles {
+                expectFileDoesNotExists(at: extractedPath.appending(component: name))
+            }
+            expectFileDoesNotExists(at: extractedPath.appending(components: "Sources", "api.key"))
         }
 
         @discardableResult

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -668,8 +668,13 @@ struct PackageRegistryCommandTests {
             )
 
             let extractedPath = try await validatePackageArchive(at: archivePath)
+            // `git archive` honors `export-ignore` for the file contents but still emits an
+            // empty directory entry for `secret/`, so only its contents must be excluded.
             expectFileDoesNotExists(at: extractedPath.appending(components: "secret", "data.txt"))
-            expectFileDoesNotExists(at: extractedPath.appending(component: "secret"))
+            let secretDirectory = extractedPath.appending(component: "secret")
+            if localFileSystem.isDirectory(secretDirectory) {
+                #expect(try localFileSystem.getDirectoryContents(secretDirectory).isEmpty)
+            }
         }
 
         // non-git package: common secret filenames must be filtered (top-level + nested)


### PR DESCRIPTION
### Motivation:

When building a package archive to publish the archiver strips omits `.build`, `.git`, `.gitignore` and `.swiftpm` using a hardcoded list. Any files the user has explicitly .gitignored are still included in the package archive.

### Modifications:

Rewrites PackageArchiver.archive so publishing no longer leaks sensitive files that happen to live in the package directory. For git-tracked packages the tarball is now built from `git archive HEAD`, so only tracked content ships and .gitattributes export-ignore is honored.

For non-git packages a recursive copy with a denylist (.env*, .netrc, id_rsa/id_ed25519/id_ecdsa keypairs, credentials*.json, secrets.json, *.pem, *.key, *.p12, *.pfx, etc.) replaces the previous four-entry top-level filter, and a warning log entry points the user at git or .gitattributes for deterministic filtering.

### Result:

Archives created using `swift package-registry publish` and `swift package archive-source` now respect the user's ignored files.