### PR TITLE
Update prebuilts builder for SwiftBuild. Fix Linux.

### DIFF
--- a/Sources/Basics/Archiver/Archiver.swift
+++ b/Sources/Basics/Archiver/Archiver.swift
@@ -34,10 +34,22 @@ public protocol Archiver: Sendable {
     /// Asynchronously compress the contents of a directory to a destination archive.
     ///
     /// - Parameters:
-    ///   - directory: The `AbsolutePath` to the archive to extract.
-    ///   - destinationPath: The `AbsolutePath` to the directory to extract to.
+    ///   - directory: The `AbsolutePath` to the directory to add to the archive
+    ///   - destinationPath: The `AbsolutePath` to the archive
     func compress(
         directory: AbsolutePath,
+        to destinationPath: AbsolutePath
+    ) async throws
+
+    /// Asynchronously compress the contents of a list of directories to a destination archive.
+    ///
+    /// - Parameters:
+    ///   - paths: The `RelativePath`s to the files or directories to archive
+    ///   - parent: The `AbsolutePath` to the parent directory to archive from
+    ///   - destinationPath: The `AbsolutePath` to the archive
+    func compress(
+        paths: [RelativePath],
+        from parent: AbsolutePath,
         to destinationPath: AbsolutePath
     ) async throws
 
@@ -66,6 +78,22 @@ extension Archiver {
         try await withCheckedThrowingContinuation { continuation in
             self.extract(from: archivePath, to: destinationPath, completion: { continuation.resume(with: $0) })
         }
+    }
+
+    /// Asynchronously compress the contents of a directory to a destination archive.
+    ///
+    /// - Parameters:
+    ///   - directory: The `AbsolutePath` to the directory to add to the archive
+    ///   - destinationPath: The `AbsolutePath` to the archive
+    public func compress(
+        directory: AbsolutePath,
+        to destinationPath: AbsolutePath
+    ) async throws {
+        try await self.compress(
+            paths: [RelativePath(validating: directory.basename)],
+            from: directory.parentDirectory,
+            to: destinationPath
+        )
     }
 
     /// Asynchronously validates if a file is an archive.

--- a/Sources/Basics/Archiver/TarArchiver.swift
+++ b/Sources/Basics/Archiver/TarArchiver.swift
@@ -96,18 +96,18 @@ public struct TarArchiver: Archiver {
     }
 
     public func compress(
-        directory: AbsolutePath,
+        paths: [RelativePath],
+        from parent: AbsolutePath,
         to destinationPath: AbsolutePath
     ) async throws {
-
-        guard self.fileSystem.isDirectory(directory) else {
-            throw FileSystemError(.notDirectory, directory.underlying)
+        guard self.fileSystem.isDirectory(parent) else {
+            throw FileSystemError(.notDirectory, parent.underlying)
         }
 
         let process = AsyncProcess(
-            arguments: [self.tarCommand, "acf", destinationPath.pathString, directory.basename],
+            arguments: [self.tarCommand, "acf", destinationPath.pathString] + paths.map(\.pathString),
             environment: .current,
-            workingDirectory: directory.parentDirectory
+            workingDirectory: parent
         )
 
         guard let registrationKey = self.cancellator.register(process) else {

--- a/Sources/Basics/Archiver/UniversalArchiver.swift
+++ b/Sources/Basics/Archiver/UniversalArchiver.swift
@@ -84,11 +84,12 @@ public struct UniversalArchiver: Archiver {
     }
 
     public func compress(
-        directory: AbsolutePath,
+        paths: [RelativePath],
+        from parent: AbsolutePath,
         to destinationPath: AbsolutePath
     ) async throws {
         let archiver = try archiver(for: destinationPath)
-        try await archiver.compress(directory: directory, to: destinationPath)
+        try await archiver.compress(paths: paths, from: parent, to: destinationPath)
     }
 
     public func validate(

--- a/Sources/Basics/Archiver/ZipArchiver.swift
+++ b/Sources/Basics/Archiver/ZipArchiver.swift
@@ -82,11 +82,12 @@ public struct ZipArchiver: Archiver, Cancellable {
     }
 
     public func compress(
-        directory: AbsolutePath,
+        paths: [RelativePath],
+        from parent: AbsolutePath,
         to destinationPath: AbsolutePath
     ) async throws {
-        guard self.fileSystem.isDirectory(directory) else {
-            throw FileSystemError(.notDirectory, directory.underlying)
+        guard self.fileSystem.isDirectory(parent) else {
+            throw FileSystemError(.notDirectory, parent.underlying)
         }
 
         #if os(FreeBSD)
@@ -95,9 +96,8 @@ public struct ZipArchiver: Archiver, Cancellable {
         let process = AsyncProcess(
                 arguments: [
                     self.tar, "-c", "--format", "zip", "-f", destinationPath.pathString,
-                    directory.basename,
-                ],
-          workingDirectory: directory.parentDirectory
+                ] + directories.map(\.pathString),
+          workingDirectory: parent
         )
         #else
         // This is to work around `swift package-registry publish` tool failing on
@@ -110,7 +110,7 @@ public struct ZipArchiver: Archiver, Cancellable {
             arguments: [
                 "/bin/sh",
                 "-c",
-                    "cd \(directory.parentDirectory.underlying.pathString) && \(self.zip) -ry \(destinationPath.pathString) \(directory.basename)"
+                "cd \(parent.underlying.pathString) && \(self.zip) -ry \(destinationPath.pathString) \(paths.map(\.pathString).joined(separator: " "))"
             ]
         )
         #endif

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -151,14 +151,6 @@ extension PackagePIFProjectBuilder {
             if mainModule.platformConstraint == .host {
                 // This is a macro test using prebuilts
                 settings[.SUPPORTED_PLATFORMS] = ["$(HOST_PLATFORM)"]
-                switch PrebuiltsPlatform.hostPlatform?.arch {
-                case .aarch64:
-                    settings[.ARCHS] = ["arm64"]
-                case .x86_64:
-                    settings[.ARCHS] = ["86_64"]
-                case .none:
-                    break
-                }
             }
         } else if mainModule.type == .executable {
             // Setup install path for executables if it's in root of a pure Swift package.

--- a/Sources/_InternalTestSupport/MockArchiver.swift
+++ b/Sources/_InternalTestSupport/MockArchiver.swift
@@ -41,11 +41,13 @@ package final class MockArchiver: Archiver {
     }
 
     package struct Compression: Equatable {
-        public let directory: AbsolutePath
+        public let paths: [RelativePath]
+        public let parent: AbsolutePath
         public let destinationPath: AbsolutePath
 
-        public init(directory: AbsolutePath, destinationPath: AbsolutePath) {
-            self.directory = directory
+        public init(paths: [RelativePath], parent: AbsolutePath, destinationPath: AbsolutePath) {
+            self.paths = paths
+            self.parent = parent
             self.destinationPath = destinationPath
         }
     }
@@ -93,10 +95,18 @@ package final class MockArchiver: Archiver {
         to destinationPath: AbsolutePath
     ) async throws {
         guard let handler = self.compressionHandler else {
-            self.compressions.append(Compression(directory: directory, destinationPath: destinationPath))
+            try self.compressions.append(Compression(
+                paths: [RelativePath(validating: directory.basename)],
+                parent: directory.parentDirectory,
+                destinationPath: destinationPath
+            ))
             return
         }
         try await handler(self, directory, destinationPath)
+    }
+
+    package func compress(paths: [RelativePath], from parent: AbsolutePath, to destinationPath: AbsolutePath) async throws {
+        self.compressions.append(Compression(paths: paths, parent: parent, destinationPath: destinationPath))
     }
 
     package func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {

--- a/Sources/_InternalTestSupport/MockRegistry.swift
+++ b/Sources/_InternalTestSupport/MockRegistry.swift
@@ -433,6 +433,10 @@ private struct MockRegistryArchiver: Archiver {
         fatalError("not implemented")
     }
 
+    func compress(paths: [RelativePath], from parent: AbsolutePath, to destinationPath: AbsolutePath) async throws {
+        fatalError("not implemented")
+    }
+
     func validate(path: AbsolutePath, completion: @escaping (Result<Bool, Error>) -> Void) {
         do {
             let lines = try self.readFileContents(path)

--- a/Sources/swift-build-prebuilts/BuildPrebuilts.swift
+++ b/Sources/swift-build-prebuilts/BuildPrebuilts.swift
@@ -166,39 +166,8 @@ struct BuildPrebuilts: AsyncParsableCommand {
                 // Build
                 if platform.os == .macos {
                     // Create universal binaries for macOS
-                    for arch in ["arm64", "x86_64"] {
-                        let cmd = "swift build -c release -debug-info-format none --arch \(arch) --product \(libraryName)"
-                        try await shell(cmd, cwd: repoDir)
-                    }
-
-                    let armTriple = "arm64-apple-macos"
-                    let armDir = scratchDir.appending("arm64-apple-macosx", "release")
-                    let armModulesDir = armDir.appending("Modules")
-                    let x86Triple = "x86_64-apple-macos"
-                    let x86Dir = scratchDir.appending("x86_64-apple-macosx", "release")
-                    let x86ModulesDir = x86Dir.appending("Modules")
-
-                    // Universal swiftmodules
-                    for swiftmodule in try fileSystem.getDirectoryContents(armModulesDir).filter({ $0.hasSuffix(".swiftmodule") }) {
-                        let moduleDir = modulesDir.appending(swiftmodule)
-                        let projectDir = moduleDir.appending("Project")
-                        try fileSystem.createDirectory(projectDir, recursive: true)
-                        let moduleName = swiftmodule.replacingOccurrences(of: ".swiftmodule", with: "")
-                        try fileSystem.copy(from: armModulesDir.appending(swiftmodule), to: moduleDir.appending(armTriple + ".swiftmodule"))
-                        try fileSystem.copy(from: x86ModulesDir.appending(swiftmodule), to: moduleDir.appending(x86Triple + ".swiftmodule"))
-                        try fileSystem.copy(from: armModulesDir.appending(moduleName + ".abi.json"), to: moduleDir.appending(armTriple + ".abi.json"))
-                        try fileSystem.copy(from: x86ModulesDir.appending(moduleName + ".abi.json"), to: moduleDir.appending(x86Triple + ".abi.json"))
-                        try fileSystem.copy(from: armModulesDir.appending(moduleName + ".swiftdoc"), to: moduleDir.appending(armTriple + ".swiftdoc"))
-                        try fileSystem.copy(from: x86ModulesDir.appending(moduleName + ".swiftdoc"), to: moduleDir.appending(x86Triple + ".swiftdoc"))
-                        try fileSystem.copy(from: armModulesDir.appending(moduleName + ".swiftsourceinfo"), to: projectDir.appending(armTriple + ".swiftsourceinfo"))
-                        try fileSystem.copy(from: x86ModulesDir.appending(moduleName + ".swiftsourceinfo"), to: projectDir.appending(x86Triple + ".swiftsourceinfo"))
-                    }
-
-                    // lipo the archive
-                    let armLib = armDir.appending(lib)
-                    let x86Lib = x86Dir.appending(lib)
-                    let cmd = "lipo -create -output \(lib) \(armLib) \(x86Lib)"
-                    try await shell(cmd, cwd: libDir)
+                    let cmd = "swift build -c release -debug-info-format none --arch arm64 --arch x86_64 --product \(libraryName)"
+                    try await shell(cmd, cwd: repoDir)
                 } else {
                     let archArg: String
                     if let arch = platform.arch {
@@ -208,18 +177,17 @@ struct BuildPrebuilts: AsyncParsableCommand {
                     }
                     let cmd = "swift build -c release \(archArg) -debug-info-format none --product \(libraryName)"
                     try await shell(cmd, cwd: repoDir)
-
-                    let buildDir = scratchDir.appending("release")
-                    let srcModulesDir = buildDir.appending("Modules")
-
-                    // Copy the swiftmodules
-                    for file in try fileSystem.getDirectoryContents(srcModulesDir) {
-                        try fileSystem.copy(from: srcModulesDir.appending(file), to: modulesDir.appending(file))
-                    }
-
-                    // Copy the library to staging
-                    try fileSystem.copy(from: buildDir.appending(lib), to: libDir.appending(lib))
                 }
+
+                let buildDir = scratchDir.appending("release")
+
+                // Copy the swiftmodules
+                for file in try fileSystem.getDirectoryContents(buildDir) where file.hasSuffix(".swiftmodule") {
+                    try fileSystem.copy(from: buildDir.appending(file), to: modulesDir.appending(file))
+                }
+
+                // Copy the library to staging
+                try fileSystem.copy(from: buildDir.appending(lib), to: libDir.appending(lib))
 
                 // Name of the prebuilt
                 let prebuiltName = try platform.prebuiltName(hostToolchain: hostToolchain)

--- a/Sources/swift-build-prebuilts/BuildPrebuilts.swift
+++ b/Sources/swift-build-prebuilts/BuildPrebuilts.swift
@@ -152,7 +152,6 @@ struct BuildPrebuilts: AsyncParsableCommand {
 
             // Build
             let cModules = libraryTargets.compactMap({ $0 as? ClangModule })
-            let lib = "lib\(libraryName).a"
 
             for platform in hostPlatform.supportedPlatforms {
                 try fileSystem.createDirectory(libDir, recursive: true)
@@ -187,6 +186,12 @@ struct BuildPrebuilts: AsyncParsableCommand {
                 }
 
                 // Copy the library to staging
+                let lib: String
+                if platform.os == .windows {
+                    lib = "\(libraryName).lib"
+                } else {
+                    lib = "lib\(libraryName).a"
+                }
                 try fileSystem.copy(from: buildDir.appending(lib), to: libDir.appending(lib))
 
                 // Name of the prebuilt

--- a/Sources/swift-build-prebuilts/BuildPrebuilts.swift
+++ b/Sources/swift-build-prebuilts/BuildPrebuilts.swift
@@ -96,21 +96,19 @@ struct BuildPrebuilts: AsyncParsableCommand {
         )
 
         let srcDir = stageDir.appending("src")
-        let libDir = stageDir.appending("lib")
-        let modulesDir = stageDir.appending("Modules")
+        let contentDir = stageDir.appending("content")
+        let libDir = contentDir.appending("lib")
+        let modulesDir = contentDir.appending("Modules")
 
         if fileSystem.exists(srcDir) {
             try fileSystem.removeFileTree(srcDir)
         }
         try fileSystem.createDirectory(srcDir, recursive: true)
 
-        if fileSystem.exists(libDir) {
-            try fileSystem.removeFileTree(libDir)
+        if fileSystem.exists(contentDir) {
+            try fileSystem.removeFileTree(contentDir)
         }
-
-        if fileSystem.exists(modulesDir) {
-            try fileSystem.removeFileTree(modulesDir)
-        }
+        try fileSystem.createDirectory(contentDir, recursive: true)
 
         // For now, hardcode what we're building prebuilts for
         let id = "swift-syntax"
@@ -198,22 +196,20 @@ struct BuildPrebuilts: AsyncParsableCommand {
                 let prebuiltName = try platform.prebuiltName(hostToolchain: hostToolchain)
 
                 // Zip it up
-                let contentDirs = ["lib", "Modules"]
                 let contents: ByteString
+                let archiver = UniversalArchiver(fileSystem)
+                let archive: AbsolutePath
                 switch platform.os {
-                case .macos:
-                    let zipFile = versionDir.appending("\(prebuiltName)-\(libraryName).zip")
-                    try await shell("zip -r \(zipFile.pathString) \(contentDirs.joined(separator: " "))", cwd: stageDir)
-                    contents = try ByteString(fileSystem.readFileContents(zipFile))
-                case .windows:
-                    let zipFile = versionDir.appending("\(prebuiltName)-\(libraryName).zip")
-                    try await shell("tar -acf \(zipFile.pathString) \(contentDirs.joined(separator: " "))", cwd: stageDir)
-                    contents = try ByteString(fileSystem.readFileContents(zipFile))
+                case .macos, .windows:
+                    archive = versionDir.appending("\(prebuiltName)-\(libraryName).zip")
                 case .linux:
-                    let tarFile = versionDir.appending("\(prebuiltName)-\(libraryName).tar.gz")
-                    try await shell("tar -zcf \(tarFile.pathString) \(contentDirs.joined(separator: " "))", cwd: stageDir)
-                    contents = try ByteString(fileSystem.readFileContents(tarFile))
+                    archive = versionDir.appending("\(prebuiltName)-\(libraryName).tar.gz")
                 }
+                try await archiver.compress(
+                    paths: [libDir, modulesDir].map({ $0.relative(to: contentDir) }),
+                    from: contentDir,
+                    to: archive)
+                contents = try ByteString(fileSystem.readFileContents(archive))
 
                 // Manifest fragment for the zip file
                 let checksum = SHA256().hash(contents).hexadecimalRepresentation
@@ -229,8 +225,7 @@ struct BuildPrebuilts: AsyncParsableCommand {
                 try fileSystem.writeFileContents(unsignedJsonFile, data: encoder.encode(manifest))
 
                 // Clean up
-                try fileSystem.removeFileTree(libDir)
-                try fileSystem.removeFileTree(modulesDir)
+                try fileSystem.removeFileTree(contentDir)
             }
 
             try await shell("git restore .", cwd: repoDir)

--- a/Tests/BasicsTests/Archiver/TarArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/TarArchiverTests.swift
@@ -163,4 +163,68 @@ final class TarArchiverTests: XCTestCase {
             )
         }
     }
+
+    func testCompressMulti() async throws {
+#if !os(Windows)
+        guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
+            throw XCTSkip("working directory not supported on this platform")
+        }
+#endif
+
+        try await testWithTemporaryDirectory { tmpdir in
+            let archiver = TarArchiver(fileSystem: localFileSystem)
+
+            let rootDir = tmpdir.appending(component: UUID().uuidString)
+            try localFileSystem.createDirectory(rootDir)
+            let file1 = rootDir.appending("file1.txt")
+            try localFileSystem.writeFileContents(file1, string: "Hello World!")
+
+            let dir1 = rootDir.appending("dir1")
+            try localFileSystem.createDirectory(dir1)
+            try localFileSystem.writeFileContents(dir1.appending("file2.txt"), string: "Hello World 2!")
+
+            let dir2 = dir1.appending("dir2")
+            try localFileSystem.createDirectory(dir2)
+            try localFileSystem.writeFileContents(dir2.appending("file3.txt"), string: "Hello World 3!")
+            try localFileSystem.writeFileContents(dir2.appending("file4.txt"), string: "Hello World 4!")
+
+            let archivePath = tmpdir.appending(component: UUID().uuidString + ".tar.gz")
+            try await archiver.compress(
+                paths: [file1, dir1].map({ $0.relative(to: rootDir) }),
+                from: rootDir, to: archivePath
+            )
+            XCTAssertFileExists(archivePath)
+
+            let extractRootDir = tmpdir.appending(component: UUID().uuidString)
+            try localFileSystem.createDirectory(extractRootDir)
+            try await archiver.extract(from: archivePath, to: extractRootDir)
+
+            XCTAssertFileExists(extractRootDir.appending("file1.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractRootDir.appending("file1.txt")),
+                "Hello World!"
+            )
+
+            let extractedDir1 = extractRootDir.appending("dir1")
+            XCTAssertDirectoryExists(extractedDir1)
+            XCTAssertFileExists(extractedDir1.appending("file2.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt")),
+                "Hello World 2!"
+            )
+
+            let extractedDir2 = extractedDir1.appending("dir2")
+            XCTAssertDirectoryExists(extractedDir2)
+            XCTAssertFileExists(extractedDir2.appending("file3.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir2.appending("file3.txt")),
+                "Hello World 3!"
+            )
+            XCTAssertFileExists(extractedDir2.appending("file4.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir2.appending("file4.txt")),
+                "Hello World 4!"
+            )
+        }
+    }
 }

--- a/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/UniversalArchiverTests.swift
@@ -226,4 +226,108 @@ final class UniversalArchiverTests: XCTestCase {
             )
         }
     }
+
+    func testCompressMulti() async throws {
+        #if !os(Windows)
+        guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
+            throw XCTSkip("working directory not supported on this platform")
+        }
+        #endif
+
+        try await testWithTemporaryDirectory { tmpdir in
+            let archiver = UniversalArchiver(localFileSystem)
+
+            let rootDir = tmpdir.appending(component: UUID().uuidString)
+            let file1 = rootDir.appending("file1.txt")
+            try localFileSystem.createDirectory(rootDir)
+            try localFileSystem.writeFileContents(file1, string: "Hello World!")
+
+            let dir1 = rootDir.appending("dir1")
+            try localFileSystem.createDirectory(dir1)
+            try localFileSystem.writeFileContents(dir1.appending("file2.txt"), string: "Hello World 2!")
+
+            let dir2 = dir1.appending("dir2")
+            try localFileSystem.createDirectory(dir2)
+            try localFileSystem.writeFileContents(dir2.appending("file3.txt"), string: "Hello World 3!")
+            try localFileSystem.writeFileContents(dir2.appending("file4.txt"), string: "Hello World 4!")
+
+            var archivePath = tmpdir.appending(component: UUID().uuidString + ".tar.gz")
+            try await archiver.compress(
+                paths: [file1, dir1].map({ $0.relative(to: rootDir) }),
+                from: rootDir,
+                to: archivePath
+            )
+            XCTAssertFileExists(archivePath)
+
+            var extractRootDir = tmpdir.appending(component: UUID().uuidString)
+            try localFileSystem.createDirectory(extractRootDir)
+            try await archiver.extract(from: archivePath, to: extractRootDir)
+
+            XCTAssertFileExists(extractRootDir.appending("file1.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractRootDir.appending("file1.txt")),
+                "Hello World!"
+            )
+
+            var extractedDir1 = extractRootDir.appending("dir1")
+            XCTAssertDirectoryExists(extractedDir1)
+            XCTAssertFileExists(extractedDir1.appending("file2.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt")),
+                "Hello World 2!"
+            )
+
+            var extractedDir2 = extractedDir1.appending("dir2")
+            XCTAssertDirectoryExists(extractedDir2)
+            XCTAssertFileExists(extractedDir2.appending("file3.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir2.appending("file3.txt")),
+                "Hello World 3!"
+            )
+            XCTAssertFileExists(extractedDir2.appending("file4.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir2.appending("file4.txt")),
+                "Hello World 4!"
+            )
+
+            archivePath = tmpdir.appending(component: UUID().uuidString + ".zip")
+            try await archiver.compress(
+                paths: [file1, dir1].map({ $0.relative(to: rootDir) }),
+                from: rootDir,
+                to: archivePath
+            )
+            XCTAssertFileExists(archivePath)
+
+            extractRootDir = tmpdir.appending(component: UUID().uuidString)
+            try localFileSystem.createDirectory(extractRootDir)
+            try await archiver.extract(from: archivePath, to: extractRootDir)
+
+            XCTAssertFileExists(extractRootDir.appending("file1.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractRootDir.appending("file1.txt")),
+                "Hello World!"
+            )
+
+            extractedDir1 = extractRootDir.appending("dir1")
+            XCTAssertDirectoryExists(extractedDir1)
+            XCTAssertFileExists(extractedDir1.appending("file2.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt")),
+                "Hello World 2!"
+            )
+
+            extractedDir2 = extractedDir1.appending("dir2")
+            XCTAssertDirectoryExists(extractedDir2)
+            XCTAssertFileExists(extractedDir2.appending("file3.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir2.appending("file3.txt")),
+                "Hello World 3!"
+            )
+            XCTAssertFileExists(extractedDir2.appending("file4.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir2.appending("file4.txt")),
+                "Hello World 4!"
+            )
+        }
+    }
 }

--- a/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
+++ b/Tests/BasicsTests/Archiver/ZipArchiverTests.swift
@@ -174,4 +174,76 @@ final class ZipArchiverTests: XCTestCase {
              )
          }
      }
+
+    func testCompressMulti() async throws {
+        #if !os(Windows)
+        guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
+            throw XCTSkip("working directory not supported on this platform")
+        }
+        #endif
+
+        try await testWithTemporaryDirectory { tmpdir in
+            let archiver = ZipArchiver(fileSystem: localFileSystem)
+
+            let rootDir = tmpdir.appending(component: UUID().uuidString)
+            let file1 = rootDir.appending("file1.txt")
+            try localFileSystem.createDirectory(rootDir)
+            try localFileSystem.writeFileContents(file1, string: "Hello World!")
+
+            let dir1 = rootDir.appending("dir1")
+            try localFileSystem.createDirectory(dir1)
+            try localFileSystem.writeFileContents(dir1.appending("file2.txt"), string: "Hello World 2!")
+
+            let dir2 = dir1.appending("dir2")
+            try localFileSystem.createDirectory(dir2)
+            try localFileSystem.writeFileContents(dir2.appending("file3.txt"), string: "Hello World 3!")
+            try localFileSystem.writeFileContents(dir2.appending("file4.txt"), string: "Hello World 4!")
+            try localFileSystem.createSymbolicLink(dir2.appending("file5.txt"), pointingAt: dir1.appending("file2.txt"), relative: true)
+
+            let archivePath = tmpdir.appending(component: UUID().uuidString + ".zip")
+            try await archiver.compress(
+                paths: [file1, dir1].map({ $0.relative(to: rootDir) }),
+                from: rootDir,
+                to: archivePath
+            )
+            XCTAssertFileExists(archivePath)
+
+            let extractRootDir = tmpdir.appending(component: UUID().uuidString)
+            try localFileSystem.createDirectory(extractRootDir)
+            try await archiver.extract(from: archivePath, to: extractRootDir)
+
+            XCTAssertFileExists(extractRootDir.appending("file1.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractRootDir.appending("file1.txt")),
+                "Hello World!"
+            )
+
+            let extractedDir1 = extractRootDir.appending("dir1")
+            XCTAssertDirectoryExists(extractedDir1)
+            XCTAssertFileExists(extractedDir1.appending("file2.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt")),
+                "Hello World 2!"
+            )
+
+            let extractedDir2 = extractedDir1.appending("dir2")
+            XCTAssertDirectoryExists(extractedDir2)
+            XCTAssertFileExists(extractedDir2.appending("file3.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir2.appending("file3.txt")),
+                "Hello World 3!"
+            )
+            XCTAssertFileExists(extractedDir2.appending("file4.txt"))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir2.appending("file4.txt")),
+                "Hello World 4!"
+            )
+
+            XCTAssertTrue(localFileSystem.isSymlink(extractedDir2.appending("file5.txt")))
+            XCTAssertEqual(
+                try? localFileSystem.readFileContents(extractedDir2.appending("file5.txt")),
+                try? localFileSystem.readFileContents(extractedDir1.appending("file2.txt"))
+            )
+        }
+    }
 }


### PR DESCRIPTION
Updates the prebuilts builder for the new default SwiftBuild which manages universal binaries for us for Mac. Also updates it to use the UniversalArchiver to create the tar/zips. To make that work in our scenario added a multi-file compress method for all Archivers since we have to directories, Modules and lib.

Also fixes macro tests on Linux that use prebuilts which were incorrectly setting the ARCHS setting.

Prebuilts testing is done out of band since we don't have prebuilts for nightlies.