### PR TITLE
[6.4] GitHubActions: add android build

### DIFF
--- a/.github/scripts/prebuild.sh
+++ b/.github/scripts/prebuild.sh
@@ -13,6 +13,14 @@
 
 set -e
 
+
+# This script is not necessarily always run in a Docker container; add sudo if needed
+if command -v sudo &> /dev/null && [ "$EUID" -ne 0 ] ; then
+    sudo=sudo
+else
+    sudo=
+fi
+
 if [[ $(uname) == Darwin ]] ; then
     if [[ "$INSTALL_CMAKE" == "1" ]] ; then
         mkdir -p "$RUNNER_TOOL_CACHE"
@@ -35,16 +43,16 @@ if [[ $(uname) == Darwin ]] ; then
 elif command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
     export DEBIAN_FRONTEND=noninteractive
 
-    apt-get update -y
+    $sudo apt-get update -y
 
     # Build dependencies
-    apt-get install -y libsqlite3-dev libncurses-dev
+    $sudo apt-get install -y libsqlite3-dev libncurses-dev
 
     # Debug symbols
-    apt-get install -y libc6-dbg
+    $sudo apt-get install -y libc6-dbg
 
     if [[ "$INSTALL_CMAKE" == "1" ]] ; then
-        apt-get install -y cmake ninja-build
+        $sudo apt-get install -y cmake ninja-build
     fi
 
     # Android NDK
@@ -56,7 +64,7 @@ elif command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
                 : # Not available
                 ;;
             noble)
-                apt-get install -y google-android-ndk-r26c-installer
+                $sudo apt-get install -y google-android-ndk-r26c-installer
                 ;;
             *)
                 echo "Unable to fetch Android NDK for unknown Linux distribution: $VERSION_CODENAME" >&2
@@ -66,20 +74,20 @@ elif command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
         echo "Skipping Android NDK installation on $dpkg_architecture" >&2
     fi
 elif command -v dnf >/dev/null 2>&1 ; then # rhel-ubi9
-    dnf update -y
+    $sudo dnf update -y
 
     # Build dependencies
-    dnf install -y sqlite-devel ncurses-devel
+    $sudo dnf install -y sqlite-devel ncurses-devel
 
     # Debug symbols
-    dnf debuginfo-install -y glibc
+    $sudo dnf debuginfo-install -y glibc
 elif command -v yum >/dev/null 2>&1 ; then # amazonlinux2
-    yum update -y
+    $sudo yum update -y
 
     # Build dependencies
-    yum install -y sqlite-devel ncurses-devel
+    $sudo yum install -y sqlite-devel ncurses-devel
 
     # Debug symbols
-    yum install -y yum-utils
-    debuginfo-install -y glibc
+    $sudo yum install -y yum-utils
+    $sudo debuginfo-install -y glibc
 fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,6 +28,9 @@ jobs:
       windows_swift_versions: '["nightly-main", "nightly-6.2"]'
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1'
       windows_build_command: 'Invoke-Program swift run -Xlinker /ignore:4217 --configuration release swift-build --build-tests --scratch-path .tests'
+      # enable_android_sdk_build: true
+      # android_sdk_build_command: "swift run swift-build --build-tests --build-system swiftbuild"
+      # android_ndk_versions: '["r27d", "r29"]'
       enable_windows_checks: true
       enable_macos_checks: true
       macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.4\"}]"
@@ -68,3 +71,13 @@ jobs:
       linux_static_sdk_pre_build_command: ./.github/scripts/prebuild.sh
       # This is a hack - replace the build command with a test command and drop the --swift-sdk arg the workflow appends.
       linux_static_sdk_build_command: "swift test --parallel --experimental-xunit-message-failure --xunit-output static-linux-xunit.xml --filter StaticLinuxIntegrationTests #"
+      enable_android_sdk_build: true
+      android_sdk_build_command: "swift test  --parallel --experimental-xunit-message-failure --xunit-output android-xunit.xml --filter AndroidSDKIntegrationTests #"
+
+  required:
+    name: Required
+    runs-on: ubuntu-latest
+    needs: [build, soundness, integration-tests]
+    steps:
+      - name: Success
+        run: echo "All required jobs succeeded."

--- a/Sources/_InternalTestSupport/SwiftSDKLookup.swift
+++ b/Sources/_InternalTestSupport/SwiftSDKLookup.swift
@@ -65,8 +65,11 @@ package func findSwiftSDK(
 }
 
 package func findCompilerAndSDKIDForTesting(
-    where predicate: (_ suffix: String) -> Bool
+    for sdk: SwiftSDKName,
 ) async throws -> (AbsolutePath, String)? {
+    let predicate = { (_ suffix: String) in
+        return suffix.hasPrefix(sdk.rawValue)
+    }
     let compilerPath: AbsolutePath
     if let githubActionsToolchain = githubActionsToolchain() {
         compilerPath = githubActionsToolchain.appending(components: ["usr", "bin", "swiftc\(ProcessInfo.exeSuffix)"])
@@ -81,6 +84,19 @@ package func findCompilerAndSDKIDForTesting(
     return (compilerPath, sdkID)
 }
 
-package func findCompilerAndStaticLinuxSDKIDForTesting() async throws -> (AbsolutePath, String)? {
-    try await findCompilerAndSDKIDForTesting { $0.hasPrefix("static-linux") }
+package enum SwiftSDKName: String {
+    case android = "android"
+    case staticLinux = "staticLinux"
+    case webassembly = "wasm"
 }
+
+
+@available(*, deprecated, message: "Use 'findCompilerAndSDKIDForTesting(for: .staticLinux)' instead")
+package func findCompilerAndStaticLinuxSDKIDForTesting() async throws -> (AbsolutePath, String)? {
+    try await  findCompilerAndSDKIDForTesting(for: .staticLinux)
+}
+
+package let androidTriplesUT = [
+    "aarch64-unknown-linux-android28",
+    "x86_64-unknown-linux-android28",
+]

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -51,6 +51,7 @@ extension Tag.Feature {
     public enum ProductType {}
     public enum TargetType {}
     public enum Product {}
+    public enum SDK {}
 
     @Tag public static var BuildCache: Tag
     @Tag public static var CodeCoverage: Tag
@@ -72,6 +73,11 @@ extension Tag.Feature {
     @Tag public static var TaskBacktraces: Tag
 }
 
+extension Tag.Feature.SDK {
+    @Tag public static var StaticLinux: Tag
+    @Tag public static var Android: Tag
+    @Tag public static var WebAssembly: Tag
+}
 extension Tag.Feature.Command {
     public enum Package {}
     public enum PackageRegistry {}

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -202,7 +202,26 @@ extension Trait where Self == Testing.ConditionTrait {
 
     public static var requiresStaticLinuxSwiftSDK: Self {
         enabled("Static Linux Swift SDK is not installed") {
-            try await findCompilerAndStaticLinuxSDKIDForTesting() != nil
+            try await findCompilerAndSDKIDForTesting(for: .staticLinux) != nil
+        }
+    }
+    public static var requiresWebAssemblySwiftSDK: Self {
+        enabled("WebAssembly Swift SDK is not installed") {
+            try await findCompilerAndSDKIDForTesting(for: .webassembly) != nil
+        }
+    }
+
+    /// Skip test if the  environment does not have the Android NDK setup/installed
+    public static var requireAndroidNDK:  Self {
+        enabled("Environment does not have an Android NDK configured") {
+            ProcessInfo.processInfo.environment["ANDROID_NDK_HOME"] != nil
+        }
+    }
+
+    // SKip the test if the Android Swift SDK is not installed
+    public static var requiresAndroidSwiftSDK: Self {
+        enabled("Android Swift SDK is not installed") {
+            try await findCompilerAndSDKIDForTesting(for: .android) != nil
         }
     }
 

--- a/Tests/BuildMetalTests/BuildMetalTests.swift
+++ b/Tests/BuildMetalTests/BuildMetalTests.swift
@@ -28,7 +28,7 @@ import Metal
 struct BuildMetalTests {
 
     @Test(
-        .disabled("Require downloadable Metal toolchain"),
+        .disabled("https://github.com/swiftlang/swift-package-manager/issues/9443: Require downloadable Metal toolchain"),
         .tags(
             .TestSize.large,
         ),

--- a/Tests/IntegrationTests/SDKs/Android/AndroindSDKIntegrationTests.swift
+++ b/Tests/IntegrationTests/SDKs/Android/AndroindSDKIntegrationTests.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import struct SPMBuildCore.BuildSystemProvider
+import _InternalTestSupport
+import var Basics.localFileSystem
+
+@Suite(
+    .tags(
+        .TestSize.large,
+        .Feature.SDK.Android,
+    ),
+    .requiresAndroidSwiftSDK,
+)
+struct AndroidSDKIntegrationTests {
+    @Test(
+        .requiresAndroidSwiftSDK,
+        .requireAndroidNDK,
+        arguments: androidTriplesUT,
+    )
+    func basicBuildAndroid(
+        tripleUT: String
+    ) async throws {
+        let buildSystem = BuildSystemProvider.Kind.swiftbuild
+        // GIVEN we have a sample package
+        try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndSDKIDForTesting(for: .android))
+
+            // WHEN we build for android using the specific target triple
+            let buildOutput = try await executeSwiftBuild(
+                fixturePath,
+                extraArgs: ["--swift-sdk", sdkID, "--triple", tripleUT],
+                // env: env,
+                buildSystem: buildSystem,
+            )
+
+            // THEN we expect the build to be successful
+            #expect(buildOutput.stdout.contains("Build complete"))
+
+            let binary = try await getBinPath(
+                fixturePath,
+                extraArgs: ["--swift-sdk", sdkID, "--triple", tripleUT],
+                buildSystem: buildSystem,
+            ).appending(component: "ExecutableNew")
+
+            // AND the binary to exist on the file system
+            #expect(localFileSystem.exists(binary), "Expected binary at \(binary)")
+
+        }
+    }
+}

--- a/Tests/SwiftPMStaticLinuxIntegrationTests/StaticLinuxIntegrationTests.swift
+++ b/Tests/SwiftPMStaticLinuxIntegrationTests/StaticLinuxIntegrationTests.swift
@@ -21,14 +21,16 @@ import class Basics.AsyncProcess
 
 @Suite(
     .tags(
-        Tag.Feature.Command.Build,
+        .TestSize.large,
+        .Feature.Command.Build,
+        .Feature.SDK.StaticLinux,
     )
 )
 private struct StaticLinuxIntegrationTests {
     @Test(.requiresStaticLinuxSwiftSDK, arguments: SupportedBuildSystemOnAllPlatforms)
     func basicSwiftExecutable(buildSystem: BuildSystemProvider.Kind) async throws {
         try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
-            let (compilerPath, sdkID) = try #require(try await findCompilerAndStaticLinuxSDKIDForTesting())
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndSDKIDForTesting(for: .staticLinux))
 
             var env = Environment()
             env["SWIFT_EXEC"] = compilerPath.pathString

--- a/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -44,29 +44,28 @@ private func findWasmKit(sdkID: String) throws -> AbsolutePath? {
     return swiftSDK.toolset.knownTools[.debugger]?.path
 }
 
+@available(*, deprecated, message: "Use 'findCompilerAndSDKIDForTesting(for: .webassembly)' instead")
 private func findCompilerAndWebAssemblySDKIDForTesting() async throws -> (AbsolutePath, String)? {
-    try await findCompilerAndSDKIDForTesting { $0 == "wasm" }
-}
-
-extension Trait where Self == Testing.ConditionTrait {
-    static var requiresWebAssemblySwiftSDK: Self {
-        enabled("WebAssembly Swift SDK is not installed") {
-            try await findCompilerAndWebAssemblySDKIDForTesting() != nil
-        }
-    }
+    try await findCompilerAndSDKIDForTesting(for: .webassembly)
 }
 
 @Suite(
     .serialized,
     .tags(
-        Tag.Feature.Command.Build,
+        .TestSize.large,
+        .Feature.SDK.WebAssembly,
     )
 )
 private struct WebAssemblyIntegrationTests {
-    @Test(.requiresWebAssemblySwiftSDK)
+    @Test(
+        .requiresWebAssemblySwiftSDK,
+        .tags(
+            .Feature.Command.Build,
+        ),
+    )
     func basicSwiftExecutable() async throws {
         try await fixture(name: "WebAssembly/SwiftExecutable") { fixturePath in
-            let (compilerPath, sdkID) = try #require(try await findCompilerAndWebAssemblySDKIDForTesting())
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndSDKIDForTesting(for: .webassembly))
 
             var env = Environment()
             env["SWIFT_EXEC"] = compilerPath.pathString
@@ -97,10 +96,16 @@ private struct WebAssemblyIntegrationTests {
         }
     }
 
-    @Test(.requiresWebAssemblySwiftSDK, arguments: SupportedBuildSystemOnAllPlatforms)
+    @Test(
+        .requiresWebAssemblySwiftSDK,
+        .tags(
+            .Feature.Command.Run,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
     func flagOverrides(buildSystem: BuildSystemProvider.Kind) async throws {
         try await fixture(name: "Miscellaneous/FlagOverrides") { fixturePath in
-            let (compilerPath, sdkID) = try #require(try await findCompilerAndWebAssemblySDKIDForTesting())
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndSDKIDForTesting(for: .webassembly))
 
             var env = Environment()
             env["SWIFT_EXEC"] = compilerPath.pathString
@@ -120,10 +125,16 @@ private struct WebAssemblyIntegrationTests {
         }
     }
 
-    @Test(.requiresWebAssemblySwiftSDK, arguments: SupportedBuildSystemOnAllPlatforms)
+    @Test(
+        .requiresWebAssemblySwiftSDK,
+        .tags(
+            .Feature.Command.Package.Plugin,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
     func flagOverridesCommandPlugin(buildSystem: BuildSystemProvider.Kind) async throws {
         try await fixture(name: "Miscellaneous/FlagOverrides") { fixturePath in
-            let (compilerPath, sdkID) = try #require(try await findCompilerAndWebAssemblySDKIDForTesting())
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndSDKIDForTesting(for: .webassembly))
 
             var env = Environment()
             env["SWIFT_EXEC"] = compilerPath.pathString
@@ -152,10 +163,15 @@ private struct WebAssemblyIntegrationTests {
         }
     }
 
-    @Test(.requiresWebAssemblySwiftSDK)
+    @Test(
+        .requiresWebAssemblySwiftSDK,
+        .tags(
+            .Feature.Command.Build,
+        ),
+    )
     func configuredSwiftSDKSearchPaths() async throws {
         try await fixture(name: "WebAssembly/ConfiguredSDKSearchPaths") { fixturePath in
-            let (compilerPath, sdkID) = try #require(try await findCompilerAndWebAssemblySDKIDForTesting())
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndSDKIDForTesting(for: .webassembly))
 
             var env = Environment()
             env["SWIFT_EXEC"] = compilerPath.pathString


### PR DESCRIPTION
Add an Android GitHub actions builds and also add a required job that needs all other jobs to complete. This way, we can eventually configure the repository settings to mahe this single job as "required".

Issue: rdar://173169034
Relates to #8577 