### PR TITLE
🍒 [6.4] Support safe.bareRepository=explicit during package resolution (#10169)

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -132,7 +132,9 @@ private struct GitShellHelper {
         }
         do {
             // DO NOT add --all here. See documentation above for why.
-            return try self.run(["-C", path.pathString, "lfs", "fetch"])
+            // Address the bare repository explicitly via `--git-dir` (rather than discovery
+            // with `-C`) so this keeps working under `safe.bareRepository=explicit`.
+            return try self.run(gitLocationArguments(path.pathString, bare: true) + ["lfs", "fetch"])
         } catch let error as CancellationError {
             throw error
         } catch {
@@ -158,6 +160,16 @@ private struct GitShellHelper {
             throw GitLFSError.pullFailed(underlyingError: error)
         }
     }
+}
+
+/// Builds the leading `git` arguments that point at a repository on disk.
+///
+/// A working tree is addressed with `-C`, letting git discover the working tree and its `.git`
+/// directory. A bare repository keeps the same `-C` working directory but *also* names the git
+/// directory explicitly via `--git-dir` rather than relying on discovery. This keeps SwiftPM
+/// working under `safe.bareRepository=explicit`.
+internal func gitLocationArguments(_ path: String, bare: Bool) -> [String] {
+    bare ? ["-C", path, "--git-dir", path] : ["-C", path]
 }
 
 // MARK: - GitRepositoryProvider
@@ -288,12 +300,44 @@ public struct GitRepositoryProvider: RepositoryProvider, Cancellable {
     }
 
     public func isValidDirectory(_ directory: Basics.AbsolutePath) throws -> Bool {
-        let result = try self.git.run(["-C", directory.pathString, "rev-parse", "--git-dir"])
-        return result == ".git" || result == "." || result == directory.pathString
+        // A working tree is found via discovery (`-C`). A bare repository is refused by
+        // discovery when the user sets `safe.bareRepository=explicit`, so fall back to
+        // addressing the directory as an explicit git directory, which that setting permits.
+        do {
+            let result = try self.git.run(["-C", directory.pathString, "rev-parse", "--git-dir"])
+            return result == ".git" || result == "." || result == directory.pathString
+        } catch let error as GitShellError {
+            let isBareRepository: String
+            do {
+                isBareRepository = try self.git.run(
+                    gitLocationArguments(directory.pathString, bare: true) + ["rev-parse", "--is-bare-repository"]
+                )
+            } catch is GitShellError {
+                throw error
+            }
+            if isBareRepository == "true" {
+                return true
+            }
+            throw error
+        }
     }
 
     public func isValidDirectory(_ directory: Basics.AbsolutePath, for repository: RepositorySpecifier) throws -> Bool {
-        let remoteURL = try self.git.run(["-C", directory.pathString, "config", "--get", "remote.origin.url"])
+        let remoteURL: String
+        do {
+            remoteURL = try self.git.run(["-C", directory.pathString, "config", "--get", "remote.origin.url"])
+        } catch let error as GitShellError {
+            // Discovery is refused for a bare repository under `safe.bareRepository=explicit`,
+            // so git exits non-zero without reading the config; re-read it with the directory
+            // named as an explicit git directory.
+            do {
+                remoteURL = try self.git.run(
+                    gitLocationArguments(directory.pathString, bare: true) + ["config", "--get", "remote.origin.url"]
+                )
+            } catch is GitShellError {
+                throw error
+            }
+        }
         return CanonicalPackageURL(remoteURL) == CanonicalPackageURL(repository.url)
     }
 
@@ -517,6 +561,11 @@ public final class GitRepository: Repository, WorkingCheckout {
         }())
     }
 
+    /// The arguments that point `git` at this repository. See `gitLocationArguments`.
+    private var repositoryLocationArguments: [String] {
+        gitLocationArguments(self.path.pathString, bare: !self.isWorkingRepo)
+    }
+
     /// Private function to invoke the Git tool with its default environment and given set of arguments, specifying the
     /// path of the repository as the one to operate on.  The specified failure message is used only in case of error.
     /// This function waits for the invocation to finish and returns the output as a string.
@@ -537,7 +586,7 @@ public final class GitRepository: Repository, WorkingCheckout {
                     gitFetchStatusFilter($0, progress: progress)
                 })
                 return try self.git.run(
-                    ["-C", self.path.pathString] + args,
+                    self.repositoryLocationArguments + args,
                     environment: environment,
                     outputRedirection: outputHandler
                 )
@@ -552,7 +601,7 @@ public final class GitRepository: Repository, WorkingCheckout {
             }
         } else {
             do {
-                return try self.git.run(["-C", self.path.pathString] + args, environment: environment)
+                return try self.git.run(self.repositoryLocationArguments + args, environment: environment)
             } catch let error as GitShellError {
                 throw GitRepositoryError(path: self.path, message: failureMessage, result: error.result)
             }
@@ -969,7 +1018,7 @@ public final class GitRepository: Repository, WorkingCheckout {
 
             let output: String
             do {
-                output = try self.git.run(["-C", self.path.pathString, "check-ignore"] + stringPaths)
+                output = try self.git.run(self.repositoryLocationArguments + ["check-ignore"] + stringPaths)
             } catch let error as GitShellError {
                 guard error.result.exitStatus == .terminated(code: 1) else {
                     throw GitRepositoryError(

--- a/Tests/SourceControlTests/GitRepositoryTests.swift
+++ b/Tests/SourceControlTests/GitRepositoryTests.swift
@@ -35,6 +35,26 @@ class GitRepositoryTests: XCTestCase {
         Git.environmentBlock = .init(Environment.current)
     }
 
+    /// Points git at a temporary global config that sets `safe.bareRepository=explicit`, mirroring
+    /// a user who has opted into the bare-repository protection globally. `additionalGlobalConfig`
+    /// is appended because `GIT_CONFIG_GLOBAL` replaces the user's global config wholesale (e.g. the
+    /// `filter.lfs.*` registration must be re-added for LFS tests). Restored by `tearDown`.
+    private func enableSafeBareRepositoryExplicit(
+        in directory: AbsolutePath,
+        additionalGlobalConfig: String = ""
+    ) throws {
+        let globalConfigPath = directory.appending("gitconfig")
+        try localFileSystem.writeFileContents(
+            globalConfigPath,
+            string: "[safe]\n\tbareRepository = explicit\n" + additionalGlobalConfig
+        )
+        var environment = Git.environmentBlock
+        environment["GIT_CONFIG_GLOBAL"] = globalConfigPath.pathString
+        environment["GIT_CONFIG_SYSTEM"] = "/dev/null"
+        environment["GIT_ALLOW_PROTOCOL"] = "file"
+        Git.environmentBlock = environment
+    }
+
     private func requireGitLFS() async throws {
         Git.environmentBlock = .init(Environment.current)
         var environment = Git.environmentBlock
@@ -608,6 +628,50 @@ class GitRepositoryTests: XCTestCase {
             // Push the changes and check again.
             try checkoutTestRepo.push(remote: "origin", branch: "main")
             XCTAssertFalse(try checkoutRepo.hasUnpushedCommits())
+        }
+    }
+
+    func testResolvesRevisionWhenSafeBareRepositoryIsExplicit() async throws {
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
+        try await testWithTemporaryDirectory { path in
+            // Create a repo with a tag, then make the bare mirror that SwiftPM caches.
+            let testRepoPath = path.appending("test-repo")
+            try makeDirectories(testRepoPath)
+            initGitRepo(testRepoPath, tag: "1.0.0")
+
+            let bareRepoPath = path.appending("test-repo-bare")
+            let provider = GitRepositoryProvider()
+            let repoSpec = RepositorySpecifier(path: testRepoPath)
+            try await provider.fetch(repository: repoSpec, to: bareRepoPath)
+
+            // Opt into the `explicit` bare-repository protection, mirroring a user who has set
+            // `safe.bareRepository=explicit` globally.
+            try self.enableSafeBareRepositoryExplicit(in: path)
+
+            // Confirm the bug is reproducible in this environment: a discovery-based
+            // invocation without the override is rejected by `explicit`. Older git
+            // versions that predate `safe.bareRepository` ignore the setting, in which
+            // case the bug cannot be reproduced and the assertion below is skipped.
+            let unguarded = try await AsyncProcess.popen(
+                arguments: [Git.tool, "-C", bareRepoPath.pathString, "rev-parse", "--verify", "1.0.0^{commit}"],
+                environment: .init(Git.environmentBlock)
+            )
+            try XCTSkipUnless(
+                unguarded.exitStatus != .terminated(code: 0),
+                "git does not honor safe.bareRepository here; cannot reproduce the bug"
+            )
+
+            // SwiftPM addresses its bare cache repositories explicitly via `--git-dir`
+            // instead of relying on discovery, so resolving against the bare cache
+            // repository succeeds despite the user's `explicit` setting.
+            let repository = provider.open(repository: repoSpec, at: bareRepoPath)
+            let revision = try repository.resolveRevision(tag: "1.0.0")
+            XCTAssertFalse(revision.identifier.isEmpty)
+
+            // The resolution cache fast-path validates the bare cache repository via
+            // `isValidDirectory`; both variants must also keep working under `explicit`.
+            XCTAssertTrue(try provider.isValidDirectory(bareRepoPath))
+            XCTAssertTrue(try provider.isValidDirectory(bareRepoPath, for: repoSpec))
         }
     }
 
@@ -1243,6 +1307,57 @@ class GitRepositoryTests: XCTestCase {
                 editable: false
             )
 
+            try workingCopy.checkout(tag: "1.0.0")
+
+            let binaryFilePath = checkoutPath.appending("test.bin")
+            XCTAssertFileExists(binaryFilePath)
+            try self.assertFileMatchesBinaryData(binaryFilePath, expected: binaryData)
+        }
+    }
+
+    /// Test that fetching an LFS repository into the bare cache still populates LFS
+    /// objects when the user has set `safe.bareRepository=explicit`. The bare-cache
+    /// `git lfs fetch` is addressed via `--git-dir`; if that failed under `explicit`,
+    /// the objects would be missing and the checkout below could not materialize the
+    /// binary file once the source repository is removed.
+    func testGitLFSFetchIntoBareCacheUnderSafeBareRepositoryExplicit() async throws {
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8564", skipSelfHostedCI: true)
+        try await self.requireGitLFS()
+        try await testWithTemporaryDirectory { path in
+            let testRepoPath = path.appending("test-repo")
+            let binaryData = try await self.createLFSRepository(at: testRepoPath)
+            let provider = GitRepositoryProvider()
+            let testClonePath = path.appending("clone")
+            let repoSpec = RepositorySpecifier(path: testRepoPath)
+
+            // Opt into the `explicit` bare-repository protection for all of SwiftPM's git
+            // invocations. Because GIT_CONFIG_GLOBAL replaces the user's global config wholesale,
+            // also carry the `filter.lfs.*` registration that `git lfs install` normally writes
+            // there, otherwise the smudge filter would not run on checkout.
+            try self.enableSafeBareRepositoryExplicit(in: path, additionalGlobalConfig: """
+                [filter "lfs"]
+                \tclean = git-lfs clean -- %f
+                \tsmudge = git-lfs smudge -- %f
+                \tprocess = git-lfs filter-process
+                \trequired = true
+
+                """)
+
+            // Fetches into the bare cache and, since the repo uses LFS, runs
+            // `git --git-dir=<bare> lfs fetch` against it.
+            try await provider.fetch(repository: repoSpec, to: testClonePath)
+
+            // If the bare cache did not fetch LFS objects, checkout can no longer
+            // materialize the file once the original repository disappears.
+            try localFileSystem.removeFileTree(testRepoPath)
+
+            let checkoutPath = path.appending("checkout")
+            let workingCopy = try await provider.createWorkingCopy(
+                repository: repoSpec,
+                sourcePath: testClonePath,
+                at: checkoutPath,
+                editable: false
+            )
             try workingCopy.checkout(tag: "1.0.0")
 
             let binaryFilePath = checkoutPath.appending("test.bin")


### PR DESCRIPTION
SwiftPM caches dependencies as bare mirror repositories under .build/repositories/ and, until now, reached them via discovery (`git -C <path>`). When a user sets `safe.bareRepository=explicit` in their git config, git refuses to operate on a discovered bare repository, causing resolution to fail with:

`fatal: cannot use bare repository '...' (safe.bareRepository is 'explicit')`

Address bare repositories explicitly via `--git-dir <path>` instead of relying on discovery.

Much of this implementation is based on @Kyle-Ye's excellent work in avoids parsing git errors to determine if we're working with with bareRepository set to `explicit`.

Issue: #8068
