### PR TITLE
Tolerate dangling remote-tracking refs on checkout

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -777,8 +777,14 @@ public final class GitRepository: Repository, WorkingCheckout {
         // may need to take a little more care here.
         // use barrier for write operations
         try self.lock.withLock {
+            // `-q` suppresses git's detached-HEAD "orphaned commit" advisory. Beyond silencing
+            // noise, that advisory walks every ref to compute reachability, which aborts the
+            // checkout with `fatal: bad object <ref>` if any remote-tracking ref is left dangling
+            // (e.g. an upstream branch was deleted and its tip was pruned from the shared object
+            // store).
             try callGit(
                 "checkout",
+                "-q",
                 "-f",
                 revision.identifier,
                 failureMessage: "Couldn’t check out revision ‘\(revision.identifier)’"

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -515,6 +515,65 @@ class GitRepositoryTests: XCTestCase {
         }
     }
 
+    func testCheckoutToleratesDanglingRemoteTrackingRef() async throws {
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
+        try await testWithTemporaryDirectory { path in
+            // Build an upstream repo with two release tags plus a "feature" branch whose tip
+            // commit is unique to that branch, so the tip becomes unreachable once the branch
+            // is deleted.
+            let originPath = path.appending("origin")
+            try makeDirectories(originPath)
+            initGitRepo(originPath, tag: "1.0.0")
+            let origin = GitRepository(path: originPath)
+            let defaultBranch = try origin.currentBranch()
+
+            try localFileSystem.writeFileContents(originPath.appending("release.txt"), bytes: "release")
+            try origin.stage(file: "release.txt")
+            try origin.commit()
+            try origin.tag(name: "1.1.0")
+
+            try await AsyncProcess.checkNonZeroExit(args: Git.tool, "-C", originPath.pathString, "checkout", "-b", "feature")
+            try localFileSystem.writeFileContents(originPath.appending("feature.txt"), bytes: "feature")
+            try origin.stage(file: "feature.txt")
+            try origin.commit()
+            let featureTip = try origin.getCurrentRevision()
+            try await AsyncProcess.checkNonZeroExit(args: Git.tool, "-C", originPath.pathString, "checkout", defaultBranch)
+
+            // Fetch into the cache as a bare mirror, exactly as SwiftPM does.
+            let provider = GitRepositoryProvider()
+            let repoSpec = RepositorySpecifier(path: originPath)
+            let mirrorPath = path.appending("mirror")
+            try await provider.fetch(repository: repoSpec, to: mirrorPath)
+
+            // Create a working copy that shares the mirror's object store while the feature
+            // branch still exists, then resolve it to a tag so HEAD is detached. This mirrors a
+            // working copy that has already been resolved to a version.
+            let checkoutPath = path.appending("checkout")
+            let workingCopy = try await provider.createWorkingCopy(
+                repository: repoSpec,
+                sourcePath: mirrorPath,
+                at: checkoutPath,
+                editable: false
+            )
+            try workingCopy.checkout(revision: try origin.resolveRevision(tag: "1.1.0"))
+
+            // Upstream deletes the feature branch; the mirror prunes the ref and garbage
+            // collects the now-unreachable tip commit. The working copy is left holding a
+            // dangling refs/remotes/origin/feature that points at a missing object.
+            try await AsyncProcess.checkNonZeroExit(args: Git.tool, "-C", mirrorPath.pathString, "update-ref", "-d", "refs/heads/feature")
+            try await AsyncProcess.checkNonZeroExit(args: Git.tool, "-C", mirrorPath.pathString, "reflog", "expire", "--all", "--expire=now")
+            try await AsyncProcess.checkNonZeroExit(args: Git.tool, "-C", mirrorPath.pathString, "gc", "--prune=now")
+            XCTAssertFalse(workingCopy.exists(revision: featureTip), "test setup: feature tip should be unreachable")
+
+            // Re-resolving to a different tag must still succeed. Previously this failed with
+            // "fatal: bad object refs/remotes/origin/feature" because git's detached-HEAD
+            // orphan-commit check walks every ref, including the dangling one.
+            let v100 = try origin.resolveRevision(tag: "1.0.0")
+            try workingCopy.checkout(revision: v100)
+            XCTAssertEqual(try workingCopy.getCurrentRevision(), v100)
+        }
+    }
+
     func testHasUnpushedCommits() async throws {
         try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try await testWithTemporaryDirectory { path in


### PR DESCRIPTION
`swift package resolve` sometimes fails with:

```
error: '<dep>': Couldn't check out revision '<sha>':
    fatal: bad object refs/remotes/origin/<branch>
```

even though SwiftPM only ever asked for a tag and never touches that branch.

Steps to reproduce:
1. Resolve a dependency at a tag -> SwiftPM creates a bare --mirror cache and a --shared working copy. The working copy gains a `refs/remotes/origin/<branch>` for every branch the dep currently has.
2. Someone deletes <branch> upstream.
3. The mirror later re-fetches with `-p` (`--prune`), which drops the ref and git GCs the now-unreachable branch tip. The working copy shares the mirror's object store, so that commit disappears from under it, but the working copy keeps its stale `refs/remotes/origin/<branch>`, now dangling.
4. Finally, re-resolve to a different tag that already exists locally. Because the revision is present, `exists(revision:)` short-circuits the pruning fetch, so the dangling ref is never cleaned up, and SwiftPM runs `git checkout` straight away.

The typical workaround was to delete both your local working copy and bare repos from `.build` and `~/.swiftpm/cache` (or `~/Library/Caches/org.swift.swiftpm` if you're using Xcode). This would delete the dangling pointer to the missing ref and packages would resolve successfully again. This is a very disruptive workaround, since it typically requires a full re-download of the entire dependency graph as well as a full rebuild.

Note that you need two things to happen to reproduce this, which is why it happens so sporadically: a branch must be deleted upstream that was present when you checked out the bare repo, and you must already have the new tag for a dependency you're update  locally. This means as time goes by and your cache grows, you're more likely you are to already have new tags for deps locally, and are thus more more likely you are to encounter the issue.

The fix is simple: tolerate dangling remote-tracking refs on checkout by passing `-q` when we do a `git checkout` in `checkout(revision:)`. Aside from silencing output, `-q` also skips the orphaned ref check that causes the error. SwiftPM doesn't care about dangling refs, so they're safe to ignore and they will be cleaned up the next time SwiftPM does a `fetch` for that dependency.
