### PR TITLE
Argument parsing is now async since apple/swift-argument-parser#855

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1125,7 +1125,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // utils/update_checkout/update-checkout-config.json
         // They are used to build the official swift toolchain.
         .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: relatedDependenciesBranch),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", revision: "1.6.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", revision: "1.8.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", revision: "3.12.5"),
         .package(url: "https://github.com/apple/swift-system.git", revision: "1.5.0"),
         .package(url: "https://github.com/apple/swift-collections.git", revision: "1.1.6"),

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -556,7 +556,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             try await printCodeCovPath(swiftCommandState)
         } else if self.options._deprecated_shouldListTests {
             // Backward compatibility 6/2022 for deprecation of a flag into a subcommand.
-            let command = try List.parse()
+            let command = try await List.parse()
             try await command.run(swiftCommandState)
         } else {
             let (productsBuildParameters, _) = try swiftCommandState.buildParametersForTest(options: self.options)


### PR DESCRIPTION
This is needed for swiftlang/swift#89404, which updates the Argument Parser used to the latest 1.8.0 tag.


Depends on https://github.com/swiftlang/swift-build/pull/1428
Blocks: swiftlang/swift#89404