### PR TITLE
Compile testTarget as static library if it is depended upon by another testTarget

### DIFF
--- a/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Package.swift
+++ b/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "TestTargetDependsOnTestTarget",
+    targets: [
+        .target(name: "MyLib"),
+        .testTarget(name: "TestUtils", dependencies: ["MyLib"]),
+        .testTarget(name: "FooTests", dependencies: ["TestUtils"]),
+        .testTarget(name: "BarTests", dependencies: ["TestUtils"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Sources/MyLib/MyLib.swift
+++ b/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Sources/MyLib/MyLib.swift
@@ -1,0 +1,4 @@
+public struct MyLib {
+    public init() {}
+    public func value() -> Int { 42 }
+}

--- a/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/BarTests/BarTests.swift
+++ b/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/BarTests/BarTests.swift
@@ -1,3 +1,4 @@
+import TestUtils
 import Testing
 
 @Suite struct BarTests {

--- a/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/BarTests/BarTests.swift
+++ b/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/BarTests/BarTests.swift
@@ -1,0 +1,7 @@
+import Testing
+
+@Suite struct BarTests {
+    @Test func example() {
+        #expect(makeLib().value() == 42)
+    }
+}

--- a/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/FooTests/FooTests.swift
+++ b/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/FooTests/FooTests.swift
@@ -1,3 +1,4 @@
+import TestUtils
 import Testing
 
 @Suite struct FooTests {

--- a/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/FooTests/FooTests.swift
+++ b/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/FooTests/FooTests.swift
@@ -1,0 +1,7 @@
+import Testing
+
+@Suite struct FooTests {
+    @Test func example() {
+        #expect(makeLib().value() == 42)
+    }
+}

--- a/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/TestUtils/TestUtils.swift
+++ b/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/TestUtils/TestUtils.swift
@@ -1,0 +1,5 @@
+@testable import MyLib
+import Testing
+
+// Shared test helpers used by FooTests and BarTests.
+func makeLib() -> MyLib { MyLib() }

--- a/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/TestUtils/TestUtils.swift
+++ b/Fixtures/Miscellaneous/TestTargetDependsOnTestTarget/Tests/TestUtils/TestUtils.swift
@@ -2,4 +2,4 @@
 import Testing
 
 // Shared test helpers used by FooTests and BarTests.
-func makeLib() -> MyLib { MyLib() }
+package func makeLib() -> MyLib { MyLib() }

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -601,9 +601,6 @@ private func createResolvedPackages(
                     if moduleBuilder.module.type == .test && dependencyBuilder.module.type == .test
                         && !dependencyBuilder.isTestSupportModule {
                         dependencyBuilder.isTestSupportModule = true
-                        dependencyBuilder.observabilityScope.emit(
-                            debug: "Treating test module '\(dependencyBuilder.module.name)' as a static library as it is depended on by other test target(s)"
-                        )
                     }
                     return .module(dependencyBuilder, conditions: conditions)
                 case .product:

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -886,6 +886,9 @@ private func createResolvedPackages(
     // Adjust the package graph for any prebuilts, removing any that are no longer needed.
     handlePrebuilts(packageBuilders: packageBuilders, root: root)
 
+    // Mark test modules that are depended upon by other test modules in the same package.
+    markTestSupportModules(packageBuilders: packageBuilders)
+
     return try IdentifiableSet(packageBuilders.map { try $0.construct() })
 }
 
@@ -1057,6 +1060,23 @@ private func handlePrebuilts(packageBuilders: [ResolvedPackageBuilder], root: Pa
             }) {
                 nonPrebuilt.dependencies = nonPrebuilt.dependencies.filter {
                     $0.package.identity != packageBuilder.package.identity
+                }
+            }
+        }
+    }
+}
+
+private func markTestSupportModules(packageBuilders: [ResolvedPackageBuilder]) {
+    for packageBuilder in packageBuilders {
+        let testModuleBuilders = packageBuilder.modules.filter { $0.module.type == .test }
+        guard testModuleBuilders.count > 1 else { continue }
+        for moduleBuilder in testModuleBuilders {
+            for case .module(let dep, _) in moduleBuilder.dependencies where dep.module.type == .test {
+                if !dep.isTestSupportModule {
+                    dep.isTestSupportModule = true
+                    dep.observabilityScope.emit(
+                        debug: "Treating test module '\(dep.module.name)' as a static library as it is depended on by other test target(s)"
+                    )
                 }
             }
         }
@@ -1517,6 +1537,10 @@ private final class ResolvedModuleBuilder: ResolvedBuilder<ResolvedModule> {
     /// A constraint on which platforms this module needs to build for.
     var platformConstraint: PlatformConstraint? = nil
 
+    /// Whether this is a test module that is directly depended upon by other test modules.
+    /// Set by `markTestSupportModules` during graph loading.
+    var isTestSupportModule: Bool = false
+
     var isHostOnly: Bool {
         module.type == .macro || (module.type == .test && dependencies.contains(where: {
                 switch $0 {
@@ -1576,7 +1600,8 @@ private final class ResolvedModuleBuilder: ResolvedBuilder<ResolvedModule> {
             supportedPlatforms: self.supportedPlatforms,
             // maintain existing functionality and default to .all
             platformConstraint: self.platformConstraint ?? .all,
-            platformVersionProvider: self.platformVersionProvider
+            platformVersionProvider: self.platformVersionProvider,
+            isTestSupportModule: self.isTestSupportModule
         )
     }
 }

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -595,10 +595,17 @@ private func createResolvedPackages(
                 switch dependency {
                 case .module(let moduleDependency, let conditions):
                     try moduleBuilder.module.validateDependency(module: moduleDependency)
-                    guard let moduleBuilder = modulesMap[moduleDependency] else {
+                    guard let dependencyBuilder = modulesMap[moduleDependency] else {
                         throw InternalError("unknown target \(moduleDependency.name)")
                     }
-                    return .module(moduleBuilder, conditions: conditions)
+                    if moduleBuilder.module.type == .test && dependencyBuilder.module.type == .test
+                        && !dependencyBuilder.isTestSupportModule {
+                        dependencyBuilder.isTestSupportModule = true
+                        dependencyBuilder.observabilityScope.emit(
+                            debug: "Treating test module '\(dependencyBuilder.module.name)' as a static library as it is depended on by other test target(s)"
+                        )
+                    }
+                    return .module(dependencyBuilder, conditions: conditions)
                 case .product:
                     return nil
                 }
@@ -886,9 +893,6 @@ private func createResolvedPackages(
     // Adjust the package graph for any prebuilts, removing any that are no longer needed.
     handlePrebuilts(packageBuilders: packageBuilders, root: root)
 
-    // Mark test modules that are depended upon by other test modules in the same package.
-    markTestSupportModules(packageBuilders: packageBuilders)
-
     return try IdentifiableSet(packageBuilders.map { try $0.construct() })
 }
 
@@ -1060,23 +1064,6 @@ private func handlePrebuilts(packageBuilders: [ResolvedPackageBuilder], root: Pa
             }) {
                 nonPrebuilt.dependencies = nonPrebuilt.dependencies.filter {
                     $0.package.identity != packageBuilder.package.identity
-                }
-            }
-        }
-    }
-}
-
-private func markTestSupportModules(packageBuilders: [ResolvedPackageBuilder]) {
-    for packageBuilder in packageBuilders {
-        let testModuleBuilders = packageBuilder.modules.filter { $0.module.type == .test }
-        guard testModuleBuilders.count > 1 else { continue }
-        for moduleBuilder in testModuleBuilders {
-            for case .module(let dep, _) in moduleBuilder.dependencies where dep.module.type == .test {
-                if !dep.isTestSupportModule {
-                    dep.isTestSupportModule = true
-                    dep.observabilityScope.emit(
-                        debug: "Treating test module '\(dep.module.name)' as a static library as it is depended on by other test target(s)"
-                    )
                 }
             }
         }
@@ -1538,7 +1525,6 @@ private final class ResolvedModuleBuilder: ResolvedBuilder<ResolvedModule> {
     var platformConstraint: PlatformConstraint? = nil
 
     /// Whether this is a test module that is directly depended upon by other test modules.
-    /// Set by `markTestSupportModules` during graph loading.
     var isTestSupportModule: Bool = false
 
     var isHostOnly: Bool {

--- a/Sources/PackageGraph/Resolution/ResolvedModule.swift
+++ b/Sources/PackageGraph/Resolution/ResolvedModule.swift
@@ -170,6 +170,10 @@ public struct ResolvedModule {
     /// Note: currently only set to .host if prebuilts are enabled.
     public let platformConstraint: PlatformConstraint
 
+    /// True if this is a test module that is directly depended upon by other test modules
+    /// in the same package.
+    package let isTestSupportModule: Bool
+
     @_spi(SwiftPMInternal)
     public let platformVersionProvider: PlatformVersionProvider
 
@@ -198,7 +202,8 @@ public struct ResolvedModule {
         defaultLocalization: String? = nil,
         supportedPlatforms: [SupportedPlatform],
         platformConstraint: PlatformConstraint,
-        platformVersionProvider: PlatformVersionProvider
+        platformVersionProvider: PlatformVersionProvider,
+        isTestSupportModule: Bool = false
     ) {
         self.packageIdentity = packageIdentity
         self.underlying = underlying
@@ -207,6 +212,7 @@ public struct ResolvedModule {
         self.supportedPlatforms = supportedPlatforms
         self.platformConstraint = platformConstraint
         self.platformVersionProvider = platformVersionProvider
+        self.isTestSupportModule = isTestSupportModule
     }
 
     public func getSupportedPlatform(for platform: Platform, usingXCTest: Bool) -> SupportedPlatform {

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -485,20 +485,6 @@ public final class PackagePIFBuilder {
         // the structure of the client(s).
         //
 
-        // Treat test targets that are depended on by other test targets as shared and build them as
-        // static libraries so they can be linked against.
-        let testSupportModules: Set<PackageGraph.ResolvedModule.ID> = {
-            var ids = Set<PackageGraph.ResolvedModule.ID>()
-            for module in self.package.modules where module.type == .test {
-                for dependency in module.dependencies {
-                    if case .module(let dep, _) = dependency, dep.type == .test {
-                        ids.insert(dep.id)
-                    }
-                }
-            }
-            return ids
-        }()
-
         self.log(.debug, "Processing \(package.products.count) products:")
 
         // For each of the **products** in the package we create a corresponding `PIFTarget` of the appropriate type.
@@ -524,7 +510,9 @@ public final class PackagePIFBuilder {
 
             case .executable, .test, .snippet:
                 if product.type == .test, let mainTarget = product.mainModule,
-                   testSupportModules.contains(mainTarget.id) {
+                   mainTarget.isTestSupportModule {
+                    // Skip creating a test bundle product as this is a shared test helper library.
+                    // It will be built as a static library in the modules loop below.
                     break
                 }
                 try projectBuilder.makeMainModuleProduct(product)
@@ -557,7 +545,7 @@ public final class PackagePIFBuilder {
                 try projectBuilder.makeSystemLibraryModule(module)
 
             case .test:
-                if testSupportModules.contains(module.id) {
+                if module.isTestSupportModule {
                     try projectBuilder.makeTestSupportModule(module)
                 }
 

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -485,6 +485,20 @@ public final class PackagePIFBuilder {
         // the structure of the client(s).
         //
 
+        // Treat test targets that are depended on by other test targets as shared and build them as
+        // static libraries so they can be linked against.
+        let testSupportModules: Set<PackageGraph.ResolvedModule.ID> = {
+            var ids = Set<PackageGraph.ResolvedModule.ID>()
+            for module in self.package.modules where module.type == .test {
+                for dependency in module.dependencies {
+                    if case .module(let dep, _) = dependency, dep.type == .test {
+                        ids.insert(dep.id)
+                    }
+                }
+            }
+            return ids
+        }()
+
         self.log(.debug, "Processing \(package.products.count) products:")
 
         // For each of the **products** in the package we create a corresponding `PIFTarget` of the appropriate type.
@@ -509,6 +523,10 @@ public final class PackagePIFBuilder {
                 }
 
             case .executable, .test, .snippet:
+                if product.type == .test, let mainTarget = product.mainModule,
+                   testSupportModules.contains(mainTarget.id) {
+                    break
+                }
                 try projectBuilder.makeMainModuleProduct(product)
 
             case .plugin:
@@ -539,9 +557,9 @@ public final class PackagePIFBuilder {
                 try projectBuilder.makeSystemLibraryModule(module)
 
             case .test:
-                // Skip test module targets.
-                // They will have been dealt with as part of the *products* to which they belong.
-                break
+                if testSupportModules.contains(module.id) {
+                    try projectBuilder.makeTestSupportModule(module)
+                }
 
             case .binary:
                 // Skip binary module targets.

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -546,6 +546,7 @@ public final class PackagePIFBuilder {
 
             case .test:
                 if module.isTestSupportModule {
+                    self.log(.debug, "Building test module '\(module.name)' as a static library as it is depended on by other test target(s)")
                     try projectBuilder.makeTestSupportModule(module)
                 }
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -199,6 +199,15 @@ extension PackagePIFProjectBuilder {
         }
     }
 
+    // MARK: - Test Support Modules
+
+    // Build a test module that is depended upon by other test modules as a static library.
+    mutating func makeTestSupportModule(_ testModule: PackageGraph.ResolvedModule) throws {
+        precondition(testModule.type == .test)
+        let (staticLibrary, _) = try buildSourceModule(testModule, type: .staticLibrary)
+        self.builtModulesAndProducts.append(staticLibrary)
+    }
+
     // MARK: - Executable Source Modules
 
     /// If we're building an *executable* and the tools version is new enough,

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -274,6 +274,11 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
                 for package in graph.rootPackages {
                     for product in package.products where product.type == .test {
+                        if let mainModule = product.mainModule, mainModule.isTestSupportModule {
+                            // This test target is built as a static library by the swiftbuild
+                            // system and has no xctest bundle to run.
+                            continue
+                        }
                         let binaryPath = try buildParameters.binaryPath(for: product)
                         let coverageBinaryPath = try buildParameters.buildPath.appending(
                             buildParameters.testCoverageBinaryRelativePath(forTestProductName: product.name)

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1397,4 +1397,18 @@ struct MiscellaneousSwiftTestingTests {
             )
         }
     }
+
+    @Test(
+        .tags(.Feature.Command.Test),
+    )
+    func testTestTargetDependsOnTestTarget_EnsureBuilds() async throws {
+        try await fixture(name: "Miscellaneous/TestTargetDependsOnTestTarget") { fixturePath in
+            let (_, stderr) = try await executeSwiftTest(
+                fixturePath,
+                buildSystem: .swiftbuild,
+                throwIfCommandFails: true,
+            )
+            #expect(stderr.contains("Build complete!"))
+        }
+    }
 }

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1399,13 +1399,14 @@ struct MiscellaneousSwiftTestingTests {
     }
 
     @Test(
-        .tags(.Feature.Command.Test),
+        .tags(.Feature.Command.Build),
+        arguments: SupportedBuildSystemOnAllPlatforms,
     )
-    func testTestTargetDependsOnTestTarget_EnsureBuilds() async throws {
+    func testTestTargetDependsOnTestTarget_EnsureBuilds(buildSystem: BuildSystemProvider.Kind) async throws {
         try await fixture(name: "Miscellaneous/TestTargetDependsOnTestTarget") { fixturePath in
             let (_, stderr) = try await executeSwiftTest(
                 fixturePath,
-                buildSystem: .swiftbuild,
+                buildSystem: buildSystem,
                 throwIfCommandFails: true,
             )
             #expect(stderr.contains("Build complete!"))

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1087,6 +1087,45 @@ struct PIFBuilderTests {
         ]
         #expect(sources == expected)
      }
+
+    @Test func testTargetDependsOnTestTarget() async throws {
+        try await withGeneratedPIF(fromFixture: "Miscellaneous/TestTargetDependsOnTestTarget") { pif, observabilitySystem in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+
+            let project = try pif.workspace.project(named: "TestTargetDependsOnTestTarget")
+
+            // TestUtils is depended upon by other test targets, so it must be built as a static
+            // library — not a test bundle — so dependents can link against it.
+            let testUtils = try project.target(named: "TestUtils")
+            guard case .target(let testUtilsTarget) = testUtils else {
+                Issue.record("Expected TestUtils to be a regular target")
+                return
+            }
+            #expect(testUtilsTarget.productType == .commonStaticArchive)
+
+            // There must be no test bundle product for TestUtils.
+            #expect(throws: (any Error).self) {
+                try project.target(named: "TestUtils-product")
+            }
+
+            // Both consuming test targets are still unit test bundles.
+            let fooTests = try project.target(named: "FooTests-product")
+            guard case .target(let fooTestsTarget) = fooTests else {
+                Issue.record("Expected FooTests-product to be a regular target")
+                return
+            }
+            #expect(fooTestsTarget.productType == .unitTest)
+            #expect(fooTestsTarget.common.dependencies.map(\.targetId).contains("PACKAGE-TARGET:TestUtils"))
+
+            let barTests = try project.target(named: "BarTests-product")
+            guard case .target(let barTestsTarget) = barTests else {
+                Issue.record("Expected BarTests-product to be a regular target")
+                return
+            }
+            #expect(barTestsTarget.productType == .unitTest)
+            #expect(barTestsTarget.common.dependencies.map(\.targetId).contains("PACKAGE-TARGET:TestUtils"))
+        }
+    }
 }
 
 extension ProjectModel.Group {


### PR DESCRIPTION
### Motivation:

Closer alignment of swiftbuild with the native build system with respect to allowing testTargets to depend on testTargets.

https://github.com/swiftlang/swift-package-manager/issues/10062

### Modifications:

Compile testTarget as static library if it is depended upon by another testTarget

### Result:

Support testTargets depending on testTargets
