### PR TITLE
Speed up `PackageLoadingTests` with a dispatch barrier

### DIFF
--- a/Sources/_InternalTestSupport/MockManifestLoader.swift
+++ b/Sources/_InternalTestSupport/MockManifestLoader.swift
@@ -75,7 +75,18 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
     public func purgeCache(observabilityScope: ObservabilityScope) async {}
 }
 
+/// A `ManifestLoaderDelegate` that owns the dispatch queue on which it expects to receive
+/// callbacks.
+public protocol TestManifestLoaderDelegate: ManifestLoaderDelegate {
+    var queue: DispatchQueue { get }
+}
+
 extension ManifestLoader {
+    /// Returns the delegate's queue if it provides one, falling back to `.sharedConcurrent`.
+    fileprivate var resolvedDelegateQueue: DispatchQueue {
+        (self.delegate as? TestManifestLoaderDelegate)?.queue ?? .sharedConcurrent
+    }
+
     public func load(
         manifestPath: AbsolutePath,
         packageKind: PackageReference.Kind,
@@ -116,7 +127,7 @@ extension ManifestLoader {
             dependencyMapper: dependencyMapper ?? DefaultDependencyMapper(identityResolver: identityResolver),
             fileSystem: fileSystem,
             observabilityScope: observabilityScope,
-            delegateQueue: .sharedConcurrent
+            delegateQueue: self.resolvedDelegateQueue
         )
     }
 }
@@ -162,7 +173,7 @@ extension ManifestLoader {
             dependencyMapper: dependencyMapper ?? DefaultDependencyMapper(identityResolver: identityResolver),
             fileSystem: fileSystem,
             observabilityScope: observabilityScope,
-            delegateQueue: .sharedConcurrent
+            delegateQueue: self.resolvedDelegateQueue
         )
     }
 }

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -63,8 +63,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
                 ))
 
                 XCTAssertNoDiagnostics(observability.diagnostics)
-                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)), [manifestPath])
-                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, (expectCached ? 0 : 1))
+                await XCTAssertAsyncEqual(await delegate.loaded(), [manifestPath])
+                await XCTAssertAsyncEqual(await delegate.parsed().count, expectCached ? 0 : 1)
                 XCTAssertEqual(manifest.displayName, "Trivial")
                 XCTAssertEqual(manifest.targets[0].name, "foo")
             }
@@ -156,8 +156,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
             ))
 
             XCTAssertNoDiagnostics(observability.diagnostics)
-            try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)), [manifestPath])
-            try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, expectCached ? 0 : 1)
+            await XCTAssertAsyncEqual(await delegate.loaded(), [manifestPath])
+            await XCTAssertAsyncEqual(await delegate.parsed().count, expectCached ? 0 : 1)
             XCTAssertEqual(manifest.displayName, "Trivial")
             XCTAssertEqual(manifest.targets[0].name, "foo")
         }
@@ -244,20 +244,20 @@ final class ManifestLoaderCacheTests: XCTestCase {
 
             do {
                 try await check(loader: manifestLoader, manifest: manifest)
-                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)).count, 1)
-                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, 1)
+                await XCTAssertAsyncEqual(await delegate.loaded().count, 1)
+                await XCTAssertAsyncEqual(await delegate.parsed().count, 1)
             }
 
             do {
                 try await check(loader: manifestLoader, manifest: manifest)
-                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)).count, 2)
-                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, 1)
+                await XCTAssertAsyncEqual(await delegate.loaded().count, 2)
+                await XCTAssertAsyncEqual(await delegate.parsed().count, 1)
             }
 
             do {
                 try await check(loader: manifestLoader, manifest: manifest + "\n\n")
-                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)).count, 3)
-                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, 2)
+                await XCTAssertAsyncEqual(await delegate.loaded().count, 3)
+                await XCTAssertAsyncEqual(await delegate.parsed().count, 2)
             }
         }
     }
@@ -314,8 +314,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
                 ))
 
                 XCTAssertNoDiagnostics(observability.diagnostics)
-                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)), [manifestPath])
-                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, expectCached ? 0 : 1)
+                await XCTAssertAsyncEqual(await delegate.loaded(), [manifestPath])
+                await XCTAssertAsyncEqual(await delegate.parsed().count, expectCached ? 0 : 1)
                 XCTAssertEqual(manifest.displayName, "Trivial")
                 XCTAssertEqual(manifest.targets[0].name, targetName)
             }
@@ -379,8 +379,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
                 ))
 
                 XCTAssertNoDiagnostics(observability.diagnostics)
-                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)), [manifestPath])
-                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, expectCached ? 0 : 1)
+                await XCTAssertAsyncEqual(await delegate.loaded(), [manifestPath])
+                await XCTAssertAsyncEqual(await delegate.parsed().count, expectCached ? 0 : 1)
                 XCTAssertEqual(manifest.displayName, "Trivial")
                 XCTAssertEqual(manifest.targets[0].name, "foo")
             }
@@ -429,8 +429,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
                 ))
 
                 XCTAssertNoDiagnostics(observability.diagnostics)
-                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)), [manifestPath])
-                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, expectCached ? 0 : 1)
+                await XCTAssertAsyncEqual(await delegate.loaded(), [manifestPath])
+                await XCTAssertAsyncEqual(await delegate.parsed().count, expectCached ? 0 : 1)
                 XCTAssertEqual(manifest.displayName, "Trivial")
                 XCTAssertEqual(manifest.targets[0].name, "foo")
             }
@@ -633,8 +633,8 @@ final class ManifestLoaderCacheTests: XCTestCase {
                 ))
 
                 XCTAssertNoDiagnostics(observability.diagnostics)
-                try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)), [manifestPath])
-                try await XCTAssertAsyncEqual(try await delegate.parsed(timeout: .seconds(1)).count, (expectCached ? 0 : 1))
+                await XCTAssertAsyncEqual(await delegate.loaded(), [manifestPath])
+                await XCTAssertAsyncEqual(await delegate.parsed().count, expectCached ? 0 : 1)
                 XCTAssertEqual(manifest.displayName, "Trivial")
                 XCTAssertEqual(manifest.targets[0].name, "foo")
             }

--- a/Tests/PackageLoadingTests/PDLoadingTests.swift
+++ b/Tests/PackageLoadingTests/PDLoadingTests.swift
@@ -119,9 +119,26 @@ class PackageDescriptionLoadingTests: XCTestCase, ManifestLoaderDelegate {
     }
 }
 
-final class ManifestTestDelegate: ManifestLoaderDelegate {
+final class ManifestTestDelegate: TestManifestLoaderDelegate {
     private let loaded = ThreadSafeArrayStore<AbsolutePath>()
     private let parsed = ThreadSafeArrayStore<AbsolutePath>()
+
+    /// Custom concurrent dispatch queue used for delegate callbacks.
+    let queue = DispatchQueue(
+        label: "org.swift.swiftpm.manifest-test-delegate",
+        attributes: .concurrent
+    )
+
+    /// Awaits execution of all previously-scheduled blocks on `queue`.
+    /// Use this before asserting values that are provided via delegate callbacks.
+    private func synchronize() async {
+        await withCheckedContinuation { continuation in
+            // Given that `queue` is concurrent, this needs to be a `.barrier`.
+            self.queue.async(flags: .barrier) {
+                continuation.resume()
+            }
+        }
+    }
 
     func willLoad(packageIdentity: PackageModel.PackageIdentity, packageLocation: String, manifestPath: AbsolutePath) {
         // noop
@@ -155,19 +172,18 @@ final class ManifestTestDelegate: ManifestLoaderDelegate {
         self.parsed.append(manifestPath)
     }
 
-
     func clear() {
         self.loaded.clear()
         self.parsed.clear()
     }
 
-    func loaded(timeout: Duration) async throws -> [AbsolutePath] {
-        try await Task.sleep(for: timeout)
+    func loaded() async -> [AbsolutePath] {
+        await self.synchronize()
         return self.loaded.get()
     }
 
-    func parsed(timeout: Duration) async throws -> [AbsolutePath] {
-        try await Task.sleep(for: timeout)
+    func parsed() async -> [AbsolutePath] {
+        await self.synchronize()
         return self.parsed.get()
     }
 }

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -638,7 +638,7 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 dependencyMapper: dependencyMapper,
                 fileSystem: localFileSystem,
                 observabilityScope: observability.topScope,
-                delegateQueue: .sharedConcurrent
+                delegateQueue: delegate.queue
             )
 
             XCTAssertNoDiagnostics(observability.diagnostics)
@@ -657,7 +657,7 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     dependencyMapper: dependencyMapper,
                     fileSystem: localFileSystem,
                     observabilityScope: observability.topScope,
-                    delegateQueue: .sharedConcurrent
+                    delegateQueue: delegate.queue
                 )
 
                 XCTAssertNoDiagnostics(observability.diagnostics)
@@ -665,7 +665,7 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                 XCTAssertEqual(manifest.targets[0].name, "foo")
             }
 
-            try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)).count, total+1)
+            await XCTAssertAsyncEqual(await delegate.loaded().count, total+1)
             XCTAssertFalse(observability.hasWarningDiagnostics, observability.diagnostics.description)
             XCTAssertFalse(observability.hasErrorDiagnostics, observability.diagnostics.description)
         }
@@ -718,14 +718,14 @@ final class PackageDescription4_2LoadingTests: PackageDescriptionLoadingTests {
                     dependencyMapper: dependencyMapper,
                     fileSystem: localFileSystem,
                     observabilityScope: observability.topScope,
-                    delegateQueue: .sharedConcurrent
+                    delegateQueue: delegate.queue
                 )
 
                 XCTAssertEqual(manifest.displayName, "Trivial-\(random)")
                 XCTAssertEqual(manifest.targets[0].name, "foo-\(random)")
             }
 
-            try await XCTAssertAsyncEqual(try await delegate.loaded(timeout: .seconds(1)).count, total)
+            await XCTAssertAsyncEqual(await delegate.loaded().count, total)
             XCTAssertFalse(observability.hasWarningDiagnostics, observability.diagnostics.description)
             XCTAssertFalse(observability.hasErrorDiagnostics, observability.diagnostics.description)
         }


### PR DESCRIPTION
This replaces an unconditional `Task.sleep` with a `synchronize()` method that drains a delegate queue instead.

### Motivation:

I saw this forum post: https://forums.swift.org/t/why-does-it-take-so-long-to-build-and-test-swiftpm-on-the-ci

And I remembered how long it has taken me to run the SwiftPM tests in the past, so I figured I'd start helping chip away at the runtime.

One place that stuck out was the manifest loader tests, which unconditionally wait a fixed timeout amount before validating the values returned by delegate callbacks.

Instead, give the manifest loader delegate a concurrent queue that it manages and synchronize via a barrier block on the queue. This ensures we don't want any longer than necessary.

This takes the runtime of `PackageLoadingTests` from 213s to 74s on my MacBook Pro, which is almost 3x faster.

### Modifications:

- Added a `TestManifestLoaderDelegate` protocol that allows manifest loader delegates to specify their own queue to run on.
- Conform `ManifestTestDelegate` to that and have it own a concurrent queue that it can synchronize on.
- Add a `synchronize() async` method that awaits a continuation resumption in a barrier async call, which ensures all previously-queued delegate callbacks have evaluated by the time we are done awaiting
- Synchronize instead of unconditionally `Task.sleep`ing.

### Result:

These tests will pass as soon as the delegate callbacks fire instead of each one waiting a full second.