### PR TITLE
[6.4] Validate traits in target build setting conditions on manifest load

### DIFF
--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -127,6 +127,24 @@ public struct ManifestValidator {
             }
         }
 
+        // Check against target setting condition traits.
+        let targets = self.manifest.targets
+
+        for target in targets {
+            let settings = target.settings
+            for setting in settings {
+                guard let traits = setting.condition?.traits else {
+                    continue
+                }
+
+                for trait in traits {
+                    if !traitKeys.contains(trait) {
+                        diagnostics.append(.invalidTraitInSettingsCondition(trait: trait, target: target))
+                    }
+                }
+            }
+        }
+
         return diagnostics
     }
 
@@ -370,6 +388,10 @@ extension Basics.Diagnostic {
 
     static func invalidEnabledTrait(trait: String, enabledBy enablerTrait: String) -> Self {
         .error("Trait \(enablerTrait) enables \(trait) which is not defined in the package")
+    }
+
+    public static func invalidTraitInSettingsCondition(trait: String, target: TargetDescription) -> Self {
+        .error("Trait '\(trait)' referenced in the build settings condition for target '\(target.name)' is not defined in the package")
     }
 
     static func invalidDefaultTrait(defaultTrait: String) -> Self {

--- a/Tests/PackageLoadingTests/TraitLoadingTests.swift
+++ b/Tests/PackageLoadingTests/TraitLoadingTests.swift
@@ -315,4 +315,55 @@ final class TraitLoadingTests: PackageDescriptionLoadingTests {
             )
         )
     }
+
+    func testTargetBuildSettingsConditionTraits() async throws {
+        let content =  """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                targets: [
+                    .target(
+                        name: "Target",
+                        cSettings: [
+                            .headerSearchPath("path/to/headers", .when(traits: ["UndefinedTrait2"])),
+                        ],
+                        cxxSettings: [
+                            .define("CXX_FLAG", .when(traits: ["UndefinedTrait3"])),
+                        ],
+                        swiftSettings: [
+                            .define("DEFINE1", .when(traits: ["Trait1"])),
+                        ],
+                        linkerSettings: [
+                            .linkedFramework("_Framework", .when(traits: ["UndefinedTrait1"]))
+                        ],
+                    )
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let firstDiagnostic = try XCTUnwrap(validationDiagnostics[0])
+        let secondDiagnostic = try XCTUnwrap(validationDiagnostics[1])
+        let thirdDiagnostic = try XCTUnwrap(validationDiagnostics[2])
+        let fourthDiagnostic = try XCTUnwrap(validationDiagnostics[3])
+
+        func createDiagnostic(_ traitName: String) throws -> Basics.Diagnostic {
+            let target = try XCTUnwrap(TargetDescription(name: "Target"))
+            return Basics.Diagnostic.invalidTraitInSettingsCondition(trait: traitName, target: target)
+        }
+
+        let diagnostic1 = try XCTUnwrap(createDiagnostic("UndefinedTrait2"))
+        XCTAssertEqual(firstDiagnostic.description, diagnostic1.description)
+
+        let diagnostic2 = try XCTUnwrap(createDiagnostic("UndefinedTrait3"))
+        XCTAssertEqual(secondDiagnostic.description, diagnostic2.description)
+
+        let diagnostic3 = try XCTUnwrap(createDiagnostic("Trait1"))
+        XCTAssertEqual(thirdDiagnostic.description, diagnostic3.description)
+
+        let diagnostic4 = try XCTUnwrap(createDiagnostic("UndefinedTrait1"))
+        XCTAssertEqual(fourthDiagnostic.description, diagnostic4.description)
+    }
 }


### PR DESCRIPTION
Cherry-picked from #9980

Traits for a target's build setting conditions were not being validated upon loading the manifest; while the trait enablement for these conditions is checked later on (post-resolution) and is not actually validated here either, we should really be validating the traits referenced in the target build setting conditions immediately after loading the manifest itself.