### PR TITLE
Emit a warning for duplicated dependencies

### DIFF
--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -151,8 +151,15 @@ public struct ManifestValidator {
     private func validateDependencies() -> [Basics.Diagnostic] {
         var diagnostics = [Basics.Diagnostic]()
 
-        // validate dependency requirements
-        let duplicateIdentities = self.manifest.dependencies.map({ $0.identity }).spm_findDuplicates()
+        // Warn about dependencies declared more than once with the same location. Dependencies that
+        // share an identity but point to different locations are a conflict reported during graph
+        // loading, not a duplicate, so they are keyed by location to avoid a misleading warning.
+        let duplicateIdentities = Set(
+            self.manifest.dependencies
+                .map { DependencyLocationKey(identity: $0.identity, location: $0.locationStringForValidation) }
+                .spm_findDuplicates()
+                .map(\.identity)
+        )
         for identity in duplicateIdentities {
             diagnostics.append(.duplicatePackageDependency(identity: identity))
         }
@@ -413,7 +420,28 @@ extension TargetDescription {
     fileprivate var isLocal: Bool { path != nil }
 }
 
+private struct DependencyLocationKey: Hashable {
+    let identity: PackageIdentity
+    let location: String
+}
+
 extension PackageDependency {
+    fileprivate var locationStringForValidation: String {
+        switch self {
+        case .fileSystem(let settings):
+            return settings.path.pathString
+        case .sourceControl(let settings):
+            switch settings.location {
+            case .local(let path):
+                return path.pathString
+            case .remote(let url):
+                return url.absoluteString
+            }
+        case .registry(let settings):
+            return settings.identity.description
+        }
+    }
+
     fileprivate var descriptionForValidation: String {
         var description = "'\(self.nameForModuleDependencyResolutionOnly)'"
 

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -152,6 +152,11 @@ public struct ManifestValidator {
         var diagnostics = [Basics.Diagnostic]()
 
         // validate dependency requirements
+        let duplicateIdentities = self.manifest.dependencies.map({ $0.identity }).spm_findDuplicates()
+        for identity in duplicateIdentities {
+            diagnostics.append(.duplicatePackageDependency(identity: identity))
+        }
+
         for dependency in self.manifest.dependencies {
             switch dependency {
             case .sourceControl(let sourceControl):
@@ -298,6 +303,10 @@ public protocol ManifestSourceControlValidator {
 }
 
 extension Basics.Diagnostic {
+    static func duplicatePackageDependency(identity: PackageIdentity) -> Self {
+        .warning("duplicate dependency '\(identity)'")
+    }
+
     static func duplicateTargetName(targetName: String) -> Self {
         .error("duplicate target named '\(targetName)'")
     }

--- a/Sources/PackageLoading/ManifestLoader+Validation.swift
+++ b/Sources/PackageLoading/ManifestLoader+Validation.swift
@@ -151,19 +151,6 @@ public struct ManifestValidator {
     private func validateDependencies() -> [Basics.Diagnostic] {
         var diagnostics = [Basics.Diagnostic]()
 
-        // Warn about dependencies declared more than once with the same location. Dependencies that
-        // share an identity but point to different locations are a conflict reported during graph
-        // loading, not a duplicate, so they are keyed by location to avoid a misleading warning.
-        let duplicateIdentities = Set(
-            self.manifest.dependencies
-                .map { DependencyLocationKey(identity: $0.identity, location: $0.locationStringForValidation) }
-                .spm_findDuplicates()
-                .map(\.identity)
-        )
-        for identity in duplicateIdentities {
-            diagnostics.append(.duplicatePackageDependency(identity: identity))
-        }
-
         for dependency in self.manifest.dependencies {
             switch dependency {
             case .sourceControl(let sourceControl):
@@ -418,6 +405,25 @@ extension Basics.Diagnostic {
 extension TargetDescription {
     fileprivate var isRemote: Bool { url != nil }
     fileprivate var isLocal: Bool { path != nil }
+}
+
+extension Manifest {
+    /// Identities of dependencies that are declared more than once with the same location.
+    ///
+    /// Dependencies that share an identity but point to different locations are a conflict reported
+    /// during graph loading, not a duplicate, so they are keyed by location to avoid a misleading
+    /// warning. This is computed on the authored manifest, before any registry transformation that
+    /// could intentionally collapse a source control dependency onto a registry one.
+    var duplicateDependencyIdentities: [PackageIdentity] {
+        Array(
+            Set(
+                self.dependencies
+                    .map { DependencyLocationKey(identity: $0.identity, location: $0.locationStringForValidation) }
+                    .spm_findDuplicates()
+                    .map(\.identity)
+            )
+        )
+    }
 }
 
 private struct DependencyLocationKey: Hashable {

--- a/Sources/PackageLoading/ManifestLoader.swift
+++ b/Sources/PackageLoading/ManifestLoader.swift
@@ -384,6 +384,10 @@ public final class ManifestLoader: ManifestLoaderProtocol {
             pruneDependencies: self.pruneDependencies
         )
 
+        for identity in manifest.duplicateDependencyIdentities {
+            observabilityScope.emit(.duplicatePackageDependency(identity: identity))
+        }
+
         // Inform the delegate.
         delegateQueue.async { [delegate = self.delegate] in
             delegate?.didLoad(

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -371,6 +371,30 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
         }
     }
 
+    func testDuplicatePackageDependencies() async throws {
+        let content = """
+            import PackageDescription
+
+            let package = Package(
+                name: "Foo",
+                dependencies: [
+                    .package(url: "https://example.com/bar.git", from: "1.0.0"),
+                    .package(url: "https://example.com/bar.git", from: "1.0.0"),
+                ],
+                targets: [
+                    .target(name: "Foo"),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        testDiagnostics(validationDiagnostics) { result in
+            result.check(diagnostic: "duplicate dependency 'bar'", severity: .warning)
+        }
+    }
+
     func testDuplicateTargets() async throws {
         let content = """
             import PackageDescription

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -389,8 +389,8 @@ final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
 
         let observability = ObservabilitySystem.makeForTesting()
         let (_, validationDiagnostics) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
-        XCTAssertNoDiagnostics(observability.diagnostics)
-        testDiagnostics(validationDiagnostics) { result in
+        XCTAssertNoDiagnostics(validationDiagnostics)
+        testDiagnostics(observability.diagnostics) { result in
             result.check(diagnostic: "duplicate dependency 'bar'", severity: .warning)
         }
     }

--- a/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
+++ b/Tests/WorkspaceTests/ManifestSourceGenerationTests.swift
@@ -242,8 +242,10 @@ final class ManifestSourceGenerationTests: XCTestCase {
 
             #if os(Windows)
             let absolutePath = "c:/a/b/c"
+            let namedAbsolutePath = "c:/a/b/d"
             #else
             let absolutePath = "/a/b/c"
+            let namedAbsolutePath = "/a/b/d"
             #endif
 
             let package = Package(
@@ -257,7 +259,7 @@ final class ManifestSourceGenerationTests: XCTestCase {
                 dependencies: [
                     // Dependencies declare other packages that this package depends on.
                     .package(path: absolutePath),
-                    .package(name: "abc", path: absolutePath),
+                    .package(name: "abc", path: namedAbsolutePath),
                 ],
                 targets: [
                     // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
If the same dependency appears twice in the manifest, emit a warning.
