### PR TITLE
Add LLDB debugger support to swift-test command

### DIFF
--- a/Fixtures/Miscellaneous/TestDebugging/Package.swift
+++ b/Fixtures/Miscellaneous/TestDebugging/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "TestDebugging",
+    targets: [
+        .target(name: "TestDebugging"),
+        .testTarget(name: "TestDebuggingTests", dependencies: ["TestDebugging"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestDebugging/Sources/TestDebugging/TestDebugging.swift
+++ b/Fixtures/Miscellaneous/TestDebugging/Sources/TestDebugging/TestDebugging.swift
@@ -1,0 +1,23 @@
+public struct Calculator {
+    public init() {}
+
+    public func add(_ a: Int, _ b: Int) -> Int {
+        return a + b
+    }
+
+    public func subtract(_ a: Int, _ b: Int) -> Int {
+        return a - b
+    }
+
+    public func multiply(_ a: Int, _ b: Int) -> Int {
+        return a * b
+    }
+
+    public func divide(_ a: Int, _ b: Int) -> Int {
+        return a / b
+    }
+
+    public func purposelyFail() -> Bool {
+        return false
+    }
+}

--- a/Fixtures/Miscellaneous/TestDebugging/Tests/TestDebuggingTests/TestDebuggingTests.swift
+++ b/Fixtures/Miscellaneous/TestDebugging/Tests/TestDebuggingTests/TestDebuggingTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import Testing
+@testable import TestDebugging
+
+final class XCTestCalculatorTests: XCTestCase {
+    func testAdditionPasses() {
+        let calculator = Calculator()
+        let result = calculator.add(2, 3)
+        XCTAssertEqual(result, 5, "Addition should return 5 for 2 + 3")
+    }
+}
+
+@Test
+func calculatorAdditionPasses() {
+    let calculator = Calculator()
+    let result = calculator.add(4, 6)
+    #expect(result == 10, "Addition should return 10 for 4 + 6")
+}

--- a/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Package.swift
+++ b/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "TestDebuggingMultiProduct",
+    targets: [
+        .target(name: "LibA"),
+        .target(name: "LibB"),
+        .testTarget(name: "LibATests", dependencies: ["LibA"]),
+        .testTarget(name: "LibBTests", dependencies: ["LibB"]),
+    ]
+)

--- a/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Sources/LibA/LibA.swift
+++ b/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Sources/LibA/LibA.swift
@@ -1,0 +1,7 @@
+public struct LibA {
+    public init() {}
+
+    public func greet() -> String {
+        return "Hello from LibA"
+    }
+}

--- a/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Sources/LibB/LibB.swift
+++ b/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Sources/LibB/LibB.swift
@@ -1,0 +1,7 @@
+public struct LibB {
+    public init() {}
+
+    public func greet() -> String {
+        return "Hello from LibB"
+    }
+}

--- a/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Tests/LibATests/LibATests.swift
+++ b/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Tests/LibATests/LibATests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import Testing
+@testable import LibA
+
+final class LibAXCTests: XCTestCase {
+    func testGreet() {
+        let lib = LibA()
+        XCTAssertEqual(lib.greet(), "Hello from LibA")
+    }
+}
+
+@Test("LibA greeting works")
+func libAGreeting() {
+    let lib = LibA()
+    #expect(lib.greet() == "Hello from LibA")
+}

--- a/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Tests/LibBTests/LibBTests.swift
+++ b/Fixtures/Miscellaneous/TestDebuggingMultiProduct/Tests/LibBTests/LibBTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import Testing
+@testable import LibB
+
+final class LibBXCTests: XCTestCase {
+    func testGreet() {
+        let lib = LibB()
+        XCTAssertEqual(lib.greet(), "Hello from LibB")
+    }
+}
+
+@Test("LibB greeting works")
+func libBGreeting() {
+    let lib = LibB()
+    #expect(lib.greet() == "Hello from LibB")
+}

--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(Commands
   Utilities/DOTManifestSerializer.swift
   Utilities/MermaidPackageSerializer.swift
   Utilities/MultiRootSupport.swift
+  Utilities/NonEmpty.swift
   Utilities/PlainTextEncoder.swift
   Utilities/PluginDelegate.swift
   Utilities/RefactoringSupport.swift

--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -19,7 +19,6 @@ import PackageModel
 import SPMBuildCore
 
 import enum TSCBasic.ProcessEnv
-import func TSCBasic.exec
 
 import enum TSCUtility.Diagnostics
 
@@ -153,7 +152,8 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                 fileSystem: swiftCommandState.fileSystem,
                 executablePath: interpreterPath,
                 originalWorkingDirectory: swiftCommandState.originalWorkingDirectory,
-                arguments: arguments
+                arguments: arguments,
+                observabilityScope: swiftCommandState.observabilityScope
             )
 
         case .debugger:
@@ -184,12 +184,17 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                         fileSystem: swiftCommandState.fileSystem,
                         executablePath: debuggerPath,
                         originalWorkingDirectory: swiftCommandState.originalWorkingDirectory,
-                        arguments: debugger.extraCLIOptions + [productAbsolutePath.pathString] + options.arguments
+                        arguments: debugger.extraCLIOptions + [productAbsolutePath.pathString] + options.arguments,
+                        observabilityScope: swiftCommandState.observabilityScope
                     )
                 } else {
                     let pathRelativeToWorkingDirectory = productAbsolutePath.relative(to: swiftCommandState.originalWorkingDirectory)
                     let lldbPath = try swiftCommandState.getTargetToolchain().getLLDB()
-                    try exec(path: lldbPath.pathString, args: ["--", pathRelativeToWorkingDirectory.pathString] + options.arguments)
+                    try safeExec(
+                        path: lldbPath.pathString,
+                        args: ["--", pathRelativeToWorkingDirectory.pathString] + options.arguments,
+                        observabilityScope: swiftCommandState.observabilityScope
+                    )
                 }
             } catch let error as RunError {
                 swiftCommandState.observabilityScope.emit(error)
@@ -208,7 +213,8 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                     fileSystem: swiftCommandState.fileSystem,
                     executablePath: swiftInterpreterPath,
                     originalWorkingDirectory: swiftCommandState.originalWorkingDirectory,
-                    arguments: arguments
+                    arguments: arguments,
+                    observabilityScope: swiftCommandState.observabilityScope
                 )
                 return
             }
@@ -248,7 +254,8 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                     fileSystem: swiftCommandState.fileSystem,
                     executablePath: runnerPath,
                     originalWorkingDirectory: swiftCommandState.originalWorkingDirectory,
-                    arguments: arguments
+                    arguments: arguments,
+                    observabilityScope: swiftCommandState.observabilityScope
                 )
             } catch Diagnostics.fatalError {
                 throw ExitCode.failure
@@ -297,7 +304,8 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
         fileSystem: FileSystem,
         executablePath: AbsolutePath,
         originalWorkingDirectory: AbsolutePath,
-        arguments: [String]
+        arguments: [String],
+        observabilityScope: ObservabilityScope
     ) throws {
         // Make sure we are running from the original working directory.
         let cwd: AbsolutePath? = fileSystem.currentWorkingDirectory
@@ -306,7 +314,7 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
         }
 
         let pathRelativeToWorkingDirectory = executablePath.relative(to: originalWorkingDirectory)
-        try execute(path: executablePath.pathString, args: [pathRelativeToWorkingDirectory.pathString] + arguments)
+        try safeExec(path: executablePath.pathString, args: [pathRelativeToWorkingDirectory.pathString] + arguments, observabilityScope: observabilityScope)
     }
 
     /// Determines if a path points to a valid swift file.
@@ -327,41 +335,6 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
             absolutePath = try AbsolutePath(cwd, validating: path)
         }
         return fileSystem.isFile(absolutePath)
-    }
-
-    /// A safe wrapper of TSCBasic.exec.
-    private func execute(path: String, args: [String]) throws -> Never {
-        #if !os(Windows)
-        // Dispatch will disable almost all asynchronous signals on its worker threads, and this is called from `async`
-        // context. To correctly `exec` a freshly built binary, we will need to:
-        // 1. reset the signal masks
-        for i in 1..<NSIG {
-            signal(i, SIG_DFL)
-        }
-        var sig_set_all = sigset_t()
-        sigfillset(&sig_set_all)
-        sigprocmask(SIG_UNBLOCK, &sig_set_all, nil)
-
-        #if os(FreeBSD) || os(OpenBSD)
-        #if os(FreeBSD)
-        pthread_suspend_all_np()
-        #endif
-        closefrom(3)
-        #else
-        #if os(Android)
-        let number_fds = Int32(sysconf(_SC_OPEN_MAX))
-        #else
-        let number_fds = getdtablesize()
-        #endif /* os(Android) */
-
-        // 2. set to close all file descriptors on exec
-        for i in 3..<number_fds {
-            _ = fcntl(i, F_SETFD, FD_CLOEXEC)
-        }
-        #endif /* os(FreeBSD) || os(OpenBSD) */
-        #endif
-
-        try TSCBasic.exec(path: path, args: args)
     }
 
     public init() {}

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -235,6 +235,11 @@ struct TestCommandOptions: ParsableArguments {
           help: "Determines whether testing measures code coverage.")
     var enableCodeCoverage: Bool = false
 
+    /// Launch tests inside an LLDB debugging session.
+    @Flag(name: .customLong("debugger"),
+          help: "Launch the tests in a debugger session. Use the `failbreak` alias to attach breakpoints that will trigger on test failures.")
+    var shouldLaunchInLLDB: Bool = false
+
     /// Configure the test output.
     @Option(help: ArgumentHelp("", visibility: .hidden))
     public var testOutput: TestOutput = .default
@@ -322,8 +327,20 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         var results = [TestProductResult]()
 
+        if options.shouldLaunchInLLDB {
+            // runTestProductsWithLLDB will replace the running swift-test process with lldb
+            // and so we don't expect any code after this call to execute.
+            try await runTestProductsWithLLDB(
+                testProducts,
+                productsBuildParameters: buildParameters,
+                swiftCommandState: swiftCommandState,
+                buildSystem: buildSystem
+            )
+            return
+        }
+
         // Run XCTest.
-        if options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
+        if !options.shouldLaunchInLLDB && options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
             // Validate XCTest is available on Darwin-based systems. If it's not available and you hit this code
             // path, the developer explicitly passed `--enable-xctest` or the toolchain is
             // corrupt.)
@@ -421,8 +438,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
         }
 
-        // Run Swift Testing (parallel or not, it has a single entry point).
-        if options.testLibraryOptions.isEnabled(.swiftTesting, swiftCommandState: swiftCommandState) {
+        // Run Swift Testing (parallel or not, it has a single entry point.)
+        if !options.shouldLaunchInLLDB && options.testLibraryOptions.isEnabled(.swiftTesting, swiftCommandState: swiftCommandState) {
             lazy var testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first
             if options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) || testEntryPointPath == nil {
                 // Filter test products to Swift testing suites.
@@ -576,6 +593,160 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 try await processCodeCoverage(testProducts, swiftCommandState: swiftCommandState, buildSystem: buildSystem)
             }
         }
+    }
+
+    /// Builds a `DebuggableTestSession` covering every enabled testing library across
+    /// the given products and launches it under LLDB via `DebugTestRunner`.
+    private func runTestProductsWithLLDB(
+        _ testProducts: [BuiltTestProduct],
+        productsBuildParameters: BuildParameters,
+        swiftCommandState: SwiftCommandState,
+        buildSystem: BuildSystem
+    ) async throws {
+        guard !testProducts.isEmpty else {
+            throw DebuggerError.noTestProducts
+        }
+
+        let toolchain = try swiftCommandState.getTargetToolchain()
+
+        let xctestEnabled = options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState)
+        let testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first
+        let swiftTestingEnabled = options.testLibraryOptions.isEnabled(.swiftTesting, swiftCommandState: swiftCommandState) &&
+                                 (options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) ||
+                                  testEntryPointPath == nil)
+
+        let skipSpecifier = options.skippedTests(fileSystem: swiftCommandState.fileSystem)
+
+        var productsWithXCTests = Set<AbsolutePath>()
+        if xctestEnabled {
+            let xctestSuites = try await TestingSupport.getTestSuites(
+                in: testProducts,
+                swiftCommandState: swiftCommandState,
+                enableCodeCoverage: options.enableCodeCoverage,
+                shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
+                experimentalTestOutput: options.enableExperimentalTestOutput,
+                sanitizers: globalOptions.build.sanitizers,
+                buildSystem: buildSystem
+            )
+            let matchingTests = try xctestSuites
+                .filteredTests(specifier: options.testCaseSpecifier)
+                .skippedTests(specifier: skipSpecifier)
+            productsWithXCTests = Set(matchingTests.map(\.testProduct.bundlePath))
+        }
+
+        var productsWithSwiftTests = Set<AbsolutePath>()
+        if swiftTestingEnabled {
+            let swiftTestingSuites = try await TestingSupport.getSwiftTestingSuites(
+                in: testProducts,
+                swiftCommandState: swiftCommandState,
+                shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
+                sanitizers: globalOptions.build.sanitizers,
+                buildSystem: buildSystem
+            )
+            let matchingTests = try swiftTestingSuites
+                .filteredTests(specifier: options.testCaseSpecifier)
+                .skippedTests(specifier: skipSpecifier)
+            for (binaryPath, tests) in matchingTests where !tests.isEmpty {
+                productsWithSwiftTests.insert(binaryPath)
+            }
+        }
+
+        var targets = [DebuggableTestSession.Target]()
+        for testProduct in testProducts {
+            if productsWithXCTests.contains(testProduct.bundlePath) {
+                targets.append(DebuggableTestSession.Target(
+                    productName: testProduct.productName,
+                    kind: .xctest(bundlePath: testProduct.bundlePath, binaryPath: testProduct.binaryPath),
+                    additionalArgs: try await additionalLLDBArguments(
+                        for: .xctest,
+                        testProduct: testProduct,
+                        swiftCommandState: swiftCommandState,
+                        buildSystem: buildSystem
+                    )
+                ))
+            }
+            if productsWithSwiftTests.contains(testProduct.binaryPath) {
+                targets.append(DebuggableTestSession.Target(
+                    productName: testProduct.productName,
+                    kind: .swiftTesting(binaryPath: testProduct.binaryPath),
+                    additionalArgs: try await additionalLLDBArguments(
+                        for: .swiftTesting,
+                        testProduct: testProduct,
+                        swiftCommandState: swiftCommandState,
+                        buildSystem: buildSystem
+                    )
+                ))
+            }
+        }
+
+        guard let sessionTargets = NonEmpty(targets) else {
+            throw DebuggerError.noEnabledTestingLibraries
+        }
+
+        try await runTestLibrariesWithLLDB(
+            target: DebuggableTestSession(targets: sessionTargets),
+            testProducts: testProducts,
+            productsBuildParameters: productsBuildParameters,
+            swiftCommandState: swiftCommandState,
+            toolchain: toolchain,
+            buildSystem: buildSystem
+        )
+    }
+
+    private func additionalLLDBArguments(
+        for library: TestingLibrary,
+        testProduct: BuiltTestProduct,
+        swiftCommandState: SwiftCommandState,
+        buildSystem: any BuildSystem
+    ) async throws -> [String] {
+        switch library {
+        case .xctest:
+            let (xctestArgs, _, _) = try await xctestArgs(
+                for: [testProduct],
+                swiftCommandState: swiftCommandState,
+                buildSystem: buildSystem
+            )
+            return xctestArgs
+
+        case .swiftTesting:
+            let commandLineArguments = CommandLine.arguments.dropFirst()
+            var swiftTestingArgs = ["--testing-library", "swift-testing", "--enable-swift-testing"]
+
+            if let separatorIndex = commandLineArguments.firstIndex(of: "--") {
+                let offset = commandLineArguments.distance(from: commandLineArguments.startIndex, to: separatorIndex)
+                swiftTestingArgs += Array(commandLineArguments.dropFirst(offset + 1))
+            }
+            return swiftTestingArgs
+        }
+    }
+
+    private func runTestLibrariesWithLLDB(
+        target: DebuggableTestSession,
+        testProducts: [BuiltTestProduct],
+        productsBuildParameters: BuildParameters,
+        swiftCommandState: SwiftCommandState,
+        toolchain: UserToolchain,
+        buildSystem: any BuildSystem
+    ) async throws {
+        let debugRunner = DebugTestRunner(
+            target: target,
+            buildParameters: productsBuildParameters,
+            toolchain: toolchain,
+            testEnv: try await TestingSupport.constructTestEnvironment(
+                toolchain: toolchain,
+                destinationBuildParameters: productsBuildParameters,
+                sanitizers: globalOptions.build.sanitizers,
+                library: .swiftTesting, // This is ignored by the DebugTestRunner, so we just hardcode it
+                testProductPaths: Array(Set(testProducts.flatMap { [$0.bundlePath, $0.binaryPath] })),
+                interopMode: nil,
+                buildSystem: buildSystem
+            ),
+            fileSystem: swiftCommandState.fileSystem,
+            observabilityScope: swiftCommandState.observabilityScope,
+            verbose: globalOptions.logging.verbose || globalOptions.logging.veryVerbose
+        )
+
+        try debugRunner.run()
     }
 
     private func runTestProducts(
@@ -790,6 +961,17 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     ///
     /// - Throws: if a command argument is invalid.
     private func validateArguments(swiftCommandState: SwiftCommandState) throws {
+        // Validation for --debugger first, since it affects other validations.
+        if options.shouldLaunchInLLDB {
+            try Self.validateLLDBCompatibility(
+                configuration: options.globalOptions.build.configuration ?? swiftCommandState.preferredBuildConfiguration,
+                shouldRunInParallel: options.shouldRunInParallel,
+                numberOfWorkers: options.numberOfWorkers,
+                shouldListTests: options._deprecated_shouldListTests,
+                shouldPrintCodeCovPath: options.shouldPrintCodeCovPath
+            )
+        }
+
         // Validation for `--num-workers`.
         if let workers = options.numberOfWorkers {
             // The `--num-worker` option should be called with `--parallel`. Because
@@ -810,6 +992,40 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         if options._deprecated_shouldListTests {
             swiftCommandState.observabilityScope.emit(warning: "'--list-tests' option is deprecated; use 'swift test list' instead")
+        }
+    }
+
+    /// Validates that --debugger is compatible with other provided arguments.
+    ///
+    /// Extracted as a static function so the validation logic can be tested
+    /// directly without invoking the full command pipeline.
+    ///
+    /// - Throws: if --debugger is used with incompatible flags.
+    static func validateLLDBCompatibility(
+        configuration: BuildConfiguration,
+        shouldRunInParallel: Bool,
+        numberOfWorkers: Int?,
+        shouldListTests: Bool,
+        shouldPrintCodeCovPath: Bool
+    ) throws {
+        if configuration == .release {
+            throw StringError("--debugger cannot be used with release configuration (debugging requires debug symbols)")
+        }
+
+        if shouldRunInParallel {
+            throw StringError("--debugger cannot be used with --parallel (debugging requires sequential execution)")
+        }
+
+        if numberOfWorkers != nil {
+            throw StringError("--debugger cannot be used with --num-workers (debugging requires sequential execution)")
+        }
+
+        if shouldListTests {
+            throw StringError("--debugger cannot be used with --list-tests (use 'swift test list' for listing tests)")
+        }
+
+        if shouldPrintCodeCovPath {
+            throw StringError("--debugger cannot be used with --show-codecov-path (debugging session cannot show paths)")
         }
     }
 

--- a/Sources/Commands/Utilities/NonEmpty.swift
+++ b/Sources/Commands/Utilities/NonEmpty.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A collection guaranteed to contain at least one element.
+struct NonEmpty<Element>: Sequence {
+    let first: Element
+    let rest: [Element]
+
+    init(_ first: Element, _ rest: [Element] = []) {
+        self.first = first
+        self.rest = rest
+    }
+
+    init?(_ elements: [Element]) {
+        guard let first = elements.first else { return nil }
+        self.first = first
+        self.rest = Array(elements.dropFirst())
+    }
+
+    func makeIterator() -> IndexingIterator<[Element]> {
+        ([first] + rest).makeIterator()
+    }
+}

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -12,10 +12,19 @@
 
 import Basics
 import CoreCommands
+import Foundation
 import PackageModel
 import SPMBuildCore
 import TSCUtility
 import Workspace
+
+#if canImport(WinSDK)
+import WinSDK
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 import struct TSCBasic.FileSystemError
 import class Basics.AsyncProcess
@@ -24,7 +33,54 @@ import TSCLibc
 import var TSCBasic.stderrStream
 import var TSCBasic.stdoutStream
 import func TSCBasic.withTemporaryFile
-import Foundation
+import func TSCBasic.withTemporaryDirectory
+import func TSCBasic.exec
+
+struct DebuggableTestSession {
+    struct Target {
+        enum Kind {
+            case xctest(bundlePath: AbsolutePath, binaryPath: AbsolutePath)
+            case swiftTesting(binaryPath: AbsolutePath)
+        }
+
+        let productName: String
+        let kind: Kind
+        let additionalArgs: [String]
+
+        var library: TestingLibrary {
+            switch kind {
+            case .xctest: .xctest
+            case .swiftTesting: .swiftTesting
+            }
+        }
+    }
+
+    let targets: NonEmpty<Target>
+
+    /// Whether this is part of a multi-session sequence
+    var isMultiSession: Bool {
+        !targets.rest.isEmpty
+    }
+}
+
+enum DebuggerError: Swift.Error {
+    case noTestProducts
+    case noEnabledTestingLibraries
+    case xctestNotFoundInToolchain
+}
+
+extension DebuggerError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .noTestProducts:
+            return "No test products found for debugging"
+        case .noEnabledTestingLibraries:
+            return "No testing libraries are enabled for debugging"
+        case .xctestNotFoundInToolchain:
+            return "XCTest not found in toolchain"
+        }
+    }
+}
 
 /// Internal helper functionality for the SwiftTestTool command and for the
 /// plugin support.
@@ -425,6 +481,782 @@ extension ToolsVersion {
     /// `SWIFT_TESTING_XCTEST_INTEROP_MODE` environment variable.
     var defaultInteropMode: String? {
         self >= .v6_4 ? "complete" : nil
+    }
+}
+
+/// A safe wrapper around TSCBasic.exec that resets signal masks and
+/// configures file descriptors before replacing the current process.
+///
+/// Dispatch disables almost all asynchronous signals on its worker threads.
+/// When called from async context, we must reset signal handlers and unblock
+/// all signals before exec so the child process starts with clean state.
+/// We also mark all non-standard file descriptors as close-on-exec to avoid
+/// leaking them to the new process.
+func safeExec(path: String, args: [String], observabilityScope: ObservabilityScope) throws -> Never {
+    #if !os(Windows)
+    for i in 1..<NSIG {
+        // SIGKILL and SIGSTOP cannot be caught or reset; skipping them avoids
+        // bogus SIG_ERR returns that would mask real failures.
+        if i == SIGKILL || i == SIGSTOP {
+            continue
+        }
+        let prior = signal(i, SIG_DFL)
+        if unsafeBitCast(prior, to: OpaquePointer?.self) == unsafeBitCast(SIG_ERR, to: OpaquePointer?.self) {
+            let err = String(cString: strerror(errno))
+            observabilityScope.emit(warning: "safeExec: signal(\(i), SIG_DFL) failed: \(err)")
+        }
+    }
+    var sig_set_all = sigset_t()
+    sigfillset(&sig_set_all)
+    if sigprocmask(SIG_UNBLOCK, &sig_set_all, nil) != 0 {
+        let err = String(cString: strerror(errno))
+        observabilityScope.emit(warning: "safeExec: sigprocmask(SIG_UNBLOCK) failed: \(err) -- LLDB may not receive Ctrl-C")
+    }
+
+    #if os(FreeBSD) || os(OpenBSD)
+    #if os(FreeBSD)
+    pthread_suspend_all_np()
+    #endif
+    closefrom(3)
+    #else
+    #if os(Android)
+    let number_fds = Int32(sysconf(_SC_OPEN_MAX))
+    #else
+    let number_fds = getdtablesize()
+    #endif
+
+    for i in 3..<number_fds {
+        // EBADF is expected for unopened slots; anything else means a real FD
+        // would leak into the exec'd process.
+        if fcntl(i, F_SETFD, FD_CLOEXEC) == -1 && errno != EBADF {
+            let err = String(cString: strerror(errno))
+            observabilityScope.emit(warning: "safeExec: fcntl(\(i), F_SETFD, FD_CLOEXEC) failed: \(err)")
+        }
+    }
+    #endif
+
+    // Once signal handlers have been reset, the signal mask unblocked, and
+    // callers (e.g. DebugTestRunner) have written test env vars into the
+    // running process, there is no safe way to restore prior state. A bad
+    // exec path (ENOENT, EACCES, ...) should not return to SwiftPM with a
+    // corrupted signal table.
+    do {
+        try exec(path: path, args: args)
+    } catch {
+        observabilityScope.emit(
+            error: "safeExec: exec(\(path)) failed after mutating process state; aborting: \(error)"
+        )
+        _exit(EXIT_FAILURE)
+    }
+    #else
+    try exec(path: path, args: args)
+    #endif
+}
+
+struct DebugTestRunner {
+    private let target: DebuggableTestSession
+    private let buildParameters: BuildParameters
+    private let toolchain: UserToolchain
+    private let testEnv: Environment
+    private let fileSystem: FileSystem
+    private let observabilityScope: ObservabilityScope
+    private let verbose: Bool
+
+    /// Escapes a string for embedding inside a double-quoted LLDB command
+    /// argument. Backslash must be doubled first so the escape we introduce
+    /// for `"` isn't itself re-escaped. Windows paths and product names
+    /// containing `\` or `"` would otherwise corrupt the command file.
+    static func escapeForQuotedLLDBArgument(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    /// Escapes a string for embedding inside a double-quoted Python string
+    /// literal. Python interprets `\n`, `\r`, `\t`, `\x`, `\u`, etc. as
+    /// escape sequences inside `"..."` literals, so LLDB-style escaping
+    /// (which only handles `\` and `"`) is not sufficient. Backslash is
+    /// doubled first so the escapes we introduce aren't re-escaped.
+    static func escapeForPythonStringLiteral(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
+    }
+
+    /// Builds an inline LLDB `script` command that registers an
+    /// `SBDebugger.SetDestroyCallback` to delete the given directory
+    /// when LLDB tears down. Fires on `quit`, `exit`, EOF, and most
+    /// normal shutdown paths; hard crashes / SIGKILL still bypass it.
+    static func atexitCleanupCommand(tempDirectory: AbsolutePath) -> String {
+        let escaped = escapeForQuotedLLDBArgument(tempDirectory.pathString)
+        return "script import shutil; lldb.debugger.SetDestroyCallback(lambda _id, d=\"\(escaped)\": shutil.rmtree(d, ignore_errors=True))"
+    }
+
+    /// Creates an instance of debug test runner.
+    init(
+        target: DebuggableTestSession,
+        buildParameters: BuildParameters,
+        toolchain: UserToolchain,
+        testEnv: Environment,
+        fileSystem: FileSystem,
+        observabilityScope: ObservabilityScope,
+        verbose: Bool = false
+    ) {
+        self.target = target
+        self.buildParameters = buildParameters
+        self.toolchain = toolchain
+        self.testEnv = testEnv
+        self.fileSystem = fileSystem
+        self.observabilityScope = observabilityScope
+        self.verbose = verbose
+    }
+
+    /// Launches the test binary under LLDB for interactive debugging.
+    ///
+    /// Uses `exec()` so LLDB inherits the controlling terminal directly.
+    func run() throws {
+        let lldbPath: AbsolutePath
+        do {
+            lldbPath = try toolchain.getLLDB()
+        } catch {
+            observabilityScope.emit(error: "Unable to get LLDB: \(error)")
+            throw error
+        }
+
+        let lldbArgs = try prepareLLDBArguments(for: target)
+        observabilityScope.emit(info: "LLDB will run: \(lldbPath.pathString) \(lldbArgs.joined(separator: " "))")
+
+        // Set on the current process so the exec'd LLDB inherits them.
+        for (key, value) in testEnv {
+            try Environment.set(key: key, value: value)
+        }
+
+        try safeExec(path: lldbPath.pathString, args: [lldbPath.pathString] + lldbArgs, observabilityScope: observabilityScope)
+    }
+
+    /// Prepares LLDB arguments for debugging based on the testing library.
+    ///
+    /// This method creates a temporary LLDB command file with the necessary setup commands
+    /// for debugging tests, including target creation, argument configuration, and symbol loading.
+    ///
+    /// - Parameter target: The testing target being used (XCTest or Swift Testing)
+    /// - Returns: Array of LLDB command line arguments
+    /// - Throws: Various errors if required tools are not found or file operations fail
+    private func prepareLLDBArguments(for target: DebuggableTestSession) throws -> [String] {
+        // One unique scratch directory per invocation so concurrent runs don't collide on fixed filenames
+        let scratchDir = try withTemporaryDirectory(
+            dir: try fileSystem.tempDirectory,
+            prefix: "swiftpm-lldb-",
+            removeTreeOnDeinit: false
+        ) { $0 }
+
+        // On success, cleanup is handed off to LLDB's SetDestroyCallback via
+        // atexitCleanupCommand. If we throw before exec, that callback never
+        // runs, so we must clean up ourselves or leak /tmp/swiftpm-lldb-*.
+        do {
+            var lldbCommands: [String] = []
+            try setupTargets(&lldbCommands, scratchDir: scratchDir)
+
+            lldbCommands.append(Self.atexitCleanupCommand(tempDirectory: scratchDir))
+
+            // Clear the screen of all the previous commands to unclutter the users initial state.
+            // Skip clearing in verbose mode so startup commands remain visible
+            if !verbose {
+                lldbCommands.append("script print(\"\\033[H\\033[J\", end=\"\")")
+            }
+
+            if Environment.current["SWIFTPM_TESTS_MODULECACHE"] != nil {
+                if Environment.current["SWIFTPM_TESTS_LLDB_RUN"] != nil {
+                    lldbCommands.append("run")
+                }
+                lldbCommands.append("quit")
+            }
+
+            let commandScript = lldbCommands.joined(separator: "\n")
+            let lldbCommandFile = scratchDir.appending("lldb-commands.txt")
+            try fileSystem.writeFileContents(lldbCommandFile, string: commandScript)
+
+            // Return script file arguments without batch mode to allow interactive debugging
+            return ["-s", lldbCommandFile.pathString]
+        } catch {
+            try? fileSystem.removeFileTree(scratchDir)
+            throw error
+        }
+    }
+
+    private func setupTargets(_ lldbCommands: inout [String], scratchDir: AbsolutePath) throws {
+        var hasSwiftTesting = false
+        var hasXCTest = false
+
+        for testingLibrary in target.targets {
+            let (executable, args) = try getExecutableAndArgs(for: testingLibrary)
+            let escapedExecutable = Self.escapeForQuotedLLDBArgument(executable.pathString)
+            let escapedProductName = Self.escapeForQuotedLLDBArgument(testingLibrary.productName)
+            // Smoke-test CI doesn't ship the toolchain's lldb alongside the in-development
+            // swiftc; it falls back to an older system lldb on PATH that doesn't support
+            // `target create -l`. Skip the label there so the command parses.
+            if Environment.current["SWIFTCI_USE_LOCAL_DEPS"] != nil {
+                lldbCommands.append("target create \"\(escapedExecutable)\"")
+            } else {
+                lldbCommands.append("target create -l \"\(escapedProductName) (\(testingLibrary.library))\" \"\(escapedExecutable)\"")
+            }
+            lldbCommands.append("settings clear target.run-args")
+
+            for arg in args {
+                lldbCommands.append("settings append target.run-args \"\(Self.escapeForQuotedLLDBArgument(arg))\"")
+            }
+
+            let modulePath = try getModulePath(for: testingLibrary)
+            lldbCommands.append("target modules add \"\(Self.escapeForQuotedLLDBArgument(modulePath.pathString))\"")
+
+            switch testingLibrary.kind {
+            case .xctest:
+                hasXCTest = true
+                #if os(macOS)
+                // Prevent the xctest binary from running any swift-testing tests it finds
+                // if the test target contains both types of tests. If the test target is mixed,
+                // we create one lldb target for each type.
+                lldbCommands.append("settings set target.env-vars SWIFT_TESTING_ENABLED=0")
+                #endif
+            case .swiftTesting:
+                hasSwiftTesting = true
+            }
+        }
+
+        try setupCommandAliases(
+            &lldbCommands,
+            scratchDir: scratchDir,
+            hasSwiftTesting: hasSwiftTesting,
+            hasXCTest: hasXCTest
+        )
+
+        if target.isMultiSession {
+            let scriptPath = try createTargetSwitchingScript(in: scratchDir)
+            lldbCommands.append("command script import \"\(Self.escapeForQuotedLLDBArgument(scriptPath.pathString))\"")
+            lldbCommands.append("target select 0")
+        }
+    }
+
+    private func setupCommandAliases(_ lldbCommands: inout [String], scratchDir: AbsolutePath, hasSwiftTesting: Bool, hasXCTest: Bool) throws {
+        #if os(macOS)
+            let swiftTestingSpec: (module: String?, symbol: String) = ("Testing", "failureBreakpoint()")
+            let xctestSpec: (module: String?, symbol: String) = (nil, "_XCTFailureBreakpoint")
+        #elseif os(Windows)
+            let swiftTestingSpec: (module: String?, symbol: String) = ("Testing.dll", "failureBreakpoint()")
+            let xctestSpec: (module: String?, symbol: String) = ("XCTest.dll", "XCTest.XCTestCase.recordFailure")
+        #else
+            let swiftTestingSpec: (module: String?, symbol: String) = ("libTesting.so", "Testing.failureBreakpoint")
+            let xctestSpec: (module: String?, symbol: String) = ("libXCTest.so", "XCTest.XCTestCase.recordFailure")
+        #endif
+
+        var specs: [(module: String?, symbol: String)] = []
+        if hasSwiftTesting {
+            specs.append(swiftTestingSpec)
+        }
+        if hasXCTest {
+            specs.append(xctestSpec)
+        }
+
+        guard !specs.isEmpty else { return }
+
+        let scriptPath = try createFailbreakScript(in: scratchDir, specs: specs)
+        lldbCommands.append("command script import \"\(Self.escapeForQuotedLLDBArgument(scriptPath.pathString))\"")
+        lldbCommands.append("command script add -f failbreak.failbreak failbreak")
+        lldbCommands.append("script print(\"failbreak command registered: \(specs.count) specs\")")
+    }
+
+    /// Creates a Python script that implements the `failbreak` command.
+    ///
+    /// On invocation, `failbreak` sets breakpoints on the failure-anchor
+    /// symbols inside the testing libraries and installs a stop hook that,
+    /// when the process stops inside one of those anchors, selects the
+    /// first stack frame that has debug info and lives outside the testing
+    /// libraries — typically the user's `XCTAssert` call or `#expect`
+    /// macro expansion site.
+    ///
+    /// A stop hook is used (rather than a breakpoint callback) because
+    /// LLDB's "most relevant frame" selection runs *after* breakpoint
+    /// callbacks and would otherwise clobber our `SetSelectedFrame` call.
+    ///
+    /// The stop hook is installed lazily on first `failbreak` invocation
+    /// rather than at LLDB startup, so users who never invoke `failbreak`
+    /// pay no per-target setup overhead.
+    private func createFailbreakScript(in scratchDir: AbsolutePath, specs: [(module: String?, symbol: String)]) throws -> AbsolutePath {
+        let scriptPath = scratchDir.appending("failbreak.py")
+
+        let specsLiteral = specs.map { spec -> String in
+            let moduleLiteral = spec.module.map { "\"\(Self.escapeForPythonStringLiteral($0))\"" } ?? "None"
+            let symbolLiteral = "\"\(Self.escapeForPythonStringLiteral(spec.symbol))\""
+            return "    (\(moduleLiteral), \(symbolLiteral)),"
+        }.joined(separator: "\n")
+
+        let pythonScript = """
+# failbreak.py
+import lldb
+
+_FAILBREAK_SPECS = [
+\(specsLiteral)
+]
+
+_FAILBREAK_SYMBOLS = {spec[1] for spec in _FAILBREAK_SPECS}
+
+_TESTING_MODULES = {
+    "Testing", "Testing.dll", "libTesting.so", "libTesting.dylib",
+    "XCTest", "XCTest.dll", "libXCTest.so", "libXCTest.dylib",
+    "XCTestCore", "libXCTestCore.dylib",
+}
+
+_stop_hook_installed = False
+
+def _is_testing_module(module):
+    if not module.IsValid():
+        return False
+    name = module.GetFileSpec().GetFilename() or ""
+    return name in _TESTING_MODULES
+
+def _is_macro_expansion(frame):
+    name = frame.GetFunctionName() or ""
+    if "macro expansion" in name:
+        return True
+    line_entry = frame.GetLineEntry()
+    if line_entry.IsValid():
+        filename = line_entry.GetFileSpec().GetFilename() or ""
+        if filename.startswith("@__swiftmacro_"):
+            return True
+    return False
+
+def _frame_is_failure_anchor(frame):
+    name = frame.GetFunctionName() or ""
+    for sym in _FAILBREAK_SYMBOLS:
+        if sym in name:
+            return True
+    return False
+
+def _select_user_frame(thread, stream):
+    \"\"\"Walk frames and select the first one outside the testing libraries and
+    outside freestanding-macro expansions.\"\"\"
+    for i in range(thread.GetNumFrames()):
+        f = thread.GetFrameAtIndex(i)
+        line_entry = f.GetLineEntry()
+        if not line_entry.IsValid() or not line_entry.GetFileSpec().IsValid():
+            continue
+        if _is_testing_module(f.GetModule()):
+            continue
+        if _is_macro_expansion(f):
+            continue
+        thread.SetSelectedFrame(i)
+        if stream is not None:
+            func = f.GetFunctionName() or "<unknown>"
+            filename = line_entry.GetFileSpec().GetFilename() or "<unknown>"
+            line = line_entry.GetLine()
+        return i
+    return None
+
+class FailbreakStopHook:
+    \"\"\"Stop hook: when we stop at a failure anchor, jump to the first user frame.\"\"\"
+
+    def __init__(self, target, extra_args, internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, stream):
+        thread = exe_ctx.GetThread()
+        if not thread.IsValid():
+            return True
+        if thread.GetStopReason() != lldb.eStopReasonBreakpoint:
+            return True
+        if not _frame_is_failure_anchor(thread.GetFrameAtIndex(0)):
+            return True
+        _select_user_frame(thread, stream)
+        return True
+
+def _install_stop_hook(debugger, result):
+    \"\"\"Install the FailbreakStopHook on every existing target.
+
+    `target stop-hook add` normally applies to the currently selected
+    target, and switching the selected target from inside a Python
+    command handler (via either `SBDebugger.SetSelectedTarget` or
+    `HandleCommand("target select N")`) doesn't reliably propagate to
+    subsequent `HandleCommand` calls — both leave us installing every
+    hook on the originally-selected target.
+
+    Pass an `SBExecutionContext` override to `HandleCommand` so the
+    command applies to the target we explicitly name. No `target select`
+    switching needed.
+
+    Returns True if at least one install succeeded; only then is the
+    module-level sentinel flipped so that a completely-failed install
+    will be retried on the next `failbreak` invocation.
+    \"\"\"
+    global _stop_hook_installed
+    if _stop_hook_installed:
+        return True
+    ci = debugger.GetCommandInterpreter()
+    installed = 0
+    attempted = 0
+    for i in range(debugger.GetNumTargets()):
+        t = debugger.GetTargetAtIndex(i)
+        if not t.IsValid():
+            continue
+        attempted += 1
+        ret = lldb.SBCommandReturnObject()
+        exe_ctx = lldb.SBExecutionContext(t)
+        ci.HandleCommand(
+            "target stop-hook add -P failbreak.FailbreakStopHook",
+            exe_ctx, ret, False
+        )
+        if ret.Succeeded():
+            installed += 1
+        else:
+            err = ret.GetError() or "unknown error"
+            result.AppendWarning(
+                "failbreak: could not install stop hook on target #%d: %s"
+                % (i, err.rstrip())
+            )
+    if installed > 0:
+        _stop_hook_installed = True
+        return True
+    if attempted > 0:
+        result.AppendWarning(
+            "failbreak: stop hook install failed on all %d target(s); "
+            "frame selection on failure will not occur" % attempted
+        )
+    return False
+
+def failbreak(debugger, command, exe_ctx, result, internal_dict):
+    \"\"\"`failbreak` command: set breakpoints on testing-library failure anchors.\"\"\"
+    target = debugger.GetSelectedTarget()
+    if not target.IsValid():
+        result.SetError("no target selected")
+        return
+    _install_stop_hook(debugger, result)
+    installed = 0
+    for module_name, symbol in _FAILBREAK_SPECS:
+        if module_name:
+            bp = target.BreakpointCreateByName(symbol, module_name)
+        else:
+            bp = target.BreakpointCreateByName(symbol)
+        if bp.IsValid():
+            installed += 1
+            result.AppendMessage("failbreak breakpoint set: " + symbol)
+        else:
+            result.AppendWarning("failbreak: could not set breakpoint on " + symbol)
+    if installed == 0 and _FAILBREAK_SPECS:
+        result.SetError(
+            "failbreak: no breakpoints could be set; "
+            "testing libraries may not be loaded yet"
+        )
+"""
+
+        try fileSystem.writeFileContents(scriptPath, string: pythonScript)
+        return scriptPath
+    }
+
+    /// Gets the executable path and arguments for a given testing library
+    private func getExecutableAndArgs(for target: DebuggableTestSession.Target) throws -> (AbsolutePath, [String]) {
+        switch target.kind {
+        case .xctest(let bundlePath, let binaryPath):
+            #if os(macOS)
+            guard let xctestPath = toolchain.xctestPath else {
+                throw DebuggerError.xctestNotFoundInToolchain
+            }
+            return (xctestPath, target.additionalArgs + [bundlePath.pathString])
+            #else
+            return (binaryPath, target.additionalArgs)
+            #endif
+        case .swiftTesting(let binaryPath):
+            #if os(macOS)
+            let executable = try toolchain.getSwiftTestingHelper()
+            let args = ["--test-bundle-path", binaryPath.pathString] + target.additionalArgs
+            #else
+            let executable = binaryPath
+            let args = target.additionalArgs
+            #endif
+            return (executable, args)
+        }
+    }
+
+    /// Gets the module path for symbol loading
+    private func getModulePath(for target: DebuggableTestSession.Target) throws -> AbsolutePath {
+        switch target.kind {
+        case .xctest(_, let binaryPath), .swiftTesting(let binaryPath):
+            return binaryPath
+        }
+    }
+
+    /// Creates a Python script that handles automatic target switching
+    private func createTargetSwitchingScript(in scratchDir: AbsolutePath) throws -> AbsolutePath {
+        let scriptPath = scratchDir.appending("target_switcher.py")
+
+        let pythonScript = """
+# target_switcher.py
+import lldb
+import re
+import threading
+import time
+import sys
+
+current_target_index = 0
+max_targets = 0
+debugger_ref = None
+sequence_active = True  # Start active by default
+
+def _log_error(message):
+    \"\"\"Emit a diagnostic to stderr; never raise.\"\"\"
+    try:
+        sys.stderr.write("[swift test] " + str(message) + "\\n")
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+def _run_lldb_command(command):
+    \"\"\"Run an LLDB command and surface failures via stderr.\"\"\"
+    if not debugger_ref:
+        _log_error("skipping command, no debugger: " + command)
+        return False
+    return_obj = lldb.SBCommandReturnObject()
+    debugger_ref.GetCommandInterpreter().HandleCommand(command, return_obj)
+    if not return_obj.Succeeded():
+        _log_error("command failed: " + command + " -- " + (return_obj.GetError() or "<no error>"))
+        return False
+    return True
+
+def sync_breakpoints_to_target(source_target, dest_target):
+    \"\"\"Synchronize breakpoints from source target to destination target.\"\"\"
+    if not source_target or not dest_target:
+        return
+
+    def breakpoint_exists_in_target_by_spec(target, file_name, line_number, function_name):
+        \"\"\"Check if a breakpoint already exists in the target by specification.\"\"\"
+        for i in range(target.GetNumBreakpoints()):
+            existing_bp = target.GetBreakpointAtIndex(i)
+            if not existing_bp.IsValid():
+                continue
+
+            # Check function name breakpoints
+            if function_name:
+                # Get the breakpoint's function name specifications
+                names = lldb.SBStringList()
+                existing_bp.GetNames(names)
+
+                # Check names from GetNames()
+                for j in range(names.GetSize()):
+                    if names.GetStringAtIndex(j) == function_name:
+                        return True
+
+                # If no names found, check the description for pending breakpoints
+                if names.GetSize() == 0:
+                    bp_desc = str(existing_bp).strip()
+                    match = re.search(r"name = '([^']+)'", bp_desc)
+                    if match and match.group(1) == function_name:
+                        return True
+
+            # Check file/line breakpoints (only if resolved)
+            if file_name and line_number:
+                for j in range(existing_bp.GetNumLocations()):
+                    location = existing_bp.GetLocationAtIndex(j)
+                    if location.IsValid():
+                        addr = location.GetAddress()
+                        line_entry = addr.GetLineEntry()
+                        if line_entry.IsValid():
+                            existing_file_spec = line_entry.GetFileSpec()
+                            existing_line_number = line_entry.GetLine()
+                            if (existing_file_spec.GetFilename() == file_name and
+                                existing_line_number == line_number):
+                                return True
+        return False
+
+    # Get all breakpoints from source target
+    for i in range(source_target.GetNumBreakpoints()):
+        bp = source_target.GetBreakpointAtIndex(i)
+        if not bp.IsValid():
+            continue
+
+        # Handle breakpoints by their specifications, not just resolved locations
+        # First check if this is a function name breakpoint
+        names = lldb.SBStringList()
+        bp.GetNames(names)
+
+        # For pending breakpoints, GetNames() might be empty, so also check the description
+        bp_desc = str(bp).strip()
+
+        # Extract function name from description if names is empty
+        function_names_to_sync = []
+        if names.GetSize() > 0:
+            # Use the names from GetNames()
+            for j in range(names.GetSize()):
+                function_name = names.GetStringAtIndex(j)
+                if function_name:
+                    function_names_to_sync.append(function_name)
+        else:
+            # Parse function name from description for pending breakpoints
+            match = re.search(r"name = '([^']+)'", bp_desc)
+            if match:
+                function_name = match.group(1)
+                function_names_to_sync.append(function_name)
+
+        # Sync the function name breakpoints
+        for function_name in function_names_to_sync:
+            if not breakpoint_exists_in_target_by_spec(dest_target, None, None, function_name):
+                new_bp = dest_target.BreakpointCreateByName(function_name)
+                if new_bp.IsValid():
+                    new_bp.SetEnabled(bp.IsEnabled())
+                    new_bp.SetCondition(bp.GetCondition())
+                    new_bp.SetIgnoreCount(bp.GetIgnoreCount())
+                else:
+                    _log_error("failed to create breakpoint by name: " + function_name)
+
+        # Handle resolved location-based breakpoints (file/line)
+        # Only process if the breakpoint has resolved locations
+        if bp.GetNumLocations() > 0:
+            for j in range(bp.GetNumLocations()):
+                location = bp.GetLocationAtIndex(j)
+                if not location.IsValid():
+                    continue
+
+                addr = location.GetAddress()
+                line_entry = addr.GetLineEntry()
+
+                if line_entry.IsValid():
+                    file_spec = line_entry.GetFileSpec()
+                    line_number = line_entry.GetLine()
+                    file_name = file_spec.GetFilename()
+
+                    # Check if this breakpoint already exists in destination target
+                    if breakpoint_exists_in_target_by_spec(dest_target, file_name, line_number, None):
+                        continue
+
+                    # Create the same breakpoint in the destination target
+                    new_bp = dest_target.BreakpointCreateByLocation(file_spec, line_number)
+                    if new_bp.IsValid():
+                        # Copy breakpoint properties
+                        new_bp.SetEnabled(bp.IsEnabled())
+                        new_bp.SetCondition(bp.GetCondition())
+                        new_bp.SetIgnoreCount(bp.GetIgnoreCount())
+                    else:
+                        _log_error("failed to create breakpoint at " + str(file_name) + ":" + str(line_number))
+
+def sync_breakpoints_to_all_targets():
+    \"\"\"Synchronize breakpoints from current target to all other targets.\"\"\"
+    global debugger_ref, max_targets
+
+    if not debugger_ref or max_targets <= 1:
+        return
+
+    current_target = debugger_ref.GetSelectedTarget()
+    if not current_target:
+        return
+
+    # Sync to all other targets
+    for i in range(max_targets):
+        target = debugger_ref.GetTargetAtIndex(i)
+        if target and target != current_target:
+            sync_breakpoints_to_target(current_target, target)
+
+def monitor_breakpoints():
+    \"\"\"Monitor breakpoint changes and sync them across targets.\"\"\"
+    global debugger_ref, max_targets
+
+    if max_targets <= 1:
+        return
+
+    last_breakpoint_count = 0
+
+    while True:  # Keep running forever, not just while current_target_index < max_targets
+        try:
+            if debugger_ref:
+                current_target = debugger_ref.GetSelectedTarget()
+                if current_target:
+                    current_bp_count = current_target.GetNumBreakpoints()
+
+                    # If breakpoint count changed, sync to all targets
+                    if current_bp_count != last_breakpoint_count:
+                        sync_breakpoints_to_all_targets()
+                        last_breakpoint_count = current_bp_count
+        except Exception as e:
+            _log_error("monitor_breakpoints iteration failed: " + repr(e))
+
+        time.sleep(0.5)  # Check every 500ms
+
+def check_process_status():
+    \"\"\"Periodically check if the current process has exited.\"\"\"
+    global current_target_index, max_targets, debugger_ref, sequence_active
+
+    while True:  # Keep running forever, don't exit
+        try:
+            if debugger_ref:
+                target = debugger_ref.GetSelectedTarget()
+                if target:
+                    process = target.GetProcess()
+                    if process and process.GetState() == lldb.eStateExited:
+                        # Process has exited
+                        if sequence_active and current_target_index < max_targets:
+                            # We're in an active sequence, trigger switch
+                            current_target_index += 1
+
+                            if current_target_index < max_targets:
+                                # Switch to next target and launch immediately
+                                print("\\n")
+                                _run_lldb_command(f'target select {current_target_index}')
+                                print(" ")
+
+                                # Get target name for user feedback
+                                new_target = debugger_ref.GetSelectedTarget()
+                                target_name = new_target.GetExecutable().GetFilename() if new_target else "Unknown"
+
+                                # Launch the next target immediately
+                                _run_lldb_command('process launch')
+                            else:
+                                # Reset to first target and deactivate sequence until user runs again
+                                current_target_index = 0
+                                sequence_active = False  # Pause automatic switching
+
+                                print("\\n")
+                                _run_lldb_command('target select 0')
+                                print("\\nAll testing targets completed.")
+                                print("Type 'run' to restart the entire test sequence from the beginning.\\n")
+
+                                # Clear the current line and move cursor to start
+                                sys.stdout.write("\\033[2K\\r")
+                                # Reprint a fake prompt
+                                sys.stdout.write("(lldb) ")
+                                sys.stdout.flush()
+                    elif process and process.GetState() in [lldb.eStateRunning, lldb.eStateLaunching]:
+                        # Process is running - if sequence was inactive, reactivate it
+                        if not sequence_active:
+                            sequence_active = True
+                            # Find which target is currently selected to set the correct index
+                            selected_target = debugger_ref.GetSelectedTarget()
+                            if selected_target:
+                                for i in range(max_targets):
+                                    if debugger_ref.GetTargetAtIndex(i) == selected_target:
+                                        current_target_index = i
+                                        break
+        except Exception as e:
+            _log_error("check_process_status iteration failed: " + repr(e))
+
+        time.sleep(0.1)  # Check every 100ms
+
+def __lldb_init_module(debugger, internal_dict):
+    global max_targets, debugger_ref
+
+    debugger_ref = debugger
+
+    # Count the number of targets
+    max_targets = debugger.GetNumTargets()
+
+    if max_targets > 1:
+        # Start the process status checker
+        status_thread = threading.Thread(target=check_process_status, daemon=True)
+        status_thread.start()
+
+        # Start the breakpoint monitor
+        bp_thread = threading.Thread(target=monitor_breakpoints, daemon=True)
+        bp_thread.start()
+"""
+
+        try fileSystem.writeFileContents(scriptPath, string: pythonScript)
+        return scriptPath
     }
 }
 

--- a/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
@@ -77,6 +77,10 @@ This will only repeat the individual test cases that meet the repetition conditi
 
 If `--maximum-repetitions` is provided without `--repeat-until`, all tests will repeat `maximum-repetitions` times.
 
+## LLDB Debugger support in `swift test`
+
+Running `swift test --debugger` will launch tests in an LLDB debugging session on the command line.  Read more [here](<doc:SwiftTest>).
+
 ## Reporting issues
 
 Please follow these steps when reporting issues:

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftTest.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftTest.md
@@ -56,6 +56,7 @@ test [--package-path=<package-path>]
   [--skip=<skip>...] [--xunit-output=<xunit-output>]
   [--enable-testable-imports|disable-testable-imports]
   [--enable-code-coverage|disable-code-coverage]
+  [--debugger]
   [--traits=<traits>] [--enable-all-traits]
   [--disable-default-traits] [--version] [--help]
 ```
@@ -360,6 +361,11 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 - term **--enable-code-coverage|disable-code-coverage**:
 
 *Enable code coverage.*
+
+
+- term **--debugger**:
+
+*Launch tests inside an LLDB debugging session. Use the `failbreak` alias to attach breakpoints that will trigger on test failures.*
 
 
 - term **--traits=\<traits\>**:

--- a/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Helpers.swift
@@ -12,6 +12,8 @@
 
 import Basics
 import Testing
+import Foundation
+import class TSCBasic.BufferedOutputByteStream
 
 
 fileprivate func fileErrorMessage(
@@ -344,4 +346,30 @@ private func _expectThrowsCommandExecutionError<R, T>(
         return Optional<R>.none
     }
     return try errorHandler(CommandExecutionError(result: processResult, stdout: stdout, stderr: stderr))
+}
+
+/// Checks if an output stream contains a specific string, with retry logic for asynchronous writes.
+/// - Parameters:
+///   - outputStream: The output stream to check
+///   - needle: The string to search for in the output stream
+///   - timeout: Maximum time to wait for the string to appear (default: 3 seconds)
+///   - retryInterval: Time to wait between checks (default: 50 milliseconds)
+/// - Returns: True if the string was found within the timeout period
+public func waitForOutputStreamToContain(
+    _ outputStream: BufferedOutputByteStream,
+    _ needle: String,
+    timeout: Duration = .seconds(3),
+    retryInterval: Duration = .milliseconds(50)
+) async throws -> Bool {
+    let clock = ContinuousClock()
+    let startTime = clock.now
+    while clock.now - startTime < timeout {
+        if outputStream.bytes.description.contains(needle) {
+            return true
+        }
+
+        try await Task.sleep(for: retryInterval)
+    }
+
+    return outputStream.bytes.description.contains(needle)
 }

--- a/Sources/_InternalTestSupport/misc.swift
+++ b/Sources/_InternalTestSupport/misc.swift
@@ -594,14 +594,7 @@ private func swiftArgs(
     Xswiftc: [String],
     buildSystem: BuildSystemProvider.Kind?
 ) -> [String] {
-    var args = ["--configuration"]
-    switch configuration {
-    case .debug:
-        args.append("debug")
-    case .release:
-        args.append("release")
-    }
-
+    var args = configuration.buildArgs
     args += Xcc.flatMap { ["-Xcc", $0] }
     args += Xld.flatMap { ["-Xlinker", $0] }
     args += Xswiftc.flatMap { ["-Xswiftc", $0] }
@@ -609,6 +602,20 @@ private func swiftArgs(
     args += extraArgs
     return args
 }
+
+extension BuildConfiguration {
+    public var buildArgs: [String] {
+        var args = ["--configuration"]
+        switch self {
+        case .debug:
+            args.append("debug")
+        case .release:
+            args.append("release")
+        }
+        return args
+    }
+}
+
 
 public let emptyZipFile = ByteString([0x80, 0x75, 0x05, 0x06] + [UInt8](repeating: 0x00, count: 18))
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+@testable import Commands
+@testable import CoreCommands
 
+import Foundation
 import Basics
 import Commands
 import struct SPMBuildCore.BuildSystemProvider
@@ -20,6 +22,10 @@ import PackageModel
 import _InternalTestSupport
 import TSCTestSupport
 import Testing
+
+import struct ArgumentParser.ExitCode
+import protocol ArgumentParser.AsyncParsableCommand
+import class TSCBasic.BufferedOutputByteStream
 
 @Suite(
     .serialized,  // to limit the number of swift executable running.
@@ -303,7 +309,7 @@ struct TestCommandTests {
         let configuration = BuildConfiguration.debug
         try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestableExeWithDifferentProductName") { fixturePath in
-                let result = try await execute(
+                _ = try await execute(
                     ["--vv"],
                     packagePath: fixturePath,
                     configuration: configuration,
@@ -1629,7 +1635,7 @@ struct TestCommandTests {
             try await fixture(name: "Miscellaneous/Errors/FatalErrorInSingleXCTest/TypeLibrary") { fixturePath in
                 // WHEN swift-test is executed
                 let error = await #expect(throws: SwiftPMError.self) {
-                    try await self.execute(
+                    try await execute(
                         [],
                         packagePath: fixturePath,
                         configuration: configuration,
@@ -1665,7 +1671,7 @@ struct TestCommandTests {
     }
 
     @Test(
-            .IssueWindowsLongPath,
+        .IssueWindowsLongPath,
             .tags(
                 .Feature.TargetType.Executable,
             ),
@@ -1677,7 +1683,7 @@ struct TestCommandTests {
             let configuration = BuildConfiguration.debug
             try await withKnownIssue(isIntermittent: true) {
                 try await fixture(name: "Miscellaneous/TestableExeWithResources") { fixturePath in
-                    let result = try await execute(
+                    _ = try await execute(
                         ["--vv"],
                         packagePath: fixturePath,
                         configuration: configuration,
@@ -1688,7 +1694,7 @@ struct TestCommandTests {
                 .windows == ProcessInfo.hostOperatingSystem
                 || ProcessInfo.processInfo.environment["SWIFTCI_EXHIBITS_GH_9524"] != nil
             }
-         }
+        }
 
     // Regression test for https://github.com/swiftlang/swift-package-manager/issues/9986. Ensure
     // environment is computed correctly throughout the testing pipeline.
@@ -1717,4 +1723,548 @@ struct TestCommandTests {
             .windows == ProcessInfo.hostOperatingSystem
         }
     }
+
+    // MARK: - LLDB Flag Validation Tests
+
+    @Suite
+    struct LLDBTests {
+        /// Probes the host lldb once per test process to discover whether it
+        /// has Python bindings. Old smoke-test CI lldb predates them, and
+        /// some Windows toolchains ship lldb without `python310.dll` on
+        /// PATH so `script` and `command script import` crash.
+        private static let lldbHasPythonBindings: Bool = {
+            let lldbPath: String
+            do {
+                lldbPath = try UserToolchain.default.getLLDB().pathString
+            } catch {
+                return false
+            }
+            let probeMarker = "SWIFT_PM_LLDB_PYTHON_OK"
+            let output = (try? AsyncProcess.checkNonZeroExit(
+                arguments: [lldbPath, "-b", "-o", "script print('\(probeMarker)')"]
+            )) ?? ""
+            return output.contains(probeMarker)
+        }()
+
+        /// Probes the host lldb once to discover whether `target create -l`
+        /// is supported. Older lldb (e.g. system lldb that smoke-test CI
+        /// sometimes falls back to) predates the `--label` option.
+        private static let lldbSupportsTargetLabels: Bool = {
+            let lldbPath: String
+            do {
+                lldbPath = try UserToolchain.default.getLLDB().pathString
+            } catch {
+                return false
+            }
+            let output = (try? AsyncProcess.checkNonZeroExit(
+                arguments: [lldbPath, "-b", "-o", "help target create"]
+            )) ?? ""
+            return output.contains("--label")
+        }()
+
+        private func execute(
+            _ args: [String],
+            packagePath: AbsolutePath? = nil,
+            configuration: BuildConfiguration = .debug,
+            buildSystem: BuildSystemProvider.Kind,
+            throwIfCommandFails: Bool = true
+        ) async throws -> (stdout: String, stderr: String) {
+            try await executeSwiftTest(
+                packagePath,
+                configuration: configuration,
+                extraArgs: args,
+                buildSystem: buildSystem,
+                throwIfCommandFails: throwIfCommandFails
+            )
+        }
+
+        /// Smoke test that verifies `validateLLDBCompatibility` is wired into
+        /// the command pipeline. The individual incompatibility rules are
+        /// covered directly by `ValidationTests` below.
+        @Test(arguments: SupportedBuildSystemOnAllPlatforms)
+        func lldbValidationIsWiredIntoCommandPipeline(buildSystem: BuildSystemProvider.Kind) async throws {
+            let args = args(["--debugger", "--parallel"], for: buildSystem)
+            let command = try #require(SwiftTestCommand.parseAsRoot(args) as? SwiftTestCommand)
+            let (state, outputStream) = try commandState()
+
+            let error = await #expect(throws: ExitCode.self) {
+                try await command.run(state)
+            }
+
+            #expect(error == ExitCode.failure, "Expected ExitCode.failure, got \(String(describing: error))")
+
+            // The output stream is written to asynchronously on a DispatchQueue and can
+            // receive output after the command has thrown.
+            let found = try await waitForOutputStreamToContain(outputStream, "--debugger")
+            #expect(
+                found,
+                "Expected validation error to surface via the command pipeline, got: \(outputStream.bytes.description)"
+            )
+        }
+
+        @Test(arguments: SupportedBuildSystemOnAllPlatforms)
+        func lldbWithAllTestingLibrariesDisabledThrowsError(buildSystem: BuildSystemProvider.Kind) async throws {
+            try await fixture(name: "Miscellaneous/TestDebugging") { fixturePath in
+                let (_, stderr) = try await execute(
+                    ["--debugger", "--disable-xctest", "--disable-swift-testing"],
+                    packagePath: fixturePath,
+                    buildSystem: buildSystem,
+                    throwIfCommandFails: false
+                )
+
+                #expect(
+                    stderr.contains("No testing libraries are enabled for debugging"),
+                    "Expected error about no testing libraries, got stderr: \(stderr)"
+                )
+            }
+        }
+
+        @Test(arguments: SupportedBuildSystemOnAllPlatforms)
+        func lldbWithNoTestTargetsThrowsError(buildSystem: BuildSystemProvider.Kind) async throws {
+            try await fixture(name: "Miscellaneous/AtMainSupport") { fixturePath in
+                let (_, stderr) = try await execute(
+                    ["--debugger"],
+                    packagePath: fixturePath,
+                    buildSystem: buildSystem,
+                    throwIfCommandFails: false
+                )
+
+                #expect(
+                    stderr.contains("no tests found"),
+                    "Expected error about no tests found, got stderr: \(stderr)"
+                )
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func debuggerFlagWithXCTestSuite(buildSystem: BuildSystemProvider.Kind) async throws {
+            let configuration = BuildConfiguration.debug
+            try await withKnownIssue {
+                try await fixture(name: "Miscellaneous/TestDebugging") { fixturePath in
+                    let (stdout, stderr) = try await execute(
+                        ["--debugger", "--disable-swift-testing", "--verbose"],
+                        packagePath: fixturePath,
+                        configuration: configuration,
+                        buildSystem: buildSystem,
+                    )
+
+                    #expect(
+                        !stderr.contains("error: --debugger cannot be used with"),
+                        "got stdout: \(stdout), stderr: \(stderr)",
+                    )
+
+                    #if os(macOS)
+                    let targetName = "xctest"
+                    #else
+                    let targetName = buildSystem == .swiftbuild ? "test-runner" : "xctest"
+                    #endif
+
+                    #expect(
+                        stdout.contains("target create") && stdout.contains(targetName),
+                        "Expected LLDB to target xctest binary, got stdout: \(stdout), stderr: \(stderr)",
+                    )
+
+                    // Probe lldb at runtime; environments without Python
+                    // bindings can't register the failbreak command, so
+                    // there's nothing to assert here.
+                    guard Self.lldbHasPythonBindings else { return }
+                    #expect(
+                        stdout.contains("failbreak command registered: 1 specs"),
+                        "Expected a failure breakpoint to be setup, got stdout: \(stdout), stderr: \(stderr)",
+                    )
+                }
+            } when: {
+                // Windows lldb ships without python310.dll on PATH, so it crashes
+                // with access violation when the failbreak `command script import`
+                // runs, and swift-test exits abnormally before producing any output.
+                ProcessInfo.hostOperatingSystem == .windows
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms
+        )
+        func debuggerFlagWithSwiftTestingSuite(buildSystem: BuildSystemProvider.Kind) async throws {
+            let configuration = BuildConfiguration.debug
+            try await withKnownIssue {
+                try await fixture(name: "Miscellaneous/TestDebugging") { fixturePath in
+                    let (stdout, stderr) = try await execute(
+                        ["--debugger", "--disable-xctest", "--verbose"],
+                        packagePath: fixturePath,
+                        configuration: configuration,
+                        buildSystem: buildSystem,
+                    )
+
+                    #expect(
+                        !stderr.contains("error: --debugger cannot be used with"),
+                        "got stdout: \(stdout), stderr: \(stderr)",
+                    )
+
+                    #if os(macOS)
+                    let targetName = "swiftpm-testing-helper"
+                    #else
+                    let targetName = buildSystem == .native ? "TestDebuggingPackageTests.xctest" : "TestDebuggingTests-test-runner"
+                    #endif
+
+                    #expect(
+                        stdout.contains("target create") && stdout.contains(targetName),
+                        "Expected LLDB to target swiftpm-testing-helper binary, got stdout: \(stdout), stderr: \(stderr)",
+                    )
+
+                    guard Self.lldbHasPythonBindings else { return }
+                    #expect(
+                        stdout.contains("failbreak command registered: 1 specs"),
+                        "Expected Swift Testing failure breakpoint setup, got stdout: \(stdout), stderr: \(stderr)",
+                    )
+                }
+            } when: {
+                // Windows lldb ships without python310.dll on PATH, so it crashes
+                // with access violation when the failbreak `command script import`
+                // runs, and swift-test exits abnormally before producing any output.
+                ProcessInfo.hostOperatingSystem == .windows
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms
+        )
+        func debuggerFlagWithBothTestingSuites(buildSystem: BuildSystemProvider.Kind) async throws {
+            let configuration = BuildConfiguration.debug
+            try await withKnownIssue {
+                try await fixture(name: "Miscellaneous/TestDebugging") { fixturePath in
+                    let (stdout, stderr) = try await execute(
+                        ["--debugger", "--verbose"],
+                        packagePath: fixturePath,
+                        configuration: configuration,
+                        buildSystem: buildSystem,
+                    )
+
+                    #expect(
+                        !stderr.contains("error: --debugger cannot be used with"),
+                        "got stdout: \(stdout), stderr: \(stderr)",
+                    )
+
+                    #expect(
+                        stdout.contains("target create"),
+                        "Expected LLDB to create targets, got stdout: \(stdout), stderr: \(stderr)",
+                    )
+
+                    let productName = buildSystem == .native ? "TestDebuggingPackageTests" : "TestDebuggingTests"
+                    if Self.lldbSupportsTargetLabels {
+                        #expect(
+                            stdout.contains("\(productName) (XCTest)") && stdout.contains("\(productName) (Swift Testing)"),
+                            "Expected labeled LLDB targets, got stdout: \(stdout), stderr: \(stderr)",
+                        )
+                    }
+
+                    if Self.lldbHasPythonBindings {
+                        #expect(
+                            stdout.contains("failbreak command registered: 2 specs"),
+                            "Expected combined failure breakpoint setup, got stdout: \(stdout), stderr: \(stderr)",
+                        )
+
+                        #expect(
+                            stdout.contains("command script import"),
+                            "Expected Python script import for multi-target switching, got stdout: \(stdout), stderr: \(stderr)",
+                        )
+                    }
+
+                    #if os(macOS)
+                    #expect(
+                        stdout.contains("settings set target.env-vars SWIFT_TESTING_ENABLED=0"),
+                        "Expected SWIFT_TESTING_ENABLED=0 scoped to the xctest target to prevent duplicate Swift Testing runs, got stdout: \(stdout), stderr: \(stderr)",
+                    )
+                    #endif
+                }
+            } when: {
+                // Windows lldb ships without python310.dll on PATH, so it crashes
+                // with access violation when the failbreak `command script import`
+                // runs, and swift-test exits abnormally before producing any output.
+                ProcessInfo.hostOperatingSystem == .windows
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms
+        )
+        func debuggerFlagWithMultipleTestProducts(buildSystem: BuildSystemProvider.Kind) async throws {
+            let configuration = BuildConfiguration.debug
+            try await withKnownIssue {
+                try await fixture(name: "Miscellaneous/TestDebuggingMultiProduct") { fixturePath in
+                    let (stdout, stderr) = try await execute(
+                        ["--debugger", "--verbose"],
+                        packagePath: fixturePath,
+                        configuration: configuration,
+                        buildSystem: buildSystem,
+                    )
+
+                    if Self.lldbHasPythonBindings {
+                        #expect(
+                            !stderr.contains("error:"),
+                            "Expected no errors, got stdout: \(stdout), stderr: \(stderr)",
+                        )
+                    }
+
+                    let targetCreateCount = getNumberOfMatches(of: "target create", in: stdout)
+                    // Native build system produces a single umbrella product (2 targets: xctest + swift-testing).
+                    // Swiftbuild produces one product per test target (4 targets: 2 products x 2 libraries).
+                    let expectedMinTargets = buildSystem == .native ? 2 : 4
+                    #expect(
+                        targetCreateCount >= expectedMinTargets,
+                        "Expected at least \(expectedMinTargets) LLDB targets, got \(targetCreateCount). stdout: \(stdout), stderr: \(stderr)",
+                    )
+
+                    if Self.lldbHasPythonBindings {
+                        #expect(
+                            stdout.contains("command script import"),
+                            "Expected Python script import for multi-target switching, got stdout: \(stdout), stderr: \(stderr)",
+                        )
+                    }
+                }
+            } when: {
+                // Windows lldb ships without python310.dll on PATH, so it crashes
+                // with access violation when the failbreak `command script import`
+                // runs, and swift-test exits abnormally before producing any output.
+                ProcessInfo.hostOperatingSystem == .windows
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms
+        )
+        func debuggerFlagWithMultipleTestProductsXCTestOnly(buildSystem: BuildSystemProvider.Kind) async throws {
+            let configuration = BuildConfiguration.debug
+            try await withKnownIssue {
+                try await fixture(name: "Miscellaneous/TestDebuggingMultiProduct") { fixturePath in
+                    let (stdout, stderr) = try await execute(
+                        ["--debugger", "--disable-swift-testing", "--verbose"],
+                        packagePath: fixturePath,
+                        configuration: configuration,
+                        buildSystem: buildSystem,
+                    )
+
+                    if Self.lldbHasPythonBindings {
+                        #expect(
+                            !stderr.contains("error:"),
+                            "Expected no errors, got stdout: \(stdout), stderr: \(stderr)",
+                        )
+                    }
+
+                    let targetCreateCount = getNumberOfMatches(of: "target create", in: stdout)
+                    // Native: 1 umbrella product → 1 xctest target.
+                    // Swiftbuild: 2 products → 2 xctest targets.
+                    let expectedMinTargets = buildSystem == .native ? 1 : 2
+                    #expect(
+                        targetCreateCount >= expectedMinTargets,
+                        "Expected at least \(expectedMinTargets) LLDB targets, got \(targetCreateCount). stdout: \(stdout), stderr: \(stderr)",
+                    )
+                }
+            } when: {
+                // Windows lldb ships without python310.dll on PATH, so it crashes
+                // with access violation when the failbreak `command script import`
+                // runs, and swift-test exits abnormally before producing any output.
+                ProcessInfo.hostOperatingSystem == .windows
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms
+        )
+        func debuggerFlagWithMultipleTestProductsSwiftTestingOnly(buildSystem: BuildSystemProvider.Kind) async throws {
+            let configuration = BuildConfiguration.debug
+            try await withKnownIssue {
+                try await fixture(name: "Miscellaneous/TestDebuggingMultiProduct") { fixturePath in
+                    let (stdout, stderr) = try await execute(
+                        ["--debugger", "--disable-xctest", "--verbose"],
+                        packagePath: fixturePath,
+                        configuration: configuration,
+                        buildSystem: buildSystem,
+                    )
+
+                    if Self.lldbHasPythonBindings {
+                        #expect(
+                            !stderr.contains("error:"),
+                            "Expected no errors, got stdout: \(stdout), stderr: \(stderr)",
+                        )
+                    }
+
+                    let targetCreateCount = getNumberOfMatches(of: "target create", in: stdout)
+                    // Native: 1 umbrella product → 1 swift-testing target.
+                    // Swiftbuild: 2 products → 2 swift-testing targets.
+                    let expectedMinTargets = buildSystem == .native ? 1 : 2
+                    #expect(
+                        targetCreateCount >= expectedMinTargets,
+                        "Expected at least \(expectedMinTargets) LLDB targets, got \(targetCreateCount). stdout: \(stdout), stderr: \(stderr)",
+                    )
+                }
+            } when: {
+                // Windows lldb ships without python310.dll on PATH, so it crashes
+                // with access violation when the failbreak `command script import`
+                // runs, and swift-test exits abnormally before producing any output.
+                ProcessInfo.hostOperatingSystem == .windows
+            }
+        }
+
+        @Test(arguments: SupportedBuildSystemOnAllPlatforms, ["XCTestCalculatorTests/testAdditionPasses", "calculatorAdditionPasses()"])
+        func lldbRunExecutesTestsSuccessfully(buildSystem: BuildSystemProvider.Kind, test: String) async throws {
+            try await fixture(name: "Miscellaneous/TestDebugging") { fixturePath in
+                let (stdout, stderr) = try await executeSwiftTest(
+                    fixturePath,
+                    configuration: .debug,
+                    extraArgs: [
+                        "--debugger",
+                        "--verbose",
+                        "--filter", test,
+                    ] + getBuildSystemArgs(for: buildSystem),
+                    env: ["SWIFTPM_TESTS_LLDB_RUN": "1"],
+                    buildSystem: buildSystem,
+                    throwIfCommandFails: false
+                )
+
+                // Probe lldb at runtime; without Python bindings the lldb
+                // run path can hit platform-specific crashes (e.g. Windows
+                // missing python310.dll), so don't progress here.
+                guard Self.lldbHasPythonBindings else { return }
+                #expect(
+                    stdout.contains("Process") && stdout.contains("launched"),
+                    "Expected LLDB to launch the process, got stdout: \(stdout), stderr: \(stderr)"
+                )
+
+                #expect(
+                    stdout.contains("exited with status = 0"),
+                    "Expected process to exit with status 0, got stdout: \(stdout), stderr: \(stderr)"
+                )
+            }
+        }
+
+        /// Direct unit tests for the validation logic, exercising
+        /// `validateLLDBCompatibility` without going through the full
+        /// command pipeline.
+        @Suite
+        struct ValidationTests {
+            private func expectValidationError(
+                configuration: BuildConfiguration = .debug,
+                shouldRunInParallel: Bool = false,
+                numberOfWorkers: Int? = nil,
+                shouldListTests: Bool = false,
+                shouldPrintCodeCovPath: Bool = false,
+                containing substrings: [String]
+            ) {
+                let error = #expect(throws: StringError.self) {
+                    try SwiftTestCommand.validateLLDBCompatibility(
+                        configuration: configuration,
+                        shouldRunInParallel: shouldRunInParallel,
+                        numberOfWorkers: numberOfWorkers,
+                        shouldListTests: shouldListTests,
+                        shouldPrintCodeCovPath: shouldPrintCodeCovPath
+                    )
+                }
+                let message = error?.description ?? ""
+                for substring in substrings {
+                    #expect(
+                        message.contains(substring),
+                        "Expected error message to contain '\(substring)', got: \(message)"
+                    )
+                }
+            }
+
+            @Test
+            func releaseConfigurationIsRejected() {
+                expectValidationError(
+                    configuration: .release,
+                    containing: ["--debugger", "release configuration"]
+                )
+            }
+
+            @Test
+            func parallelFlagIsRejected() {
+                expectValidationError(
+                    shouldRunInParallel: true,
+                    containing: ["--debugger", "--parallel"]
+                )
+            }
+
+            @Test
+            func numWorkersIsRejected() {
+                expectValidationError(
+                    numberOfWorkers: 2,
+                    containing: ["--debugger", "--num-workers"]
+                )
+            }
+
+            @Test
+            func listTestsIsRejected() {
+                expectValidationError(
+                    shouldListTests: true,
+                    containing: ["--debugger", "--list-tests"]
+                )
+            }
+
+            @Test
+            func showCodeCovPathIsRejected() {
+                expectValidationError(
+                    shouldPrintCodeCovPath: true,
+                    containing: ["--debugger", "--show-codecov-path"]
+                )
+            }
+
+            @Test
+            func compatibleOptionsPassValidation() throws {
+                try SwiftTestCommand.validateLLDBCompatibility(
+                    configuration: .debug,
+                    shouldRunInParallel: false,
+                    numberOfWorkers: nil,
+                    shouldListTests: false,
+                    shouldPrintCodeCovPath: false
+                )
+            }
+
+            @Test
+            func configurationIsCheckedBeforeOtherFlags() {
+                // When multiple incompatible flags are set, the release-configuration
+                // check fires first so callers see a single, deterministic error.
+                expectValidationError(
+                    configuration: .release,
+                    shouldRunInParallel: true,
+                    numberOfWorkers: 2,
+                    shouldListTests: true,
+                    shouldPrintCodeCovPath: true,
+                    containing: ["release configuration"]
+                )
+            }
+        }
+
+        func args(_ args: [String], for buildSystem: BuildSystemProvider.Kind, buildConfiguration: BuildConfiguration = .debug) -> [String] {
+            return args + buildConfiguration.buildArgs + getBuildSystemArgs(for: buildSystem)
+        }
+
+        func commandState() throws -> (SwiftCommandState, BufferedOutputByteStream) {
+            let outputStream = BufferedOutputByteStream()
+
+            let state = try SwiftCommandState(
+                outputStream: outputStream,
+                options: try GlobalOptions.parse([]),
+                toolWorkspaceConfiguration: .init(shouldInstallSignalHandlers: false),
+                workspaceDelegateProvider: {
+                    CommandWorkspaceDelegate(
+                        observabilityScope: $0,
+                        outputHandler: $1,
+                        progressHandler: $2,
+                        inputHandler: $3
+                    )
+                },
+                workspaceLoaderProvider: {
+                    XcodeWorkspaceLoader(
+                        fileSystem: $0,
+                        observabilityScope: $1
+                    )
+                },
+                createPackagePath: false
+            )
+            return (state, outputStream)
+        }
+    }
 }
+


### PR DESCRIPTION
Introduces interactive debugging capabilities to `swift test` via a `--debugger` flag enabling developers to failing tests directly within LLDB.

This adds debugging parity with `swift run --debugger` which allows users to debug their executables directly.

When launching lldb this implenentation uses `execv()` to replace the `swift-test` process with LLDB. This approach avoids process hierarchy complications and ensures LLDB has full terminal control for interactive debugging features.

When there is only one type of test the debugger creates a single LLDB target configured specifically for that framework. For XCTest, this means targeting the test bundle with xctest as the executable, while Swift Testing targets the test binary directly with appropriate command-line arguments.

When both testing frameworks have tests available we create multiple LLDB targets within a single debugging session. A Python script automatically switches targets as the executable exits, which lets users debug both types of tests spread across two executables in the same session. The Python script also maintains breakpoint persistence across target switches, allowing you to set a breakpoint for either test type no matter the active target.

Note that the CI smoke tests use an old version of LLDB that ships Swift 5.9.2. The `--debugger` feature relies on the version of LLDB that ships alongside swift-package-manager in the latest toolchain, and so many supporting tests probe to see if the LLDB installed supports the required features for `--debugger` to work.

Issue: #8129
