### PR TITLE
SBOMModel: make swiftRegexParser dependency explicit (#10110)

### DIFF
--- a/Sources/SBOMModel/CMakeLists.txt
+++ b/Sources/SBOMModel/CMakeLists.txt
@@ -67,10 +67,10 @@ target_link_libraries(SBOMModel PUBLIC
   PackageGraph
   PackageModel
   SourceControl
-  SwiftBuildSupport
-)
+  SwiftBuildSupport)
+target_link_libraries(SBOMModel PRIVATE
+  swiftRegexBuilder)
 
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(SBOMModel PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-  


### PR DESCRIPTION
This makes the swiftRegexParser dependency explicit in the build graph. In the case of WMO, we need the dynamic library to satisfy the imported conformance witness. This enables us to finally enable WMO on Windows for the toolchain build.

(cherry picked from commit 18fd52286ee4cc6635171fe17d0c697de2c2faa9)