### PR TITLE
[SE-0521] Update ExistentialAny migrator test.

### DIFF
--- a/Fixtures/SwiftMigrate/ExistentialAnyMigration/Sources/Fixed/Test.swift
+++ b/Fixtures/SwiftMigrate/ExistentialAnyMigration/Sources/Fixed/Test.swift
@@ -10,7 +10,7 @@ func test2(_: (any P).Protocol) {
 }
 
 func test3() {
-    let _: [(any P)?] = []
+    let _: [any P?] = []
 }
 
 func test4() {


### PR DESCRIPTION
The fix-it no longer adds parentheses around `any P` in `any P?`.

This test fix is needed to get the full CI passing for https://github.com/swiftlang/swift/pull/87115.