### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1109,7 +1109,7 @@ func swiftSyntaxDependencies(_ names: [String]) -> [Target.Dependency] {
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-let relatedDependenciesBranch = "release/6.4.x"
+let relatedDependenciesBranch = "main"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {


### PR DESCRIPTION
The automerger from release/6.4.x to main incorrectly updated the branch dependencies in the Package.swift.  update the branch dependencies back to branch main
