### PR TITLE
[6.4] Emit warning for unhandled files in SwiftBuild; Avoid unnecessary network requests

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -434,6 +434,12 @@ public final class PIFBuilder {
                     observabilityScope: observabilityScope
                 )
 
+                self.diagnoseUnhandledFiles(
+                    package: package,
+                    module: module,
+                    buildToolPluginInvocationResults: buildToolPluginResults
+                )
+
                 let result = PackagePIFBuilder.BuildToolPluginInvocationResult(
                     prebuildCommandOutputPaths: runResults.flatMap( { $0.derivedFiles }),
                     buildCommands: buildCommands
@@ -608,6 +614,38 @@ public final class PIFBuilder {
             observabilityScope: observabilityScope
         )
         return try await builder.generatePIF(preservePIFModelStructure: preservePIFModelStructure, buildParameters: buildParameters)
+    }
+
+    private func diagnoseUnhandledFiles(
+        package: ResolvedPackage,
+        module: ResolvedModule,
+        buildToolPluginInvocationResults: [BuildToolPluginInvocationResult]
+    ) {
+        guard package.manifest.toolsVersion >= .v5_3 else {
+            return
+        }
+
+        var unhandledFiles = Set(module.underlying.others)
+        if unhandledFiles.isEmpty {
+            return
+        }
+
+        let handledFiles = buildToolPluginInvocationResults.flatMap { $0.buildCommands.flatMap(\.inputFiles) }
+        unhandledFiles.subtract(handledFiles)
+
+        if unhandledFiles.isEmpty {
+            return
+        }
+
+        let diagnosticsEmitter = self.observabilityScope.makeDiagnosticsEmitter {
+            var metadata = ObservabilityMetadata()
+            metadata.packageIdentity = package.identity
+            metadata.packageKind = package.manifest.packageKind
+            metadata.moduleName = module.name
+            return metadata
+        }
+        
+        diagnosticsEmitter.emit(.unhandledFiles(unhandledFiles))
     }
 }
 
@@ -896,5 +934,16 @@ extension PIFBuilderParameters {
             addLocalRpaths: addLocalRpaths,
             hostBuildProductsPath: hostBuildProductsPath
         )
+    }
+}
+
+extension Basics.Diagnostic {
+    public static func unhandledFiles(_ files: Set<AbsolutePath>) -> Self {
+        var message =
+            "found \(files.count) file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n"
+        for file in files {
+            message += "    " + file.pathString + "\n"
+        }
+        return .warning(message)
     }
 }

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -386,12 +386,45 @@ extension Workspace {
             )
         }
 
-        // Request all the containers to fetch them in parallel.
+        // Determine which packages actually need to be cloned or re-checked-out before
+        // touching the network. A package is "required" when workspace-state.json has no
+        // record of it, or when its recorded checkout state does not match the resolved pin
+        // in the Package.resolved.
         //
-        // We just request the packages here, repository manager will
-        // automatically manage the parallelism.
+        // Computing this set first is important for --force-resolved-versions:
+        // 1) If all checkouts are already correct then the set of required dependencies is empty
+        //    and we skip both the prefetch and the checkout loops below
+        // 2) This avoids any network access even when .build/repositories/ is absent (e.g. after
+        //    moving the project to a different machine or container).
+        //
+        // Previously the prefetch loop ran over every resolved package unconditionally,
+        // which caused RepositoryManager.performLookup to call fetchAndPopulateCache for
+        // each one whenever the bare-repo cache (.build/repositories) was missing.
+        let dependencies = await state.dependencies
+        let requiredResolvedPackages = resolvedPackagesStore.resolvedPackages.values.filter { pin in
+            // also compare the location in case it has changed
+            guard let dependency = dependencies[comparingLocation: pin.packageRef] else {
+                return true
+            }
+            switch dependency.state {
+            case .sourceControlCheckout(let checkoutState):
+                return !pin.state.equals(checkoutState)
+            case .registryDownload(let version, _):
+                return !pin.state.equals(version)
+            case .edited, .fileSystem, .custom:
+                return true
+            }
+        }
+
+        // Prefetch containers for packages that need work, in parallel.
+        //
+        // RepositoryManager will deduplicate concurrent lookups for the same specifier,
+        // so it is safe to fire these without additional coordination. We limit the set to
+        // requiredResolvedPackages so that packages with valid existing checkouts never
+        // trigger a bare-repo lookup (and therefore never trigger a network fetch when the
+        // .build/repositories/ cache is unavailable).
         await withThrowingTaskGroup(of: Void.self) { taskGroup in
-            for resolvedPackage in resolvedPackagesStore.resolvedPackages.values {
+            for resolvedPackage in requiredResolvedPackages {
                 let observabilityScope = observabilityScope.makeChildScope(
                     description: "requesting package containers",
                     metadata: resolvedPackage.packageRef.diagnosticsMetadata
@@ -424,27 +457,7 @@ extension Workspace {
             }
         }
 
-        // Compute resolved packages that we need to actually clone.
-        //
-        // We require cloning if there is no checkout or if the checkout doesn't
-        // match with the pin.
-        let dependencies = await state.dependencies
-        let requiredResolvedPackages = resolvedPackagesStore.resolvedPackages.values.filter { pin in
-            // also compare the location in case it has changed
-            guard let dependency = dependencies[comparingLocation: pin.packageRef] else {
-                return true
-            }
-            switch dependency.state {
-            case .sourceControlCheckout(let checkoutState):
-                return !pin.state.equals(checkoutState)
-            case .registryDownload(let version, _):
-                return !pin.state.equals(version)
-            case .edited, .fileSystem, .custom:
-                return true
-            }
-        }
-
-        // Retrieve the required resolved packages.
+        // Check out only the packages that are actually needed.
         await withThrowingTaskGroup(of: Void.self) { taskGroup in
             for resolvedPackage in requiredResolvedPackages {
                 let observabilityScope = observabilityScope.makeChildScope(

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -66,7 +66,7 @@ struct PluginTests {
     }
 
     @Test(
-        .bug("https://github.com/swiftlang/swift-package-manager/issues/8786"),
+        .IssueWindowsRelativePathAssert,
         .requiresSwiftConcurrencySupport,
         .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),
         .tags(
@@ -79,16 +79,12 @@ struct PluginTests {
     func testUseOfBuildToolPluginTargetNoPreBuildCommands(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
-            try await fixture(name: "Miscellaneous/Plugins/MySourceGenPluginNoPreBuildCommands") { fixturePath in
-                let (_, stderr) = try await executeSwiftTest(
-                    fixturePath,
-                    buildSystem: buildSystem,
-                )
-                #expect(stderr.contains("file(s) which are unhandled; explicitly declare them as resources or exclude from the target"), "expected warning not emitted")
-            }
-        } when: {
-            buildSystem == .swiftbuild
+        try await fixture(name: "Miscellaneous/Plugins/MySourceGenPluginNoPreBuildCommands") { fixturePath in
+            let (_, stderr) = try await executeSwiftTest(
+                fixturePath,
+                buildSystem: buildSystem,
+            )
+            #expect(stderr.contains("file(s) which are unhandled; explicitly declare them as resources or exclude from the target"), "expected warning not emitted")
         }
     }
 

--- a/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
@@ -208,7 +208,9 @@ import SwiftBuild
         ).0
     }
 
-    /// This is more to test out that the setup routines provide a good test environment
+    /// This is more to test out that the setup routines provide a good test environment.
+    /// The `data.in` file in the module directory is not listed as an input by the mock plugin,
+    /// so it is correctly flagged as an unhandled file.
     @Test func testSwift() async throws {
         let observability = ObservabilitySystem.makeForTesting()
         _ = try await setup(
@@ -216,7 +218,14 @@ import SwiftBuild
             gened: ["Gened.swift"],
             observability: observability.topScope
         )
-        #expect(!observability.hasErrorDiagnostics && !observability.hasWarningDiagnostics)
+        #expect(!observability.hasErrorDiagnostics)
+
+        // Check unused file warning.
+        let warnings = observability.warnings
+        #expect(warnings.count == 1)
+        let warning = try #require(warnings.first)
+        let dataInPath: AbsolutePath = "/MyPkg/Sources/MyModule/data.in"
+        #expect(warning.message == Diagnostic.unhandledFiles([dataInPath]).message)
     }
 
     @Test func testSuccessPath() async throws {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -5504,6 +5504,136 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    /// Tests that `--force-resolved-versions` does not trigger repository fetches
+    /// when package checkouts are already present in the build directory.
+    ///
+    /// This is a regression test for a cross-platform migration scenario where
+    /// running `--force-resolved-versions` in a new environment (e.g., Docker) after
+    /// resolving on the host machine would attempt to re-fetch all dependencies from
+    /// the network, failing if network access is unavailable.
+    ///
+    /// Steps reproduced:
+    /// 1. Resolve on "machine A" (e.g., macOS host) — populates `.build` directory.
+    /// 2. Move project + `.build` to "machine B" (e.g., Linux container).
+    /// 3. On machine B, the local repository cache (`.build/repositories/`) may be
+    ///    inaccessible/have a different absolute path than what is stored while
+    ///    checkouts (`.build/checkouts/`) and `workspace-state.json`
+    ///    remain present.
+    /// 4. Run `swift package resolve --force-resolved-versions` on "machine B".
+    ///
+    /// Expected: resolves from the already-present checkouts, no network fetches.
+    func testForceResolvedVersionsDoesNotRefetchWithExistingCheckouts() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(name: "Root", dependencies: ["Foo", "Bar"]),
+                    ],
+                    products: [],
+                    dependencies: [
+                        .sourceControl(path: "./Foo", requirement: .exact("1.0.0")),
+                        .sourceControl(path: "./Bar", requirement: .exact("1.0.0")),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [
+                        MockTarget(name: "Foo"),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", modules: ["Foo"]),
+                    ],
+                    versions: ["1.0.0"]
+                ),
+                MockPackage(
+                    name: "Bar",
+                    targets: [
+                        MockTarget(name: "Bar"),
+                    ],
+                    products: [
+                        MockProduct(name: "Bar", modules: ["Bar"]),
+                    ],
+                    versions: ["1.0.0"]
+                ),
+            ]
+        )
+
+        // Step 1: Initial resolution on "machine A" — populates .build with
+        // workspace-state.json, .build/checkouts/, and .build/repositories/.
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
+            result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
+        }
+        workspace.checkResolved { result in
+            result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
+            result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
+        }
+
+        // Step 2: Simulate cross-platform migration to "machine B".
+        //
+        // On the new machine the local repository cache (.build/repositories/)
+        // may not be accessible — e.g., only .build/checkouts/ and
+        // workspace-state.json were transferred, or the path to the cache
+        // changed between environments.
+        //
+        // Clearing fetchedMap simulates the repository cache being unavailable
+        // while leaving checkouts and workspace-state.json intact.
+        workspace.repositoryProvider.fetchedMap.clear()
+
+        // Record how many working copies exist before the second resolve so we
+        // can assert that none were re-created.
+        let checkoutsCountBeforeResolve = workspace.repositoryProvider.checkoutsMap.count
+
+        // Close the workspace to simulate a fresh SPM process on "machine B".
+        // Setting the resetState to false ensures that the workspace's managed
+        // dependencies aren't cleared, which is reflected by the workspace-state.json
+        // The resetResolvedFile is similarly set to false to ensure that we keep
+        // the Package.resolved file, as one would here for a "machine A -> B" migration.
+        try await workspace.closeWorkspace(resetState: false, resetResolvedFile: false)
+
+        // Step 3: Run --force-resolved-versions on "machine B".
+        // Should resolve from existing .build/checkouts/ without any network access.
+        try await workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+
+        // fetchedMap is written to by InMemoryGitRepositoryProvider.fetch(repository:to:),
+        // which is the single entry point for a bare-repo network clone. If it is still
+        // empty here, no network access occurred — the correct outcome for
+        // --force-resolved-versions when all checkouts are already present.
+        XCTAssertTrue(
+            workspace.repositoryProvider.fetchedMap.isEmpty,
+            "--force-resolved-versions triggered unexpected repository fetches; " +
+            "all packages should be resolved from existing checkouts."
+        )
+
+        // checkoutsMap is written to by InMemoryGitRepositoryProvider.createWorkingCopy.
+        // An unchanged count means no working copies were re-created.
+        XCTAssertEqual(
+            workspace.repositoryProvider.checkoutsMap.count,
+            checkoutsCountBeforeResolve,
+            "--force-resolved-versions unexpectedly created new working copies; " +
+            "checkouts should already exist."
+        )
+
+        // Verify the dependency graph is still correct after migration.
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "foo", at: .checkout(.version("1.0.0")))
+            result.check(dependency: "bar", at: .checkout(.version("1.0.0")))
+        }
+    }
+
     // This verifies that the simplest possible loading APIs are available for package clients.
     func testSimpleAPI() async throws {
         try await testWithTemporaryDirectory { path in


### PR DESCRIPTION
Cherry-picks of #10132, #10140

