### PR TITLE
Don't include language mode that matches the default for the tools version used in package template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -475,9 +475,12 @@ public final class InitPackage {
                 pkgParams.append(param)
             }
 
-            if (!options.swiftLanguageModes.isEmpty) {
+            let nonDefaultModes = options.swiftLanguageModes.filter {
+                $0 != InitPackage.newPackageToolsVersion.swiftLanguageVersion
+            }
+            if !nonDefaultModes.isEmpty {
                 pkgParams.append("""
-                    swiftLanguageModes: [\(options.swiftLanguageModes.map { ".v\($0)" }.joined(separator: ", "))]
+                    swiftLanguageModes: [\(nonDefaultModes.map { ".v\($0)" }.joined(separator: ", "))]
                 """)
             }
 

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -697,10 +697,39 @@ struct InitTests {
             )
             try initPackage.writePackageStructure()
 
-            // Verify the manifest includes Swift language mode
+            // swiftLanguageModes should be omitted when it matches the default for the current tools version
             let manifest = path.appending("Package.swift")
             let manifestContents: String = try localFileSystem.readFileContents(manifest)
-            #expect(manifestContents.contains("swiftLanguageModes: [.v6]"))
+            #expect(!manifestContents.contains("swiftLanguageModes"))
+        }
+    }
+
+    @Test(
+        .tags(
+            .TestSize.medium,
+        ),
+    )
+    func initPackageIncludesNonDefaultSwiftLanguageMode() throws {
+        try withTemporaryDirectory { tmpPath in
+            let path = tmpPath.appending("testInitPackageNonDefaultLanguageMode")
+            try localFileSystem.createDirectory(path)
+
+            let options = InitPackage.InitPackageOptions(
+                packageType: .library,
+                supportedTestingLibraries: [],
+                swiftLanguageModes: [.v5]
+            )
+            let initPackage = try InitPackage(
+                name: path.basename,
+                options: options,
+                destinationPath: path,
+                installedSwiftPMConfiguration: .default,
+                fileSystem: localFileSystem
+            )
+            try initPackage.writePackageStructure()
+
+            let manifestContents: String = try localFileSystem.readFileContents(path.appending("Package.swift"))
+            #expect(manifestContents.contains("swiftLanguageModes: [.v5]"))
         }
     }
 


### PR DESCRIPTION
Don't include language mode that matches the default for the tools version used in package template

### Motivation:

Avoid including the language mode attribute in new packages from template when it matches the default used by the tools version.

### Modifications:

Filter out language modes that are covered by the tools version used

### Result:

Avoid writing swiftLanguageModes attribute in new package manifest when not needed.
