### PR TITLE
Fix typo in PIF construction error message

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -840,7 +840,7 @@ extension PIFGenerationError: CustomStringConvertible {
             "Printed PIF manifest as graphviz"
 
         case .errorDiagnosticsReported:
-            "Errors reportes in PIF builder"
+            "PIF construction reported errors"
         }
     }
 }


### PR DESCRIPTION
Fix a small typo in the PIF construction failure error message