### PR TITLE
Make DiagnosticsTestResult.check report failures under swift-testing

### DIFF
--- a/Sources/_InternalTestSupport/Observability.swift
+++ b/Sources/_InternalTestSupport/Observability.swift
@@ -235,11 +235,36 @@ public class DiagnosticsTestResult {
         self.uncheckedDiagnostics = diagnostics
     }
 
+    /// Record a check failure so that it is reported regardless of whether the
+    /// surrounding test is an `XCTestCase` or a swift-testing `@Test`.
+    ///
+    /// `XCTFail` is a silent no-op when invoked outside of an `XCTestCase`, so
+    /// when running under swift-testing we instead record an `Issue`. This
+    /// mirrors the approach used by `swiftTestingTestCalledAnXCTestAPI()` in
+    /// `XCTAssertHelpers.swift`.
+    private func recordFailure(
+        _ message: @autoclosure () -> String,
+        file: StaticString,
+        line: UInt
+    ) {
+        if Test.current != nil {
+            Issue.record(Comment(rawValue: message()))
+        } else {
+            XCTFail(message(), file: file, line: line)
+        }
+    }
+
     package func checkIsEmpty(
         file: StaticString = #file,
         line: UInt = #line
     ) {
-        XCTAssertTrue(self.uncheckedDiagnostics.isEmpty, file: file, line: line)
+        if !self.uncheckedDiagnostics.isEmpty {
+            self.recordFailure(
+                "expected no diagnostics, but found: \(self.uncheckedDiagnostics)",
+                file: file,
+                line: line
+            )
+        }
     }
 
     @discardableResult
@@ -251,14 +276,26 @@ public class DiagnosticsTestResult {
         line: UInt = #line
     ) -> Basics.Diagnostic? {
         guard !self.uncheckedDiagnostics.isEmpty else {
-            XCTFail("No diagnostics left to check", file: file, line: line)
+            self.recordFailure("No diagnostics left to check", file: file, line: line)
             return nil
         }
 
         let diagnostic: Basics.Diagnostic = self.uncheckedDiagnostics.removeFirst()
 
-        XCTAssertMatch(diagnostic.message, message, file: file, line: line)
-        XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
+        if !(message ~= diagnostic.message) {
+            self.recordFailure(
+                "diagnostic message \(diagnostic.message.debugDescription) does not match pattern \(message)",
+                file: file,
+                line: line
+            )
+        }
+        if diagnostic.severity != severity {
+            self.recordFailure(
+                "diagnostic severity \(diagnostic.severity) does not match expected \(severity)",
+                file: file,
+                line: line
+            )
+        }
         // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed
         //XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
         //XCTAssertEqual(diagnostic.metadata?.droppingLegacyKeys(), metadata?.droppingLegacyKeys(), file: file, line: line)
@@ -275,18 +312,28 @@ public class DiagnosticsTestResult {
         line: UInt = #line
     ) -> Basics.Diagnostic? {
         guard !self.uncheckedDiagnostics.isEmpty else {
-            XCTFail("No diagnostics left to check", file: file, line: line)
+            self.recordFailure("No diagnostics left to check", file: file, line: line)
             return nil
         }
 
         let matching = self.uncheckedDiagnostics.indices
             .filter { diagnosticPattern ~= self.uncheckedDiagnostics[$0].message }
         if matching.isEmpty {
-            XCTFail("No diagnostics match \(diagnosticPattern)", file: file, line: line)
+            self.recordFailure(
+                "No diagnostics match \(diagnosticPattern)",
+                file: file,
+                line: line
+            )
             return nil
         } else if matching.count == 1, let index = matching.first {
             let diagnostic = self.uncheckedDiagnostics[index]
-            XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
+            if diagnostic.severity != severity {
+                self.recordFailure(
+                    "diagnostic severity \(diagnostic.severity) does not match expected \(severity)",
+                    file: file,
+                    line: line
+                )
+            }
             // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed
             //XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
             //XCTAssertEqual(diagnostic.metadata?.droppingLegacyKeys(), metadata?.droppingLegacyKeys(), file: file, line: line)

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -178,7 +178,7 @@ struct ObservabilitySystemTest {
                 #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "debug", severity: .error))
+                let diagnostic = try #require(result.check(diagnostic: "debug", severity: .debug))
                 let diagnostic_metadata = try #require(diagnostic.metadata)
                 #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
@@ -289,6 +289,51 @@ struct ObservabilitySystemTest {
                 #expect(diagnostic_metadata.testKey1 == diagnosticMergedMetadata.testKey1)
                 #expect(diagnostic_metadata.testKey2 == diagnosticMergedMetadata.testKey2)
                 #expect(diagnostic_metadata.testKey3 == diagnosticMergedMetadata.testKey3)
+            }
+        }
+    }
+
+    // Regression tests for https://github.com/swiftlang/swift-package-manager/issues/10061
+    // `DiagnosticsTestResult.check` previously validated the diagnostic message
+    // and severity using XCTest primitives only, which are silent no-ops when
+    // the surrounding test is a swift-testing `@Test`. As a result a wrong
+    // expected message or severity passed silently under swift-testing.
+
+    @Test
+    func diagnosticsCheckReportsMismatchedMessage() throws {
+        let collector = Collector()
+        let observabilitySystem = ObservabilitySystem(collector)
+        observabilitySystem.topScope.emit(error: "actual error message")
+
+        withKnownIssue("a mismatched diagnostic message must be reported") {
+            try expectDiagnostics(collector.diagnostics) { result in
+                result.check(diagnostic: "this message does not match", severity: .error)
+            }
+        }
+    }
+
+    @Test
+    func diagnosticsCheckReportsMismatchedSeverity() throws {
+        let collector = Collector()
+        let observabilitySystem = ObservabilitySystem(collector)
+        observabilitySystem.topScope.emit(error: "actual error message")
+
+        withKnownIssue("a mismatched diagnostic severity must be reported") {
+            try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+                result.check(diagnostic: "actual error message", severity: .warning)
+            }
+        }
+    }
+
+    @Test
+    func diagnosticsCheckUnorderedReportsMismatchedSeverity() throws {
+        let collector = Collector()
+        let observabilitySystem = ObservabilitySystem(collector)
+        observabilitySystem.topScope.emit(error: "actual error message")
+
+        withKnownIssue("a mismatched diagnostic severity must be reported") {
+            try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+                result.checkUnordered(diagnostic: "actual error message", severity: .warning)
             }
         }
     }


### PR DESCRIPTION
Make `DiagnosticsTestResult.check` report failures under swift-testing

### Motivation:

`DiagnosticsTestResult.check(diagnostic:severity:)`, `checkUnordered`, and `checkIsEmpty` validated their inputs using XCTest primitives (`XCTAssertMatch`, `XCTAssertEqual`, `XCTAssertTrue`, `XCTFail`). Those APIs are silent no-ops when invoked outside of an `XCTestCase`, so when a test helper is driven from a swift-testing `@Test`, a wrong expected diagnostic message or severity was accepted silently. Only *missing* diagnostics (which throw or short-circuit) were still caught.

This means a test could pass even though its assertions never actually ran, which is how the issue was discovered: a test passed before its implementation was finished correctly.

Fixes #10061

### Modifications:

- Added a private `recordFailure` helper on `DiagnosticsTestResult` that records a swift-testing `Issue` when running under a `@Test` (`Test.current != nil`) and otherwise falls back to `XCTFail`. This mirrors the existing `swiftTestingTestCalledAnXCTestAPI()` pattern in `XCTAssertHelpers.swift`, so the helpers now report failures in both XCTest and swift-testing contexts.
- Reworked `checkIsEmpty`, `check(diagnostic:severity:)`, and `checkUnordered(diagnostic:severity:)` to compare message (via the existing `StringPattern` `~=` operator) and severity explicitly and route any failure through `recordFailure` instead of calling XCTest assertions directly. The public signatures are unchanged (still `file: StaticString = #file, line: UInt = #line`), so all existing XCTest and swift-testing callers continue to compile.
- Fixed a latent severity typo in `ObservabilitySystemTest.basicDiagnostics()`: the `"debug"` diagnostic is emitted at `.debug` but was checked against `.error`. The old silent behavior hid this; the fix surfaces it, so the expectation is corrected to `.debug`.
- Added regression tests (`diagnosticsCheckReportsMismatchedMessage`, `diagnosticsCheckReportsMismatchedSeverity`, `diagnosticsCheckUnorderedReportsMismatchedSeverity`) that emit a known diagnostic, check it with a deliberately wrong message/severity, and assert via `withKnownIssue` that a failure is now recorded under swift-testing.

### Result:

Diagnostic message and severity checks now fail correctly whether the surrounding test is an `XCTestCase` or a swift-testing `@Test`, so mismatches can no longer pass silently.

Verification (local, macOS, Swift 6.3):
- `swift build --target _InternalTestSupport` succeeds.
- `swift test --filter BasicsTests.ObservabilitySystemTest` passes: 7 tests, 0 unexpected failures (the 3 new regression tests pass via recorded known issues).
