### PR TITLE
[6.4] Improve internal error when reading print-target-info

### DIFF
--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -19,8 +19,12 @@ public typealias StringError = TSCBasic.StringError
 
 public struct InternalError: Error {
     private let description: String
-    public init(_ description: String) {
-        assertionFailure(description)
+    public init(
+        _ description: String,
+        file: StaticString = #fileID,
+        line: UInt = #line,
+    ) {
+        assertionFailure(description, file: file, line: line)
         self.description =
             "Internal error. Please file a bug at https://github.com/swiftlang/swift-package-manager/issues with this info. \(description)"
     }

--- a/Sources/Basics/Triple+Basics.swift
+++ b/Sources/Basics/Triple+Basics.swift
@@ -101,9 +101,15 @@ extension Triple {
     public static func getHostTriple(usingSwiftCompiler swiftCompiler: AbsolutePath) throws -> (versionedTriple: Triple, unversionedTriple: Triple) {
         // Call the compiler to get the target info JSON.
         let compilerOutput: String
+        var result: AsyncProcessResult? = nil
+        let command: [String]  = [swiftCompiler.pathString, "-print-target-info"]
         do {
-            let result = try AsyncProcess.popen(args: swiftCompiler.pathString, "-print-target-info")
-            compilerOutput = try result.utf8Output().spm_chomp()
+            result = try AsyncProcess.popen(arguments: command)
+            compilerOutput = if let result {
+                try result.utf8Output().spm_chomp()
+            } else {
+                "<frontend failed>"
+            }
         } catch {
             throw InternalError("Failed to get target info (\(error.interpolationDescription))")
         }
@@ -112,8 +118,13 @@ extension Triple {
         do {
             parsedTargetInfo = try JSON(string: compilerOutput)
         } catch {
+            let errorMsg = [
+                "Failed to parse target info from frontend while executing command '\(command.joined(separator: " "))'.",
+                "Raw compiler output: \(compilerOutput)",
+                "Error: \(error.interpolationDescription)",
+            ]
             throw InternalError(
-                "Failed to parse target info (\(error.interpolationDescription)).\nRaw compiler output: \(compilerOutput)"
+                errorMsg.joined(separator: "\n")
             )
         }
         // Get the triple string from the parsed JSON.

--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -204,8 +204,9 @@ public final class UserToolchain: Toolchain {
         let result: AsyncProcessResult
         let compilerOutput: String
         let compilerStderr: String
+        let command = [swiftCompiler.pathString, "-print-target-info"]
         do {
-            result = try AsyncProcess.popen(args: swiftCompiler.pathString, "-print-target-info")
+            result = try AsyncProcess.popen(arguments: command)
             compilerOutput = try result.utf8Output().spm_chomp()
             compilerStderr = try result.utf8stderrOutput().spm_chomp()
         } catch {
@@ -217,8 +218,15 @@ public final class UserToolchain: Toolchain {
         do {
             return try JSON(string: compilerOutput)
         } catch {
+            let errMsg = [
+                "Failed to parse target info JSON from Swift frontend while executing command '\(command.joined(separator: " "))'.",
+                "Compiler exited with status '\(result.exitStatus)'.",
+                "Raw compiler stdout: \(compilerOutput)",
+                "Raw compiler stderr: \(compilerStderr)",
+                "Error: \(error.interpolationDescription)",
+            ]
             throw InternalError(
-                "Failed to parse target info (\(error.interpolationDescription)).\nCompiler exited with staus \(result.exitStatus).\nRaw compiler stdout: \(compilerOutput)\nRaw compiler stderr: \(compilerStderr)"
+                errMsg.joined(separator: "\n")
             )
         }
     }


### PR DESCRIPTION
While bringing up FreeBSD platform, SwiftPM raised a cryptic error message that was caused by a swift-frontend issue.  Improve the internal error raised by SwiftPM to help provide clarity on the failure

Issue: rdar://171860020
