### PR TITLE
GHA: Fix Check Documentation action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
     name: Build
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.12
     with:
       enable_cross_pr_testing: true
       linux_os_versions: '["amazonlinux2", "bookworm", "noble", "jammy", "rhel-ubi9"]'
@@ -40,7 +40,7 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.12
     with:
       license_header_check_project_name: "Swift"
       license_header_check_enabled: true
@@ -49,6 +49,9 @@ jobs:
       format_check_enabled: false
       shell_check_enabled: false
       docs_check_enabled: true
+      docs_check_analyze: false
+      docs_check_targets: "PackageManagerDocs"
+      docs_check_macos_enabled: false
       broken_symlink_check_enabled: true
       python_lint_check_enabled: true
       yamllint_check_enabled: true
@@ -56,7 +59,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     needs: [soundness]
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.12
     with:
       enable_linux_checks: false
       enable_windows_checks: false

--- a/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
@@ -10,7 +10,7 @@ Organize, manage, and edit Swift packages.
 
 The Swift Package Manager lets you share your code as a package, depend on and use other shared packages, as well as build, test, document, and run your code.
 
-> Note: Swift Package Manager [introduced the Swift Build build system as a preview](<doc:SwiftBuildPreview>) in Swift 6.3, and [adopted it as the default build system ](<doc:SwiftBuildDefault>) in Swift 6.4.
+> Note: Swift Package Manager [introduced the Swift Build build system as a preview](<doc:SwiftBuildPreview>) in Swift 6.3, and [adopted it as the default build system ](<doc:6.4>) in Swift 6.4.
 
 ## Topics
 
@@ -22,7 +22,6 @@ The Swift Package Manager lets you share your code as a package, depend on and u
 
 ### Guides
 
-- <doc:SwiftBuildDefault>
 - <doc:CreatingSwiftPackage>
 - <doc:SettingSwiftToolsVersion>
 - <doc:AddingDependencies>

--- a/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
@@ -4,7 +4,7 @@ Swift Package Manager 6.4 makes Swift Build the new default build system, provid
 
 ## SwiftBuild: The new default build system
 
-SwiftPM has changed its default build system to Swift Build. Read more [here](<doc:SwiftBuildDefault>).
+SwiftPM has changed its default build system to Swift Build.
 
 ### Key changes from the native build system
 


### PR DESCRIPTION
The "Check Documentation" actions was not actually checking any documentation as a required `.spi.yml` file was missing.

Update the repository to use a new tag of the workflow that allows to specify the documentation targets.

Fixes: #10186

Depends on https://github.com/swiftlang/github-workflows/pull/282


- Update the Soundness workflow to the actual version that contains https://github.com/swiftlang/github-workflows/pull/282