### PR TITLE
[6.4] Ensure PIF delegates cannot adjust deployment targets below the oldest supported version

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -38,6 +38,7 @@ import struct PackageModel.Platform
 import struct PackageModel.PlatformDescription
 import struct PackageModel.PlatformRegistry
 import struct PackageModel.PlatformsCondition
+import struct PackageModel.PlatformVersion
 import class PackageModel.PluginModule
 import class PackageModel.Product
 import enum PackageModel.ProductType
@@ -460,7 +461,7 @@ extension PackageGraph.ResolvedModule {
                 iOSVersion: iOSDeploymentTarget
             )
 
-            if let mappedVersion {
+            if let mappedVersion, PlatformVersion(mappedVersion) >= targetPlatform.oldestSupportedVersion {
                 deploymentTargets[targetPlatform] = mappedVersion
             }
         }


### PR DESCRIPTION
Closes https://github.com/swiftlang/swift-package-manager/issues/10187

When building a package where:

- The manifest does not specify an explicit watchOS deployment target
- The iOS deployment target is unspecified or explicitly set to iOS 15.0
- The PIF client (Xcode) infers the watchOS deployment target based on the iOS deployment target
The watchOS deployment target will be incorrectly inferred as 8.0, which is not supported by the watchOS 27.0 SDK.

The inferred deployment target needs to be clamped to the oldest supported deployment target for the target platform, similar to how this is already handled when it's derived by SwiftPM directly.
