### PR TITLE
[6.4] Fix intermittent test issue on Windows due to path behaviour

### DIFF
--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3730,10 +3730,6 @@ struct PackageCommandTests {
     }
 
     @Test(
-        .issue(
-            "error: Package.resolved file is corrupted or malformed, needs investigation",
-            relationship: .defect
-        ),
         .tags(
             .Feature.Command.Package.Resolve,
         ),
@@ -3743,7 +3739,6 @@ struct PackageCommandTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let config = BuildConfiguration.debug
-        // try XCTSkipOnWindows(because: "error: Package.resolved file is corrupted or malformed, needs investigation")
         func writeResolvedFile(
             packageDir: AbsolutePath,
             repositoryURL: String,
@@ -3773,7 +3768,7 @@ struct PackageCommandTests {
                     """
             )
         }
-        try await withKnownIssue(isIntermittent: true) {
+
             try await testWithTemporaryDirectory { tmpPath in
                 let packageDir = tmpPath.appending(components: "library")
                 try localFileSystem.writeFileContents(
@@ -3804,7 +3799,7 @@ struct PackageCommandTests {
                 try depGit.tag(name: "1.0.0")
 
                 let initialRevision = try depGit.revision(forTag: "1.0.0")
-                let repositoryURL = #"file://\#(packageDir.pathString)"#
+                let repositoryURL = packageDir.asURL.absoluteString
 
                 let clientDir = tmpPath.appending(components: "client")
                 try localFileSystem.writeFileContents(
@@ -3889,9 +3884,6 @@ struct PackageCommandTests {
                     #expect(!err.contains("Fetching \(repositoryURL)"))
                 }
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
-        }
     }
 
     @Test(


### PR DESCRIPTION
### Motivation:

We were unconditionally appending file:// and writing the URL as a literal, depending on the character sequence this may cause escaping. Use URL when writing the path as it knows how to handle platform specific paths.

### Modifications:

Use URL.absoluteString when writing the path.

### Result:

Consistent path formatting

Depends on #10146 