### PR TITLE
Add support to PIF builder for executable product aliasing for plugin tools

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -199,6 +199,20 @@ public final class PIFBuilder {
         pluginsPerModule: [ResolvedModule.ID: [ResolvedModule]],
         hostTriple: Basics.Triple
     ) async throws -> [ResolvedModule.ID: [String: PluginTool]] {
+        // SwiftBuild names executable binaries after their product name (TARGET_NAME = product.name),
+        // not the underlying target name. Build a map from target name → product name for cases where
+        // they differ, so we can resolve the correct binary path for both .product and .module
+        // plugin tool dependencies.
+        var targetNameToProductName: [String: String] = [:]
+        for package in graph.packages {
+            for product in package.products where product.type == .executable {
+                if let executableModule = product.modules.first(where: { $0.type == .executable }),
+                   executableModule.name != product.name {
+                    targetNameToProductName[executableModule.name] = product.name
+                }
+            }
+        }
+
         var accessibleToolsPerPlugin: [ResolvedModule.ID: [String: PluginTool]] = [:]
 
         for (_, plugins) in pluginsPerModule {
@@ -210,7 +224,14 @@ public final class PIFBuilder {
                     environment: buildParameters.buildEnvironment,
                     for: hostTriple
                 ) { name, path in
-                    return self.parameters.hostBuildProductsPath.appending(path)
+                    // `name` is the product name (for .product dependencies) or target name (for
+                    // .module dependencies). `path` is always derived from the underlying target name.
+                    // SwiftBuild produces the binary at the product name, so use targetNameToProductName
+                    // to find the correct name when a target is wrapped in a differently-named product.
+                    let binaryName = targetNameToProductName[name] ?? name
+                    return self.parameters.hostBuildProductsPath.appending(
+                        try RelativePath(validating: binaryName + hostTriple.executableExtension)
+                    )
                 }
 
                 accessibleToolsPerPlugin[plugin.id] = accessibleTools

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -574,7 +574,12 @@ extension PackageGraph.ResolvedModule {
     }
 
     func productRepresentingDependencyOfBuildPlugin(in mainModuleProducts: [ResolvedProduct]) -> ResolvedProduct? {
-        mainModuleProducts.only { (mainModuleProduct: ResolvedProduct) -> Bool in
+        // When a dependency package has an explicit product with a different name than the
+        // executable target (e.g. product "PluginExecutable2" wrapping target "PluginExecutable"),
+        // SwiftPM also auto-promotes an implicit product with the target's name for plugin use.
+        // Both match the predicate below, causing `only` to return nil. Prefer explicit products
+        // to resolve this ambiguity correctly.
+        func matchesDependency(_ mainModuleProduct: ResolvedProduct) -> Bool {
             // Handle binary-only executable products that don't have a main module, i.e. binaryTarget
             guard let mainModule = mainModuleProduct.mainModule else {
                 return mainModuleProduct.type == .executable &&
@@ -589,6 +594,14 @@ extension PackageGraph.ResolvedModule {
                 mainModule.name == self.name
             // Intentionally ignore the build triple!
         }
+
+        let explicitMatch = mainModuleProducts
+            .filter { !$0.underlying.isImplicit }
+            .only(where: matchesDependency)
+        if let explicitMatch {
+            return explicitMatch
+        }
+        return mainModuleProducts.only(where: matchesDependency)
     }
 
     struct AllBuildSettings {

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
+import Foundation
 import Testing
 import PackageGraph
 import PackageLoading
@@ -1334,6 +1335,231 @@ struct PIFBuilderTests {
                 #expect(noHeadersPhases.isEmpty)
             }
         }
+    }
+
+    /// Regression test: a build tool plugin and its executable tool live in the same dependency
+    /// package, but the executable product has a different name than its underlying target.
+    ///
+    /// Before the fix, SwiftPM auto-promotes an implicit product named after the target alongside
+    /// the explicit product. Both matched `productRepresentingDependencyOfBuildPlugin`, causing
+    /// `only` to return nil and no PIF dependency being added to the plugin target.
+    @Test func buildToolPluginWithExplicitProductNameSamePackage() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/PluginPkg/Plugins/MyPlugin/plugin.swift",
+            "/PluginPkg/Sources/PluginTool/main.swift",
+            "/Root/Sources/RootLib/RootLib.swift",
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    dependencies: [.fileSystem(path: "/PluginPkg")],
+                    products: [],
+                    targets: [
+                        TargetDescription(
+                            name: "RootLib",
+                            pluginUsages: [.plugin(name: "MyPlugin", package: "PluginPkg")]
+                        ),
+                    ]
+                ),
+                Manifest.createFileSystemManifest(
+                    displayName: "PluginPkg",
+                    path: "/PluginPkg",
+                    toolsVersion: .v5_9,
+                    products: [
+                        // Explicit product name differs from the underlying target name — this
+                        // is the exact case that triggered the bug.
+                        ProductDescription(name: "plugin-tool", type: .executable, targets: ["PluginTool"]),
+                        ProductDescription(name: "MyPlugin", type: .plugin, targets: ["MyPlugin"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "PluginTool", type: .executable),
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: ["PluginTool"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: true,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let pluginPkgProject = try pif.workspace.project(named: "PluginPkg")
+        // The explicit product generates a PIF target named "<productName>-product".
+        let pluginToolProductTarget = try pluginPkgProject.target(named: "plugin-tool-product")
+        let pluginTarget = try pluginPkgProject.target(named: "MyPlugin")
+
+        #expect(
+            pluginTarget.common.dependencies.contains { $0.targetId == pluginToolProductTarget.common.id },
+            "Expected MyPlugin to depend on plugin-tool-product (the explicit product). Actual dependencies: \(pluginTarget.common.dependencies.map(\.targetId.value))"
+        )
+    }
+
+    /// Tests the cross-package case: the build tool plugin lives in one package and its
+    /// executable tool lives in a separate package. The plugin declares the dependency via
+    /// `.product(name:package:)`, which routes through a different code path than the
+    /// same-package case.
+    @Test func buildToolPluginWithExecutableProductCrossPackage() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/ToolPkg/Sources/MyTool/main.swift",
+            "/PluginPkg/Plugins/MyPlugin/plugin.swift",
+            "/Root/Sources/RootLib/RootLib.swift",
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    dependencies: [
+                        .fileSystem(path: "/ToolPkg"),
+                        .fileSystem(path: "/PluginPkg"),
+                    ],
+                    products: [],
+                    targets: [
+                        TargetDescription(
+                            name: "RootLib",
+                            pluginUsages: [.plugin(name: "MyPlugin", package: "PluginPkg")]
+                        ),
+                    ]
+                ),
+                Manifest.createFileSystemManifest(
+                    displayName: "ToolPkg",
+                    path: "/ToolPkg",
+                    toolsVersion: .v5_9,
+                    products: [
+                        // Explicit product name differs from the underlying target name.
+                        ProductDescription(name: "my-tool", type: .executable, targets: ["MyTool"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "MyTool", type: .executable),
+                    ]
+                ),
+                Manifest.createFileSystemManifest(
+                    displayName: "PluginPkg",
+                    path: "/PluginPkg",
+                    toolsVersion: .v5_9,
+                    dependencies: [.fileSystem(path: "/ToolPkg")],
+                    products: [
+                        ProductDescription(name: "MyPlugin", type: .plugin, targets: ["MyPlugin"]),
+                    ],
+                    targets: [
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: [.product(name: "my-tool", package: "ToolPkg")],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: true,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let toolPkgProject = try pif.workspace.project(named: "ToolPkg")
+        let pluginPkgProject = try pif.workspace.project(named: "PluginPkg")
+
+        let myToolProductTarget = try toolPkgProject.target(named: "my-tool-product")
+        let pluginTarget = try pluginPkgProject.target(named: "MyPlugin")
+
+        #expect(
+            pluginTarget.common.dependencies.contains { $0.targetId == myToolProductTarget.common.id },
+            "Expected MyPlugin to depend on my-tool-product from ToolPkg. Actual dependencies: \(pluginTarget.common.dependencies.map(\.targetId.value))"
+        )
+    }
+}
+
+/// A no-op plugin script runner for use in PIF builder tests that need a plugin in the graph
+/// but don't care about the plugin's build commands.
+private struct NoOpPluginScriptRunner: PluginScriptRunner {
+    func compilePluginScript(
+        sourceFiles: [AbsolutePath],
+        pluginName: String,
+        toolsVersion: ToolsVersion,
+        workers: UInt32,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        delegate: any PluginScriptCompilerDelegate,
+        completion: @escaping (Result<PluginCompilationResult, any Error>) -> Void
+    ) {
+        callbackQueue.sync { completion(.failure(StringError("unimplemented"))) }
+    }
+
+    func buildCommandLine(
+        sourceFiles: [AbsolutePath],
+        pluginName: String,
+        toolsVersion: ToolsVersion,
+        workers: UInt32,
+        observabilityScope: ObservabilityScope?
+    ) -> (commandLine: [String], execName: String, execFilePath: AbsolutePath, diagFilePath: AbsolutePath) {
+        fatalError("Not implemented")
+    }
+
+    func runPluginScript(
+        sourceFiles: [AbsolutePath],
+        pluginName: String,
+        initialMessage: Data,
+        toolsVersion: ToolsVersion,
+        workingDirectory: AbsolutePath,
+        writableDirectories: [AbsolutePath],
+        readOnlyDirectories: [AbsolutePath],
+        allowNetworkConnections: [SandboxNetworkPermission],
+        workers: UInt32,
+        fileSystem: any FileSystem,
+        observabilityScope: ObservabilityScope,
+        callbackQueue: DispatchQueue,
+        delegate: any PluginScriptCompilerDelegate & PluginScriptRunnerDelegate,
+        completion: @escaping (Result<Int32, any Error>) -> Void
+    ) {
+        callbackQueue.sync { completion(.success(0)) }
+    }
+
+    var hostTriple: Triple {
+        get throws { try UserToolchain.default.targetTriple }
     }
 }
 

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1395,7 +1395,7 @@ struct PIFBuilderTests {
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: AbsolutePath.root.appending("tmp"),
-                addLocalRpaths: true,
+                addLocalRpaths: .always,
                 pluginScriptRunner: NoOpPluginScriptRunner()
             ),
             fileSystem: fs,
@@ -1487,7 +1487,7 @@ struct PIFBuilderTests {
             graph: graph,
             parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
                 temporaryDirectory: AbsolutePath.root.appending("tmp"),
-                addLocalRpaths: true,
+                addLocalRpaths: .always,
                 pluginScriptRunner: NoOpPluginScriptRunner()
             ),
             fileSystem: fs,


### PR DESCRIPTION
Executable targets are automatically promoted as products with the same
name. They can also be named differently using an explicit product that
depends on the executable target.
    
When declaring a plugin in the same package as an executable used as a
plugin tool the package manifest requires that the dependency be on the
executable target and not a product of the package, and so the
dependency is always on the target.
    
In this case when the plugin gets the tool using `PluginContext.tool` it
generally uses the executable target name as the name of the tool, which is
logical given that the dependency is on that target.
    
Make the PIF builder take into account that the explicit product of the
executable target may not have the same name as the executable target
when doing the tool lookup. It should relate the executable target's name
to an executable product that builds and runs on the host to make the
dependency from the custom task in the PIF, and also calculate the tool's
URL when invoking the plugin on a particular target.