### PR TITLE
Use access level on import in resource_bundle_accessor.swift

### DIFF
--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -420,9 +420,17 @@ public final class SwiftModuleBuildDescription {
                 #"Bundle.main.bundleURL.appendingPathComponent("\#(bundlePath.basename.asSwiftStringLiteralConstant)").path"#
         }
 
+        // Emit an explicit access level on the Foundation import if
+        // access-level-on-import is part of the language mode (>= 6.0).
+        //
+        // Without this, targets that use access levels on imports will fail to compile.
+        let foundationImport = self.toolsVersion >= .v6_0
+            ? "public import Foundation"
+            : "import Foundation"
+
         let content =
             """
-            import Foundation
+            \(foundationImport)
 
             extension Foundation.Bundle {
                 static nonisolated let module: Bundle = {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -6217,6 +6217,8 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         // See https://bugs.swift.org/browse/SR-14555 and
         // https://github.com/swiftlang/swift-package-manager/pull/2972/files#r623861646
         XCTAssertMatch(contents, .contains("let mainPath = Bundle.main."))
+        // For tools-versions older than 6.0, access-level-on-import is not part of the language mode.
+        XCTAssertMatch(contents, .contains("\nimport Foundation\n"))
 
         let barTarget = try result.moduleBuildDescription(for: "Bar").swift()
         XCTAssertEqual(try barTarget.objects.map(\.pathString), [
@@ -6225,6 +6227,53 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
 
         XCTAssertTrue(try fooTarget.compileArguments().contains(["-DSWIFT_MODULE_RESOURCE_BUNDLE_AVAILABLE"]))
         XCTAssertTrue(try barTarget.compileArguments().contains(["-DSWIFT_MODULE_RESOURCE_BUNDLE_UNAVAILABLE"]))
+    }
+
+    func testSwiftBundleAccessorEmitsExplicitAccessLevelImport() async throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles:
+            "/PkgA/Sources/Foo/Foo.swift",
+            "/PkgA/Sources/Foo/foo.txt"
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "PkgA",
+                    path: "/PkgA",
+                    // access-level-on-import is part of the language mode
+                    // for tools-version >= 6.0, so the emitted file must
+                    // have an access level on the Foundation import.
+                    toolsVersion: .v6_0,
+                    targets: [
+                        TargetDescription(
+                            name: "Foo",
+                            resources: [
+                                .init(rule: .copy, path: "foo.txt"),
+                            ]
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let plan = try await mockBuildPlan(
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let result = try BuildPlanResult(plan: plan)
+
+        let fooTarget = try result.moduleBuildDescription(for: "Foo").swift()
+        let resourceAccessor = fooTarget.sources.first { $0.basename == "resource_bundle_accessor.swift" }!
+        let contents: String = try fs.readFileContents(resourceAccessor)
+        XCTAssertMatch(contents, .contains("public import Foundation"))
     }
 
     func testSwiftWASIBundleAccessor() async throws {


### PR DESCRIPTION
This patch updates the generation logic to include the `public` access level modifier for the Foundation import in `bundle_resource_accessor.swift` if the tools-version is >= 6.0.

### Motivation:

When a Swift package specifies a resource as part of a build target, SwiftPM synthesizes a resource_bundle_accessor.swift to provide runtime hooks to access the resource. This generated file imports Foundation but does not specify an access level. With Swift 6.0, access-level-on-import is part of the language mode, meaning that if any import in a build target uses access levels, then **all** imports must specify an access level. The lack of an access level on the import in this generated file meant that if a target specified a resource and used access levels, the build would fail with:

```
error: ambiguous implicit access level for import of 'Foundation'
```

### Modifications:

This patch fixes the above issue by adding an access level to the import in the generated file. This is gated behind a version check to ensure that Swift versions that do not support access-level-on-import can continue to use the generated file and build without issues.

### Result:

Swift packages that declare a resource and use access levels on import can successfully build while having a non-public access level on Foundation imports within the package.

Fixes #10163