### PR TITLE
Make mirrors.json more deterministic

### DIFF
--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -37,52 +37,18 @@ extension SwiftPackageCommand.Config {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(name: .customLong("package-url"), help: .hidden)
-        var _deprecate_packageURL: String?
-
-        @Option(name: .customLong("original-url"), help: .hidden)
-        var _deprecate_originalURL: String?
-
-        @Option(name: .customLong("mirror-url"), help: .hidden)
-        var _deprecate_mirrorURL: String?
-
         @Option(help: "The original url or identity.")
-        var original: String?
+        var original: String
 
         @Option(help: "The mirror url or identity.")
-        var mirror: String?
+        var mirror: String
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
             let config = try getMirrorsConfig(swiftCommandState)
 
-            if self._deprecate_packageURL != nil {
-                swiftCommandState.observabilityScope.emit(
-                    warning: "'--package-url' option is deprecated; use '--original' instead"
-                )
-            }
-            if self._deprecate_originalURL != nil {
-                swiftCommandState.observabilityScope.emit(
-                    warning: "'--original-url' option is deprecated; use '--original' instead"
-                )
-            }
-            if self._deprecate_mirrorURL != nil {
-                swiftCommandState.observabilityScope.emit(
-                    warning: "'--mirror-url' option is deprecated; use '--mirror' instead"
-                )
-            }
-
-            guard let original = self._deprecate_packageURL ?? self._deprecate_originalURL ?? self.original else {
-                swiftCommandState.observabilityScope.emit(.missingRequiredArg("--original"))
-                throw ExitCode.failure
-            }
-
-            guard let mirror = self._deprecate_mirrorURL ?? self.mirror else {
-                swiftCommandState.observabilityScope.emit(.missingRequiredArg("--mirror"))
-                throw ExitCode.failure
-            }
 
             try config.applyLocal { mirrors in
-                try mirrors.set(mirror: mirror, for: original)
+                try mirrors.set(mirror: self.mirror, for: self.original)
             }
         }
     }
@@ -95,15 +61,6 @@ extension SwiftPackageCommand.Config {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
-        @Option(name: .customLong("package-url"), help: .hidden)
-        var _deprecate_packageURL: String?
-
-        @Option(name: .customLong("original-url"), help: .hidden)
-        var _deprecate_originalURL: String?
-
-        @Option(name: .customLong("mirror-url"), help: .hidden)
-        var _deprecate_mirrorURL: String?
-
         @Option(help: "The original url or identity.")
         var original: String?
 
@@ -113,24 +70,7 @@ extension SwiftPackageCommand.Config {
         func run(_ swiftCommandState: SwiftCommandState) throws {
             let config = try getMirrorsConfig(swiftCommandState)
 
-            if self._deprecate_packageURL != nil {
-                swiftCommandState.observabilityScope.emit(
-                    warning: "'--package-url' option is deprecated; use '--original' instead"
-                )
-            }
-            if self._deprecate_originalURL != nil {
-                swiftCommandState.observabilityScope.emit(
-                    warning: "'--original-url' option is deprecated; use '--original' instead"
-                )
-            }
-            if self._deprecate_mirrorURL != nil {
-                swiftCommandState.observabilityScope.emit(
-                    warning: "'--mirror-url' option is deprecated; use '--mirror' instead"
-                )
-            }
-
-            guard let originalOrMirror = self._deprecate_packageURL ?? self._deprecate_originalURL ?? self
-                .original ?? self._deprecate_mirrorURL ?? self.mirror
+            guard let originalOrMirror = self.original ?? self.mirror
             else {
                 swiftCommandState.observabilityScope.emit(.missingRequiredArg("--original or --mirror"))
                 throw ExitCode.failure
@@ -149,35 +89,14 @@ extension SwiftPackageCommand.Config {
 
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
-        @Option(name: .customLong("package-url"), help: .hidden)
-        var _deprecate_packageURL: String?
-
-        @Option(name: .customLong("original-url"), help: .hidden)
-        var _deprecate_originalURL: String?
 
         @Option(help: "The original url or identity.")
-        var original: String?
+        var original: String
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
             let config = try getMirrorsConfig(swiftCommandState)
 
-            if self._deprecate_packageURL != nil {
-                swiftCommandState.observabilityScope.emit(
-                    warning: "'--package-url' option is deprecated; use '--original' instead"
-                )
-            }
-            if self._deprecate_originalURL != nil {
-                swiftCommandState.observabilityScope.emit(
-                    warning: "'--original-url' option is deprecated; use '--original' instead"
-                )
-            }
-
-            guard let original = self._deprecate_packageURL ?? self._deprecate_originalURL ?? self.original else {
-                swiftCommandState.observabilityScope.emit(.missingRequiredArg("--original"))
-                throw ExitCode.failure
-            }
-
-            if let mirror = config.mirrors.mirror(for: original) {
+            if let mirror = config.mirrors.mirror(for: self.original) {
                 print(mirror)
             } else {
                 stderrStream.send("not found\n")

--- a/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
@@ -78,6 +78,12 @@ If `--maximum-repetitions` is provided without `--repeat-until`, all tests will 
 
 Running `swift test --debugger` will launch tests in an LLDB debugging session on the command line.  Read more [here](<doc:SwiftTest>).
 
+### Mirrors deterministic order
+
+When adding or removing a mirror configuration using `swift package config <command>`, the produced `mirrors.json` file
+was being completely rewritting with a non-deterministic order.  A change to SwiftPM renders the `mirror.json` file in a
+deterministic order.
+
 ## Reporting issues
 
 Please follow these steps when reporting issues:

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -637,7 +637,9 @@ extension Workspace.Configuration {
             }
 
             let encoder = JSONEncoder.makeWithDefaults()
-            let mirrors = MirrorsStorage(version: 1, object: mirrors.map { .init(original: $0, mirror: $1) })
+            // Sort mirrors by original URL to ensure deterministic output
+            let sortedMirrors = mirrors.sorted { $0.key < $1.key }
+            let mirrors = MirrorsStorage(version: 1, object: sortedMirrors.map { .init(original: $0.key, mirror: $0.value) })
             let data = try encoder.encode(mirrors)
             if !fileSystem.exists(path.parentDirectory) {
                 try fileSystem.createDirectory(path.parentDirectory, recursive: true)

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -3975,39 +3975,6 @@ struct PackageCommandTests {
         @Test(
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
-        func mirrorConfigDeprecation(
-            buildSystem: BuildSystemProvider.Kind,
-        ) async throws {
-            let config = BuildConfiguration.debug
-            try await testWithTemporaryDirectory { fixturePath in
-                localFileSystem.createEmptyFiles(
-                    at: fixturePath,
-                    files:
-                        "/Sources/Foo/Foo.swift",
-                    "/Package.swift"
-                )
-
-                let (_, stderr) = try await execute(
-                    [
-                        "config", "set-mirror", "--package-url", "https://github.com/foo/bar", "--mirror-url",
-                        "https://mygithub.com/foo/bar",
-                    ],
-                    packagePath: fixturePath,
-                    configuration: config,
-                    buildSystem: buildSystem,
-                )
-                #expect(
-                    stderr.contains("warning: '--package-url' option is deprecated; use '--original' instead")
-                )
-                #expect(
-                    stderr.contains("warning: '--mirror-url' option is deprecated; use '--mirror' instead")
-                )
-            }
-        }
-
-        @Test(
-            arguments: SupportedBuildSystemOnAllPlatforms,
-        )
         func mirrorConfig(
             buildSystem: BuildSystemProvider.Kind,
         ) async throws {

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -304,9 +304,9 @@ struct DependencyResolutionTests {
                     extraArgs: [
                         "config",
                         "set-mirror",
-                        "--original-url",
+                        "--original",
                         prefix.appending("Bar").pathString,
-                        "--mirror-url",
+                        "--mirror",
                         prefix.appending("BarMirror").pathString,
                     ],
                     buildSystem: buildSystem,

--- a/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
+++ b/Tests/WorkspaceTests/MirrorsConfigurationTests.swift
@@ -10,10 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import Basics
-import _InternalTestSupport
 import Workspace
 import Testing
+import struct TSCBasic.ByteString
+
+import _InternalTestSupport
 
 fileprivate struct MirrorsConfigurationTests {
     @Test
@@ -151,5 +154,278 @@ fileprivate struct MirrorsConfigurationTests {
         // should not see the shared any longer
         #expect(config.mirrors.mirror(for: original1URL) == nil)
         #expect(config.mirrors.original(for: mirror1URL) == nil)
+    }
+
+    // MARK: - Deterministic Output Tests
+
+    @Test
+    func deterministicJSONOutputWithMultipleMirrors() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/mirrors.json")
+
+        let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
+
+        // Add multiple mirrors in a specific order
+        let mirrorsToAdd = [
+            ("https://github.com/zebra/package-z.git", "https://mirror.com/zebra/package-z.git"),
+            ("https://github.com/apple/swift-argument-parser.git", "https://mirror.com/apple/swift-argument-parser.git"),
+            ("https://github.com/mona/swift-nio.git", "https://mirror.com/mona/swift-nio.git"),
+            ("https://github.com/beta/package-b.git", "https://mirror.com/beta/package-b.git")
+        ]
+
+        try config.apply { mirrors in
+            for (original, mirror) in mirrorsToAdd {
+                try mirrors.set(mirror: mirror, for: original)
+            }
+        }
+
+        // Read the file content multiple times and verify it's identical
+        let content1 = try fs.readFileContents(configFile)
+        let content2 = try fs.readFileContents(configFile)
+        #expect(content1 == content2)
+
+        // Parse the JSON and verify it's properly structured
+        let jsonObject = try JSONSerialization.jsonObject(with: Data(content1.contents), options: [])
+        guard let json = jsonObject as? [String: Any],
+              let version = json["version"] as? Int,
+              let objects = json["object"] as? [[String: String]] else {
+            throw StringError("Invalid JSON structure")
+        }
+
+        #expect(version == 1)
+        #expect(objects.count == mirrorsToAdd.count)
+
+        // Verify the objects are sorted deterministically
+        let sortedObjects = objects.sorted { $0["original"]! < $1["original"]! }
+        #expect(objects == sortedObjects, "Mirror objects should be sorted deterministically by original URL")
+    }
+
+    @Test
+    func consistentOrderingAcrossMultipleSaves() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/mirrors.json")
+
+        let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
+
+        let mirrorsToAdd = [
+            ("https://github.com/third/package.git", "https://mirror3.com/third/package.git"),
+            ("https://github.com/first/package.git", "https://mirror1.com/first/package.git"),
+            ("https://github.com/second/package.git", "https://mirror2.com/second/package.git")
+        ]
+
+        // Perform multiple save operations and collect file contents
+        var fileContents: [ByteString] = []
+
+        for iteration in 0..<5 {
+            // Clear the file
+            if fs.exists(configFile) {
+                try fs.removeFileTree(configFile)
+            }
+
+            // Add mirrors in different orders each time
+            let shuffledMirrors = iteration % 2 == 0 ? mirrorsToAdd : mirrorsToAdd.reversed()
+
+            try config.apply { mirrors in
+                for (original, mirror) in shuffledMirrors {
+                    try mirrors.set(mirror: mirror, for: original)
+                }
+            }
+
+            let content = try fs.readFileContents(configFile)
+            fileContents.append(content)
+        }
+
+        // All file contents should be identical regardless of insertion order
+        for i in 1..<fileContents.count {
+            #expect(fileContents[0] == fileContents[i],
+                    "File content should be identical across saves (iteration \(i))")
+        }
+    }
+
+    @Test
+    func sameInputProducesIdenticalFileContents() throws {
+        let fs1 = InMemoryFileSystem()
+        let fs2 = InMemoryFileSystem()
+        let configFile1 = AbsolutePath("/config/mirrors1.json")
+        let configFile2 = AbsolutePath("/config/mirrors2.json")
+
+        let config1 = Workspace.Configuration.MirrorsStorage(path: configFile1, fileSystem: fs1, deleteWhenEmpty: true)
+        let config2 = Workspace.Configuration.MirrorsStorage(path: configFile2, fileSystem: fs2, deleteWhenEmpty: true)
+
+        // Identical mirror configurations
+        let mirrors = [
+            ("https://github.com/user/repo1.git", "https://mirror.example.com/user/repo1.git"),
+            ("https://github.com/user/repo2.git", "https://mirror.example.com/user/repo2.git"),
+            ("https://github.com/org/project.git", "https://private-mirror.com/org/project.git")
+        ]
+
+        // Apply same configuration to both
+        try config1.apply { mirrorsConfig in
+            for (original, mirror) in mirrors {
+                try mirrorsConfig.set(mirror: mirror, for: original)
+            }
+        }
+
+        try config2.apply { mirrorsConfig in
+            for (original, mirror) in mirrors {
+                try mirrorsConfig.set(mirror: mirror, for: original)
+            }
+        }
+
+        let content1 = try fs1.readFileContents(configFile1)
+        let content2 = try fs2.readFileContents(configFile2)
+
+        #expect(content1 == content2, "Identical mirror configurations should produce identical file contents")
+    }
+
+    @Test
+    func incrementalMirrorAdditionPreservesOrder() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/mirrors.json")
+
+        let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
+
+        // First, add initial mirrors
+        let initialMirrors = [
+            ("https://github.com/zebra/zoo.git", "https://mirror.com/zebra/zoo.git"),
+            ("https://github.com/apple/swift.git", "https://mirror.com/apple/swift.git"),
+            ("https://github.com/microsoft/vscode.git", "https://mirror.com/microsoft/vscode.git")
+        ]
+
+        try config.apply { mirrors in
+            for (original, mirror) in initialMirrors {
+                try mirrors.set(mirror: mirror, for: original)
+            }
+        }
+
+        // Capture the initial state
+        let initialContent = try fs.readFileContents(configFile)
+        let initialJson = try JSONSerialization.jsonObject(with: Data(initialContent.contents), options: [])
+        guard let initialDict = initialJson as? [String: Any],
+              let initialObjects = initialDict["object"] as? [[String: String]] else {
+            throw StringError("Invalid initial JSON structure")
+        }
+        let initialOriginals = initialObjects.compactMap { $0["original"] }
+
+        // Add more mirrors to the existing configuration
+        let additionalMirrors = [
+            ("https://github.com/beta/test.git", "https://mirror.com/beta/test.git"),
+            ("https://github.com/gamma/gamma.git", "https://mirror.com/gamma/gamma.git")
+        ]
+
+        try config.apply { mirrors in
+            for (original, mirror) in additionalMirrors {
+                try mirrors.set(mirror: mirror, for: original)
+            }
+        }
+
+        // Verify the final state maintains deterministic order
+        let finalContent = try fs.readFileContents(configFile)
+        let finalJson = try JSONSerialization.jsonObject(with: Data(finalContent.contents), options: [])
+        guard let finalDict = finalJson as? [String: Any],
+              let finalObjects = finalDict["object"] as? [[String: String]] else {
+            throw StringError("Invalid final JSON structure")
+        }
+        let finalOriginals = finalObjects.compactMap { $0["original"] }
+
+        // Verify all expected mirrors are present
+        let allExpectedOriginals = (initialMirrors + additionalMirrors).map { $0.0 }
+        #expect(finalOriginals.count == allExpectedOriginals.count)
+        for expectedOriginal in allExpectedOriginals {
+            #expect(finalOriginals.contains(expectedOriginal), "All mirrors should be present")
+        }
+
+        // Verify the order is deterministic (alphabetical)
+        let sortedExpected = allExpectedOriginals.sorted()
+        #expect(finalOriginals == sortedExpected, "Final mirror order should be deterministic (alphabetical)")
+
+        // Test that adding the same configuration again produces identical results
+        try config.apply { mirrors in
+            for (original, mirror) in additionalMirrors {
+                try mirrors.set(mirror: mirror, for: original) // Re-adding same mirrors
+            }
+        }
+
+        let duplicateAddContent = try fs.readFileContents(configFile)
+        #expect(finalContent == duplicateAddContent, "Re-adding same mirrors should produce identical content")
+    }
+
+    @Test
+    func deterministicOutputForEdgeCases() throws {
+        let configFile = AbsolutePath("/config/edge-cases-mirrors.json")
+        let fs = InMemoryFileSystem()
+
+        let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: false)
+
+        // Test empty configuration - need to add at least one mirror first to create the file
+        try config.apply { mirrors in
+            try mirrors.set(mirror: "https://temp.com/temp.git", for: "https://github.com/temp.git")
+        }
+        try config.apply { mirrors in
+            try mirrors.unset(originalOrMirror: "https://github.com/temp.git")  // Remove it to make empty
+        }
+        #expect(fs.exists(configFile))
+        let emptyContent1 = try fs.readFileContents(configFile)
+
+        // Apply empty configuration again
+        try config.apply { _ in }
+        let emptyContent2 = try fs.readFileContents(configFile)
+        #expect(emptyContent1 == emptyContent2, "Empty configurations should produce identical output")
+
+        // Test single mirror
+        try config.apply { mirrors in
+            try mirrors.set(mirror: "https://mirror.com/single.git", for: "https://github.com/single.git")
+        }
+        let singleContent1 = try fs.readFileContents(configFile)
+
+        // Clear and add the same single mirror again
+        try config.apply { mirrors in
+            try mirrors.unset(originalOrMirror: "https://github.com/single.git")
+            try mirrors.set(mirror: "https://mirror.com/single.git", for: "https://github.com/single.git")
+        }
+        let singleContent2 = try fs.readFileContents(configFile)
+        #expect(singleContent1 == singleContent2, "Single mirror configurations should produce identical output")
+    }
+
+    @Test
+    func jsonOutputOrderingIsAlphabetical() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/mirrors.json")
+
+        let config = Workspace.Configuration.MirrorsStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
+
+        // Add mirrors in non-alphabetical order
+        let mirrors = [
+            ("https://github.com/zebra/zoo.git", "https://mirror.com/zebra/zoo.git"),
+            ("https://github.com/apple/swift.git", "https://mirror.com/apple/swift.git"),
+            ("https://github.com/microsoft/vscode.git", "https://mirror.com/microsoft/vscode.git"),
+            ("https://github.com/beta/test.git", "https://mirror.com/beta/test.git")
+        ]
+
+        try config.apply { mirrorsConfig in
+            for (original, mirror) in mirrors {
+                try mirrorsConfig.set(mirror: mirror, for: original)
+            }
+        }
+
+        let content = try fs.readFileContents(configFile)
+        let jsonObject = try JSONSerialization.jsonObject(with: Data(content.contents), options: [])
+
+        guard let json = jsonObject as? [String: Any],
+              let objects = json["object"] as? [[String: String]] else {
+            throw StringError("Invalid JSON structure")
+        }
+
+        // Extract the original URLs and verify they are in alphabetical order
+        let originalUrls = objects.compactMap { $0["original"] }
+        let sortedUrls = originalUrls.sorted()
+
+        #expect(originalUrls == sortedUrls, "Original URLs should be in alphabetical order in JSON output")
+
+        // Verify all expected mirrors are present
+        #expect(originalUrls.count == mirrors.count)
+        for (expectedOriginal, _) in mirrors {
+            #expect(originalUrls.contains(expectedOriginal), "All mirrors should be present in output")
+        }
     }
 }

--- a/Utilities/build-using-self
+++ b/Utilities/build-using-self
@@ -235,7 +235,8 @@ def main() -> None:
 
             event_stream_path = pathlib.Path.cwd() / "swift-testing-event-stream.json"
             # Delete any lingering event stream JSON file
-            event_stream_path.unlink(missing_ok=True)
+            if event_stream_path.exists():
+                os.remove(event_stream_path)
 
             def dispaly_event_stream_json_file_contents() -> None:
                 logging.info("Event stream path: %s", event_stream_path.name)
@@ -316,7 +317,8 @@ def main() -> None:
                 )
             except:
                 dispaly_event_stream_json_file_contents()
-                event_stream_path.unlink(missing_ok=True)
+                if event_stream_path.exists():
+                    os.remove(event_stream_path)
 
 
         if is_on_darwin() and not args.skip_bootstrap:


### PR DESCRIPTION
Ensure the mirrors.json file is made more deterministic by sorting on the keys when saving the contents

Depends on #10146 