### PR TITLE
Reject .artifactbundle directories used as regular targets

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -87,6 +87,9 @@ public enum ModuleError: Swift.Error {
     /// Indicates several targets with the same name exist in packages
     case duplicateModules(package: PackageIdentity, otherPackage: PackageIdentity, modules: [String])
 
+    /// A normal target points to an artifact bundle.
+    case artifactBundleAsNormalTarget(target: String)
+
     /// Indicates several targets with the same name exist in a registry and scm package
     case duplicateModulesScmAndRegistry(
         registryPackage: PackageIdentity.RegistryIdentity,
@@ -159,6 +162,8 @@ extension ModuleError: CustomStringConvertible {
             return "plugin target '\(target)' doesn't have a 'capability' property"
         case .embedInCodeNotSupported(let target):
             return "embedding resources in code not supported for C-family language target \(target)"
+        case .artifactBundleAsNormalTarget(let target):
+            return "target '\(target)' cannot point to an artifact bundle; use '.binaryTarget' instead"
         case .duplicateModules(let package, let otherPackage, let targets):
             var targetsDescription = "'\(targets.sorted().prefix(3).joined(separator: "', '"))'"
             if targets.count > 3 {
@@ -631,6 +636,9 @@ public final class PackageBuilder {
         let potentialTargets: [PotentialModule]
         potentialTargets = try self.manifest.targetsRequired(for: self.productFilter).map { target in
             let path = try findPath(for: target)
+            if target.type != .binary && path.extension == "artifactbundle" {
+                throw ModuleError.artifactBundleAsNormalTarget(target: target.name)
+            }
             return PotentialModule(
                 name: target.name,
                 path: path,

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -3595,6 +3595,31 @@ struct PackageBuilderTests {
             }
         }
     }
+
+    @Test
+    func testArtifactBundleAsNormalTargetError() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/foo.artifactbundle/info.json",
+            "/Sources/foo.artifactbundle/libfoo.a"
+        )
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "pkg",
+            targets: [
+                try TargetDescription(
+                    name: "foo",
+                    path: "Sources/foo.artifactbundle"
+                ),
+            ]
+        )
+
+        try PackageBuilderTester(manifest, in: fs) { _, diagnostics in
+            diagnostics.check(
+                diagnostic: "target 'foo' cannot point to an artifact bundle; use '.binaryTarget' instead",
+                severity: .error
+            )
+        }
+    }
 }
 
 final class PackageBuilderTester {


### PR DESCRIPTION
Reject .artifactbundle directories used as normal targets

### Motivation:

Fixes #10081 

SwiftPM currently allows unpacked .artifactbundle directories to be referenced through .target(path:), causing them to be partially treated as normal targets. This results in undocumented and inconsistent behavior where files like info.json are discovered. Since .artifactbundle directories are intended to be consumed through .binaryTarget, the current behavior is misleading and can lead to invalid package configurations.

### Modifications:

- Added validation in PackageBuilder to detect when a non-binary target points to a .artifactbundle directory.
- Introduced a dedicated diagnostic error explaining that .artifactbundle directories must be used with .binaryTarget.
- Added a regression test covering the invalid .target(path: "...artifactbundle") case.

### Result:

SwiftPM now rejects unsupported usage of .artifactbundle directories as normal targets instead of partially accepting them with undefined behavior. Users receive a clear diagnostic directing them to use .binaryTarget instead.