### PR TITLE
remove unnecessary typed aliases

### DIFF
--- a/Sources/Build/TestObservation.swift
+++ b/Sources/Build/TestObservation.swift
@@ -159,11 +159,11 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
                     let h: HANDLE = lockFile.path.withCString(encodedAs: UTF16.self, {
                         CreateFileW(
                             $0,
-                            UInt32(GENERIC_READ) | UInt32(GENERIC_WRITE),
-                            UInt32(FILE_SHARE_READ) | UInt32(FILE_SHARE_WRITE),
+                            GENERIC_READ | GENERIC_WRITE,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE,
                             nil,
-                            DWORD(OPEN_ALWAYS),
-                            DWORD(FILE_ATTRIBUTE_NORMAL),
+                            OPEN_ALWAYS,
+                            FILE_ATTRIBUTE_NORMAL,
                             nil
                         )
                     })
@@ -176,7 +176,7 @@ public func generateTestObservationCode(buildParameters: BuildParameters) -> Str
                 overlapped.Offset = 0
                 overlapped.OffsetHigh = 0
                 overlapped.hEvent = nil
-                if !LockFileEx(handle, DWORD(LOCKFILE_EXCLUSIVE_LOCK), 0,
+                if !LockFileEx(handle, LOCKFILE_EXCLUSIVE_LOCK, 0,
                                    UInt32.max, UInt32.max, &overlapped) {
                         throw ProcessLockError.unableToAquireLock(errno: Int32(GetLastError()))
                     }

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1962,7 +1962,7 @@ private var EXIT_NO_TESTS_FOUND: CInt {
 #if os(macOS) || os(Linux) || canImport(Android) || os(FreeBSD)
     EX_UNAVAILABLE
 #elseif os(Windows)
-    ERROR_NOT_FOUND
+    CInt(ERROR_NOT_FOUND)
 #else
 #warning("Platform-specific implementation missing: value for EXIT_NO_TESTS_FOUND unavailable")
     return 2 // We're assuming that EXIT_SUCCESS = 0 and EXIT_FAILURE = 1.

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -320,7 +320,7 @@ enum TestingSupport {
         #if os(macOS) || os(Linux) || canImport(Android) || os(FreeBSD)
         EX_UNAVAILABLE
         #elseif os(Windows)
-        ERROR_NOT_FOUND
+        CInt(ERROR_NOT_FOUND)
         #else
         #warning("Platform-specific implementation missing: value for exitNoTestsFound unavailable")
         return 2 // We're assuming that EXIT_SUCCESS = 0 and EXIT_FAILURE = 1.

--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
@@ -44,7 +44,7 @@ private func readpassword(_ prompt: String) throws -> String {
 
     print(prompt, terminator: "")
 
-    guard SetConsoleMode(hStdIn, DWORD(ENABLE_LINE_INPUT)) else {
+    guard SetConsoleMode(hStdIn, ENABLE_LINE_INPUT) else {
         throw StringError("unable to read input: SetConsoleMode failed")
     }
     defer { SetConsoleMode(hStdIn, dwMode) }


### PR DESCRIPTION
The compiler now imports these as their canonical type, allowing us to directly use without the explicit type cast.