### PR TITLE
tests: Do not serialize suites/tests on Windows

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+Traits.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Traits.swift
@@ -13,12 +13,14 @@
 import Testing
 
 #if os(Windows)
+    @available(*, deprecated, message: "Use the standard `.serialized` trait instead")
     extension Trait where Self == ParallelizationTrait {
         public static var serializedIfOnWindows: Self {
             .serialized
         }
     }
 #else
+    @available(*, deprecated, message: "Use the standard `.serialized` trait instead")
     extension Trait where Self == ConditionTrait {
         public static var serializedIfOnWindows: Self {
             .enabled(if: true)

--- a/Tests/CommandsTests/APIDiffTests.swift
+++ b/Tests/CommandsTests/APIDiffTests.swift
@@ -34,7 +34,6 @@ extension Trait where Self == Testing.ConditionTrait {
 }
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         .FunctionalArea.APIDiff,
     ),

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -121,7 +121,6 @@ fileprivate func build(
 }
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         Tag.TestSize.large,
         Tag.Feature.Command.Build,

--- a/Tests/CommandsTests/CoverageTests.swift
+++ b/Tests/CommandsTests/CoverageTests.swift
@@ -20,7 +20,6 @@ import struct SPMBuildCore.BuildSystemProvider
 import Testing
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
         .Feature.CodeCoverage,

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -31,7 +31,6 @@ let defaultRegistryBaseURL = URL("https://packages.example.com")
 let customRegistryBaseURL = URL("https://custom.packages.example.com")
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         .Feature.Command.PackageRegistry.General,
     ),

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -24,7 +24,6 @@ import Testing
 import class Basics.AsyncProcess
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
         .Feature.CTargets,

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -23,7 +23,6 @@ import struct SPMBuildCore.BuildSystemProvider
 import enum TSCUtility.Git
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
         .Feature.DependencyResolution,

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -19,7 +19,6 @@ import PackageModel
 import Testing
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         Tag.TestSize.large
     ),

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -20,7 +20,6 @@ import Workspace
 import Testing
 
 @Suite(
-    .serializedIfOnWindows,
     .issue("https://github.com/swiftlang/swift-package-manager/issues/8987", relationship: .verifies),
     .tags(
         .TestSize.large,

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -24,7 +24,6 @@ import Testing
 import Foundation
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
         .Feature.Command.Package.Plugin,

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -19,7 +19,6 @@ import struct Foundation.UUID
 import class Foundation.ProcessInfo
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         .Feature.TestDiscovery,
     ),

--- a/Tests/FunctionalTests/TraitTests.swift
+++ b/Tests/FunctionalTests/TraitTests.swift
@@ -20,7 +20,6 @@ import Testing
 import _InternalTestSupport
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
         .Feature.Traits,

--- a/Tests/FunctionalTests/VersionSpecificTests.swift
+++ b/Tests/FunctionalTests/VersionSpecificTests.swift
@@ -19,7 +19,6 @@ import struct SPMBuildCore.BuildSystemProvider
 import enum PackageModel.BuildConfiguration
 
 @Suite(
-    .serializedIfOnWindows,
     .tags(
         .TestSize.large,
     ),


### PR DESCRIPTION
Treat all platform the same.  As such, remove the `.serializedIfOnWindows` traits from all suites/tests, and mark the trait as deprecated.