### PR TITLE
Replace GitFileSystemView fatalErrors with throwing FileSystem operations

### DIFF
--- a/Sources/PackageModel/DependencyMapper.swift
+++ b/Sources/PackageModel/DependencyMapper.swift
@@ -100,7 +100,13 @@ public struct DefaultDependencyMapper: DependencyMapper {
             case .none:
                 // if the dependency URL starts with '~/', try to expand it.
                 if dependencyLocation.hasPrefix("~/") {
-                    return try AbsolutePath(validating: String(dependencyLocation.dropFirst(2)), relativeTo: fileSystem.homeDirectory).pathString
+                    let homeDirectory: AbsolutePath
+                    do {
+                        homeDirectory = try fileSystem.homeDirectory
+                    } catch {
+                        throw DependencyMappingError.invalidLocation("'~/'-prefixed dependency path '\(dependencyLocation)' cannot be expanded because the package manifest is being loaded from a context without a home directory (e.g. a remote source-control package); use a relative path or a remote URL instead")
+                    }
+                    return try AbsolutePath(validating: String(dependencyLocation.dropFirst(2)), relativeTo: homeDirectory).pathString
                 }
 
                 // check if already absolute path
@@ -336,11 +342,13 @@ extension PackageDependency {
 
 private enum DependencyMappingError: Swift.Error, CustomStringConvertible {
     case invalidFileURL(_ message: String)
+    case invalidLocation(_ message: String)
     case invalidMapping(_ message: String)
 
     var description: String {
         switch self {
         case .invalidFileURL(let message): return message
+        case .invalidLocation(let message): return message
         case .invalidMapping(let message): return message
         }
     }

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1310,15 +1310,19 @@ private class GitFileSystemView: FileSystem {
     // MARK: Unsupported methods.
 
     public var homeDirectory: TSCAbsolutePath {
-        fatalError("unsupported")
+        get throws {
+            throw FileSystemError(.unsupported)
+        }
     }
 
     public var cachesDirectory: TSCAbsolutePath? {
-        fatalError("unsupported")
+        nil
     }
 
     public var tempDirectory: TSCAbsolutePath {
-        fatalError("unsupported")
+        get throws {
+            throw FileSystemError(.unsupported)
+        }
     }
 
     func createDirectory(_ path: TSCAbsolutePath) throws {
@@ -1346,11 +1350,11 @@ private class GitFileSystemView: FileSystem {
     }
 
     func copy(from sourcePath: TSCAbsolutePath, to destinationPath: TSCAbsolutePath) throws {
-        fatalError("will never be supported")
+        throw FileSystemError(.unsupported, sourcePath)
     }
 
     func move(from sourcePath: TSCAbsolutePath, to destinationPath: TSCAbsolutePath) throws {
-        fatalError("will never be supported")
+        throw FileSystemError(.unsupported, sourcePath)
     }
 }
 

--- a/Tests/PackageModelTests/DependencyMapperTests.swift
+++ b/Tests/PackageModelTests/DependencyMapperTests.swift
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+@testable import PackageModel
+import XCTest
+
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.ByteString
+import enum TSCBasic.FileMode
+import struct TSCBasic.FileSystemError
+
+final class DependencyMapperTests: XCTestCase {
+    private let parentPath = try! Basics.AbsolutePath(validating: "/parent")
+
+    private func mappedFileSystemPath(
+        _ path: String,
+        fileSystem: FileSystem
+    ) throws -> Basics.AbsolutePath {
+        let mapper = DefaultDependencyMapper(identityResolver: DefaultIdentityResolver())
+        let dependency = MappablePackageDependency(
+            parentPackagePath: parentPath,
+            kind: .fileSystem(name: nil, path: path),
+            productFilter: .everything,
+            traits: nil
+        )
+        let mapped = try mapper.mappedDependency(dependency, fileSystem: fileSystem)
+        guard case .fileSystem(let settings) = mapped else {
+            XCTFail("expected fileSystem-kind dependency, got \(mapped)")
+            throw FileSystemError(.unsupported)
+        }
+        return settings.path
+    }
+
+    func testTildePathIsExpandedAgainstHomeDirectory() throws {
+        // InMemoryFileSystem provides a synthetic home at /home/user — the
+        // happy path that should keep working after the regression fix.
+        let resolved = try mappedFileSystemPath("~/Library/Stuff", fileSystem: InMemoryFileSystem())
+        XCTAssertEqual(resolved.pathString, "/home/user/Library/Stuff")
+    }
+
+    func testTildePathThrowsInsteadOfCrashingWhenHomeDirectoryUnsupported() {
+        // Regression test for rdar://177668882: a remote source-control
+        // package whose manifest contains `.package(path: "~/...")` previously
+        // crashed Xcode because the underlying GitFileSystemView's
+        // `homeDirectory` aborted with `fatalError` instead of throwing. Make
+        // sure the dependency mapper now produces an actionable error.
+        XCTAssertThrowsError(
+            try mappedFileSystemPath(
+                "~/Documents/games/BoardGameKitHost",
+                fileSystem: ThrowingHomeDirectoryFileSystem()
+            )
+        ) { error in
+            let description = String(describing: error)
+            XCTAssertTrue(description.contains("~/"), "expected error to mention the offending '~/' prefix; got: \(description)")
+            XCTAssertTrue(description.contains("BoardGameKitHost"), "expected error to mention the offending dependency path; got: \(description)")
+        }
+    }
+
+    func testAbsolutePathIsLeftAlone() throws {
+        let resolved = try mappedFileSystemPath("/absolute/path", fileSystem: InMemoryFileSystem())
+        XCTAssertEqual(resolved.pathString, "/absolute/path")
+    }
+
+    func testRelativePathIsResolvedAgainstParent() throws {
+        let resolved = try mappedFileSystemPath("Sibling", fileSystem: InMemoryFileSystem())
+        XCTAssertEqual(resolved.pathString, "/parent/Sibling")
+    }
+}
+
+// MARK: - Test FileSystem stub
+
+/// A minimal `FileSystem` whose only meaningful behavior is that
+/// `homeDirectory` throws `FileSystemError(.unsupported)`. Mirrors the surface
+/// area that production `GitFileSystemView` exposes for `~/` expansion. Every
+/// other method traps so that any unexpected access during the test fails
+/// loudly rather than silently returning bogus data.
+private final class ThrowingHomeDirectoryFileSystem: FileSystem {
+    var homeDirectory: TSCBasic.AbsolutePath {
+        get throws { throw FileSystemError(.unsupported) }
+    }
+
+    var cachesDirectory: TSCBasic.AbsolutePath? { nil }
+
+    var tempDirectory: TSCBasic.AbsolutePath {
+        get throws { throw FileSystemError(.unsupported) }
+    }
+
+    var currentWorkingDirectory: TSCBasic.AbsolutePath? { nil }
+
+    func exists(_ path: TSCBasic.AbsolutePath, followSymlink: Bool) -> Bool { unreachable() }
+    func isDirectory(_ path: TSCBasic.AbsolutePath) -> Bool { unreachable() }
+    func isFile(_ path: TSCBasic.AbsolutePath) -> Bool { unreachable() }
+    func isExecutableFile(_ path: TSCBasic.AbsolutePath) -> Bool { unreachable() }
+    func isSymlink(_ path: TSCBasic.AbsolutePath) -> Bool { unreachable() }
+    func isReadable(_ path: TSCBasic.AbsolutePath) -> Bool { unreachable() }
+    func isWritable(_ path: TSCBasic.AbsolutePath) -> Bool { unreachable() }
+    func getDirectoryContents(_ path: TSCBasic.AbsolutePath) throws -> [String] { unreachable() }
+    func changeCurrentWorkingDirectory(to path: TSCBasic.AbsolutePath) throws { unreachable() }
+    func createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws { unreachable() }
+    func createSymbolicLink(_ path: TSCBasic.AbsolutePath, pointingAt destination: TSCBasic.AbsolutePath, relative: Bool) throws { unreachable() }
+    func readFileContents(_ path: TSCBasic.AbsolutePath) throws -> ByteString { unreachable() }
+    func writeFileContents(_ path: TSCBasic.AbsolutePath, bytes: ByteString) throws { unreachable() }
+    func removeFileTree(_ path: TSCBasic.AbsolutePath) throws { unreachable() }
+    func chmod(_ mode: FileMode, path: TSCBasic.AbsolutePath, options: Set<FileMode.Option>) throws { unreachable() }
+    func copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws { unreachable() }
+    func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws { unreachable() }
+
+    private func unreachable(function: StaticString = #function) -> Never {
+        XCTFail("ThrowingHomeDirectoryFileSystem.\(function) was called unexpectedly")
+        fatalError("ThrowingHomeDirectoryFileSystem.\(function) was called unexpectedly")
+    }
+}

--- a/Tests/PackageModelTests/DependencyMapperTests.swift
+++ b/Tests/PackageModelTests/DependencyMapperTests.swift
@@ -107,19 +107,24 @@ private final class ThrowingHomeDirectoryFileSystem: FileSystem {
     func isSymlink(_ path: TSCBasic.AbsolutePath) -> Bool { unreachable() }
     func isReadable(_ path: TSCBasic.AbsolutePath) -> Bool { unreachable() }
     func isWritable(_ path: TSCBasic.AbsolutePath) -> Bool { unreachable() }
-    func getDirectoryContents(_ path: TSCBasic.AbsolutePath) throws -> [String] { unreachable() }
-    func changeCurrentWorkingDirectory(to path: TSCBasic.AbsolutePath) throws { unreachable() }
-    func createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws { unreachable() }
-    func createSymbolicLink(_ path: TSCBasic.AbsolutePath, pointingAt destination: TSCBasic.AbsolutePath, relative: Bool) throws { unreachable() }
-    func readFileContents(_ path: TSCBasic.AbsolutePath) throws -> ByteString { unreachable() }
-    func writeFileContents(_ path: TSCBasic.AbsolutePath, bytes: ByteString) throws { unreachable() }
-    func removeFileTree(_ path: TSCBasic.AbsolutePath) throws { unreachable() }
-    func chmod(_ mode: FileMode, path: TSCBasic.AbsolutePath, options: Set<FileMode.Option>) throws { unreachable() }
-    func copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws { unreachable() }
-    func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws { unreachable() }
+    func getDirectoryContents(_ path: TSCBasic.AbsolutePath) throws -> [String] { try unreachableThrowing() }
+    func changeCurrentWorkingDirectory(to path: TSCBasic.AbsolutePath) throws { try unreachableThrowing() }
+    func createDirectory(_ path: TSCBasic.AbsolutePath, recursive: Bool) throws { try unreachableThrowing() }
+    func createSymbolicLink(_ path: TSCBasic.AbsolutePath, pointingAt destination: TSCBasic.AbsolutePath, relative: Bool) throws { try unreachableThrowing() }
+    func readFileContents(_ path: TSCBasic.AbsolutePath) throws -> ByteString { try unreachableThrowing() }
+    func writeFileContents(_ path: TSCBasic.AbsolutePath, bytes: ByteString) throws { try unreachableThrowing() }
+    func removeFileTree(_ path: TSCBasic.AbsolutePath) throws { try unreachableThrowing() }
+    func chmod(_ mode: FileMode, path: TSCBasic.AbsolutePath, options: Set<FileMode.Option>) throws { try unreachableThrowing() }
+    func copy(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws { try unreachableThrowing() }
+    func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws { try unreachableThrowing() }
 
-    private func unreachable(function: StaticString = #function) -> Never {
+    private func unreachable(function: StaticString = #function) -> Bool {
         Issue.record("ThrowingHomeDirectoryFileSystem.\(function) was called unexpectedly")
-        fatalError("ThrowingHomeDirectoryFileSystem.\(function) was called unexpectedly")
+        return false
+    }
+
+    private func unreachableThrowing(function: StaticString = #function) throws -> Never {
+        Issue.record("ThrowingHomeDirectoryFileSystem.\(function) was called unexpectedly")
+        throw FileSystemError(.unsupported)
     }
 }

--- a/Tests/PackageModelTests/DependencyMapperTests.swift
+++ b/Tests/PackageModelTests/DependencyMapperTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift open source project
 //
-// Copyright (c) 2024-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -12,14 +12,14 @@
 
 import Basics
 @testable import PackageModel
-import XCTest
+import Testing
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.ByteString
 import enum TSCBasic.FileMode
 import struct TSCBasic.FileSystemError
 
-final class DependencyMapperTests: XCTestCase {
+struct DependencyMapperTests {
     private let parentPath = try! Basics.AbsolutePath(validating: "/parent")
 
     private func mappedFileSystemPath(
@@ -35,45 +35,48 @@ final class DependencyMapperTests: XCTestCase {
         )
         let mapped = try mapper.mappedDependency(dependency, fileSystem: fileSystem)
         guard case .fileSystem(let settings) = mapped else {
-            XCTFail("expected fileSystem-kind dependency, got \(mapped)")
+            Issue.record("expected fileSystem-kind dependency, got \(mapped)")
             throw FileSystemError(.unsupported)
         }
         return settings.path
     }
 
-    func testTildePathIsExpandedAgainstHomeDirectory() throws {
+    @Test
+    func tildePathIsExpandedAgainstHomeDirectory() throws {
         // InMemoryFileSystem provides a synthetic home at /home/user — the
         // happy path that should keep working after the regression fix.
         let resolved = try mappedFileSystemPath("~/Library/Stuff", fileSystem: InMemoryFileSystem())
-        XCTAssertEqual(resolved.pathString, "/home/user/Library/Stuff")
+        #expect(resolved.pathString == "/home/user/Library/Stuff")
     }
 
-    func testTildePathThrowsInsteadOfCrashingWhenHomeDirectoryUnsupported() {
+    @Test
+    func tildePathThrowsInsteadOfCrashingWhenHomeDirectoryUnsupported() {
         // Regression test for rdar://177668882: a remote source-control
         // package whose manifest contains `.package(path: "~/...")` previously
         // crashed Xcode because the underlying GitFileSystemView's
         // `homeDirectory` aborted with `fatalError` instead of throwing. Make
         // sure the dependency mapper now produces an actionable error.
-        XCTAssertThrowsError(
+        #expect {
             try mappedFileSystemPath(
                 "~/Documents/games/BoardGameKitHost",
                 fileSystem: ThrowingHomeDirectoryFileSystem()
             )
-        ) { error in
+        } throws: { error in
             let description = String(describing: error)
-            XCTAssertTrue(description.contains("~/"), "expected error to mention the offending '~/' prefix; got: \(description)")
-            XCTAssertTrue(description.contains("BoardGameKitHost"), "expected error to mention the offending dependency path; got: \(description)")
+            return description.contains("~/") && description.contains("BoardGameKitHost")
         }
     }
 
-    func testAbsolutePathIsLeftAlone() throws {
+    @Test
+    func absolutePathIsLeftAlone() throws {
         let resolved = try mappedFileSystemPath("/absolute/path", fileSystem: InMemoryFileSystem())
-        XCTAssertEqual(resolved.pathString, "/absolute/path")
+        #expect(resolved.pathString == "/absolute/path")
     }
 
-    func testRelativePathIsResolvedAgainstParent() throws {
+    @Test
+    func relativePathIsResolvedAgainstParent() throws {
         let resolved = try mappedFileSystemPath("Sibling", fileSystem: InMemoryFileSystem())
-        XCTAssertEqual(resolved.pathString, "/parent/Sibling")
+        #expect(resolved == parentPath.appending(component: "Sibling"))
     }
 }
 
@@ -116,7 +119,7 @@ private final class ThrowingHomeDirectoryFileSystem: FileSystem {
     func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws { unreachable() }
 
     private func unreachable(function: StaticString = #function) -> Never {
-        XCTFail("ThrowingHomeDirectoryFileSystem.\(function) was called unexpectedly")
+        Issue.record("ThrowingHomeDirectoryFileSystem.\(function) was called unexpectedly")
         fatalError("ThrowingHomeDirectoryFileSystem.\(function) was called unexpectedly")
     }
 }

--- a/Tests/PackageModelTests/DependencyMapperTests.swift
+++ b/Tests/PackageModelTests/DependencyMapperTests.swift
@@ -46,7 +46,7 @@ struct DependencyMapperTests {
         // InMemoryFileSystem provides a synthetic home at /home/user — the
         // happy path that should keep working after the regression fix.
         let resolved = try mappedFileSystemPath("~/Library/Stuff", fileSystem: InMemoryFileSystem())
-        #expect(resolved.pathString == "/home/user/Library/Stuff")
+        #expect(resolved == (try Basics.AbsolutePath(validating: "/home/user/Library/Stuff")))
     }
 
     @Test
@@ -70,7 +70,7 @@ struct DependencyMapperTests {
     @Test
     func absolutePathIsLeftAlone() throws {
         let resolved = try mappedFileSystemPath("/absolute/path", fileSystem: InMemoryFileSystem())
-        #expect(resolved.pathString == "/absolute/path")
+        #expect(resolved == (try Basics.AbsolutePath(validating: "/absolute/path")))
     }
 
     @Test

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -387,6 +387,46 @@ class GitRepositoryTests: XCTestCase {
         }
     }
 
+    /// Verifies that operations that the git-backed `FileSystem` view cannot
+    /// support throw rather than crashing the process. Regression test for the
+    /// `fatalError` chain inside `GitFileSystemView` — see rdar://177668882,
+    /// where a remote package manifest containing `.package(path: "~/...")`
+    /// crashed Xcode because `homeDirectory` aborted instead of throwing.
+    func testGitFileViewUnsupportedOperationsThrow() async throws {
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
+        try await testWithTemporaryDirectory { path in
+            let testRepoPath = path.appending("test-repo")
+            try localFileSystem.createDirectory(testRepoPath)
+            initGitRepo(testRepoPath, tag: "test-tag")
+
+            let testClonePath = path.appending("clone")
+            let provider = GitRepositoryProvider()
+            let repoSpec = RepositorySpecifier(path: testRepoPath)
+            try await provider.fetch(repository: repoSpec, to: testClonePath)
+            let repository = provider.open(repository: repoSpec, at: testClonePath)
+            let view = try repository.openFileView(revision: repository.resolveRevision(tag: "test-tag"))
+
+            // `homeDirectory` and `tempDirectory` are now `get throws`.
+            XCTAssertThrowsError(try view.homeDirectory) { error in
+                XCTAssertEqual((error as? FileSystemError)?.kind, .unsupported)
+            }
+            XCTAssertThrowsError(try view.tempDirectory) { error in
+                XCTAssertEqual((error as? FileSystemError)?.kind, .unsupported)
+            }
+
+            // `cachesDirectory` is optional; absence is signalled with `nil`.
+            XCTAssertNil(view.cachesDirectory)
+
+            // `copy` and `move` previously fatal-errored; they now throw.
+            XCTAssertThrowsError(try view.copy(from: AbsolutePath("/a"), to: AbsolutePath("/b"))) { error in
+                XCTAssertEqual((error as? FileSystemError)?.kind, .unsupported)
+            }
+            XCTAssertThrowsError(try view.move(from: AbsolutePath("/a"), to: AbsolutePath("/b"))) { error in
+                XCTAssertEqual((error as? FileSystemError)?.kind, .unsupported)
+            }
+        }
+    }
+
     /// Test the handling of local checkouts.
     func testCheckouts() async throws {
         try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)


### PR DESCRIPTION
### Motivation:

A remote source-control package whose manifest contains a `~/`-prefixed dependency path (e.g. `.package(path: "~/Documents/foo")`) crashed the process during resolution. The crash fired in `GitFileSystemView.homeDirectory`, which aborted with `fatalError` instead of throwing.

### Modifications:

Replace the `fatalError`s on `GitFileSystemView` with the throwing / optional behavior the FileSystem protocol already allows.

### Result:

Provide an error message explaining the root issue instead of unceremoniously crashing.
