### PR TITLE
Respect `useXcrun` when searching for the Metal Toolchain

### DIFF
--- a/Sources/PackageModel/UserToolchain.swift
+++ b/Sources/PackageModel/UserToolchain.swift
@@ -959,7 +959,16 @@ public final class UserToolchain: Toolchain {
             )
         }
 
-        let metalToolchain = try? Self.deriveMetalToolchainPath(fileSystem: fileSystem, triple: triple, environment: environment)
+        let metalToolchain: (path: AbsolutePath, identifier: String)?
+        if case .custom(_, let useXcrun) = searchStrategy, !useXcrun {
+            metalToolchain = nil
+        } else {
+            metalToolchain = try? Self.deriveMetalToolchainPath(
+                fileSystem: fileSystem,
+                triple: triple,
+                environment: environment
+            )
+        }
 
         self.configuration = .init(
             librarianPath: librarianPath,


### PR DESCRIPTION
Follow the same pattern as XCTest does above, respecting the setting in the supplied search strategy.
