### PR TITLE
Evict binary-artifact cache on validation failure

### DIFF
--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -291,6 +291,7 @@ extension Workspace {
                                         artifactURL: artifact.url,
                                         targetName: artifact.targetName
                                     ))
+                                    self.evictFromCache(artifact: artifact, observabilityScope: observabilityScope)
                                     return nil
                                 }
 
@@ -426,6 +427,7 @@ extension Workspace {
                                     targetName: artifact.targetName,
                                     reason: error.interpolationDescription
                                 ))
+                                self.evictFromCache(artifact: artifact, observabilityScope: observabilityScope)
                                 self.delegate?.didDownloadBinaryArtifact(
                                     from: artifact.url.absoluteString,
                                     result: .failure(error),
@@ -665,6 +667,16 @@ extension Workspace {
             } catch {
                 try? self.fileSystem.removeFileTree(cachedArtifactPath)
                 throw error
+            }
+        }
+
+        private func evictFromCache(artifact: RemoteArtifact, observabilityScope: ObservabilityScope) {
+            guard let cachePath = self.cachePath else { return }
+            let cacheKey = artifact.url.absoluteString.spm_mangledToC99ExtendedIdentifier()
+            let cachedArtifactPath = cachePath.appending(cacheKey)
+            guard self.fileSystem.exists(cachedArtifactPath) else { return }
+            observabilityScope.trap {
+                try self.fileSystem.removeFileTree(cachedArtifactPath)
             }
         }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -7942,6 +7942,75 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testDownloadedArtifactInvalidArchiveDoesNotPoisonCache() async throws {
+        let fs = InMemoryFileSystem()
+        let sandbox = AbsolutePath("/tmp/ws/")
+        try fs.createDirectory(sandbox, recursive: true)
+        let artifactUrl = "https://artifactory.example.com/a.zip"
+
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
+            }
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: "<html>403 Forbidden</html>",
+                atomically: true
+            )
+            return .okay()
+        }
+
+        let archiver = MockArchiver(
+            validationHandler: { _, _, completion in
+                completion(.success(false))
+            }
+        )
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "A",
+                            type: .binary,
+                            url: artifactUrl,
+                            checksum: "a"
+                        ),
+                    ]
+                ),
+            ],
+            binaryArtifactsManager: .init(
+                httpClient: httpClient,
+                archiver: archiver,
+                useCache: true
+            )
+        )
+
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: .contains(
+                        "invalid archive returned from '\(artifactUrl)' which is required by binary target 'A'"
+                    ),
+                    severity: .error
+                )
+            }
+        }
+
+        let artifactCacheKey = artifactUrl.spm_mangledToC99ExtendedIdentifier()
+        guard let cachePath = workspace.workspaceLocation?
+            .sharedBinaryArtifactsCacheDirectory?
+            .appending(artifactCacheKey)
+        else {
+            XCTFail("Required workspace location wasn't found")
+            return
+        }
+        XCTAssertFalse(fs.exists(cachePath))
+    }
+
     func testDownloadedArtifactInvalid() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
Evict binary-artifact cache on validation failure

### Motivation

If a binary target download succeeds at the HTTP level but the bytes turn out not to be a valid archive, the cached file is left behind. From that point on, every `swift package resolve` reads the poisoned bytes back out of the cache and fails the same way until somebody manually deletes the file

### Modifications

Added a small private helper `evictFromCache(artifact:observabilityScope:)` that re-derives the same `cacheKey` `fetch()` uses and removes the cached file (trapping any I/O error via `observabilityScope.trap`)

### Result

After a validation failure, the cache no longer holds onto the bad bytes. Diagnostics are unchanged, users still see `invalid archive returned from '<url>' which is required by binary target '<name>'`, but the next `swift package resolve` re-downloads cleanly instead of replaying the poisoned cache

Resolves #6635