### PR TITLE
Supply git HTTP transport with low-speed timeouts

### DIFF
--- a/Sources/Basics/Environment/ConfigurableEnvVar.swift
+++ b/Sources/Basics/Environment/ConfigurableEnvVar.swift
@@ -41,6 +41,9 @@ package enum ConfigurableEnvVar: String, CaseIterable {
     /// Inline netrc-formatted content for per-host credentials
     case SWIFTPM_NETRC_DATA
 
+    /// Whether to disable low speed timeouts for Git operations
+    case SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED
+
     private var isCacheable : Bool {
         switch self {
         case .SWIFTPM_BUILD_SBOM_SPEC: false
@@ -52,7 +55,7 @@ package enum ConfigurableEnvVar: String, CaseIterable {
         case .SWIFTPM_REGISTRY_PASSWORD: false
         case .SWIFTPM_SOURCE_CONTROL_TOKEN: false
         case .SWIFTPM_NETRC_DATA: false
-
+        case .SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED: false
         }
     }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -182,7 +182,7 @@ internal enum GitNetworkTimeoutDefaults {
 /// truthy value (`1`, `true`, `yes`, `on`), restoring the historical
 /// "wait forever" behaviour for users who explicitly opt out.
 internal func gitNetworkTimeoutOverrides(environment: Environment) -> [String] {
-    if let raw = environment["SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED"]?.lowercased(),
+    if let raw = environment[ConfigurableEnvVar.SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED]?.lowercased(),
        ["1", "true", "yes", "on"].contains(raw) {
         return []
     }

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -14,6 +14,7 @@
 import Basics
 import Dispatch
 import class Foundation.NSLock
+import class Foundation.ProcessInfo
 
 import struct PackageModel.CanonicalPackageURL
 
@@ -48,8 +49,9 @@ private struct GitShellHelper {
         environment: Environment = .init(Git.environmentBlock),
         outputRedirection: AsyncProcess.OutputRedirection = .collect
     ) throws -> String {
+        let arguments = gitNetworkTimeoutOverrides(environment: environment) + args
         let process = AsyncProcess(
-            arguments: [Git.tool] + args,
+            arguments: [Git.tool] + arguments,
             environment: environment,
             outputRedirection: outputRedirection
         )
@@ -158,6 +160,37 @@ private struct GitShellHelper {
             throw GitLFSError.pullFailed(underlyingError: error)
         }
     }
+}
+
+/// HTTP transport timeouts that SwiftPM injects into every `git` invocation to
+/// time out connections to remotes that become unreachable during a checkout.
+/// Git defaults these values to 'unlimited', which means that without these overrides
+/// losing connection to a remote mid-checkout could cause the checkout to stall indefinitely.
+///
+/// Users who need different values should set `SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED=1`
+/// to suppress the injection entirely and then configure `http.lowSpeedLimit` / `http.lowSpeedTime`
+/// in their own `~/.gitconfig`, which `git` reads on every invocation.
+internal enum GitNetworkTimeoutDefaults {
+    static let lowSpeedLimitBytesPerSecond = 1024
+    static let lowSpeedTimeSeconds = 60
+}
+
+/// Returns `git -c key=value` argument pairs that bound the HTTP network
+/// operations of any subsequent `git` subcommand.
+///
+/// Returns an empty array when `SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED` is set to a
+/// truthy value (`1`, `true`, `yes`, `on`), restoring the historical
+/// "wait forever" behaviour for users who explicitly opt out.
+internal func gitNetworkTimeoutOverrides(environment: Environment) -> [String] {
+    if let raw = environment["SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED"]?.lowercased(),
+       ["1", "true", "yes", "on"].contains(raw) {
+        return []
+    }
+
+    return [
+        "-c", "http.lowSpeedLimit=\(GitNetworkTimeoutDefaults.lowSpeedLimitBytesPerSecond)",
+        "-c", "http.lowSpeedTime=\(GitNetworkTimeoutDefaults.lowSpeedTimeSeconds)",
+    ]
 }
 
 // MARK: - GitRepositoryProvider

--- a/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
+++ b/Tests/BasicsTests/Environment/EnvironmentKeyTests.swift
@@ -53,6 +53,7 @@ struct EnvironmentKeyTests {
             ConfigurableEnvVar.SWIFTPM_BUILD_SBOM_FILTER,
             ConfigurableEnvVar.SWIFTPM_BUILD_SBOM_OUTPUT_DIR,
             ConfigurableEnvVar.SWIFTPM_BUILD_SBOM_WARNING_ONLY,
+            ConfigurableEnvVar.SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED,
         ],
     ) func nonCachableEnvVars(
         envVar: ConfigurableEnvVar,

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -138,3 +138,31 @@ struct GitRepositoryProviderTests {
         )
     }
 }
+
+struct GitNetworkTimeoutOverridesTests {
+    @Test
+    func defaultsAreInjectedWhenEnvironmentIsEmpty() {
+        let overrides = gitNetworkTimeoutOverrides(environment: [:])
+        #expect(overrides == [
+            "-c", "http.lowSpeedLimit=\(GitNetworkTimeoutDefaults.lowSpeedLimitBytesPerSecond)",
+            "-c", "http.lowSpeedTime=\(GitNetworkTimeoutDefaults.lowSpeedTimeSeconds)",
+        ])
+    }
+
+
+    @Test(arguments: ["1", "true", "TRUE", "yes", "Yes", "on", "ON"])
+    func disableFlagSuppressesOverrides(value: String) {
+        let overrides = gitNetworkTimeoutOverrides(environment: [
+            "SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED": value,
+        ])
+        #expect(overrides == [])
+    }
+
+    @Test(arguments: ["", "0", "false", "no", "off", "anything-else"])
+    func nonTruthyDisableFlagDoesNotSuppressOverrides(value: String) {
+        let overrides = gitNetworkTimeoutOverrides(environment: [
+            "SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED": value,
+        ])
+        #expect(!overrides.isEmpty)
+    }
+}

--- a/Tests/SourceControlTests/GitRepositoryProviderTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryProviderTests.swift
@@ -149,11 +149,10 @@ struct GitNetworkTimeoutOverridesTests {
         ])
     }
 
-
     @Test(arguments: ["1", "true", "TRUE", "yes", "Yes", "on", "ON"])
     func disableFlagSuppressesOverrides(value: String) {
         let overrides = gitNetworkTimeoutOverrides(environment: [
-            "SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED": value,
+            EnvironmentKey(ConfigurableEnvVar.SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED.rawValue): value,
         ])
         #expect(overrides == [])
     }
@@ -161,7 +160,7 @@ struct GitNetworkTimeoutOverridesTests {
     @Test(arguments: ["", "0", "false", "no", "off", "anything-else"])
     func nonTruthyDisableFlagDoesNotSuppressOverrides(value: String) {
         let overrides = gitNetworkTimeoutOverrides(environment: [
-            "SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED": value,
+            EnvironmentKey(ConfigurableEnvVar.SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED.rawValue): value,
         ])
         #expect(!overrides.isEmpty)
     }


### PR DESCRIPTION
### Motivation:

If the network connection drops after a connection has been established then git will wait indefinitely for bytes that do not come.

### Modifications:

Inject `http.lowSpeedLimit=1024` and `http.lowSpeedTime=60` via `-c` arguments on every `git` invocation so that checkouts no longer stall indefinitely when a remote becomes unreachable mid-operation. Git must see at least 1024 bytes over 60 seconds, or the connection is deemed terminated and an error is thrown. Git defaults both values to unlimited, which has occasionally caused CI jobs to stall for hours waiting on a dead connection.

Users can opt out by setting `SWIFTPM_GIT_LOW_SPEED_TIMEOUTS_DISABLED` to a truthy value. If users want to specify their own value, they can disable with the env var and then configure their own values in `~/.gitconfig`.

### Result:

An error is thrown when a connection is established but less than 1024 bytes have been seen in 60 seconds. 