### PR TITLE
[6.4]Ensure transitive dependencies of testable macros are correctly linked into test targets

### DIFF
--- a/Fixtures/Macros/MinimalMacroPackage/Package.swift
+++ b/Fixtures/Macros/MinimalMacroPackage/Package.swift
@@ -8,9 +8,11 @@ let package = Package(
         .macOS(.v13),
     ],
     targets: [
-        .macro(name: "MacroImpl"),
+        .target(name: "MacroImplHelpers"),
+        .macro(name: "MacroImpl", dependencies: ["MacroImplHelpers"]),
         .target(name: "MacroDef", dependencies: ["MacroImpl"]),
         .executableTarget(name: "MacroClient", dependencies: ["MacroDef"]),
+        .testTarget(name: "MinimalMacroPackageTests", dependencies: ["MacroDef"]),
     ],
     swiftLanguageModes: [.v5]
 )

--- a/Fixtures/Macros/MinimalMacroPackage/Sources/MacroImpl/StringifyMacro.swift
+++ b/Fixtures/Macros/MinimalMacroPackage/Sources/MacroImpl/StringifyMacro.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MacroImplHelpers
 
 @main
 struct MacroPlugin {
@@ -40,7 +41,7 @@ struct MacroPlugin {
             } else if json.keys.contains("expandFreestandingMacro") {
                 let response: [String: Any] = [
                     "expandMacroResult": [
-                        "expandedSource": "\"expanded\"",
+                        "expandedSource": "\"\(macroImplHelper())\"",
                         "diagnostics": []
                     ]
                 ]

--- a/Fixtures/Macros/MinimalMacroPackage/Sources/MacroImplHelpers/MacroImplHelpers.swift
+++ b/Fixtures/Macros/MinimalMacroPackage/Sources/MacroImplHelpers/MacroImplHelpers.swift
@@ -1,0 +1,3 @@
+public func macroImplHelper() -> String {
+    "expanded"
+}

--- a/Fixtures/Macros/MinimalMacroPackage/Tests/MinimalMacroPackageTests/MinimalMacroPackageTests.swift
+++ b/Fixtures/Macros/MinimalMacroPackage/Tests/MinimalMacroPackageTests/MinimalMacroPackageTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+
+import MacroDef
+
+final class MinimalMacroPackageTests: XCTestCase {
+    func testStringify() {
+        let result = #stringify(42)
+        XCTAssertEqual(result, "expanded")
+    }
+}

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -969,8 +969,8 @@ extension PackageGraph.ResolvedProduct {
 }
 
 extension PackageGraph.ResolvedModule {
-    func recursivelyTraverseDependencies(with block: (ResolvedModule.Dependency) -> Void) {
-        [self].recursivelyTraverseDependencies(with: block)
+    func recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: Bool, with block: (ResolvedModule.Dependency) -> Void) {
+        [self].recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: includeMacroDependencies, with: block)
     }
 
     func addParseAsLibrarySettings(to settings: inout BuildSettings, toolsVersion: ToolsVersion, fileSystem: FileSystem) {
@@ -996,9 +996,9 @@ extension PackageGraph.ResolvedModule {
 }
 
 extension Collection<PackageGraph.ResolvedModule> {
-    /// Recursively applies a block to each of the *dependencies* of the given module, in topological sort order.
+    /// Recursively applies a block to each of the linkage dependencies of the given module, in topological sort order.
     /// Each module or product dependency is visited only once.
-    func recursivelyTraverseDependencies(with block: (ResolvedModule.Dependency) -> Void) {
+    func recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: Bool, with block: (ResolvedModule.Dependency) -> Void) {
         var moduleIDsSeen: Set<ResolvedModule.ID> = []
         var productIDsSeen: Set<ResolvedProduct.ID> = []
 
@@ -1008,10 +1008,20 @@ extension Collection<PackageGraph.ResolvedModule> {
                 let (unseenModule, _) = moduleIDsSeen.insert(moduleDependency.id)
                 guard unseenModule else { return }
 
-                // Do not traverse into *macro* or *plugin* dependencies.
-                // Macros run at compile time and their dependencies should not be linked into the client.
-                // Plugins run at build time and their dependencies should not be linked into the client neither.
-                if ![.macro, .plugin].contains(moduleDependency.underlying.type) {
+                // Do not traverse into *macro* or *plugin* dependencies unless explicitly requested.
+                // Macros run at compile time and their dependencies should not be linked into the client, unless a client includes their testable variant.
+                // Plugins run at build time and their dependencies should not be linked into the client.
+                let stopTraversal: Bool
+                switch moduleDependency.type {
+                case .macro:
+                    stopTraversal = !includeMacroDependencies
+                case .plugin:
+                    stopTraversal = true
+                default:
+                    stopTraversal = false
+                }
+
+                if !stopTraversal {
                     for dependency in moduleDependency.dependencies {
                         visitDependency(dependency)
                     }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -61,7 +61,7 @@ extension PackagePIFProjectBuilder {
         var buildSettings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
         // Add the dependencies.
-        pluginModule.recursivelyTraverseDependencies { dependency in
+        pluginModule.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: false) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
                 // This assertion is temporarily disabled since we may see targets from
@@ -731,7 +731,7 @@ extension PackagePIFProjectBuilder {
         // Handle the target's dependencies (but only link against them if needed).
         let shouldLinkProduct = (desiredModuleType == .dynamicLibrary) || (desiredModuleType == .macro)
         var moduleTarget = self.project[keyPath: sourceModuleTargetKeyPath]
-        sourceModule.recursivelyTraverseDependencies { dependency in
+        sourceModule.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: false) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
                 // This assertion is temporarily disabled since we may see targets from

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -371,7 +371,8 @@ extension PackagePIFProjectBuilder {
 
         // Handle the main target's dependencies (and link against them).
         var mainModuleTarget = self.project[keyPath: mainModuleTargetKeyPath]
-        mainModule.recursivelyTraverseDependencies { dependency in
+        // If this is a test target, include dependencies of macros, as we will be linking their testable variant.
+        mainModule.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: product.type == .test) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
                 // This assertion is temporarily disabled since we may see targets from
@@ -432,23 +433,6 @@ extension PackagePIFProjectBuilder {
                             indent: 1,
                             "Added linked dependency on target '\(moduleDependency.pifTargetGUID(suffix: .testable))'"
                         )
-
-                        // FIXME: Manually propagate product dependencies of macros but the build system should really handle this.
-                        moduleDependency.recursivelyTraverseDependencies { dependency in
-                            switch dependency {
-                            case .product(let productDependency, let packageConditions):
-                                let isLinkable = productDependency.isLinkable
-                                self.handleProduct(
-                                    productDependency,
-                                    with: packageConditions,
-                                    isLinkable: isLinkable,
-                                    target: &mainModuleTarget,
-                                    settings: &settings
-                                )
-                            case .module:
-                                break
-                            }
-                        }
                     }
 
                 case .executable, .snippet:
@@ -785,7 +769,7 @@ extension PackagePIFProjectBuilder {
         // (and link against them, which in the case of a package product, really just means that clients should link
         // against them).
         var libraryUmbrellaTarget = self.project[keyPath: libraryUmbrellaTargetKeyPath]
-        product.modules.recursivelyTraverseDependencies { dependency in
+        product.modules.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: false) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
                 // This assertion is temporarily disabled since we may see targets from

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -61,7 +61,8 @@ struct MacroTests {
         try await fixture(name: "Macros/MinimalMacroPackage") { fixturePath in
             let (stdout, _) = try await executeSwiftBuild(
                 fixturePath,
-                buildSystem: buildSystem,
+                extraArgs: ["--build-tests"],
+                buildSystem: buildSystem
             )
             #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1180,6 +1180,33 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test func macroPackageTestDependencies() async throws {
+        try await withGeneratedPIF(fromFixture: "Macros/MinimalMacroPackage") { pif, observabilitySystem, _ in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+
+            let project = try pif.workspace.project(named: "MinimalMacroPackage")
+
+            let testProduct = try project.target(named: "MinimalMacroPackageTests-product")
+            guard case .target(let testTarget) = testProduct else {
+                Issue.record("Expected MinimalMacroPackageTests-product to be a regular target")
+                return
+            }
+            #expect(testTarget.productType == .unitTest)
+
+            let depIDs = testTarget.common.dependencies.map(\.targetId.value)
+
+            // The test bundle should link both the testable variant of the macro target, and its transitive dependency.
+            #expect(
+                depIDs.contains { $0.hasPrefix("PACKAGE-TARGET:MacroImpl-") && $0.hasSuffix("-testable") },
+                "Expected test bundle to link testable variant of MacroImpl, found dependencies: \(depIDs)"
+            )
+            #expect(
+                depIDs.contains("PACKAGE-TARGET:MacroImplHelpers"),
+                "Expected test bundle to link MacroImplHelpers, found dependencies: \(depIDs)"
+            )
+        }
+    }
+
     @Test func mixedSourceTarget() async throws {
         let fs = InMemoryFileSystem(
             emptyFiles:


### PR DESCRIPTION
Previously, a special case hack was used to ensure that when a test bundle consumed the testable variant of a macro target, the products that macro transitively depended on were linked. However, when a testable macro had a transitive dependency on a regular library target in the same package, we would fail to link it and then report missing symbols at build time. Replace the special case we previously had with a new parameter on recursivelyTraverseTransitiveLinkageDependencies which lets clients opt into looking through macro dependencies when generating PIF for a test bundle, simplifying the code and resolving the original issue. 