### PR TITLE
Commands: make truncation explicit

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -1877,7 +1877,7 @@ private var EXIT_NO_TESTS_FOUND: CInt {
 #if os(macOS) || os(Linux) || canImport(Android) || os(FreeBSD)
     EX_UNAVAILABLE
 #elseif os(Windows)
-    ERROR_NOT_FOUND
+    CInt(ERROR_NOT_FOUND)
 #else
 #warning("Platform-specific implementation missing: value for EXIT_NO_TESTS_FOUND unavailable")
     return 2 // We're assuming that EXIT_SUCCESS = 0 and EXIT_FAILURE = 1.


### PR DESCRIPTION
This adjusts the code to be very explicit about the truncation of the high order bit. This is required to enable the compiler to improve the named constants canonically typed.