### PR TITLE
[6.4] Address feedback

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -819,6 +819,7 @@ public enum PIFGenerationError: Error {
     /// Early build termination when using `--print-pif-manifest-graph`.
     case printedPIFManifestGraphviz
 
+    /// One or more error diagnostics were reported during PIF generation.
     case errorDiagnosticsReported
 }
 
@@ -840,7 +841,7 @@ extension PIFGenerationError: CustomStringConvertible {
             "Printed PIF manifest as graphviz"
 
         case .errorDiagnosticsReported:
-            "Errors reportes in PIF builder"
+            "Errors reported during PIF building"
         }
     }
 }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1102,15 +1102,16 @@ struct PIFBuilderTests {
     @Test
     func errorEmittedWhenTestTargetDependsOnAnotherTestTarget() async throws {
         try await withGeneratedPIF(fromFixture: "TestTargetDependOnTestTarget") { pif, observabilitySystem in
-            let expectedErrors = [
+            let expectedErrors: Set = [
                 "PIF: Test target 'myOtherTestTarget' cannot depend on another test target 'leafTestTarget'",
-                "PIF: Test target 'myOtherTestTarget' cannot depend on another test target 'myTestTarget'",
                 "PIF: Test target 'myTestTarget' cannot depend on another test target 'leafTestTarget'",
-            ].sorted()
+                "PIF: Test target 'myOtherTestTarget' cannot depend on another test target 'myTestTarget'",
+            ]
             let actualDiags = observabilitySystem.diagnostics.filter { $0.severity == .error }
-            let diagMsgs = actualDiags.map { $0.message }.sorted()
+            let diagMsgs = Set(actualDiags.map { $0.message })
 
             #expect(actualDiags.count == expectedErrors.count)
+            #expect(actualDiags.count == diagMsgs.count)
             #expect(diagMsgs == expectedErrors)
         }
     }


### PR DESCRIPTION
In #10064, a diagnostic error was introduced during PIF generation when a test target has a dependency on another test target.  There were non-blocking feedback in the PR which are being addressed here.

Relates to #10062
Issue: rdar://174431298
Depends on #10064