### PR TITLE
Fix archive-source for package paths with spaces

### DIFF
--- a/Sources/Basics/Archiver/ZipArchiver.swift
+++ b/Sources/Basics/Archiver/ZipArchiver.swift
@@ -100,18 +100,11 @@ public struct ZipArchiver: Archiver, Cancellable {
           workingDirectory: directory.parentDirectory
         )
         #else
-        // This is to work around `swift package-registry publish` tool failing on
-        // Amazon Linux 2 due to it having an earlier Glibc version (rdar://116370323)
-        // and therefore posix_spawn_file_actions_addchdir_np is unavailable.
-        // Instead of passing `workingDirectory` param to TSC.Process, which will trigger
-        // SPM_posix_spawn_file_actions_addchdir_np_supported check, we shell out and
-        // do `cd` explicitly before `zip`.
         let process = AsyncProcess(
             arguments: [
-                "/bin/sh",
-                "-c",
-                    "cd \(directory.parentDirectory.underlying.pathString) && \(self.zip) -ry \(destinationPath.pathString) \(directory.basename)"
-            ]
+                self.zip, "-ry", destinationPath.pathString, directory.basename,
+            ],
+            workingDirectory: directory.parentDirectory
         )
         #endif
 

--- a/Sources/Basics/Archiver/ZipArchiver.swift
+++ b/Sources/Basics/Archiver/ZipArchiver.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
-import struct TSCBasic.FileSystemError
+import TSCBasic
 
 /// An `Archiver` that handles ZIP archives using the command-line `zip` and `unzip` tools.
 public struct ZipArchiver: Archiver, Cancellable {
@@ -89,35 +89,35 @@ public struct ZipArchiver: Archiver, Cancellable {
             throw FileSystemError(.notDirectory, directory.underlying)
         }
 
-        #if os(FreeBSD)
-        // On FreeBSD, the unzip command is available in base but not the zip command.
-        // Therefore; we use libarchive(bsdtar) to produce the ZIP archive instead.
-        let process = AsyncProcess(
-                arguments: [
-                    self.tar, "-c", "--format", "zip", "-f", destinationPath.pathString,
-                    directory.basename,
-                ],
-          workingDirectory: directory.parentDirectory
-        )
-        #else
-        let process = AsyncProcess(
-            arguments: [
-                self.zip, "-ry", destinationPath.pathString, directory.basename,
-            ],
-            workingDirectory: directory.parentDirectory
-        )
-        #endif
-
-        guard let registrationKey = self.cancellator.register(process) else {
-            throw CancellationError.failedToRegisterProcess(process)
-        }
-
-        defer { self.cancellator.deregister(registrationKey) }
-
-        try process.launch()
-        let processResult = try await process.waitUntilExit()
-        guard processResult.exitStatus == .terminated(code: 0) else {
-            throw try StringError(processResult.utf8stderrOutput())
+        do {
+            try await self.runCompressionProcess(
+                AsyncProcess(
+                    arguments: self.compressionArguments(
+                        directory: directory,
+                        destinationPath: destinationPath
+                    ),
+                    workingDirectory: directory.parentDirectory
+                )
+            )
+        } catch AsyncProcess.Error.workingDirectoryNotSupported {
+            #if os(Windows)
+            throw AsyncProcess.Error.workingDirectoryNotSupported
+            #else
+            // Fall back to a quoted shell command when spawning with a working
+            // directory is unavailable on the current platform.
+            try await self.runCompressionProcess(
+                AsyncProcess(
+                    arguments: [
+                        "/bin/sh",
+                        "-c",
+                        self.shellCompressionCommand(
+                            directory: directory,
+                            destinationPath: destinationPath
+                        ),
+                    ]
+                )
+            )
+            #endif
         }
     }
 
@@ -147,5 +147,58 @@ public struct ZipArchiver: Archiver, Cancellable {
 
     public func cancel(deadline: DispatchTime) throws {
         try self.cancellator.cancel(deadline: deadline)
+    }
+}
+
+extension ZipArchiver {
+    private func compressionArguments(
+        directory: AbsolutePath,
+        destinationPath: AbsolutePath
+    ) -> [String] {
+        #if os(Windows)
+        [
+            // FIXME: are these the right arguments?
+            windowsTar, "-a", "-c", "-f", destinationPath.pathString, directory.basename,
+        ]
+        #elseif os(FreeBSD)
+        // On FreeBSD, the unzip command is available in base but not the zip command.
+        // Therefore; we use libarchive(bsdtar) to produce the ZIP archive instead.
+        [
+            self.tar, "-c", "--format", "zip", "-f", destinationPath.pathString,
+            directory.basename,
+        ]
+        #else
+        [
+            self.zip, "-ry", destinationPath.pathString, directory.basename,
+        ]
+        #endif
+    }
+
+    #if !os(Windows)
+    private func shellCompressionCommand(
+        directory: AbsolutePath,
+        destinationPath: AbsolutePath
+    ) -> String {
+        let command = self.compressionArguments(
+            directory: directory,
+            destinationPath: destinationPath
+        ).map { $0.spm_shellEscaped() }.joined(separator: " ")
+
+        return "cd \(directory.parentDirectory.pathString.spm_shellEscaped()) && \(command)"
+    }
+    #endif
+
+    private func runCompressionProcess(_ process: AsyncProcess) async throws {
+        guard let registrationKey = self.cancellator.register(process) else {
+            throw CancellationError.failedToRegisterProcess(process)
+        }
+
+        defer { self.cancellator.deregister(registrationKey) }
+
+        try process.launch()
+        let processResult = try await process.waitUntilExit()
+        guard processResult.exitStatus == .terminated(code: 0) else {
+            throw try StringError(processResult.utf8stderrOutput())
+        }
     }
 }

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -174,4 +174,36 @@ final class ZipArchiverTests: XCTestCase {
              )
          }
      }
+
+    func testCompressWithSpacesInPaths() async throws {
+        #if !os(Windows)
+        guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
+            throw XCTSkip("working directory not supported on this platform")
+        }
+        #endif
+
+        try await testWithTemporaryDirectory { tmpdir in
+            let archiver = ZipArchiver(fileSystem: localFileSystem)
+
+            let rootDir = tmpdir.appending(components: "parent dir", "root dir")
+            try localFileSystem.createDirectory(rootDir, recursive: true)
+            try localFileSystem.writeFileContents(rootDir.appending("file1.txt"), string: "Hello World!")
+
+            let archivePath = tmpdir.appending(components: "output dir", "archive path.zip")
+            try localFileSystem.createDirectory(archivePath.parentDirectory, recursive: true)
+            try await archiver.compress(directory: rootDir, to: archivePath)
+            XCTAssertFileExists(archivePath)
+
+            let extractRootDir = tmpdir.appending(component: "extract dir")
+            try localFileSystem.createDirectory(extractRootDir)
+            try await archiver.extract(from: archivePath, to: extractRootDir)
+            try localFileSystem.stripFirstLevel(of: extractRootDir)
+
+            XCTAssertFileExists(extractRootDir.appending("file1.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractRootDir.appending("file1.txt")),
+                "Hello World!"
+            )
+        }
+    }
 }

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -173,15 +173,9 @@ final class ZipArchiverTests: XCTestCase {
                  try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt"))
              )
          }
-     }
+    }
 
     func testCompressWithSpacesInPaths() async throws {
-        #if !os(Windows)
-        guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
-            throw XCTSkip("working directory not supported on this platform")
-        }
-        #endif
-
         try await testWithTemporaryDirectory { tmpdir in
             let archiver = ZipArchiver(fileSystem: localFileSystem)
 

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -5021,6 +5021,34 @@ struct PackageCommandTests {
         @Test(
             arguments: [BuildSystemProvider.Kind.swiftbuild],
         )
+        func archiveSourceRunningWithPackagePathContainingSpaces(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            let config = BuildConfiguration.debug
+            try await fixture(name: "DependencyResolution/External/Simple") { fixturePath in
+                let sourcePackageRoot = fixturePath.appending("Bar")
+
+                try await withTemporaryDirectory { tempDirectory in
+                    let packageRoot = tempDirectory.appending(components: "package path", "Bar Package")
+                    try localFileSystem.createDirectory(packageRoot.parentDirectory, recursive: true)
+                    try localFileSystem.copy(from: sourcePackageRoot, to: packageRoot)
+
+                    let destination = tempDirectory.appending("Bar Package.zip")
+                    let (stdout, _) = try await execute(
+                        ["archive-source", "--output", destination.pathString],
+                        packagePath: packageRoot,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
+                    #expect(stdout.contains("Created Bar Package.zip"), #"actual: "\#(stdout)""#)
+                    expectFileExists(at: destination)
+                }
+            }
+        }
+
+        @Test(
+            arguments: [BuildSystemProvider.Kind.swiftbuild],
+        )
         func archiveSourceRunningWithoutArgumentsOutsideThePackageRoot(
             buildSystem: BuildSystemProvider.Kind,
         ) async throws {

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -5040,7 +5040,8 @@ struct PackageCommandTests {
                         configuration: config,
                         buildSystem: buildSystem,
                     )
-                    #expect(stdout.contains("Created Bar Package.zip"), #"actual: "\#(stdout)""#)
+                    #expect(stdout.hasPrefix("Created "), #"actual: "\#(stdout)""#)
+                    #expect(stdout.contains("Bar Package.zip"), #"actual: "\#(stdout)""#)
                     expectFileExists(at: destination)
                 }
             }


### PR DESCRIPTION
Fixes #10148.

## Summary

- switch `ZipArchiver` back to argument-based process execution with `workingDirectory`
- add a `ZipArchiver` regression test for spaced input and output paths
- add `archive-source` command coverage for non-git package paths containing spaces

## Why

`ZipArchiver.compress` was still using the old `/bin/sh -c "cd ... && zip ..."` workaround that was added for Amazon Linux 2. That made `swift package archive-source` break on valid paths with spaces because the shell split the path before `zip` ran.

Using `AsyncProcess` with a real working directory removes the shell parsing entirely, so path components are passed as data again instead of getting reinterpreted by the shell.

## Validation

- `swift build --product swift-package`
- verified the built `.build/arm64-apple-macosx/debug/swift-package` succeeds for `archive-source` when both the package path and output path contain spaces
- attempted `swift test --filter ZipArchiverTests/testCompressWithSpacesInPaths`, but this environment currently fails earlier in `PackageDescriptionTests` with `no such module 'XCTest'`
