### PR TITLE
[6.4] Tests: Remove withKnownIssues on tests

### DIFF
--- a/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitsBug.swift
@@ -55,14 +55,6 @@ extension Trait where Self == Testing.Bug {
         )
     }
 
-    public static var IssueWindowsLongPath: Self {
-        .issue(
-            // "https://github.com/swiftlang/swift-tools-support-core/pull/521",
-            "rdar://157310562",
-            relationship: .fixedBy,
-        )
-    }
-
     public static var IssueWindowsPathTestsFailures: Self {
         .issue(
             "https://github.com/swiftlang/swift-package-manager/issues/8511",

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -472,7 +472,6 @@ struct BuildCommandTestCases {
               .Feature.Command.Build,
               .Feature.TargetType.Executable
         ),
-        .IssueWindowsLongPath,
         buildDataUsingAllBuildSystemWithTags.tags,
         arguments: buildDataUsingAllBuildSystemWithTags.buildData,
     )
@@ -950,7 +949,6 @@ struct BuildCommandTestCases {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         .tags(
             .Feature.BuildCache,
         ),
@@ -960,7 +958,6 @@ struct BuildCommandTestCases {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let config = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
                 let buildCompleteRegex = try Regex(#"Build complete!\s?(\([0-9]*\.[0-9]*\s*s(econds)?\))?"#)
                 do {
@@ -999,9 +996,6 @@ struct BuildCommandTestCases {
                     #expect(lastLine.contains(buildCompleteRegex))
                 }
             }
-        } when: {
-            (buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows)
-        }
     }
 
     @Test(
@@ -1037,14 +1031,12 @@ struct BuildCommandTestCases {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func buildSystemDefaultSettings(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let config = BuildConfiguration.debug
-        try await withKnownIssue("Sometimes failed to build due to a possible path issue", isIntermittent: true) {
             try await fixture(name: "ValidLayouts/SingleModule/ExecutableNew") { fixturePath in
                 // try await building using XCBuild with default parameters.  This should succeed.  We build verbosely so we get
                 // full command lines.
@@ -1066,9 +1058,6 @@ struct BuildCommandTestCases {
                 // Look for build completion message from the particular build system
                 #expect(output.stdout.contains("Build complete!"))
             }
-        } when: {
-            (buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows)
-        }
     }
 
     @Test(
@@ -1888,7 +1877,6 @@ struct BuildCommandTestCases {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         .tags(
             .Feature.CommandLineArguments.BuildSystem,
             .Feature.CommandLineArguments.Configuration,
@@ -1898,7 +1886,6 @@ struct BuildCommandTestCases {
     func executableTargetIntegratedIntoTwoProducts(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue("Sometimes failed to build due to a possible path issue", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/ExecutableTargetWithTwoProducts") { fixturePath in
                 let config = BuildConfiguration.debug
                 let _ = try await build(
@@ -1909,9 +1896,6 @@ struct BuildCommandTestCases {
                     buildSystem: buildSystem,
                 )
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
-        }
     }
 
     @Test(

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1219,7 +1219,6 @@ struct PackageCommandTests {
             .Feature.Command.Package.DumpSymbolGraph,
         ),
         .issue("https://github.com/swiftlang/swift-package-manager/issues/8848", relationship: .defect),
-        .IssueWindowsLongPath,
         .requiresSymbolgraphExtract,
         arguments: [BuildSystemProvider.Kind.swiftbuild],
         [
@@ -1289,7 +1288,6 @@ struct PackageCommandTests {
         .tags(
             .Feature.Command.Package.DumpSymbolGraph,
         ),
-        .IssueWindowsLongPath,
         .requiresSymbolgraphExtract,
         arguments: [BuildSystemProvider.Kind.swiftbuild],
     )
@@ -6308,9 +6306,6 @@ struct PackageCommandTests {
                 .Feature.Command.Run,
                 .Feature.Command.Package.CommandPlugin,
             ),
-            .IssueWindowsRelativePathAssert,
-            .IssueWindowsLongPath,
-            .IssueWindowsPathLastComponent,
             .issue(
                 "https://github.com/swiftlang/swift-package-manager/issues/9083",
                 relationship: .defect,

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -297,7 +297,6 @@ struct TestCommandTests {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         .tags(
             .Feature.TargetType.Executable,
         ),
@@ -307,7 +306,6 @@ struct TestCommandTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestableExeWithDifferentProductName") { fixturePath in
                 _ = try await execute(
                     ["--vv"],
@@ -316,9 +314,6 @@ struct TestCommandTests {
                     buildSystem: buildSystem,
                 )
             }
-        } when: {
-            .windows == ProcessInfo.hostOperatingSystem
-        }
     }
 
     @Test(
@@ -358,13 +353,11 @@ struct TestCommandTests {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testProductFlag(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue(isIntermittent: true) {
             let configuration = BuildConfiguration.debug
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 let (stdout, _) = try await executeSwiftTest(
@@ -376,9 +369,6 @@ struct TestCommandTests {
                 )
                 #expect(stdout.contains("Executed 3 tests"))
             }
-        } when: {
-            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
-        }
     }
 
     @Test(
@@ -1727,7 +1717,6 @@ struct TestCommandTests {
     }
 
     @Test(
-        .IssueWindowsLongPath,
             .tags(
                 .Feature.TargetType.Executable,
             ),
@@ -1747,8 +1736,7 @@ struct TestCommandTests {
                     )
                 }
             } when: {
-                .windows == ProcessInfo.hostOperatingSystem
-                || ProcessInfo.processInfo.environment["SWIFTCI_EXHIBITS_GH_9524"] != nil
+                ProcessInfo.processInfo.environment["SWIFTCI_EXHIBITS_GH_9524"] != nil
             }
         }
 

--- a/Tests/FunctionalTests/DependencyResolutionTests.swift
+++ b/Tests/FunctionalTests/DependencyResolutionTests.swift
@@ -31,7 +31,6 @@ import enum TSCUtility.Git
 )
 struct DependencyResolutionTests {
     @Test(
-        .IssueWindowsLongPath,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Build,
@@ -42,7 +41,6 @@ struct DependencyResolutionTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "DependencyResolution/Internal/Simple") { fixturePath in
                 try await executeSwiftBuild(
                     fixturePath,
@@ -59,9 +57,6 @@ struct DependencyResolutionTests {
                 let output = try await AsyncProcess.checkNonZeroExit(args: executablePath.pathString).withSwiftLineEnding
                 #expect(output == "Foo\nBar\n")
             }
-        } when: {
-            (ProcessInfo.hostOperatingSystem  == .windows && buildSystem == .swiftbuild)
-        }
     }
 
     @Test(
@@ -88,7 +83,6 @@ struct DependencyResolutionTests {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         .IssueProductTypeForObjectLibraries,
         .tags(
             Tag.Feature.Command.Build,
@@ -99,7 +93,6 @@ struct DependencyResolutionTests {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "DependencyResolution/Internal/Complex") { fixturePath in
                 try await executeSwiftBuild(
                     fixturePath,
@@ -117,9 +110,6 @@ struct DependencyResolutionTests {
                     .withSwiftLineEnding
                 #expect(output == "meiow Baz\n")
             }
-        } when: {
-            (ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild)
-        }
     }
 
     /// Check resolution of a trivial package with one dependency.
@@ -167,7 +157,6 @@ struct DependencyResolutionTests {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         .IssueLdFailsUnexpectedly,
         .issue("rdar://162339964", relationship: .defect),
         .tags(
@@ -180,9 +169,7 @@ struct DependencyResolutionTests {
     ) async throws {
         let configuration = BuildConfiguration.debug
         try await withKnownIssue(
-            isIntermittent: ProcessInfo.hostOperatingSystem == .windows
-            // rdar://162339964
-            || (ProcessInfo.isHostAmazonLinux2() && buildSystem == .swiftbuild)
+            isIntermittent: true,
         ) {
             try await fixture(name: "DependencyResolution/External/Complex", createGitRepo: true) { fixturePath in
                 let packageRoot = fixturePath.appending("app")
@@ -203,8 +190,7 @@ struct DependencyResolutionTests {
                 #expect(output == "♣︎K\n♣︎Q\n♣︎J\n♣︎10\n♣︎9\n♣︎8\n♣︎7\n♣︎6\n♣︎5\n♣︎4\n")
             }
         } when: {
-            ProcessInfo.hostOperatingSystem == .windows // due to long path issues
-            || (ProcessInfo.isHostAmazonLinux2() && buildSystem == .swiftbuild) // Linker ld throws an unexpected error.
+            ProcessInfo.isHostAmazonLinux2() && buildSystem == .swiftbuild // Linker ld throws an unexpected error.
         }
     }
 

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -718,7 +718,6 @@ struct MiscellaneousTestCase {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         .skipHostOS(.linux),
         .skipHostOS(.android),
         .tags(
@@ -731,7 +730,6 @@ struct MiscellaneousTestCase {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/Unicode") { fixturePath in
                 // See the fixture manifest for an explanation of this string.
                 let complicatedString = "πשּׁµ𝄞🇺🇳🇮🇱x̱̱̱̱̱̄̄̄̄̄"
@@ -777,9 +775,6 @@ struct MiscellaneousTestCase {
                     ProcessInfo.hostOperatingSystem == .linux && buildSystem == .swiftbuild
                 }
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows
-        }
     }
 
     @Test(
@@ -1321,7 +1316,6 @@ struct MiscellaneousTestCase {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         .tags(
             .Feature.Command.Build,
         ),
@@ -1331,7 +1325,6 @@ struct MiscellaneousTestCase {
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "Miscellaneous/RootPackageWithConditionals") { path in
                 let (_, stderr) = try await executeSwiftBuild(
                     path,
@@ -1351,9 +1344,6 @@ struct MiscellaneousTestCase {
                         break
                 }
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
-        }
     }
 
     @Test(

--- a/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
+++ b/Tests/FunctionalTests/ModuleAliasingFixtureTests.swift
@@ -77,7 +77,6 @@ struct ModuleAliasingFixtureTests {
 
     @Test(
         .issue("https://github.com/swiftlang/swift-package-manager/pull/9130", relationship: .fixedBy),
-        .IssueWindowsLongPath,
         .IssueWindowsCannotSaveAttachment,
         .tags(
             Tag.Feature.Command.Build,
@@ -88,7 +87,6 @@ struct ModuleAliasingFixtureTests {
         buildSystem: BuildSystemProvider.Kind
     ) async throws {
         let configuration = BuildConfiguration.debug
-        try await withKnownIssue(isIntermittent: true) {
             try await fixture(name: "ModuleAliasing/DirectDeps2") { fixturePath in
                 let pkgPath = fixturePath.appending(components: "AppPkg")
                 let expectedModules = [
@@ -123,9 +121,6 @@ struct ModuleAliasingFixtureTests {
                     buildSystem: buildSystem,
                 )
             }
-        } when: {
-            ProcessInfo.hostOperatingSystem == .windows && buildSystem == .swiftbuild
-        }
     }
 
     @Test(
@@ -182,7 +177,6 @@ struct ModuleAliasingFixtureTests {
 
     @Test(
         .issue("https://github.com/swiftlang/swift-package-manager/pull/9130", relationship: .fixedBy),
-        .IssueWindowsLongPath,
         .IssueWindowsCannotSaveAttachment,
         .tags(
             Tag.Feature.Command.Build,

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1685,13 +1685,11 @@ struct PluginTests {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func testCommandPluginBuildingPackageUsingBuildToolPlugin(
         buildSystem: BuildSystemProvider.Kind,
     ) async throws {
-        try await withKnownIssue("Windows builds encounter long path handling issues", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/Plugins/CommandPluginBuildingBuildToolPlugin") { fixturePath in
                 let (stdout, stderr) = try await executeSwiftPackage(
                     fixturePath,
@@ -1700,8 +1698,5 @@ struct PluginTests {
                 )
                 #expect(stdout.contains("Built successfully"))
             }
-        } when: {
-            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
-        }
     }
 }

--- a/Tests/FunctionalTests/TestDiscoveryTests.swift
+++ b/Tests/FunctionalTests/TestDiscoveryTests.swift
@@ -48,7 +48,6 @@ struct TestDiscoveryTests {
     }
 
     @Test(
-        .IssueWindowsLongPath,
         .tags(
             .Feature.Command.Test,
             .Feature.CommandLineArguments.VeryVerbose,
@@ -59,7 +58,6 @@ struct TestDiscoveryTests {
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func discovery(_ buildSystem: BuildSystemProvider.Kind) async throws {
-        try await withKnownIssue("Windows builds encounter long path handling issues", isIntermittent: true) {
             try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
                 let (stdout, stderr) = try await executeSwiftTest(fixturePath, extraArgs: ["-vv"], buildSystem: buildSystem)
                 // in "swift test" build output goes to stderr
@@ -67,9 +65,6 @@ struct TestDiscoveryTests {
                 // in "swift test" test output goes to stdout
                 #expect(stdout.contains("Executed 3 tests"))
             }
-        } when: {
-            buildSystem == .swiftbuild && ProcessInfo.hostOperatingSystem == .windows
-        }
     }
 
     @Test(


### PR DESCRIPTION
Some tests were marked with a Bug Traits which has been fixed.

Remove the trait definition, and update all tests to remove the withKnownIssue, which was added as a result of this trait.

Relates to swiftlang/swift-tools-support-core#521
Issue: rdar://178167065
