### PR TITLE
Docs: Include test runner delta

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
@@ -12,6 +12,8 @@ SwiftPM has changed its default build system to Swift Build. Read more [here](<d
 - **`--static-swift-stdlib`**: Stricter validation (errors instead of silently ignoring)
   - The native build system silently ignored this option on some platforms; Swift Build now produces an error.
   - Swift Build generates an error on platforms where statically linking the standard library is not supported.
+- Swift Build creates a test runner per test target defined in the package manifest, while the native build system created a single monolithic test runner.
+
 ### Detailed differences
 
 The following sections describe specific behavioral differences you may encounter when migrating to Swift Build.


### PR DESCRIPTION
Add a snippet related to SwiftBuild creating a test runner per test target, which is a key difference from the native build system.
