### PR TITLE
Resolve build system provider directly instead of stashing it on SwiftCommandState

### DIFF
--- a/Sources/Commands/SwiftBuildCommand.swift
+++ b/Sources/Commands/SwiftBuildCommand.swift
@@ -277,9 +277,3 @@ public struct SwiftBuildCommand: AsyncSwiftCommand {
 
     public init() {}
 }
-
-public extension _SwiftCommand {
-    func buildSystemProvider(_ swiftCommandState: SwiftCommandState) throws -> BuildSystemProvider {
-        swiftCommandState.defaultBuildSystemProvider
-    }
-}

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -150,7 +150,7 @@ private struct SwiftBuildSystemFactory: BuildSystemFactory {
 }
 
 extension SwiftCommandState {
-    public var defaultBuildSystemProvider: BuildSystemProvider {
+    var defaultBuildSystemProvider: BuildSystemProvider {
         .init(providers: [
             .native: NativeBuildSystemFactory(swiftCommandState: self),
             .swiftbuild: SwiftBuildSystemFactory(swiftCommandState: self),

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -96,7 +96,6 @@ public protocol _SwiftCommand {
     var toolWorkspaceConfiguration: ToolWorkspaceConfiguration { get }
     var workspaceDelegateProvider: WorkspaceDelegateProvider { get }
     var workspaceLoaderProvider: WorkspaceLoaderProvider { get }
-    func buildSystemProvider(_ swiftCommandState: SwiftCommandState) throws -> BuildSystemProvider
 
     // If a packagePath is specificed, this indicates that the command allows
     // creating the directory if it doesn't exist.
@@ -140,7 +139,6 @@ extension SwiftCommand {
         // We use this to attempt to catch misuse of the locking APIs since we only release the lock from here.
         swiftCommandState.setNeedsLocking()
 
-        swiftCommandState.buildSystemProvider = try buildSystemProvider(swiftCommandState)
         var toolError: Error? = .none
         do {
             try self.run(swiftCommandState)
@@ -240,7 +238,6 @@ extension AsyncSwiftCommand {
         // We use this to attempt to catch misuse of the locking APIs since we only release the lock from here.
         swiftCommandState.setNeedsLocking()
 
-        swiftCommandState.buildSystemProvider = try buildSystemProvider(swiftCommandState)
         var toolError: Error? = .none
         do {
             try await self.run(swiftCommandState)
@@ -358,8 +355,6 @@ public final class SwiftCommandState {
     private let workspaceLoaderProvider: WorkspaceLoaderProvider
 
     private let toolWorkspaceConfiguration: ToolWorkspaceConfiguration
-
-    fileprivate var buildSystemProvider: BuildSystemProvider?
 
     private let environment: Environment
 
@@ -979,9 +974,7 @@ public final class SwiftCommandState {
             self.observabilityScope.emit(warning: "`--use-integrated-swift-driver` option is deprecated as the feature is not fully functional.")
         }
 
-        guard let buildSystemProvider else {
-            fatalError("build system provider not initialized")
-        }
+        let buildSystemProvider = self.defaultBuildSystemProvider
         var productsParameters = try productsBuildParameters ?? self.productsBuildParameters
         productsParameters.linkingParameters.shouldLinkStaticSwiftStdlib = shouldLinkStaticSwiftStdlib
         let buildSystem = try await buildSystemProvider.createBuildSystem(


### PR DESCRIPTION
A small code refactor to improve initialization safety. The build system provider didn't need to be a mutable optional, It's now resolved on demand via `defaultBuildSystemProvider`, removing the optional property, the protocol requirement, and the crash path.