### PR TITLE
PIF: Do not emit unhandled files warning on dependent package

### DIFF
--- a/Fixtures/PIFBuilder/UnhandledFiled/App/.gitignore
+++ b/Fixtures/PIFBuilder/UnhandledFiled/App/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Fixtures/PIFBuilder/UnhandledFiled/App/Package.swift
+++ b/Fixtures/PIFBuilder/UnhandledFiled/App/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 6.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "App",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "App",
+            targets: ["App"]
+        ),
+    ],
+    dependencies:[
+        .package(path: "../Dependent1"),
+        .package(path: "../Dependent2"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "App",
+            swiftSettings: [
+                .enableUpcomingFeature("ApproachableConcurrency"),
+            ],
+        ),
+        .testTarget(
+            name: "AppTests",
+            dependencies: ["App"],
+            swiftSettings: [
+                .enableUpcomingFeature("ApproachableConcurrency"),
+            ],
+        ),
+    ]
+)

--- a/Fixtures/PIFBuilder/UnhandledFiled/App/Sources/App/App.swift
+++ b/Fixtures/PIFBuilder/UnhandledFiled/App/Sources/App/App.swift
@@ -1,0 +1,5 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+public func hello() {
+    print("Hello, world!")
+}

--- a/Fixtures/PIFBuilder/UnhandledFiled/App/Sources/App/README.md
+++ b/Fixtures/PIFBuilder/UnhandledFiled/App/Sources/App/README.md
@@ -1,0 +1,1 @@
+Unhandled file App

--- a/Fixtures/PIFBuilder/UnhandledFiled/App/Tests/AppTests/AppTests.swift
+++ b/Fixtures/PIFBuilder/UnhandledFiled/App/Tests/AppTests/AppTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import App
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://swiftpackageindex.com/swiftlang/swift-testing/documentation
+}

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/.gitignore
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/Package.swift
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 6.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Dependent1",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Dependent1",
+            targets: ["Dependent1"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "Dependent1",
+            swiftSettings: [
+                .enableUpcomingFeature("ApproachableConcurrency"),
+            ],
+        ),
+        .testTarget(
+            name: "Dependent1Tests",
+            dependencies: ["Dependent1"],
+            swiftSettings: [
+                .enableUpcomingFeature("ApproachableConcurrency"),
+            ],
+        ),
+    ]
+)

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/Sources/Dependent1/Dependent1.swift
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/Sources/Dependent1/Dependent1.swift
@@ -1,0 +1,5 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+public func hello() {
+    print("Hello, world!")
+}

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/Sources/Dependent1/README.md
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/Sources/Dependent1/README.md
@@ -1,0 +1,1 @@
+Unhandled file dependent 1

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/Tests/Dependent1Tests/Dependent1Tests.swift
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent1/Tests/Dependent1Tests/Dependent1Tests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import Dependent1
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://swiftpackageindex.com/swiftlang/swift-testing/documentation
+}

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/.gitignore
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/Package.swift
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 6.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Dependent2",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Dependent2",
+            targets: ["Dependent2"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "Dependent2",
+            swiftSettings: [
+                .enableUpcomingFeature("ApproachableConcurrency"),
+            ],
+        ),
+        .testTarget(
+            name: "Dependent2Tests",
+            dependencies: ["Dependent2"],
+            swiftSettings: [
+                .enableUpcomingFeature("ApproachableConcurrency"),
+            ],
+        ),
+    ]
+)

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/Sources/Dependent2/Dependent2.swift
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/Sources/Dependent2/Dependent2.swift
@@ -1,0 +1,5 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+public func hello() {
+    print("Hello, world!")
+}

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/Sources/Dependent2/README.md
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/Sources/Dependent2/README.md
@@ -1,0 +1,1 @@
+Unhandled file dependent 2

--- a/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/Tests/Dependent2Tests/Dependent2Tests.swift
+++ b/Fixtures/PIFBuilder/UnhandledFiled/Dependent2/Tests/Dependent2Tests/Dependent2Tests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import Dependent2
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://swiftpackageindex.com/swiftlang/swift-testing/documentation
+}

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -434,11 +434,13 @@ public final class PIFBuilder {
                     observabilityScope: observabilityScope
                 )
 
-                self.diagnoseUnhandledFiles(
-                    package: package,
-                    module: module,
-                    buildToolPluginInvocationResults: buildToolPluginResults
-                )
+                if graph.rootPackages.contains(id: package.id) {
+                    self.diagnoseUnhandledFiles(
+                        package: package,
+                        module: module,
+                        buildToolPluginInvocationResults: buildToolPluginResults
+                    )
+                }
 
                 let result = PackagePIFBuilder.BuildToolPluginInvocationResult(
                     prebuildCommandOutputPaths: runResults.flatMap( { $0.derivedFiles }),
@@ -644,7 +646,7 @@ public final class PIFBuilder {
             metadata.moduleName = module.name
             return metadata
         }
-        
+
         diagnosticsEmitter.emit(.unhandledFiles(unhandledFiles))
     }
 }
@@ -941,7 +943,7 @@ extension Basics.Diagnostic {
     public static func unhandledFiles(_ files: Set<AbsolutePath>) -> Self {
         var message =
             "found \(files.count) file(s) which are unhandled; explicitly declare them as resources or exclude from the target\n"
-        for file in files {
+        for file in files.sorted() {
             message += "    " + file.pathString + "\n"
         }
         return .warning(message)

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -59,18 +59,24 @@ extension PIFBuilderParameters {
 
 fileprivate func withGeneratedPIF(
     fromFixture fixtureName: String,
+    withPackage packageName: String? = nil,
     addLocalRpaths: PackagePIFBuilder.AddLocalRpaths = .always,
     shouldCreateDylibForDynamicProducts: Bool = true,
     buildParameters: BuildParameters? = nil,
     hostBuildProductsPath: AbsolutePath? = nil,
-    do doIt: (SwiftBuildSupport.PIF.TopLevelObject, TestingObservability) async throws -> ()
+    do doIt: (SwiftBuildSupport.PIF.TopLevelObject, TestingObservability, AbsolutePath) async throws -> ()
 ) async throws {
     let buildParameters = if let buildParameters {
         buildParameters
     } else {
         mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
     }
-    try await fixture(name: fixtureName) { fixturePath in
+    try await fixture(name: fixtureName) { tmpFixturePath in
+        let fixturePath = if let packageName {
+            tmpFixturePath.appending(packageName)
+        } else {
+            tmpFixturePath
+        }
         let observabilitySystem: TestingObservability = ObservabilitySystem.makeForTesting(verbose: false)
         let toolchain = try UserToolchain.default
         var config = WorkspaceConfiguration.default
@@ -101,7 +107,7 @@ fileprivate func withGeneratedPIF(
         let (pif, _) = try await builder.constructPIF(
             buildParameters: buildParameters
         )
-        try await doIt(pif, observabilitySystem)
+        try await doIt(pif, observabilitySystem, fixturePath)
     }
 }
 
@@ -406,7 +412,7 @@ struct PIFBuilderTests {
     }
 
     @Test func platformExecutableModuleLibrarySearchPath() async throws {
-        try await withGeneratedPIF(fromFixture: "PIFBuilder/BasicExecutable") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/BasicExecutable") { pif, observabilitySystem, fixturePath in
             let releaseConfig = try pif.workspace
                 .project(named: "BasicExecutable")
                 .target(named: "Executable")
@@ -424,8 +430,35 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test
+    func emitUnhandledFilesOnlyForRootPackages() async throws {
+        try await withGeneratedPIF(
+            fromFixture: "PIFBuilder/UnhandledFiled",
+            withPackage: "App",
+        ) { pif, observabilitySystem, fixturePath in
+
+
+            let actualUnhandledFilesWarnings =  observabilitySystem.warnings.filter { $0.message.contains("which are unhandled;")}
+            let expected: [Basics.Diagnostic] =  [
+                Basics.Diagnostic.unhandledFiles([
+                    fixturePath.appending(components: ["Sources", "App", "Foo.txt"]),
+                    fixturePath.appending(components: ["Sources", "App", "README.md"]),
+                ])
+            ]
+
+            #expect(
+                observabilitySystem.hasErrorDiagnostics == false,
+                "Unexepcted errors occurred >> \(observabilitySystem.errors)"
+            )
+            #expect(
+                actualUnhandledFilesWarnings.count == expected.count,
+                "Actual number of diagnostics is not as expected... actual: \(actualUnhandledFilesWarnings)",
+            )
+        }
+    }
+
     @Test func platformConditionBasics() async throws {
-        try await withGeneratedPIF(fromFixture: "PIFBuilder/UnknownPlatforms") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/UnknownPlatforms") { pif, observabilitySystem, fixturePath in
             // We should emit a warning to the PIF log about the unknown platform
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .warning && $0.message.contains("Ignoring settings assignments for unknown platform 'DoesNotExist'")
@@ -444,7 +477,7 @@ struct PIFBuilderTests {
     }
 
     @Test func platformCCLibrary() async throws {
-        try await withGeneratedPIF(fromFixture: "PIFBuilder/CCPackage") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/CCPackage") { pif, observabilitySystem, fixturePath in
             let releaseConfig = try pif.workspace
                 .project(named: "CCPackage")
                 .target(id: "PACKAGE-TARGET:CCTarget")
@@ -465,7 +498,7 @@ struct PIFBuilderTests {
     }
 
     @Test func packageWithInternal() async throws {
-        try await withGeneratedPIF(fromFixture: "PIFBuilder/PackageWithSDKSpecialization") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/PackageWithSDKSpecialization") { pif, observabilitySystem, fixturePath in
             let errors: [Diagnostic] = observabilitySystem.diagnostics.filter { $0.severity == .error }
             #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
 
@@ -478,7 +511,7 @@ struct PIFBuilderTests {
     }
 
     @Test func pluginWithBinaryTargetDependency() async throws {
-        try await withGeneratedPIF(fromFixture: "Miscellaneous/Plugins/BinaryTargetExePlugin") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "Miscellaneous/Plugins/BinaryTargetExePlugin") { pif, observabilitySystem, fixturePath in
             // Verify that PIF generation succeeds for a package with a plugin that depends on a binary target
             #expect(pif.workspace.projects.count > 0)
 
@@ -518,7 +551,7 @@ struct PIFBuilderTests {
             fromFixture: "Miscellaneous/Plugins/MySourceGenPlugin",
             buildParameters: destBuildParams,
             hostBuildProductsPath: hostBuildPath
-        ) { pif, observabilitySystem in
+        ) { pif, observabilitySystem, fixturePath in
             let project = try pif.workspace.project(named: "MySourceGenPlugin")
             let target = try project.target(named: "MyLocalTool-product")
             for task in target.common.customTasks {
@@ -538,7 +571,7 @@ struct PIFBuilderTests {
         try await withGeneratedPIF(
             fromFixture: "PIFBuilder/Library",
             shouldCreateDylibForDynamicProducts: true
-        ) { pif, observabilitySystem in
+        ) { pif, observabilitySystem, fixturePath in
             let errors: [Diagnostic] = observabilitySystem.diagnostics.filter { $0.severity == .error }
             #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
 
@@ -559,7 +592,7 @@ struct PIFBuilderTests {
         try await withGeneratedPIF(
             fromFixture: "PIFBuilder/Library",
             shouldCreateDylibForDynamicProducts: false
-        ) { pif, observabilitySystem in
+        ) { pif, observabilitySystem, fixturePath in
             let errors: [Diagnostic] = observabilitySystem.diagnostics.filter { $0.severity == .error }
             #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
 
@@ -578,7 +611,7 @@ struct PIFBuilderTests {
     func executablePrefixIsSetCorrectly(
         configuration: BuildConfiguration,
     ) async throws {
-        try await withGeneratedPIF(fromFixture: "PIFBuilder/Library") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/Library") { pif, observabilitySystem, fixturePath in
             let errors: [Diagnostic] = observabilitySystem.diagnostics.filter { $0.severity == .error }
             #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
 
@@ -622,7 +655,7 @@ struct PIFBuilderTests {
 
     @Test(arguments: BuildConfiguration.allCases)
     func conditionalLinkerSettings(configuration: BuildConfiguration) async throws {
-        try await withGeneratedPIF(fromFixture: "PIFBuilder/ConditionalBuildSettings") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/ConditionalBuildSettings") { pif, observabilitySystem, fixturePath in
             let errors = observabilitySystem.diagnostics.filter { $0.severity == .error }
             #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
 
@@ -646,7 +679,7 @@ struct PIFBuilderTests {
     }
 
     @Test func impartedModuleMaps() async throws {
-        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .error
             }.isEmpty)
@@ -681,7 +714,7 @@ struct PIFBuilderTests {
     }
 
     @Test func moduleMapPathAndContents() async throws {
-        try await withGeneratedPIF(fromFixture: "PIFBuilder/Library") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "PIFBuilder/Library") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
 
             let releaseConfig = try pif.workspace
@@ -699,7 +732,7 @@ struct PIFBuilderTests {
             """)
         }
 
-        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
 
             let project = try pif.workspace.project(named: "ModuleMapGenerationCases")
@@ -765,7 +798,7 @@ struct PIFBuilderTests {
     }
 
     @Test func disablingLocalRpaths() async throws {
-        try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .error
             }.isEmpty)
@@ -789,7 +822,7 @@ struct PIFBuilderTests {
             }
         }
 
-        try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple", addLocalRpaths: .never) { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple", addLocalRpaths: .never) { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .error
             }.isEmpty)
@@ -818,7 +851,7 @@ struct PIFBuilderTests {
         try await withGeneratedPIF(
             fromFixture: "Miscellaneous/Simple",
             addLocalRpaths: .debugOnly
-        ) { pif, observabilitySystem in
+        ) { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter {
                 $0.severity == .error
             }.isEmpty)
@@ -1012,7 +1045,7 @@ struct PIFBuilderTests {
             try await withGeneratedPIF(
                 fromFixture: "PIFBuilder/Simple",
                 buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild, indexStoreMode: indexStoreSettingUT),
-            ) { pif, observabilitySystem in
+            ) { pif, observabilitySystem, fixturePath in
                 // #expect(false, "fail purposefully...")
                 #expect(observabilitySystem.diagnostics.filter {
                     $0.severity == .error
@@ -1128,7 +1161,7 @@ struct PIFBuilderTests {
     }
 
     @Test func macroPackageSupportedPlatforms() async throws {
-        try await withGeneratedPIF(fromFixture: "Macros/MinimalMacroPackage") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "Macros/MinimalMacroPackage") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
             let project = try pif.workspace.project(named: "MinimalMacroPackage")
             let projectPlatforms = try project.buildConfig(named: .debug).settings[.SUPPORTED_PLATFORMS]
@@ -1209,7 +1242,7 @@ struct PIFBuilderTests {
      }
 
     @Test func testTargetDependsOnTestTarget() async throws {
-        try await withGeneratedPIF(fromFixture: "Miscellaneous/TestTargetDependsOnTestTarget") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "Miscellaneous/TestTargetDependsOnTestTarget") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
 
             let project = try pif.workspace.project(named: "TestTargetDependsOnTestTarget")
@@ -1245,10 +1278,10 @@ struct PIFBuilderTests {
             #expect(barTestsTarget.productType == .unitTest)
             #expect(barTestsTarget.common.dependencies.map(\.targetId).contains("PACKAGE-TARGET:TestUtils"))
         }
-    } 
+    }
 
     @Test func noHeaderMaps() async throws {
-        try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "Miscellaneous/Simple") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
             let project = try pif.workspace.project(named: "Foo")
             for configName in [BuildConfiguration.debug, .release] {
@@ -1261,7 +1294,7 @@ struct PIFBuilderTests {
     }
 
     @Test func symbolGraphExtractorBuildSettings() async throws {
-        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
 
             // configureSourceModuleBuildSettings is called for every source module via the same
@@ -1281,7 +1314,7 @@ struct PIFBuilderTests {
     }
 
     @Test func cFamilyHeadersAddedToHeadersBuildPhase() async throws {
-        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem in
+        try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
 
             let project = try pif.workspace.project(named: "ModuleMapGenerationCases")


### PR DESCRIPTION
A recent change introduced the unhandled files warnings in Swift Build build system by emitting the warning in the PIF Builder.  However, this change was also emitting the unhandled files against package dependency, which package authors are unable to address in the current package.

Change the PIF builder to only diagnose unhandled files for root packages.

Fixes: #10182
Issue: rdar://179028180