### PR TITLE
Prebuilts: reject extracted archives with escaping symlinks

### DIFF
--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -520,6 +520,28 @@ extension Workspace {
             try fileSystem.createDirectory(artifactDir, recursive: true)
             try await archiver.extract(from: destination, to: artifactDir)
 
+            // Reject any extracted entry whose symbolic link target escapes the
+            // artifact directory. The checksum only guarantees the archive
+            // matches the prebuilts manifest, not that its contents are safe to
+            // unpack: an archive containing a symlink such as
+            // `evil -> /Users/victim/.ssh` followed by a regular file at
+            // `evil/authorized_keys` would otherwise let the archiver write
+            // outside artifactDir. This mirrors the guard already applied after
+            // archiver.extract in Sources/Workspace/Workspace+BinaryArtifacts.swift
+            // and Sources/PackageRegistry/RegistryClient.swift. If validation
+            // fails we discard the extracted tree and fall back to building the
+            // dependency from source rather than using the prebuilt.
+            do {
+                try fileSystem.validateNoEscapingSymlinks(in: artifactDir)
+            } catch {
+                try? fileSystem.removeFileTree(artifactDir)
+                observabilityScope.emit(
+                    warning: "Prebuilt artifact \(artifactFile) rejected; falling back to source",
+                    underlyingError: error
+                )
+                return nil
+            }
+
             observabilityScope.emit(
                 info: "Prebuilt artifact \(artifactFile) downloaded"
             )

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -950,6 +950,74 @@ final class PrebuiltsTests: XCTestCase {
         }
     }
 
+    // Mirrors the post-extract symlink validation in PrebuiltsManager.downloadPrebuilt.
+    // The prebuilt extraction directory must not contain a symbolic link whose target
+    // escapes that directory, otherwise a malicious-but-correctly-checksummed archive
+    // could write outside the package's scratch area. This exercises the same
+    // FileSystem.validateNoEscapingSymlinks(in:) call against an archive whose contents
+    // are produced on a real file system, so symlink resolution actually runs (the
+    // in-memory file system used elsewhere in this file is a no-op for resolution).
+    func testExtractedPrebuiltRejectsEscapingSymlink() async throws {
+        try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
+            let archivePath = tmpDir.appending("MacroSupport.zip")
+            let artifactDir = tmpDir.appending("MacroSupport")
+            try localFileSystem.writeFileContents(archivePath, bytes: [])
+
+            // An archiver whose extracted output contains a top-level symlink pointing
+            // outside the destination, e.g. `escape -> tmpDir`, which a later write
+            // through `escape/...` would follow out of the artifact directory.
+            let archiver = MockArchiver(handler: { _, _, destination, completion in
+                do {
+                    try localFileSystem.createDirectory(destination, recursive: true)
+                    try localFileSystem.createSymbolicLink(
+                        destination.appending("escape"),
+                        pointingAt: tmpDir,
+                        relative: false
+                    )
+                    completion(.success(()))
+                } catch {
+                    completion(.failure(error))
+                }
+            })
+
+            try await archiver.extract(from: archivePath, to: artifactDir)
+
+            XCTAssertThrowsError(try localFileSystem.validateNoEscapingSymlinks(in: artifactDir)) { error in
+                XCTAssertTrue(error is StringError, "expected a StringError, got \(error)")
+            }
+        }.value
+    }
+
+    // The complement of the above: a prebuilt whose extracted contents only reference
+    // files inside the artifact directory must be accepted.
+    func testExtractedPrebuiltAllowsInternalSymlink() async throws {
+        try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
+            let archivePath = tmpDir.appending("MacroSupport.zip")
+            let artifactDir = tmpDir.appending("MacroSupport")
+            try localFileSystem.writeFileContents(archivePath, bytes: [])
+
+            let archiver = MockArchiver(handler: { _, _, destination, completion in
+                do {
+                    let lib = destination.appending("lib")
+                    try localFileSystem.createDirectory(lib, recursive: true)
+                    try localFileSystem.writeFileContents(lib.appending("libMacroSupport.a"), bytes: [])
+                    try localFileSystem.createSymbolicLink(
+                        destination.appending("libMacroSupport.a"),
+                        pointingAt: lib.appending("libMacroSupport.a"),
+                        relative: true
+                    )
+                    completion(.success(()))
+                } catch {
+                    completion(.failure(error))
+                }
+            })
+
+            try await archiver.extract(from: archivePath, to: artifactDir)
+
+            XCTAssertNoThrow(try localFileSystem.validateNoEscapingSymlinks(in: artifactDir))
+        }.value
+    }
+
     // Test a macro that uses a library that doesn't use prebuilts which then uses a library that does works.
     // Also test plugins work
     func testIndirectLibrary() async throws {

--- a/Tests/WorkspaceTests/PrebuiltsTests.swift
+++ b/Tests/WorkspaceTests/PrebuiltsTests.swift
@@ -958,6 +958,7 @@ final class PrebuiltsTests: XCTestCase {
     // are produced on a real file system, so symlink resolution actually runs (the
     // in-memory file system used elsewhere in this file is a no-op for resolution).
     func testExtractedPrebuiltRejectsEscapingSymlink() async throws {
+        try XCTSkipOnWindows(because: "creating symbolic links requires elevated privileges on Windows, so the symlink fixture cannot be created there")
         try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
             let archivePath = tmpDir.appending("MacroSupport.zip")
             let artifactDir = tmpDir.appending("MacroSupport")
@@ -991,6 +992,7 @@ final class PrebuiltsTests: XCTestCase {
     // The complement of the above: a prebuilt whose extracted contents only reference
     // files inside the artifact directory must be accepted.
     func testExtractedPrebuiltAllowsInternalSymlink() async throws {
+        try XCTSkipOnWindows(because: "creating symbolic links requires elevated privileges on Windows, so the symlink fixture cannot be created there")
         try await withTemporaryDirectory(removeTreeOnDeinit: true) { tmpDir in
             let archivePath = tmpDir.appending("MacroSupport.zip")
             let artifactDir = tmpDir.appending("MacroSupport")


### PR DESCRIPTION
The prebuilts download path in `PrebuiltsManager.downloadPrebuilt` (`Sources/Workspace/Workspace+Prebuilts.swift`) extracts a downloaded archive into the artifact directory and immediately returns it, with no validation of the extracted contents. The SHA-256 check earlier in the same function only confirms the archive bytes match the prebuilts manifest; it does not guarantee the archive is safe to unpack.

An archive whose entries include a symbolic link whose target escapes the artifact directory, for example a stored `evil -> /Users/victim/.ssh` symlink followed by a regular file written through `evil/authorized_keys`, would cause the archiver to write outside the package's scratch directory.

The binary-artifacts path in `Workspace+BinaryArtifacts.swift` already calls `validateNoEscapingSymlinks(in:)` after every `archiver.extract`, and #10001 added the same guard to the registry source-archive path in `RegistryClient.swift`. This change brings the prebuilts path to the same posture; it is the prebuilts follow-up that #10001 flagged.

Behavior on rejection follows the existing prebuilts error handling rather than the hard failure used on the registry and binary-artifact paths. Prebuilts are an optimization layered on top of the regular source checkout, and the current code already degrades gracefully for a checksum mismatch, a bad signature, or a malformed manifest by skipping the prebuilt and building from source. A rejected artifact is handled the same way: the partial extraction is removed, a warning is emitted, and `downloadPrebuilt` returns `nil` so the dependency is built from source. This is strictly safer than the status quo and never breaks a build that has a valid prebuilt.

The regression tests exercise the same `validateNoEscapingSymlinks(in:)` call against an archive extracted on a real file system, covering both an escaping top-level symlink (rejected) and an internal symlink (allowed). The in-memory file system used by the other prebuilts tests resolves symlinks through `realpath` on disk, which is a no-op for in-memory paths, so the new tests run on a temporary directory to make resolution actually run.

Verification, with the 6.3 toolchain on macOS:

- `swift build --target Workspace` succeeds with no new warnings.
- `swift build --target WorkspaceTests` succeeds.
- `swift test --filter PrebuiltsTests` passes 18 tests, 0 failures, including the two new tests and the existing prebuilts coverage (no change to the happy path).

A sibling site, `SwiftSDKBundleStore.unpackIfNeeded` in `Sources/PackageModel/SwiftSDKs/SwiftSDKBundleStore.swift`, extracts a downloaded Swift SDK bundle archive without the same guard. I kept this PR scoped to prebuilts but am happy to follow up there if you would like the SDK install path covered too.
