### PR TITLE
BSP - report build tool plugin inputs in sources responses

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -381,6 +381,7 @@ public final class PackagePIFBuilder {
 
         public var indexableFileURLs: [SourceControlURL]
         public var headerFiles: Set<AbsolutePath>
+        public var buildToolPluginInputs: Set<AbsolutePath>
         public var doccCatalogs: Set<AbsolutePath>
         /// Source files implementing the plugin represented by this target, which
         /// are compiled during build planning as opposed to participating in the
@@ -749,6 +750,7 @@ extension PackagePIFBuilder.ModuleOrProduct {
         pifTarget: ProjectModel.BaseTarget?,
         indexableFileURLs: [SourceControlURL] = [],
         headerFiles: Set<AbsolutePath> = [],
+        buildToolPluginInputs: Set<AbsolutePath> = [],
         doccCatalogs: Set<AbsolutePath> = [],
         pluginScriptSourcePaths: [AbsolutePath] = [],
         linkedPackageBinaries: [PackagePIFBuilder.LinkedPackageBinary] = [],
@@ -764,6 +766,7 @@ extension PackagePIFBuilder.ModuleOrProduct {
         self.indexableFileURLs = indexableFileURLs
         self.pluginScriptSourcePaths = pluginScriptSourcePaths
         self.headerFiles = headerFiles
+        self.buildToolPluginInputs = buildToolPluginInputs
         self.doccCatalogs = doccCatalogs
         self.linkedPackageBinaries = linkedPackageBinaries
         self.swiftLanguageVersion = swiftLanguageVersion

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -911,6 +911,14 @@ extension PackagePIFProjectBuilder {
             .module
         }
 
+        // The input files of any build tool plugin commands (which may live outside the target
+        // directory).
+        let buildToolPluginInputs = Set(
+            (pifBuilder.buildToolPluginResultsByTargetName[sourceModule.name] ?? [])
+                .flatMap(\.buildCommands)
+                .flatMap(\.inputPaths)
+        )
+
         let moduleOrProduct = PackagePIFBuilder.ModuleOrProduct(
             type: productOrModuleType,
             name: sourceModule.name,
@@ -918,6 +926,7 @@ extension PackagePIFProjectBuilder {
             pifTarget: .target(self.project[keyPath: sourceModuleTargetKeyPath]),
             indexableFileURLs: indexableFileURLs,
             headerFiles: headerFiles,
+            buildToolPluginInputs: buildToolPluginInputs,
             doccCatalogs: doccCatalogs,
             linkedPackageBinaries: linkedPackageBinaries,
             swiftLanguageVersion: sourceModule.packageSwiftLanguageVersion(manifest: packageManifest),

--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -138,6 +138,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
 
     private var headersByTargetGUID: [String: Set<Basics.AbsolutePath>] = [:]
     private var doccCatalogsByTargetGUID: [String: Set<Basics.AbsolutePath>] = [:]
+    private var buildToolPluginInputsByTargetGUID: [String: Set<Basics.AbsolutePath>] = [:]
 
     private struct PluginInfo {
         var name: String
@@ -311,6 +312,12 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                             )
                         )
                     }
+                    let buildToolPluginInputs = self.buildToolPluginInputsByTargetGUID[targetGUID] ?? []
+                    for pluginInput in buildToolPluginInputs {
+                        sourcesResponse.items[index].sources.append(
+                            SourceItem(uri: DocumentURI(pluginInput.asURL), kind: .file, generated: false)
+                        )
+                    }
                 }
                 return sourcesResponse
             }
@@ -377,7 +384,12 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                 outputPathsProvider: true,
                 prepareProvider: true,
                 sourceKitOptionsProvider: true,
-                watchers: []
+                // Watch all files in the workspace so that changes to non-Swift inputs (e.g. the
+                // input files of build tool plugins) invalidate the affected target's preparation
+                // and cause it to be rebuilt/re-indexed. This matches the native `SwiftPMBuildServer`,
+                // which registers a `**/*` watcher. SourceKit-LSP otherwise only watches `*.swift`
+                // and `*.swiftmodule` by default.
+                watchers: [FileSystemWatcher(globPattern: "**/*", kind: [.create, .change, .delete])]
             ).encodeToLSPAny()
         )
     }
@@ -524,6 +536,18 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         self.headersByTargetGUID = headers
     }
 
+    private func rebuildBuildToolPluginInputsMapping(pifAccompanyingMetadata: [PackagePIFBuilder.ModuleOrProduct]) async {
+        var buildToolPluginInputs: [String: Set<Basics.AbsolutePath>] = [:]
+        for moduleOrProduct in pifAccompanyingMetadata {
+            guard let pifTarget = moduleOrProduct.pifTarget else { continue }
+            let guid = pifTarget.id.value
+            if !moduleOrProduct.buildToolPluginInputs.isEmpty {
+                buildToolPluginInputs[guid] = moduleOrProduct.buildToolPluginInputs
+            }
+        }
+        self.buildToolPluginInputsByTargetGUID = buildToolPluginInputs
+    }
+
     private func rebuildDocCCatalogMapping(pifAccompanyingMetadata: [PackagePIFBuilder.ModuleOrProduct]) async {
         var doccCatalogs: [String: Set<Basics.AbsolutePath>] = [:]
         for moduleOrProduct in pifAccompanyingMetadata {
@@ -597,6 +621,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
                 let result = try await buildSystem.generatePIFAndAccompanyingMetadata(preserveStructure: false)
                 try localFileSystem.writeIfChanged(path: buildSystem.buildParameters.pifManifest, string: result.pif)
                 await self.rebuildHeaderMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
+                await self.rebuildBuildToolPluginInputsMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
                 await self.rebuildDocCCatalogMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
                 self.rebuildPluginMapping(pifAccompanyingMetadata: result.accompanyingMetadata)
                 self.connectionToUnderlyingBuildServer.send(OnWatchedFilesDidChangeNotification(changes: [

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -426,6 +426,20 @@ struct SwiftPMBuildServerTests {
     }
 
     @Test
+    func buildToolPluginInputsAreReportedAsSources() async throws {
+        try await withSwiftPMBSP(fixtureName: "Miscellaneous/Plugins/MySourceGenPlugin") { connection, _, _ in
+            // SourceKit-LSP expects a build server to report built tool plugin inputs in the BuildTargetSourcesResponse so it knows to re-prepare a target when they change.
+            let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            let myLocalTool = try #require(targetResponse.targets.first(where: { $0.displayName == "MyLocalTool" }))
+            let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [myLocalTool.id]))
+            let sources = try #require(sourcesResponse.items.only?.sources)
+            let pluginInput = try #require(sources.first(where: { $0.uri.fileURL?.lastPathComponent == "foo.dat" }))
+            #expect(pluginInput.kind == .file)
+            #expect(!pluginInput.generated)
+        }
+    }
+
+    @Test
     func doccCatalogSources() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/LibraryWithDocC") { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())


### PR DESCRIPTION
This ensures that SourceKit-LSP / other clients know to re-prepare a target if one of them is modified, since they may generate additional source files.