### PR TITLE
SwiftBuildSupport: hoist target before PIF dependency recursion

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -639,11 +639,13 @@ extension PackagePIFProjectBuilder {
         //
         // Symlinks should be resolved externally.
         var indexableFileURLs: [SourceControlURL] = []
+        var sourceFileGroup = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath]
+        var moduleTargetForSources = self.project[keyPath: sourceModuleTargetKeyPath]
         for sourcePath in sourceModule.sourceFileRelativePaths {
-            let sourceFileRef = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath].addFileReference { id in
+            let sourceFileRef = sourceFileGroup.addFileReference { id in
                 FileReference(id: id, path: sourcePath.pathString, pathBase: .groupDir)
             }
-            self.project[keyPath: sourceModuleTargetKeyPath].addSourceFile { id in
+            moduleTargetForSources.addSourceFile { id in
                 BuildFile(id: id, fileRef: sourceFileRef)
             }
             indexableFileURLs.append(
@@ -663,12 +665,12 @@ extension PackagePIFProjectBuilder {
         // a build setting to instruct it to use project visible header files. In the future
         // it may be possible to add public header files with public header visibility.
         for headerPath in headerFiles {
-            let headerFileRef = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath]
+            let headerFileRef = sourceFileGroup
                 .addFileReference { id in
                     FileReference(id: id, path: headerPath.pathString, pathBase: .absolute)
                 }
 
-            self.project[keyPath: sourceModuleTargetKeyPath].common.withHeadersBuildPhase { phase in
+            moduleTargetForSources.common.withHeadersBuildPhase { phase in
                 phase.common.addBuildFile { id in
                     BuildFile(id: id, fileRef: headerFileRef)
                     // headerVisibility: nil (omitted) = "project" visibility
@@ -680,14 +682,16 @@ extension PackagePIFProjectBuilder {
 
         // Add any additional source files emitted by custom build commands.
         for path in generatedFiles.sources {
-            let sourceFileRef = self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath].addFileReference { id in
+            let sourceFileRef = sourceFileGroup.addFileReference { id in
                 FileReference(id: id, path: path.pathString, pathBase: .absolute)
             }
-            self.project[keyPath: sourceModuleTargetKeyPath].addSourceFile { id in
+            moduleTargetForSources.addSourceFile { id in
                 BuildFile(id: id, fileRef: sourceFileRef)
             }
             log(.debug, indent: 2, "Added generated source file '\(path)'")
         }
+        self.project.mainGroup[keyPath: targetSourceFileGroupKeyPath] = sourceFileGroup
+        self.project[keyPath: sourceModuleTargetKeyPath] = moduleTargetForSources
 
         if let resourceBundle = resourceBundleName {
             impartedSettings[.EMBED_PACKAGE_RESOURCE_BUNDLE_NAMES] = ["$(inherited)", resourceBundle]
@@ -726,6 +730,7 @@ extension PackagePIFProjectBuilder {
 
         // Handle the target's dependencies (but only link against them if needed).
         let shouldLinkProduct = (desiredModuleType == .dynamicLibrary) || (desiredModuleType == .macro)
+        var moduleTarget = self.project[keyPath: sourceModuleTargetKeyPath]
         sourceModule.recursivelyTraverseDependencies { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
@@ -744,7 +749,7 @@ extension PackagePIFProjectBuilder {
                     if let product = moduleDependency
                         .productRepresentingDependencyOfBuildPlugin(in: moduleMainProducts)
                     {
-                        self.project[keyPath: sourceModuleTargetKeyPath].common.addDependency(
+                        moduleTarget.common.addDependency(
                             on: product.pifTargetGUID,
                             platformFilters: dependencyPlatformFilters,
                             linkProduct: false
@@ -767,7 +772,7 @@ extension PackagePIFProjectBuilder {
                         return Self.createBinaryModuleFileReference(binaryModule, id: id)
                     }
                     if shouldLinkProduct {
-                        self.project[keyPath: sourceModuleTargetKeyPath].addLibrary { id in
+                        moduleTarget.addLibrary { id in
                             BuildFile(
                                 id: id,
                                 fileRef: binaryReference,
@@ -779,7 +784,7 @@ extension PackagePIFProjectBuilder {
                     } else {
                         // If we are producing a single ".o", don't link binaries since they
                         // could be static which would cause them to become part of the ".o".
-                        self.project[keyPath: sourceModuleTargetKeyPath].addResourceFile { id in
+                        moduleTarget.addResourceFile { id in
                             BuildFile(
                                 id: id,
                                 fileRef: binaryReference,
@@ -791,7 +796,7 @@ extension PackagePIFProjectBuilder {
 
                 case .plugin:
                     let dependencyGUID = moduleDependency.pifTargetGUID
-                    self.project[keyPath: sourceModuleTargetKeyPath].common.addDependency(
+                    moduleTarget.common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters,
                         linkProduct: false
@@ -799,7 +804,7 @@ extension PackagePIFProjectBuilder {
                     log(.debug, indent: 1, "Added use of plugin target '\(dependencyGUID)'")
 
                 case .library, .test, .macro, .systemModule:
-                    self.project[keyPath: sourceModuleTargetKeyPath].common.addDependency(
+                    moduleTarget.common.addDependency(
                         on: moduleDependency.pifTargetGUID,
                         platformFilters: dependencyPlatformFilters,
                         linkProduct: shouldLinkProduct
@@ -825,7 +830,7 @@ extension PackagePIFProjectBuilder {
                         .toPlatformFilter(toolsVersion: self.package.manifest.toolsVersion)
                     let shouldLinkProduct = shouldLinkProduct && productDependency.isLinkable
 
-                    self.project[keyPath: sourceModuleTargetKeyPath].common.addDependency(
+                    moduleTarget.common.addDependency(
                         on: productDependency.pifTargetGUID,
                         platformFilters: dependencyPlatformFilters,
                         linkProduct: shouldLinkProduct
@@ -838,6 +843,7 @@ extension PackagePIFProjectBuilder {
                 }
             }
         }
+        self.project[keyPath: sourceModuleTargetKeyPath] = moduleTarget
 
         // Custom source module build settings, if any.
         pifBuilder.delegate.configureSourceModuleBuildSettings(sourceModule: sourceModule, settings: &settings)
@@ -881,7 +887,8 @@ extension PackagePIFProjectBuilder {
             impartedDebugSettings[.LD_RUNPATH_SEARCH_PATHS] = rpaths + ["$(inherited)"]
         }
 
-        self.project[keyPath: sourceModuleTargetKeyPath].common.addBuildConfig { id in
+        var moduleTargetForConfigs = self.project[keyPath: sourceModuleTargetKeyPath]
+        moduleTargetForConfigs.common.addBuildConfig { id in
             BuildConfig(
                 id: id,
                 name: "Debug",
@@ -889,7 +896,7 @@ extension PackagePIFProjectBuilder {
                 impartedBuildSettings: impartedDebugSettings
             )
         }
-        self.project[keyPath: sourceModuleTargetKeyPath].common.addBuildConfig { id in
+        moduleTargetForConfigs.common.addBuildConfig { id in
             BuildConfig(
                 id: id,
                 name: "Release",
@@ -897,6 +904,7 @@ extension PackagePIFProjectBuilder {
                 impartedBuildSettings: impartedSettings
             )
         }
+        self.project[keyPath: sourceModuleTargetKeyPath] = moduleTargetForConfigs
 
         // Collect linked binaries.
         let linkedPackageBinaries: [PackagePIFBuilder.LinkedPackageBinary] = sourceModule.dependencies.compactMap {

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -370,6 +370,7 @@ extension PackagePIFProjectBuilder {
         }
 
         // Handle the main target's dependencies (and link against them).
+        var mainModuleTarget = self.project[keyPath: mainModuleTargetKeyPath]
         mainModule.recursivelyTraverseDependencies { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
@@ -387,7 +388,7 @@ extension PackagePIFProjectBuilder {
                         Self.createBinaryModuleFileReference(binaryModule, id: id)
                     }
                     let toolsVersion = self.package.manifest.toolsVersion
-                    self.project[keyPath: mainModuleTargetKeyPath].addLibrary { id in
+                    mainModuleTarget.addLibrary { id in
                         BuildFile(
                             id: id,
                             fileRef: binaryFileRef,
@@ -400,7 +401,7 @@ extension PackagePIFProjectBuilder {
 
                 case .plugin:
                     let dependencyId = moduleDependency.pifTargetGUID
-                    self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
+                    mainModuleTarget.common.addDependency(
                         on: dependencyId,
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -410,7 +411,7 @@ extension PackagePIFProjectBuilder {
 
                 case .macro:
                     let dependencyId = moduleDependency.pifTargetGUID
-                    self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
+                    mainModuleTarget.common.addDependency(
                         on: dependencyId,
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -420,7 +421,7 @@ extension PackagePIFProjectBuilder {
 
                     // Link with a testable version of the macro if appropriate.
                     if product.type == .test {
-                        self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
+                        mainModuleTarget.common.addDependency(
                             on: moduleDependency.pifTargetGUID(suffix: .testable),
                             platformFilters: packageConditions
                                 .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -441,7 +442,7 @@ extension PackagePIFProjectBuilder {
                                     productDependency,
                                     with: packageConditions,
                                     isLinkable: isLinkable,
-                                    targetKeyPath: mainModuleTargetKeyPath,
+                                    target: &mainModuleTarget,
                                     settings: &settings
                                 )
                             case .module:
@@ -456,7 +457,7 @@ extension PackagePIFProjectBuilder {
                     let productDependency = modulesGraph.allProducts.only { $0.mainModule?.name == moduleDependency.name }
                     if let productDependency {
                         let productDependencyGUID = productDependency.pifTargetGUID
-                        self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
+                        mainModuleTarget.common.addDependency(
                             on: productDependencyGUID,
                             platformFilters: packageConditions
                                 .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -469,7 +470,7 @@ extension PackagePIFProjectBuilder {
                     // we also link against a testable version of the executable.
                     if product.type == .test, self.package.manifest.toolsVersion >= .v5_5 {
                         let moduleDependencyGUID = moduleDependency.pifTargetGUID(suffix: .testable)
-                        self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
+                        mainModuleTarget.common.addDependency(
                             on: moduleDependencyGUID,
                             platformFilters: packageConditions
                                 .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -482,7 +483,7 @@ extension PackagePIFProjectBuilder {
                 case .library, .systemModule, .test:
                     let shouldLinkProduct = moduleDependency.type != .systemModule
                     let dependencyGUID = moduleDependency.pifTargetGUID
-                    self.project[keyPath: mainModuleTargetKeyPath].common.addDependency(
+                    mainModuleTarget.common.addDependency(
                         on: dependencyGUID,
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -501,11 +502,12 @@ extension PackagePIFProjectBuilder {
                     productDependency,
                     with: packageConditions,
                     isLinkable: isLinkable,
-                    targetKeyPath: mainModuleTargetKeyPath,
+                    target: &mainModuleTarget,
                     settings: &settings
                 )
             }
         }
+        self.project[keyPath: mainModuleTargetKeyPath] = mainModuleTarget
 
         // Custom source module build settings, if any.
         pifBuilder.delegate.configureSourceModuleBuildSettings(sourceModule: mainModule, settings: &settings)
@@ -555,11 +557,11 @@ extension PackagePIFProjectBuilder {
         }
     }
 
-    private mutating func handleProduct(
+    private func handleProduct(
         _ product: PackageGraph.ResolvedProduct,
         with packageConditions: [PackageModel.PackageCondition],
         isLinkable: Bool,
-        targetKeyPath: WritableKeyPath<ProjectModel.Project, ProjectModel.Target>,
+        target: inout ProjectModel.Target,
         settings: inout ProjectModel.BuildSettings
     ) {
         // Do not add a dependency for binary-only executable products since they are not part of the build.
@@ -569,7 +571,7 @@ extension PackagePIFProjectBuilder {
 
         if !pifBuilder.delegate.shouldSuppressProductDependency(product: product.underlying, buildSettings: &settings) {
             let shouldLinkProduct = isLinkable
-            self.project[keyPath: targetKeyPath].common.addDependency(
+            target.common.addDependency(
                 on: product.pifTargetGUID,
                 platformFilters: packageConditions.toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                 linkProduct: shouldLinkProduct
@@ -673,13 +675,14 @@ extension PackagePIFProjectBuilder {
         }
 
         // Add linked dependencies on the *targets* that comprise the product.
+        var libraryUmbrellaTargetForModules = self.project[keyPath: libraryUmbrellaTargetKeyPath]
         for module in product.modules {
             // Binary targets are special in that they are just linked, not built.
             if let binaryTarget = module.underlying as? BinaryModule {
                 let binaryFileRef = self.binaryGroup.addFileReference { id in
                     FileReference(id: id, path: binaryTarget.artifactPath.pathString)
                 }
-                self.project[keyPath: libraryUmbrellaTargetKeyPath].addLibrary { id in
+                libraryUmbrellaTargetForModules.addLibrary { id in
                     BuildFile(id: id, fileRef: binaryFileRef, codeSignOnCopy: true, removeHeadersOnCopy: true)
                 }
                 log(.debug, indent: 1, "Added use of binary library '\(binaryTarget.artifactPath)'")
@@ -688,7 +691,7 @@ extension PackagePIFProjectBuilder {
             // We add these as linked dependencies; because the product type is `.packageProduct`,
             // SwiftBuild won't actually link them, but will instead impart linkage to any clients that
             // link against the package product.
-            self.project[keyPath: libraryUmbrellaTargetKeyPath].common.addDependency(
+            libraryUmbrellaTargetForModules.common.addDependency(
                 on: module.pifTargetGUID,
                 platformFilters: [],
                 linkProduct: true
@@ -699,7 +702,7 @@ extension PackagePIFProjectBuilder {
         for module in product.modules where module.underlying.isSourceModule && module.resources.hasContent {
             // FIXME: Find a way to determine whether a module has generated resources
             // here so that we can embed resources into dynamic targets.
-            self.project[keyPath: libraryUmbrellaTargetKeyPath].common.addDependency(
+            libraryUmbrellaTargetForModules.common.addDependency(
                 on: pifTargetIdForResourceBundle(module.name),
                 platformFilters: []
             )
@@ -709,7 +712,7 @@ extension PackagePIFProjectBuilder {
                 FileReference(id: id, path: "$(CONFIGURATION_BUILD_DIR)/\(packageName)_\(module.name).bundle")
             }
             if embedResources {
-                self.project[keyPath: libraryUmbrellaTargetKeyPath].addResourceFile { id in
+                libraryUmbrellaTargetForModules.addResourceFile { id in
                     BuildFile(id: id, fileRef: fileRef)
                 }
                 log(.debug, indent: 1, "Added use of resource bundle '\(fileRef.path)'")
@@ -721,6 +724,7 @@ extension PackagePIFProjectBuilder {
                 )
             }
         }
+        self.project[keyPath: libraryUmbrellaTargetKeyPath] = libraryUmbrellaTargetForModules
 
         var settings: ProjectModel.BuildSettings = package.underlying.packageBaseBuildSettings
 
@@ -780,6 +784,7 @@ extension PackagePIFProjectBuilder {
         // Handle the dependencies of the targets in the product
         // (and link against them, which in the case of a package product, really just means that clients should link
         // against them).
+        var libraryUmbrellaTarget = self.project[keyPath: libraryUmbrellaTargetKeyPath]
         product.modules.recursivelyTraverseDependencies { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
@@ -797,7 +802,7 @@ extension PackagePIFProjectBuilder {
                         FileReference(id: id, path: binaryTarget.artifactPath.pathString)
                     }
                     let toolsVersion = package.manifest.toolsVersion
-                    self.project[keyPath: libraryUmbrellaTargetKeyPath].addLibrary { id in
+                    libraryUmbrellaTarget.addLibrary { id in
                         BuildFile(
                             id: id,
                             fileRef: binaryFileRef,
@@ -812,7 +817,7 @@ extension PackagePIFProjectBuilder {
 
                 if moduleDependency.type == .plugin {
                     let dependencyId = moduleDependency.pifTargetGUID
-                    self.project[keyPath: libraryUmbrellaTargetKeyPath].common.addDependency(
+                    libraryUmbrellaTarget.common.addDependency(
                         on: dependencyId,
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -833,7 +838,7 @@ extension PackagePIFProjectBuilder {
                     if let product = moduleDependency
                         .productRepresentingDependencyOfBuildPlugin(in: mainModuleProducts)
                     {
-                        self.project[keyPath: libraryUmbrellaTargetKeyPath].common.addDependency(
+                        libraryUmbrellaTarget.common.addDependency(
                             on: product.pifTargetGUID,
                             platformFilters: packageConditions
                                 .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -850,7 +855,7 @@ extension PackagePIFProjectBuilder {
                     }
                 }
 
-                self.project[keyPath: libraryUmbrellaTargetKeyPath].common.addDependency(
+                libraryUmbrellaTarget.common.addDependency(
                     on: moduleDependency.pifTargetGUID,
                     platformFilters: packageConditions.toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
                     linkProduct: true
@@ -868,7 +873,7 @@ extension PackagePIFProjectBuilder {
                     buildSettings: &settings
                 ) {
                     let shouldLinkProduct = productDependency.isLinkable
-                    self.project[keyPath: libraryUmbrellaTargetKeyPath].common.addDependency(
+                    libraryUmbrellaTarget.common.addDependency(
                         on: productDependency.pifTargetGUID,
                         platformFilters: packageConditions
                             .toPlatformFilter(toolsVersion: package.manifest.toolsVersion),
@@ -882,6 +887,7 @@ extension PackagePIFProjectBuilder {
                 }
             }
         }
+        self.project[keyPath: libraryUmbrellaTargetKeyPath] = libraryUmbrellaTarget
 
         // For *registry* packages, vend any registry release metadata to the build system.
         if let metadata = package.registryMetadata,
@@ -903,12 +909,14 @@ extension PackagePIFProjectBuilder {
             settings[.PACKAGE_REGISTRY_SIGNATURE] = String(data: data, encoding: .utf8)
         }
 
-        self.project[keyPath: libraryUmbrellaTargetKeyPath].common.addBuildConfig { id in
+        var libraryUmbrellaTargetForConfigs = self.project[keyPath: libraryUmbrellaTargetKeyPath]
+        libraryUmbrellaTargetForConfigs.common.addBuildConfig { id in
             BuildConfig(id: id, name: "Debug", settings: settings)
         }
-        self.project[keyPath: libraryUmbrellaTargetKeyPath].common.addBuildConfig { id in
+        libraryUmbrellaTargetForConfigs.common.addBuildConfig { id in
             BuildConfig(id: id, name: "Release", settings: settings)
         }
+        self.project[keyPath: libraryUmbrellaTargetKeyPath] = libraryUmbrellaTargetForConfigs
 
         // Collect linked binaries.
         let linkedPackageBinaries = product.modules.compactMap {


### PR DESCRIPTION
Avoids per-iteration BaseTarget copies through the WritableKeyPath subscript.

rdar://178073760

### Motivation:

Address a performance regression with the new PIF builder

### Modifications:

Hoist the target before recursive dependency-handling closures

### Result:

With aws-sdk-swift's 31 dependency package graph, workspace-loading time on the new PIF builder drops from ~25.6s to ~21.2s, closing roughly half the regression standalone.