### PR TITLE
[6.4] Fix issue with id mismatch when using --use-registry-identity-for-scm

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -551,7 +551,7 @@ private func createResolvedPackages(
                 }
 
                 let nameForModuleDependencyResolution = dependency
-                    .explicitNameForModuleDependencyResolutionOnly ?? dependency.identity.description
+                    .nameForModuleDependencyResolutionOnly
                 dependenciesByNameForModuleDependencyResolution[nameForModuleDependencyResolution] = resolvedPackage
                 dependencyNamesForModuleDependencyResolutionOnly[resolvedPackage.package.identity] =
                     nameForModuleDependencyResolution

--- a/Sources/PackageModel/DependencyMapper.swift
+++ b/Sources/PackageModel/DependencyMapper.swift
@@ -62,7 +62,7 @@ public struct DefaultDependencyMapper: DependencyMapper {
                 requirement: try dependency.sourceControlRequirement(for: mappedLocationString),
                 productFilter: dependency.productFilter,
                 traits: dependency.traits,
-                registryIdentity: nil // todo bp
+                registryIdentity: nil
             )
 
         } else {
@@ -76,7 +76,7 @@ public struct DefaultDependencyMapper: DependencyMapper {
                 requirement: try dependency.sourceControlRequirement(for: mappedLocationString),
                 productFilter: dependency.productFilter,
                 traits: dependency.traits,
-                registryIdentity: nil // todo bp
+                registryIdentity: nil
             )
         }
     }
@@ -321,7 +321,7 @@ extension PackageDependency {
                 requirement: requirement,
                 productFilter: seed.productFilter,
                 traits: seed.traits,
-                registryIdentity: nil // todo bp
+                registryIdentity: nil
             )
         case .registry(let id, let requirement):
             self = .registry(

--- a/Sources/PackageModel/DependencyMapper.swift
+++ b/Sources/PackageModel/DependencyMapper.swift
@@ -61,7 +61,8 @@ public struct DefaultDependencyMapper: DependencyMapper {
                 url: url,
                 requirement: try dependency.sourceControlRequirement(for: mappedLocationString),
                 productFilter: dependency.productFilter,
-                traits: dependency.traits
+                traits: dependency.traits,
+                registryIdentity: nil // todo bp
             )
 
         } else {
@@ -74,7 +75,8 @@ public struct DefaultDependencyMapper: DependencyMapper {
                 path: localPath,
                 requirement: try dependency.sourceControlRequirement(for: mappedLocationString),
                 productFilter: dependency.productFilter,
-                traits: dependency.traits
+                traits: dependency.traits,
+                registryIdentity: nil // todo bp
             )
         }
     }
@@ -318,7 +320,8 @@ extension PackageDependency {
                 location: location,
                 requirement: requirement,
                 productFilter: seed.productFilter,
-                traits: seed.traits
+                traits: seed.traits,
+                registryIdentity: nil // todo bp
             )
         case .registry(let id, let requirement):
             self = .registry(

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -179,17 +179,6 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
             try container.encodeIfPresent(traits?.sorted { $0.name < $1.name }, forKey: .traits)
             try container.encodeIfPresent(registryIdentity, forKey: .registryIdentity)
         }
-
-//        public init(from decoder: Decoder) throws {
-//            var decodingContainer = try decoder.container(keyedBy: CodingKeys.self)
-//            try canonicalIdentity = decodingContainer.decode(PackageIdentity.self, forKey: .identity)
-//            try nameForTargetDependencyResolutionOnly = decodingContainer.decodeIfPresent(String.self, forKey: .nameForTargetDependencyResolutionOnly)
-//            try location = decodingContainer.decode(Location.self, forKey: .location)
-//            try requirement = decodingContainer.decode(Requirement.self, forKey: .requirement)
-//            try productFilter = decodingContainer.decode(ProductFilter.self, forKey: .productFilter)
-//            try traits = decodingContainer.decodeIfPresent([Trait].self, forKey: .traits)?.toSet()
-//            try registryIdentity = decodingContainer.decodeIfPresent(PackageIdentity.self, forKey: .registryIdentity)
-//        }
     }
 
     public struct Registry: Equatable, Hashable, Encodable, Sendable {

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -124,12 +124,16 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
     }
 
     public struct SourceControl: Equatable, Hashable, Encodable, Sendable {
-        public let identity: PackageIdentity
+        public var identity: PackageIdentity {
+            self.registryIdentity ?? self.canonicalIdentity
+        }
         public let nameForTargetDependencyResolutionOnly: String?
         public let location: Location
         public let requirement: Requirement
         public let productFilter: ProductFilter
         package let traits: Set<Trait>?
+        package let canonicalIdentity: PackageIdentity
+        package let registryIdentity: PackageIdentity?
 
         public enum Requirement: Equatable, Hashable, Sendable {
             case exact(Version)
@@ -144,18 +148,48 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         }
 
         private enum CodingKeys: CodingKey {
-            case identity, nameForTargetDependencyResolutionOnly, location, requirement, productFilter, traits
+            case identity, nameForTargetDependencyResolutionOnly, location, requirement, productFilter, traits, registryIdentity
+        }
+
+        public init(
+            identity: PackageIdentity,
+            nameForTargetDependencyResolutionOnly: String?,
+            location: Location,
+            requirement: Requirement,
+            productFilter: ProductFilter,
+            traits: Set<Trait>?,
+            registryIdentity: PackageIdentity?
+        ) {
+            self.canonicalIdentity = identity
+            self.nameForTargetDependencyResolutionOnly = nameForTargetDependencyResolutionOnly
+            self.location = location
+            self.requirement = requirement
+            self.productFilter = productFilter
+            self.traits = traits
+            self.registryIdentity = registryIdentity
         }
 
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(identity, forKey: .identity)
+            try container.encode(canonicalIdentity, forKey: .identity)
             try container.encodeIfPresent(nameForTargetDependencyResolutionOnly, forKey: .nameForTargetDependencyResolutionOnly)
             try container.encode(location, forKey: .location)
             try container.encode(requirement, forKey: .requirement)
             try container.encode(productFilter, forKey: .productFilter)
             try container.encodeIfPresent(traits?.sorted { $0.name < $1.name }, forKey: .traits)
+            try container.encodeIfPresent(registryIdentity, forKey: .registryIdentity)
         }
+
+//        public init(from decoder: Decoder) throws {
+//            var decodingContainer = try decoder.container(keyedBy: CodingKeys.self)
+//            try canonicalIdentity = decodingContainer.decode(PackageIdentity.self, forKey: .identity)
+//            try nameForTargetDependencyResolutionOnly = decodingContainer.decodeIfPresent(String.self, forKey: .nameForTargetDependencyResolutionOnly)
+//            try location = decodingContainer.decode(Location.self, forKey: .location)
+//            try requirement = decodingContainer.decode(Requirement.self, forKey: .requirement)
+//            try productFilter = decodingContainer.decode(ProductFilter.self, forKey: .productFilter)
+//            try traits = decodingContainer.decodeIfPresent([Trait].self, forKey: .traits)?.toSet()
+//            try registryIdentity = decodingContainer.decodeIfPresent(PackageIdentity.self, forKey: .registryIdentity)
+//        }
     }
 
     public struct Registry: Equatable, Hashable, Encodable, Sendable {
@@ -266,7 +300,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
                 location: settings.location,
                 requirement: settings.requirement,
                 productFilter: productFilter,
-                traits: settings.traits
+                traits: settings.traits,
+                registryIdentity: settings.registryIdentity
             )
         case .registry(let settings):
             return .registry(
@@ -324,7 +359,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
             path: path,
             requirement: requirement,
             productFilter: productFilter,
-            traits: nil
+            traits: nil,
+            registryIdentity: nil
         )
     }
 
@@ -334,7 +370,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         path: AbsolutePath,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter,
-        traits: Set<Trait>?
+        traits: Set<Trait>?,
+        registryIdentity: PackageIdentity?
     ) -> Self {
         .sourceControl(
             identity: identity,
@@ -342,7 +379,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
             location: .local(path),
             requirement: requirement,
             productFilter: productFilter,
-            traits: traits
+            traits: traits,
+            registryIdentity: registryIdentity
         )
     }
     
@@ -359,7 +397,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
             url: url,
             requirement: requirement,
             productFilter: productFilter,
-            traits: nil
+            traits: nil,
+            registryIdentity: nil
         )
     }
 
@@ -369,7 +408,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         url: SourceControlURL,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter,
-        traits: Set<Trait>?
+        traits: Set<Trait>?,
+        registryIdentity: PackageIdentity?
     ) -> Self {
         .sourceControl(
             identity: identity,
@@ -377,7 +417,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
             location: .remote(url),
             requirement: requirement,
             productFilter: productFilter,
-            traits: traits
+            traits: traits,
+            registryIdentity: registryIdentity
         )
     }
 
@@ -394,7 +435,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
             location: location,
             requirement: requirement,
             productFilter: productFilter,
-            traits: nil
+            traits: nil,
+            registryIdentity: nil
         )
     }
 
@@ -404,7 +446,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         location: SourceControl.Location,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter,
-        traits: Set<Trait>?
+        traits: Set<Trait>?,
+        registryIdentity: PackageIdentity?
     ) -> Self {
         .sourceControl(
             .init(
@@ -413,7 +456,8 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
                 location: location,
                 requirement: requirement,
                 productFilter: productFilter,
-                traits: traits
+                traits: traits,
+                registryIdentity: registryIdentity
             )
         )
     }

--- a/Sources/Workspace/Workspace+Registry.swift
+++ b/Sources/Workspace/Workspace+Registry.swift
@@ -184,12 +184,13 @@ extension Workspace {
                                 info: "adjusting '\(dependency.locationString)' identity to registry identity of '\(registryIdentity)'."
                             )
                         modifiedDependency = .sourceControl(
-                            identity: registryIdentity,
+                            identity: settings.identity,
                             nameForTargetDependencyResolutionOnly: settings.nameForTargetDependencyResolutionOnly,
                             location: settings.location,
                             requirement: settings.requirement,
                             productFilter: settings.productFilter,
-                            traits: settings.traits
+                            traits: settings.traits,
+                            registryIdentity: registryIdentity
                         )
                     case .swizzle:
                         // we replace the *entire* source control dependency with a registry one
@@ -220,12 +221,13 @@ extension Workspace {
                                     info: "adjusting '\(dependency.locationString)' identity to registry identity of '\(registryIdentity)'."
                                 )
                             modifiedDependency = .sourceControl(
-                                identity: registryIdentity,
+                                identity: settings.identity,
                                 nameForTargetDependencyResolutionOnly: settings.nameForTargetDependencyResolutionOnly,
                                 location: settings.location,
                                 requirement: settings.requirement,
                                 productFilter: settings.productFilter,
-                                traits: settings.traits
+                                traits: settings.traits,
+                                registryIdentity: registryIdentity
                             )
                         }
                     }

--- a/Sources/_InternalTestSupport/PackageDependencyDescriptionExtensions.swift
+++ b/Sources/_InternalTestSupport/PackageDependencyDescriptionExtensions.swift
@@ -40,7 +40,8 @@ package extension PackageDependency {
         path: AbsolutePath,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = [.init(name: "default")]
+        traits: Set<Trait> = [.init(name: "default")],
+        registryIdentity: PackageIdentity? = nil
     ) -> Self {
         let identity = identity ?? PackageIdentity(path: path)
         return .localSourceControl(
@@ -49,7 +50,8 @@ package extension PackageDependency {
             path: path,
             requirement: requirement,
             productFilter: productFilter,
-            traits: traits
+            traits: traits,
+            registryIdentity: registryIdentity
         )
     }
 
@@ -59,7 +61,8 @@ package extension PackageDependency {
         url: SourceControlURL,
         requirement: SourceControl.Requirement,
         productFilter: ProductFilter = .everything,
-        traits: Set<Trait> = [.init(name: "default")]
+        traits: Set<Trait> = [.init(name: "default")],
+        registryIdentity: PackageIdentity? = nil
     ) -> Self {
         let identity = identity ?? PackageIdentity(url: url)
         return .remoteSourceControl(
@@ -68,7 +71,8 @@ package extension PackageDependency {
             url: url,
             requirement: requirement,
             productFilter: productFilter,
-            traits: traits
+            traits: traits,
+            registryIdentity: registryIdentity
         )
     }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -14267,6 +14267,112 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    // Regression test for: registry identity substitution fails for packages using tools-version >= 5.8.
+    //
+    // Tools-version 5.8 switches product dependency lookup from name-based ("ProductName") to
+    // identity-based ("packagename_ProductName"). When --use-registry-identity-for-scm replaces an
+    // SCM dependency's identity with a registry identity (e.g., "org.foo"), but does NOT update the
+    // target dependency's `package:` parameter, the two keys diverge:
+    //   Map key (built from registry identity):    "org.foo_FooProduct"
+    //   productRef.identity (from package: "foo"): "foo_FooProduct"
+    // → product not found, "Did you mean 'FooProduct'?" error.
+    //
+    // The same scenario with tools-version < 5.8 uses name-based lookup so it never fails.
+    func testResolutionWithRegistryIdentitySubstitutionAndToolsVersionV58() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    path: "root",
+                    targets: [
+                        MockTarget(name: "RootTarget", dependencies: [
+                            // `package:` uses the URL-derived name "foo", not the registry identity "org.foo".
+                            // This is the standard pattern that fails under .identity mode + tools-version 5.8.
+                            .product(name: "FooProduct", package: "foo"),
+                        ]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        .sourceControl(url: "https://git/org/foo", requirement: .upToNextMajor(from: "1.0.0")),
+                    ],
+                    toolsVersion: .v5_8
+                ),
+            ],
+            packages: [
+                // SCM entry needed for .identity mode (package stays as sourceControl, so the
+                // mock workspace must be able to resolve the URL directly).
+                MockPackage(
+                    name: "FooPackage",
+                    url: "https://git/org/foo",
+                    targets: [
+                        MockTarget(name: "FooTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
+                    ],
+                    versions: ["1.0.0", "1.1.0", "1.2.0"]
+                ),
+                // Registry entry needed for .swizzle mode (SCM dep is replaced with a registry dep).
+                MockPackage(
+                    name: "FooPackage",
+                    identity: "org.foo",
+                    alternativeURLs: ["https://git/org/foo"],
+                    targets: [
+                        MockTarget(name: "FooTarget"),
+                    ],
+                    products: [
+                        MockProduct(name: "FooProduct", modules: ["FooTarget"]),
+                    ],
+                    versions: ["1.0.0", "1.1.0", "1.2.0"]
+                ),
+            ]
+        )
+
+        // .identity mode (--use-registry-identity-for-scm): replaces SCM dependency identity with
+        // registry identity but does NOT rewrite target dependency package: names.
+        // With tools-version 5.8 product ID lookup this causes "product not found".
+        workspace.sourceControlToRegistryDependencyTransformation = .identity
+
+        try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTesterXCTest(graph) { result in
+                result.check(roots: "Root")
+                result.check(packages: "org.foo", "Root")
+                result.check(modules: "FooTarget", "RootTarget")
+                result.checkTarget("RootTarget") { result in result.check(dependencies: "FooProduct") }
+            }
+        }
+
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "org.foo", at: .checkout(.version("1.2.0")))
+        }
+
+        try await workspace.closeWorkspace()
+
+        // .swizzle mode (--replace-scm-with-registry): rewrites both the dependency AND the target
+        // dependency package: names, so 5.8 product ID lookup works correctly.
+        workspace.sourceControlToRegistryDependencyTransformation = .swizzle
+
+        try await workspace.checkPackageGraph(roots: ["root"]) { graph, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+            PackageGraphTesterXCTest(graph) { result in
+                result.check(roots: "Root")
+                result.check(packages: "org.foo", "Root")
+                result.check(modules: "FooTarget", "RootTarget")
+                result.checkTarget("RootTarget") { result in result.check(dependencies: "FooProduct") }
+            }
+        }
+
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "org.foo", at: .registryDownload("1.2.0"))
+        }
+    }
+
     // duplicate package at root level
     func testResolutionMixedRegistryAndSourceControl2() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
@@ -14892,14 +14998,6 @@ final class WorkspaceTests: XCTestCase {
                         """),
                         severity: .warning
                     )
-                    if ToolsVersion.current >= .v5_8 {
-                        result.check(
-                            diagnostic: .contains("""
-                            product 'FooProduct' required by package 'org.bar' target 'BarTarget' not found in package 'foo'.
-                            """),
-                            severity: .error
-                        )
-                    }
                 }
                 PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")
@@ -15180,14 +15278,6 @@ final class WorkspaceTests: XCTestCase {
                         """),
                         severity: .warning
                     )
-                    if ToolsVersion.current >= .v5_8 {
-                        result.check(
-                            diagnostic: .contains("""
-                            product 'BazProduct' required by package 'org.foo' target 'FooTarget' not found in package 'baz'.
-                            """),
-                            severity: .error
-                        )
-                    }
                 }
                 PackageGraphTesterXCTest(graph) { result in
                     result.check(roots: "Root")


### PR DESCRIPTION
Initially, we were overwriting the `identity` property whenever SwiftPM encountered the --use-registry-identity-for-scm without changing the dependency type (as opposed to --replace-scm-with-registry, that mutates the dependency to be that of a registry kind). There wasn't a clear history to identify what the original canonical name would be, and this was causing errors for tools version >= 5.8.

In this change, PackageDependency.SourceControl tracks the canonical identity and a possible registryIdentity mapping, and the identity property now becomes a computed property; depending on whether the registryIdentity is present, it will default to that otherwise it will use the canonicalIdentity.

Remove instances in WorkspaceTests where we've asserted against an error being thrown for tools versions >= 5.8.

Fixes #7912