### PR TITLE
Update help text/release note for test repetition flags and restrict the values passed to `--repeat-until`

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -169,12 +169,16 @@ struct TestCommandOptions: ParsableArguments {
     var experimentalMaximumParallelizationWidth: Int? = nil
 
     /// The maximum number of times each test will repeat (Swift Testing only).
-    @Option(help: .hidden)
+    @Option(help: "The maximum number of times each test will repeat. Only supported for Swift Testing test suites.")
     var maximumRepetitions: Int?
 
-    /// The condition upon which repetition stops (Swift Testing only).
-    @Option(help: .hidden)
-    var repeatUntil: String?
+    enum RepeatCondition: String, ExpressibleByArgument {
+        case pass, fail
+    }
+
+    /// The condition upon which to stop repeating (Swift Testing only).
+    @Option(help: "The condition upon which to stop repeating a test. Must be either `pass` or `fail`. Only supported for Swift Testing test suites.")
+    var repeatUntil: RepeatCondition?
 
     /// List the tests and exit.
     @Flag(name: [.customLong("list-tests"), .customShort("l")],

--- a/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
@@ -63,6 +63,20 @@ If your build passes using the native build system but fails using Swift Build, 
 
 Swift Package Manager can now generate an SBOM for your Swift package. Read more [here](<doc:GeneratingSBOMs>).
 
+## Additional features
+
+### Test repetition for Swift Testing
+
+`swift test` now supports repeating tests until they match a condition via the `--repeat-until` and `--maximum-repetitions` arguments.
+This will only repeat the individual test cases that meet the repetition condition.
+
+- `--maximum-repetitions` provides an upper bound on the number of times a test will repeat.
+- `--repeat-until` supports the following repetition conditions:
+- `pass`: If the test fails, it will repeat until it passes, or until `maximum-repetitions` has been reached.
+- `fail`: If the test passes, it will repeat until it fails, or until `maximum-repetitions` has been reached.
+
+If `--maximum-repetitions` is provided without `--repeat-until`, all tests will repeat `maximum-repetitions` times.
+
 ## Reporting issues
 
 Please follow these steps when reporting issues:


### PR DESCRIPTION
This is a follow-up to #10051 that adds proper help text and restricts the arguments passed to `--repeat-until` to match Swift Testing's expectations.

### Motivation:

I accidentally left these options `hidden`, which is not intended. This unhides them and adds a little extra safety when using them.

### Modifications:

- Adds release note to the 6.4 release notes file
- Adds a RepeatCondition enum for better parsing

### Result:

`swift test --help` will list the new flags
`swift test --repeat-until hello` will be rejected and the help text will specify the supported arguments.


Issue: rdar://177615900