### PR TITLE
Recover from an incomplete local repository cache instead of failing

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -1445,13 +1445,19 @@ extension GitFileSystemView: @unchecked Sendable {}
 
 // MARK: - Errors
 
+extension AsyncProcessResult {
+    fileprivate var combinedOutput: String {
+        let stdout = (try? self.utf8Output()) ?? ""
+        let stderr = (try? self.utf8stderrOutput()) ?? ""
+        return stdout + stderr
+    }
+}
+
 package struct GitShellError: Error, CustomStringConvertible {
     let result: AsyncProcessResult
 
     public var description: String {
-        let stdout = (try? self.result.utf8Output()) ?? ""
-        let stderr = (try? self.result.utf8stderrOutput()) ?? ""
-        let output = (stdout + stderr).spm_chomp()
+        let output = self.result.combinedOutput.spm_chomp()
         let command = self.result.arguments.joined(separator: " ")
         return "Git command '\(command)' failed: \(output)"
     }
@@ -1510,9 +1516,7 @@ public struct GitRepositoryError: Error, CustomStringConvertible, DiagnosticLoca
     }
 
     public var description: String {
-        let stdout = (try? self.result.utf8Output()) ?? ""
-        let stderr = (try? self.result.utf8stderrOutput()) ?? ""
-        let output = (stdout + stderr).spm_chomp().spm_multilineIndent(count: 4)
+        let output = self.result.combinedOutput.spm_chomp().spm_multilineIndent(count: 4)
         return "\(self.message):\n\(output)"
     }
 }
@@ -1534,11 +1538,46 @@ public struct GitCloneError: Error, CustomStringConvertible, DiagnosticLocationP
     }
 
     public var description: String {
-        let stdout = (try? self.result.utf8Output()) ?? ""
-        let stderr = (try? self.result.utf8stderrOutput()) ?? ""
-        let output = (stdout + stderr).spm_chomp().spm_multilineIndent(count: 4)
+        let output = self.result.combinedOutput.spm_chomp().spm_multilineIndent(count: 4)
         return "\(self.message):\n\(output)"
     }
+}
+
+// MARK: - Object store corruption detection
+
+/// Substrings `git` emits when an operation fails because the local object store is missing or has
+/// corrupt/incomplete objects (e.g. cached object files were evicted from disk). These failures are
+/// recoverable by purging the repository and re-fetching from its origin, so they are deliberately
+/// distinct from "the revision does not exist" failures (which a re-fetch cannot fix). Matched
+/// case-insensitively. `git`'s plumbing object errors are not localized.
+private let gitObjectStoreCorruptionMarkers: [String] = [
+    "unable to read tree",        // "unable to read tree (<oid>)"
+    "not a tree object",
+    "not a valid object name",    // "Not a valid object name <oid>" (object missing from store)
+    "bad object",                 // includes dangling "bad object refs/remotes/origin/<branch>"
+    "is corrupt",                 // "loose object <oid> is corrupt"
+    "object file",                // "object file ... is empty"
+    "missing blob object",
+    "missing tree object",
+    "missing commit object",
+]
+
+/// Returns whether `output` indicates the local object store is missing or corrupt, such that
+/// purging the repository and re-fetching from origin may recover.
+func gitOutputIndicatesObjectStoreCorruption(_ output: String) -> Bool {
+    let lowercased = output.lowercased()
+    return gitObjectStoreCorruptionMarkers.contains { lowercased.contains($0) }
+}
+
+/// Returns whether `error` indicates the local git object store is missing or corrupt, in which
+/// case purging the repository and re-fetching from its origin may recover.
+///
+/// Matches the error's full textual description (like `isOffline`) rather than switching on concrete
+/// git error types: by the time a read failure reaches a recovery seam it has usually been wrapped by
+/// a higher layer (e.g. manifest loading or tools-version parsing), but the underlying `git` message
+/// is preserved in the description chain. See `gitObjectStoreCorruptionMarkers`.
+func isGitObjectStoreCorruptionError(_ error: Error) -> Bool {
+    gitOutputIndicatesObjectStoreCorruption("\(error)")
 }
 
 public enum GitProgressParser: FetchProgress {

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -430,6 +430,70 @@ public class RepositoryManager: Cancellable {
         try self.fileSystem.removeFileTree(repositoryPath)
     }
 
+    /// Evicts a single repository from both the working location and the shared cache, forcing a
+    /// fresh fetch from its origin on the next lookup.
+    ///
+    /// Unlike `remove(repository:)`, this also discards the shared cache copy. It is used to
+    /// recover from an incomplete or corrupt local object store which can happen when a package
+    /// resolution is interrupted and a repo is only partially fetched. Re-copying the cached
+    /// repository would only reproduce the corruption, so the cached copy must be discarded as well.
+    public func purge(repository: RepositorySpecifier, observabilityScope: ObservabilityScope) throws {
+        // Remove the working (per-destination) clone.
+        try self.remove(repository: repository)
+
+        // Remove the shared cache copy, if caching is enabled, so it cannot be re-copied.
+        guard let cachePath else {
+            return
+        }
+        let cachedRepositoryPath = try cachePath.appending(repository.storagePath())
+        do {
+            // Match `fetchAndPopulateCache`'s locking: a shared lock on the cache directory plus an
+            // exclusive lock on this repository's entry, so evicting one repository does not block
+            // concurrent cache fetches of unrelated repositories.
+            try self.fileSystem.withLock(on: cachePath, type: .shared) {
+                try self.fileSystem.withLock(on: cachedRepositoryPath, type: .exclusive) {
+                    try self.fileSystem.removeFileTree(cachedRepositoryPath)
+                }
+            }
+        } catch {
+            observabilityScope.emit(
+                error: "Error purging repository cache for '\(repository.location)' at '\(cachedRepositoryPath)'",
+                underlyingError: error
+            )
+        }
+    }
+
+    /// Runs `operation` against `repository`, recovering once from an incomplete or corrupt local
+    /// object store.
+    ///
+    /// If `operation` throws an error indicating the object store is incomplete or corrupt (see
+    /// `isGitObjectStoreCorruptionError`), this purges the repository from both the working
+    /// location and the shared cache, runs `beforeRetry` (so the caller can discard derived
+    /// state such as a working copy), and retries `operation` exactly once.  The retried `operation`
+    /// re-fetches the repository from its durable origin. Any other error, or a second failure,
+    /// propagates unchanged.
+    public func withObjectStoreRecovery<T>(
+        repository: RepositorySpecifier,
+        observabilityScope: ObservabilityScope,
+        beforeRetry: () async throws -> Void = {},
+        operation: () async throws -> T
+    ) async throws -> T {
+        do {
+            return try await operation()
+        } catch {
+            guard isGitObjectStoreCorruptionError(error) else {
+                throw error
+            }
+            observabilityScope.emit(
+                warning: "the local repository for '\(repository.location)' is incomplete or corrupt; re-fetching from its origin",
+                underlyingError: error
+            )
+            try self.purge(repository: repository, observabilityScope: observabilityScope)
+            try await beforeRetry()
+            return try await operation()
+        }
+    }
+
     /// Returns true if the directory is valid git location.
     public func isValidDirectory(_ directory: Basics.AbsolutePath) throws -> Bool {
         try self.provider.isValidDirectory(directory)

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -57,6 +57,8 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     public let package: PackageReference
     private let repositorySpecifier: RepositorySpecifier
     private let repository: Repository
+    private let repositoryManager: RepositoryManager
+    private let repositoryUpdateStrategy: RepositoryUpdateStrategy
     private let identityResolver: IdentityResolver
     private let dependencyMapper: DependencyMapper
     private let manifestLoader: ManifestLoaderProtocol
@@ -84,6 +86,8 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         dependencyMapper: DependencyMapper,
         repositorySpecifier: RepositorySpecifier,
         repository: Repository,
+        repositoryManager: RepositoryManager,
+        repositoryUpdateStrategy: RepositoryUpdateStrategy,
         manifestLoader: ManifestLoaderProtocol,
         currentToolsVersion: ToolsVersion,
         fingerprintStorage: PackageFingerprintStorage?,
@@ -96,6 +100,8 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         self.dependencyMapper = dependencyMapper
         self.repositorySpecifier = repositorySpecifier
         self.repository = repository
+        self.repositoryManager = repositoryManager
+        self.repositoryUpdateStrategy = repositoryUpdateStrategy
         self.manifestLoader = manifestLoader
         self.currentToolsVersion = currentToolsVersion
         self.fingerprintStorage = fingerprintStorage
@@ -143,17 +149,17 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     /// The available version list (in reverse order).
     public func toolsVersionsAppropriateVersionsDescending() async throws -> [Version] {
         let reversedVersions = try await self.versionsDescending()
-        return reversedVersions.lazy.filter {
-            // If we have the result cached, return that.
-            if let result = self.validToolsVersionsCache[$0] {
-                return result
+        var appropriateVersions: [Version] = []
+        for version in reversedVersions {
+            if let cached = self.validToolsVersionsCache[version] {
+                if cached { appropriateVersions.append(version) }
+                continue
             }
-
-            // Otherwise, compute and cache the result.
-            let isValid = (try? self.toolsVersion(for: $0)).flatMap(self.isValidToolsVersion(_:)) ?? false
-            self.validToolsVersionsCache[$0] = isValid
-            return isValid
+            let isValid = await self.isToolsVersionCompatible(at: version)
+            self.validToolsVersionsCache[version] = isValid
+            if isValid { appropriateVersions.append(version) }
         }
+        return appropriateVersions
     }
 
     public func getTag(for version: Version) -> String? {
@@ -232,7 +238,13 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     }
 
     /// Returns the tools version of the given version of the package.
-    public func toolsVersion(for version: Version) throws -> ToolsVersion {
+    public func toolsVersion(for version: Version) async throws -> ToolsVersion {
+        try await self.withObjectStoreRecovery {
+            try self.readToolsVersion(for: version)
+        }
+    }
+
+    private func readToolsVersion(for version: Version) throws -> ToolsVersion {
         try self.toolsVersionsCache.memoize(version) {
             guard let tag = try self.knownVersions()[version] else {
                 throw StringError("unknown tag \(version)")
@@ -380,22 +392,51 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         }
     }
 
-    public func isToolsVersionCompatible(at version: Version) -> Bool {
-        return (try? self.toolsVersion(for: version)).flatMap(self.isValidToolsVersion(_:)) ?? false
+    public func isToolsVersionCompatible(at version: Version) async -> Bool {
+        // Route through the recovering `toolsVersion(for:)` so an incomplete/corrupt object store is
+        // repaired rather than silently treated as an incompatible (and therefore unusable) version.
+        do {
+            return self.isValidToolsVersion(try await self.toolsVersion(for: version))
+        } catch {
+            return false
+        }
     }
 
     private func loadManifest(tag: String, version: Version?) async throws -> Manifest {
         try await self.manifestsCache.memoize(tag) {
-            let fileSystem = try self.repository.openFileView(tag: tag)
-            return try await self.loadManifest(fileSystem: fileSystem, version: version, revision: tag)
+            try await self.withObjectStoreRecovery {
+                let fileSystem = try self.repository.openFileView(tag: tag)
+                return try await self.loadManifest(fileSystem: fileSystem, version: version, revision: tag)
+            }
         }
     }
 
     private func loadManifest(at revision: Revision, version: Version?) async throws -> Manifest {
         try await self.manifestsCache.memoize(revision.identifier) {
-            let fileSystem = try self.repository.openFileView(revision: revision)
-            return try await self.loadManifest(fileSystem: fileSystem, version: version, revision: revision.identifier)
+            try await self.withObjectStoreRecovery {
+                let fileSystem = try self.repository.openFileView(revision: revision)
+                return try await self.loadManifest(fileSystem: fileSystem, version: version, revision: revision.identifier)
+            }
         }
+    }
+
+    /// Runs a repository read, recovering once if the local object store turns out to be incomplete
+    /// or corrupt (e.g. cached objects were evicted). On recovery the repository is re-fetched from
+    /// its origin into the same location, so the existing `repository` reads cleanly on retry.
+    private func withObjectStoreRecovery<T>(_ operation: () async throws -> T) async throws -> T {
+        try await self.repositoryManager.withObjectStoreRecovery(
+            repository: self.repositorySpecifier,
+            observabilityScope: self.observabilityScope,
+            beforeRetry: {
+                _ = try await self.repositoryManager.lookup(
+                    package: self.package.identity,
+                    repository: self.repositorySpecifier,
+                    updateStrategy: self.repositoryUpdateStrategy,
+                    observabilityScope: self.observabilityScope
+                )
+            },
+            operation: operation
+        )
     }
 
     private func loadManifest(fileSystem: FileSystem, version: Version?, revision: String) async throws -> Manifest {

--- a/Sources/Workspace/Workspace+PackageContainer.swift
+++ b/Sources/Workspace/Workspace+PackageContainer.swift
@@ -62,6 +62,8 @@ extension Workspace: PackageContainerProvider {
                 dependencyMapper: self.dependencyMapper,
                 repositorySpecifier: repositorySpecifier,
                 repository: repository,
+                repositoryManager: self.repositoryManager,
+                repositoryUpdateStrategy: updateStrategy.repositoryUpdateStrategy,
                 manifestLoader: self.manifestLoader,
                 currentToolsVersion: self.currentToolsVersion,
                 fingerprintStorage: self.fingerprints,

--- a/Sources/Workspace/Workspace+SourceControl.swift
+++ b/Sources/Workspace/Workspace+SourceControl.swift
@@ -19,6 +19,7 @@ import struct Dispatch.DispatchTime
 import enum PackageGraph.PackageRequirement
 import class PackageGraph.ResolvedPackagesStore
 import struct PackageModel.PackageReference
+import struct SourceControl.RepositorySpecifier
 import struct SourceControl.Revision
 import struct TSCUtility.Version
 
@@ -42,6 +43,34 @@ extension Workspace {
     ) async throws -> AbsolutePath {
         let repository = try package.makeRepositorySpecifier()
 
+        // If the checkout fails because the local object store is incomplete or corrupt, 
+        // `withObjectStoreRecovery` purges the repository and re-fetches from its origin;
+        // `beforeRetry` discards the now-stale working copy so the retry re-clones it from
+        // the re-fetched repository.
+        return try await self.repositoryManager.withObjectStoreRecovery(
+            repository: repository,
+            observabilityScope: observabilityScope,
+            beforeRetry: {
+                let checkoutPath = self.location.repositoriesCheckoutsDirectory.appending(component: repository.basename)
+                try? self.fileSystem.chmod(.userWritable, path: checkoutPath, options: [.recursive, .onlyFiles])
+                try self.fileSystem.removeFileTree(checkoutPath)
+            }
+        ) {
+            try await self.fetchAndCheckoutRepository(
+                package: package,
+                repository: repository,
+                at: checkoutState,
+                observabilityScope: observabilityScope
+            )
+        }
+    }
+
+    private func fetchAndCheckoutRepository(
+        package: PackageReference,
+        repository: SourceControl.RepositorySpecifier,
+        at checkoutState: CheckoutState,
+        observabilityScope: ObservabilityScope
+    ) async throws -> AbsolutePath {
         // first fetch the repository
         let checkoutPath = try await self.fetchRepository(
             package: package,

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -776,6 +776,45 @@ class GitRepositoryTests: XCTestCase {
         }
     }
 
+    func testGitObjectStoreCorruptionDetection() {
+        // Outputs that indicate the local object store is incomplete/corrupt — purging the
+        // repository and re-fetching from the origin can recover these.
+        let recoverable = [
+            "fatal: unable to read tree (0e71ce1f3149e7c6093f0fc571ba3ad50dcc1a3b)",
+            "fatal: unable to read tree 0e71ce1f3149e7c6093f0fc571ba3ad50dcc1a3b",
+            "fatal: not a tree object",
+            "fatal: Not a valid object name 8aa586f08e81064ee56a2eb8816a6443a4d86746",
+            "fatal: bad object refs/remotes/origin/some-deleted-branch",
+            "error: object file .git/objects/0e/71ce is empty\nfatal: loose object 0e71ce is corrupt",
+            "fatal: missing blob object 'abc123'",
+            // Wrapped form: the underlying git message is preserved in a higher-level error's description.
+            "the package at '/' cannot be accessed (Couldn’t read '1.0.0': fatal: not a tree object)",
+        ]
+        for output in recoverable {
+            XCTAssertTrue(
+                gitOutputIndicatesObjectStoreCorruption(output),
+                "expected object-store-corruption to be detected in: \(output)"
+            )
+        }
+
+        // Outputs that are NOT object-store corruption — re-fetching would not help, so we must
+        // not trigger a wasteful purge-and-reclone for these.
+        let notRecoverable = [
+            "error: pathspec 'nonExistent' did not match any file(s) known to git",
+            "fatal: Authentication failed for 'https://example.com/repo.git'",
+            "fatal: could not read Username for 'https://example.com': terminal prompts disabled",
+            "fatal: unable to read current working directory",
+            "error: Permission denied",
+            "Updating files: 100% (3/3), done.",
+        ]
+        for output in notRecoverable {
+            XCTAssertFalse(
+                gitOutputIndicatesObjectStoreCorruption(output),
+                "did not expect object-store-corruption to be detected in: \(output)"
+            )
+        }
+    }
+
     func testSubmodules() async throws {
         try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
         try await testWithTemporaryDirectory { path in

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -195,6 +195,172 @@ final class RepositoryManagerTests: XCTestCase {
         }
     }
 
+    func testPurge() async throws {
+        let fs = localFileSystem
+        let observability = ObservabilitySystem.makeForTesting()
+
+        try await fixtureXCTest(name: "DependencyResolution/External/Simple", createGitRepo: true) { (fixturePath: AbsolutePath) in
+            let cachePath = fixturePath.appending("cache")
+            let repositoriesPath = fixturePath.appending("repositories")
+            let repo = RepositorySpecifier(path: fixturePath.appending("Foo"))
+
+            let provider = GitRepositoryProvider()
+            let delegate = DummyRepositoryManagerDelegate()
+
+            let manager = RepositoryManager(
+                fileSystem: fs,
+                path: repositoriesPath,
+                provider: provider,
+                cachePath: cachePath,
+                cacheLocalPackages: true,
+                delegate: delegate
+            )
+
+            // fetch the package, populating both the shared cache and the working repositories path
+            delegate.prepare(fetchExpected: true, updateExpected: false)
+            _ = try await manager.lookup(repository: repo, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            try XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
+            try XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            try await delegate.wait(timeout: .now() + 2)
+
+            // purge must evict the repository from BOTH the working path and the shared cache,
+            // so that a later lookup cannot re-copy an incomplete/corrupt cached object store.
+            try manager.purge(repository: repo, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            try XCTAssertNoSuchPath(cachePath.appending(repo.storagePath()))
+            try XCTAssertNoSuchPath(repositoriesPath.appending(repo.storagePath()))
+
+            // the next lookup must re-fetch from the origin (not from cache), repopulating both.
+            delegate.prepare(fetchExpected: true, updateExpected: false)
+            _ = try await manager.lookup(repository: repo, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            try await delegate.wait(timeout: .now() + 2)
+            try XCTAssertDirectoryExists(cachePath.appending(repo.storagePath()))
+            try XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+            XCTAssertEqual(delegate.willFetch.last?.details, RepositoryManager.FetchDetails(fromCache: false, updatedCache: false))
+        }
+    }
+
+    func testWithObjectStoreRecovery() async throws {
+        struct UnrelatedError: Error {}
+
+        // The classifier matches the error's textual description, so this stands in for any error
+        // (git or a higher-level wrapper) whose description carries an object-store-corruption marker.
+        struct ObjectStoreCorruptionError: Error, CustomStringConvertible {
+            var description: String { "fatal: unable to read tree (abc123)" }
+        }
+
+        let fs = localFileSystem
+        let observability = ObservabilitySystem.makeForTesting()
+
+        try await testWithTemporaryDirectory { path in
+            let repos = path.appending("repo")
+            try fs.createDirectory(repos, recursive: true)
+            let manager = RepositoryManager(
+                fileSystem: fs,
+                path: repos,
+                provider: DummyRepositoryProvider(fileSystem: fs),
+                delegate: DummyRepositoryManagerDelegate()
+            )
+            let repo = RepositorySpecifier(path: "/dummy")
+
+            // Success on the first attempt: the operation runs once and beforeRetry is never called.
+            var operationCount = 0
+            var retryCount = 0
+            let value = try await manager.withObjectStoreRecovery(
+                repository: repo,
+                observabilityScope: observability.topScope,
+                beforeRetry: { retryCount += 1 }
+            ) {
+                operationCount += 1
+                return 42
+            }
+            XCTAssertEqual(value, 42)
+            XCTAssertEqual(operationCount, 1)
+            XCTAssertEqual(retryCount, 0)
+
+            // Object-store corruption then success: purge + beforeRetry + exactly one retry.
+            operationCount = 0
+            retryCount = 0
+            let recovered = try await manager.withObjectStoreRecovery(
+                repository: repo,
+                observabilityScope: observability.topScope,
+                beforeRetry: { retryCount += 1 }
+            ) {
+                operationCount += 1
+                if operationCount == 1 {
+                    throw ObjectStoreCorruptionError()
+                }
+                return 7
+            }
+            XCTAssertEqual(recovered, 7)
+            XCTAssertEqual(operationCount, 2)
+            XCTAssertEqual(retryCount, 1)
+
+            // A non-corruption error propagates immediately, without purge or retry.
+            operationCount = 0
+            retryCount = 0
+            await XCTAssertAsyncThrowsError(
+                try await manager.withObjectStoreRecovery(
+                    repository: repo,
+                    observabilityScope: observability.topScope,
+                    beforeRetry: { retryCount += 1 }
+                ) {
+                    operationCount += 1
+                    throw UnrelatedError()
+                }
+            )
+            XCTAssertEqual(operationCount, 1)
+            XCTAssertEqual(retryCount, 0)
+
+            // Persistent corruption is retried exactly once, then propagates.
+            operationCount = 0
+            retryCount = 0
+            await XCTAssertAsyncThrowsError(
+                try await manager.withObjectStoreRecovery(
+                    repository: repo,
+                    observabilityScope: observability.topScope,
+                    beforeRetry: { retryCount += 1 }
+                ) {
+                    operationCount += 1
+                    throw ObjectStoreCorruptionError()
+                }
+            )
+            XCTAssertEqual(operationCount, 2)
+            XCTAssertEqual(retryCount, 1)
+        }
+    }
+
+    func testPurgeWithoutCacheIsIdempotent() async throws {
+        let fs = localFileSystem
+        let observability = ObservabilitySystem.makeForTesting()
+
+        try await fixtureXCTest(name: "DependencyResolution/External/Simple", createGitRepo: true) { (fixturePath: AbsolutePath) in
+            let repositoriesPath = fixturePath.appending("repositories")
+            let repo = RepositorySpecifier(path: fixturePath.appending("Foo"))
+
+            // No cachePath configured: purge must still remove the working clone via its no-cache branch.
+            let manager = RepositoryManager(
+                fileSystem: fs,
+                path: repositoriesPath,
+                provider: GitRepositoryProvider(),
+                cacheLocalPackages: true
+            )
+
+            _ = try await manager.lookup(repository: repo, observabilityScope: observability.topScope)
+            try XCTAssertDirectoryExists(repositoriesPath.appending(repo.storagePath()))
+
+            try manager.purge(repository: repo, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+            try XCTAssertNoSuchPath(repositoriesPath.appending(repo.storagePath()))
+
+            // Purging again, with the paths already gone, neither throws nor emits a diagnostic.
+            try manager.purge(repository: repo, observabilityScope: observability.topScope)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+        }
+    }
+
     func testReset() async throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()


### PR DESCRIPTION
### Motivation:

SwiftPM materializes dependency working copies via `git clone --shared` from a bare mirror in a shared cache (`~/Library/Caches/org.swift.swiftpm`). If this clone is interrupted (e.g. by a crash, force quit, etc...) then only part of the git tree is copied, leaving an incomplete object store. During subsequent resolution attempts SwiftPM assumes that if the shared cache copy exists then it's valid, and if the information for the commit its looking for never made it in to the bare mirror then it fails with an error like `"unable to read tree <sha>"`.

### Modifications:

Add `withObjectStoreRecovery` and pipe through git-resolving operations through it so that if we see an error that matches the "corrupt object store" pattern, we purge the repository from both the working location and the shared cache and then retry. If, after the retry, we still get an error then we pass that through. 

### Result:

SwiftPM can recover from a partial clone of its mirrored repo. This approach means we aren't adding any cost to the happy-path and we can recover from these types of errors without user intervention.

We pattern match against the following types of git errors to determine if we want to purge and retry fetching the mirrored repository:

```
"unable to read tree"
"not a tree object"
"not a valid object name"
"bad object"
"is corrupt"
"object file"
"missing blob object"
"missing tree object"
"missing commit object"
```