### PR TITLE
Better "file not found" error message

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -182,6 +182,10 @@ struct BinaryArtifactsManagerError: Error, CustomStringConvertible {
         .init(description: "local archive of binary target '\(targetName)' at '\(archivePath)' does not contain a binary artifact.")
     }
 
+    static func localArchiveNotFound(archivePath: AbsolutePath, targetName: String) -> Self {
+        .init(description: "local archive of binary target '\(targetName)' at '\(archivePath)' does not exist.")
+    }
+
     static func localArtifactNotFound(artifactPath: AbsolutePath, targetName: String) -> Self {
         .init(description: "local binary target '\(targetName)' at '\(artifactPath)' does not contain a binary artifact.")
     }

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -92,6 +92,15 @@ extension Workspace {
                         // TODO: find a better way to get the base path (not via the manifest)
                         let absolutePath = try manifest.path.parentDirectory.appending(RelativePath(validating: path))
                         if absolutePath.extension?.lowercased() == "zip" {
+                            guard self.fileSystem.exists(absolutePath) else {
+                                observabilityScope.emit(
+                                    BinaryArtifactsManagerError.localArchiveNotFound(
+                                        archivePath: absolutePath,
+                                        targetName: target.name
+                                    )
+                                )
+                                continue
+                            }
                             localArtifacts.append(
                                 .local(
                                     packageRef: packageReference,
@@ -541,7 +550,7 @@ extension Workspace {
                                 )
                             }
                         } catch {
-                            let reason = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                            let reason = error.interpolationDescription
 
                             observabilityScope.emit(BinaryArtifactsManagerError.localArtifactFailedExtraction(
                                 artifactPath: artifact.path,


### PR DESCRIPTION
If you reference a file that doesn't exist in `Package.swift`, you get this error:

```bash
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull length]: unrecognized selector sent to instance 0x1fc8bf700'
*** First throw call stack:
(
        0   CoreFoundation                      0x000000018f54abf0 __exceptionPreprocess + 176
        1   libobjc.A.dylib                     0x000000018efd691c objc_exception_throw + 88
        2   CoreFoundation                      0x000000018f60bc6c -[NSObject(NSObject) __retain_OA] + 0
        3   CoreFoundation                      0x000000018f4bbbc8 ___forwarding___ + 1480
        4   CoreFoundation                      0x000000018f4bb540 _CF_forwarding_prep_0 + 96
        5   Foundation                          0x00000001910f00a0 $ss5ErrorP10FoundationE20localizedDescriptionSSvg + 980
        6   swift-package                       0x000000010642cb8c $s9WorkspaceAAC22BinaryArtifactsManagerV7extract_18artifactsDirectory18observabilityScopeSayAB15ManagedArtifactVGAJ_6Basics12AbsolutePathVAK013ObservabilityI0CtYaKFAJScgyAISgs5Error_pGzYaKXEfU_AP  7   swift-package                       0x000000010643ed6d $s9WorkspaceAAC22BinaryArtifactsManagerV7extract_18artifactsDirectory18observabilityScopeSayAB15ManagedArtifactVGAJ_6Basics12AbsolutePathVAK013ObservabilityI0CtYaKFAJScgyAISgs5Error_pGzYaKXEfU_AP 8   libswift_Concurrency.dylib          0x0000000293b2aec5 _ZL23completeTaskWithClosurePN5swift12AsyncContextEPNS_10SwiftErrorE + 1
)
libc++abi: terminating due to uncaught exception of type NSException

💣 Program crashed: Signal 6: Backtracing from 0x18f3e45e8...
```

This PR throws this error instead:

```bash
error: local archive of binary target 'bin.zip' at '~/Desktop/Code/sandbox/ReproRdar177455391/bin.zip' does not exist.
```