### PR TITLE
Revert "Remove duplicate logs from `swift test` output (#9783)"

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -356,16 +356,9 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
 
             if !self.options.shouldRunInParallel {
-                let (xctestArgs, testCount, testPaths) = try await xctestArgs(for: testProducts, swiftCommandState: swiftCommandState, buildSystem: buildSystem)
-
-                // Tests have been filtered or skipped; assure you only run test products
-                // of the tests you must run.
-                var filteredTestProducts = testProducts
-                if let testPaths, testProducts.count != testPaths.count {
-                    filteredTestProducts = testProducts.filter({ testPaths.contains($0.bundlePath) })
-                }
+                let (xctestArgs, testCount) = try await xctestArgs(for: testProducts, swiftCommandState: swiftCommandState, buildSystem: buildSystem)
                 let productResults = try await runTestProducts(
-                    filteredTestProducts,
+                    testProducts,
                     additionalArguments: xctestArgs,
                     productsBuildParameters: buildParameters,
                     swiftCommandState: swiftCommandState,
@@ -442,41 +435,16 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         if !options.shouldLaunchInLLDB && options.testLibraryOptions.isEnabled(.swiftTesting, swiftCommandState: swiftCommandState) {
             lazy var testEntryPointPath = testProducts.lazy.compactMap(\.testEntryPointPath).first
             if options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) || testEntryPointPath == nil {
-                // Filter test products to Swift testing suites.
-                let testSuites = try await TestingSupport.getSwiftTestingSuites(
-                    in: testProducts,
-                    swiftCommandState: swiftCommandState,
-                    shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
-                    sanitizers: globalOptions.build.sanitizers,
-                    buildSystem: buildSystem
-                )
-
-                // Filter test cases based on specifiers.
-                let tests = try testSuites
-                    .filteredTests(specifier: options.testCaseSpecifier)
-                    .skippedTests(specifier: options.skippedTests(fileSystem: swiftCommandState.fileSystem))
-
-                let filteredTestProducts = testProducts.filter { tests[$0.binaryPath] != nil }
-
-                if !filteredTestProducts.isEmpty {
-                    results.append(contentsOf:
-                        try await runTestProducts(
-                            filteredTestProducts,
-                            additionalArguments: [],
-                            productsBuildParameters: buildParameters,
-                            swiftCommandState: swiftCommandState,
-                            library: .swiftTesting,
-                            buildSystem: buildSystem
-                        )
-                    )
-                } else {
-                    results.append(TestProductResult(
-                        productName: "",
+                results.append(contentsOf:
+                    try await runTestProducts(
+                        testProducts,
+                        additionalArguments: [],
+                        productsBuildParameters: buildParameters,
+                        swiftCommandState: swiftCommandState,
                         library: .swiftTesting,
-                        result: .noMatchingTests
-                    ))
-                }
-
+                        buildSystem: buildSystem
+                    )
+                )
             } else if let testEntryPointPath {
                 // Can't run Swift Testing because an entry point file was used and the developer
                 // didn't explicitly enable Swift Testing.
@@ -506,13 +474,13 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         }
     }
 
-    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState, buildSystem: any BuildSystem) async throws -> (arguments: [String], testCount: Int?, testPaths: Set<AbsolutePath>?) {
+    private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState, buildSystem: any BuildSystem) async throws -> (arguments: [String], testCount: Int?) {
         switch options.testCaseSpecifier {
         case .none:
             if case .skip = options.skippedTests(fileSystem: swiftCommandState.fileSystem) {
                 fallthrough
             } else {
-                return ([], nil, nil)
+                return ([], nil)
             }
 
         case .regex, .specific, .skip:
@@ -535,7 +503,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 .filteredTests(specifier: options.testCaseSpecifier)
                 .skippedTests(specifier: options.skippedTests(fileSystem: swiftCommandState.fileSystem))
 
-            return (TestRunner.xctestArguments(forTestSpecifiers: tests.map(\.specifier)), tests.count, Set(tests.map(\.testProduct.bundlePath)))
+            return (TestRunner.xctestArguments(forTestSpecifiers: tests.map(\.specifier)), tests.count)
         }
     }
 
@@ -636,19 +604,9 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         var productsWithSwiftTests = Set<AbsolutePath>()
         if swiftTestingEnabled {
-            let swiftTestingSuites = try await TestingSupport.getSwiftTestingSuites(
-                in: testProducts,
-                swiftCommandState: swiftCommandState,
-                shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
-                sanitizers: globalOptions.build.sanitizers,
-                buildSystem: buildSystem
-            )
-            let matchingTests = try swiftTestingSuites
-                .filteredTests(specifier: options.testCaseSpecifier)
-                .skippedTests(specifier: skipSpecifier)
-            for (binaryPath, tests) in matchingTests where !tests.isEmpty {
-                productsWithSwiftTests.insert(binaryPath)
-            }
+            // Swift Testing handles filtering at runtime, so attach an LLDB target
+            // for every product that has Swift Testing enabled.
+            productsWithSwiftTests = Set(testProducts.map(\.binaryPath))
         }
 
         var targets = [DebuggableTestSession.Target]()
@@ -701,7 +659,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     ) async throws -> [String] {
         switch library {
         case .xctest:
-            let (xctestArgs, _, _) = try await xctestArgs(
+            let (xctestArgs, _) = try await xctestArgs(
                 for: [testProduct],
                 swiftCommandState: swiftCommandState,
                 buildSystem: buildSystem
@@ -1753,49 +1711,6 @@ fileprivate extension Array where Element == UnitTest {
                 }
             }
             return result
-        case .regex, .specific:
-            throw InternalError("Tests to filter should never have been passed here.")
-        }
-    }
-}
-
-fileprivate extension Dictionary where Key == AbsolutePath, Value == [String] {
-    /// Return Swift Testing test IDs matching the provided specifier.
-    func filteredTests(specifier: TestCaseSpecifier) throws -> [AbsolutePath: [String]] {
-        switch specifier {
-        case .none:
-            return self
-        case .regex(let patterns):
-            return self.mapValues { testIDs in
-                testIDs.filter { testID in
-                    patterns.contains { pattern in
-                        testID.range(of: pattern, options: .regularExpression) != nil
-                    }
-                }
-            }.filter { !$0.value.isEmpty }
-        case .specific(let name):
-            return self.mapValues { $0.filter { $0 == name } }
-                .filter { !$0.value.isEmpty }
-        case .skip:
-            throw InternalError("Tests to skip should never have been passed here.")
-        }
-    }
-
-    /// Skip Swift Testing test IDs matching the provided specifier.
-    func skippedTests(specifier: TestCaseSpecifier) throws -> [AbsolutePath: [String]] {
-        switch specifier {
-        case .none:
-            return self
-        case .skip(let skippedTests):
-            return self.mapValues { testIDs in
-                var result = testIDs
-                for skippedTest in skippedTests {
-                    result = result.filter {
-                        $0.range(of: skippedTest, options: .regularExpression) == nil
-                    }
-                }
-                return result
-            }.filter { !$0.value.isEmpty }
         case .regex, .specific:
             throw InternalError("Tests to filter should never have been passed here.")
         }

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -28,8 +28,6 @@ import Glibc
 
 import struct TSCBasic.FileSystemError
 import class Basics.AsyncProcess
-import struct Basics.AsyncProcessResult
-import TSCLibc
 import var TSCBasic.stderrStream
 import var TSCBasic.stdoutStream
 import func TSCBasic.withTemporaryFile
@@ -224,107 +222,6 @@ enum TestingSupport {
         #endif
         // Parse json and return TestSuites.
         return try TestSuite.parse(jsonString: data, context: args.joined(separator: " "))
-    }
-
-    static func getSwiftTestingSuites(
-        in testProducts: [BuiltTestProduct],
-        swiftCommandState: SwiftCommandState,
-        shouldSkipBuilding: Bool,
-        sanitizers: [Sanitizer],
-        buildSystem: any BuildSystem
-    ) async throws -> [AbsolutePath: [String]] {
-        var result: [(AbsolutePath, [String])] = []
-        for product in testProducts {
-            let suites = try await Self.getSwiftTestingSuites(
-                testProduct: product,
-                swiftCommandState: swiftCommandState,
-                shouldSkipBuilding: shouldSkipBuilding,
-                sanitizers: sanitizers,
-                buildSystem: buildSystem
-            )
-            result.append((product.binaryPath, suites))
-        }
-        return try Dictionary(throwingUniqueKeysWithValues: result)
-    }
-
-    /// Runs the test binary to list Swift Testing tests and returns their identifiers.
-    /// On macOS, we use the swiftpm-testing-helper tool bundled with swiftpm.
-    /// On Linux, the test binary handles `--list-tests` directly.
-    ///
-    /// - Parameters:
-    ///     - testProduct: The test product.
-    ///
-    /// - Throws: TestError, SystemError, TSCUtility.Error
-    ///
-    /// - Returns: Array of test identifiers in the format "Module.Suite/testFunction()"
-    static func getSwiftTestingSuites(
-        testProduct: BuiltTestProduct,
-        swiftCommandState: SwiftCommandState,
-        shouldSkipBuilding: Bool,
-        sanitizers: [Sanitizer],
-        buildSystem: any BuildSystem
-    ) async throws -> [String] {
-        let toolchain = try swiftCommandState.getTargetToolchain()
-        let env = try await Self.constructTestEnvironment(
-            toolchain: toolchain,
-            destinationBuildParameters: swiftCommandState.buildParametersForTest(
-                // Unlike the XCTest helper tool, the Swift Testing runtime initialises LLVM
-                // profiling on startup and writes a profraw file even when only listing tests,
-                // which would inflate the profraw file count produced by the actual test run.
-                // Code coverage is not necessary here as we are simply listing tests.
-                enableCodeCoverage: false,
-                shouldSkipBuilding: shouldSkipBuilding
-            ).productsBuildParameters,
-            sanitizers: sanitizers,
-            library: .swiftTesting,
-            testProductPaths: [testProduct.bundlePath],
-            interopMode: nil, // Interop not required when listing tests
-            buildSystem: buildSystem
-        )
-
-        var args: [String]
-        #if os(macOS)
-        let helper = try toolchain.getSwiftTestingHelper()
-        args = [helper.pathString, "--test-bundle-path", testProduct.binaryPath.pathString,
-                "--list-tests", "--testing-library", "swift-testing",
-                testProduct.binaryPath.pathString]
-        #else
-        args = [testProduct.binaryPath.pathString, "--list-tests", "--testing-library", "swift-testing"]
-        #endif
-
-        let output: String
-        do {
-            output = try Self.runProcessWithExistenceCheck(
-                path: testProduct.binaryPath,
-                fileSystem: swiftCommandState.fileSystem,
-                args: args,
-                env: env
-            )
-        } catch AsyncProcessResult.Error.nonZeroExit(let result)
-            where result.exitStatus == .terminated(code: Self.exitNoTestsFound) {
-            return []
-        }
-
-        return output
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-    }
-
-    /// The exit code used by Swift Testing when no tests are found.
-    ///
-    /// Because Swift Package Manager does not directly link to the testing library,
-    /// it duplicates the definition of this constant in its own source. Any changes
-    /// to this constant in either package must be mirrored in the other.
-    private static var exitNoTestsFound: CInt {
-        #if os(macOS) || os(Linux) || canImport(Android) || os(FreeBSD)
-        EX_UNAVAILABLE
-        #elseif os(Windows)
-        ERROR_NOT_FOUND
-        #else
-        #warning("Platform-specific implementation missing: value for exitNoTestsFound unavailable")
-        return 2 // We're assuming that EXIT_SUCCESS = 0 and EXIT_FAILURE = 1.
-        #endif
     }
 
     /// Run a process and throw a more specific error if the file doesn't exist.


### PR DESCRIPTION
This reverts commit fb05bad03998d567e54c028f539103ea4117d317.

Swift Testing should be passed the filter without pre-processing from swift-package-manager, which ensures the filtering logic doesn't diverge.

Follow on PRs in swift-testing and swift-package-manager should supply and respect an env var that suppresses output if `--filter` omits all tests from a test target. If all test targets have no tests to run after a filter then swift-package-manager should emit its own message, otherwise nothing would be printed to the user.