### PR TITLE
[6.4] Tests: Ensure tests are not executed if build fails

### DIFF
--- a/Fixtures/Miscellaneous/ImportOfMissingDependency/Package.swift
+++ b/Fixtures/Miscellaneous/ImportOfMissingDependency/Package.swift
@@ -16,5 +16,11 @@ let package = Package(
         .target(
             name: "B",
             dependencies: []),
+        .testTarget(
+            name: "myXCTests",
+        ),
+        .testTarget(
+            name: "mySwiftTestingTests",
+        ),
     ]
 )

--- a/Fixtures/Miscellaneous/ImportOfMissingDependency/Tests/mySwiftTestingTests/mySwiftTestTests.swift
+++ b/Fixtures/Miscellaneous/ImportOfMissingDependency/Tests/mySwiftTestingTests/mySwiftTestTests.swift
@@ -1,0 +1,9 @@
+import Testing
+
+@Suite
+struct MySwiftTestTestsTests {
+    @Test("MySwiftTestTests tests")
+    func example() {
+        #expect(42 == 17 + 25)
+    }
+}

--- a/Fixtures/Miscellaneous/ImportOfMissingDependency/Tests/myXCTests/myXCTests.swift
+++ b/Fixtures/Miscellaneous/ImportOfMissingDependency/Tests/myXCTests/myXCTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+class MyXCTestsTests: XCTestCase {
+    func testMyXCTests() {
+        XCTAssertEqual(42, 17 + 25)
+    }
+}

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -353,7 +353,10 @@ struct BuildCommandTestCases {
             let fullPath = try resolveSymlinks(path)
             let error = await #expect(throws: SwiftPMError.self ) {
                 try await build(
-                    ["--explicit-target-dependency-import-check=warn"],
+                    [
+                        "--explicit-target-dependency-import-check=warn",
+                        "--build-tests",
+                    ],
                     packagePath: fullPath,
                     configuration: configuration,
                     buildSystem: buildSystem,
@@ -397,7 +400,10 @@ struct BuildCommandTestCases {
             let fullPath = try resolveSymlinks(path)
             let error = await #expect(throws: SwiftPMError.self ) {
                 try await build(
-                    ["--explicit-target-dependency-import-check=error"],
+                    [
+                        "--explicit-target-dependency-import-check=error",
+                        "--build-tests",
+                    ],
                     packagePath: fullPath,
                     configuration: config,
                     buildSystem: buildSystem,
@@ -436,7 +442,9 @@ struct BuildCommandTestCases {
             let fullPath = try resolveSymlinks(path)
             let error = await #expect(throws: SwiftPMError.self ) {
                 try await build(
-                    [],
+                    [
+                        "--build-tests",
+                    ],
                     packagePath: fullPath,
                     configuration: config,
                     buildSystem: buildSystem,

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -1191,6 +1191,62 @@ struct TestCommandTests {
     }
 
     @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9431", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func noTestingIfBuildFails(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/ImportOfMissingDependency") { path in
+            let fullPath = try resolveSymlinks(path)
+            let error = await #expect(throws: SwiftPMError.self ) {
+                try await executeSwiftTest(
+                    fullPath,
+                    configuration: configuration,
+                    // extraArgs: ["--explicit-target-dependency-import-check=warn"],
+                    buildSystem: buildSystem,
+                    throwIfCommandFails: true,
+                )
+            }
+
+            guard case SwiftPMError.executionFailure(_, let stdout, let stderr) = try #require(error) else {
+                Issue.record("Incorrect error was raised.")
+                return
+            }
+
+            #expect(
+                stderr.contains("error: fatalError") == true,
+                "stdout: \(stdout)\n\nstderr: \(stderr)",
+            )
+            #expect(
+                stderr.contains("myTests") == false,
+                "stdout: \(stdout)\n\nstderr: \(stderr)",
+            )
+            #expect(
+                stderr.contains("mySwiftTestingTests (Swift Testing)") == false,
+                "stdout: \(stdout)\n\nstderr: \(stderr)",
+            )
+            #expect(
+                stderr.contains("myXCTests (XCTest)") == false,
+                "stdout: \(stdout)\n\nstderr: \(stderr)",
+            )
+            switch buildSystem {
+                case .native:
+                    break
+                case .swiftbuild:
+                    #expect(
+                        stderr.contains("Build failed"),
+                        "stdout: \(stdout)\n\nstderr: \(stderr)",
+                    )
+                case .xcode:
+                    Issue.record("Test expectation have not been implemented")
+                    break
+            }
+        }
+    }
+
+    @Test(
         .tags(
             .Feature.TargetType.Executable,
         ),


### PR DESCRIPTION
Add a test that ensures `swift test` does not execute the tests if the build fails

Fixes: #9431
Issue: rdar://165573287
