### PR TITLE
BSP - do not forward an empty prepare response to the underlying build server

### DIFF
--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -247,6 +247,10 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
             await request.reply {
                 var underlyingRequest = request.params
                 underlyingRequest.targets.removeAll(where: \.isSwiftPMBuildServerTargetID )
+                // Don't forward an empty prepare request to the underlying build server.
+                guard !underlyingRequest.targets.isEmpty else {
+                    return BuildTargetPrepareResponse()
+                }
                 return try await connectionToUnderlyingBuildServer.send(underlyingRequest)
             }
         case let request as RequestAndReply<BuildTargetSourcesRequest>:

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -442,5 +442,17 @@ struct SwiftPMBuildServerTests {
             #expect(doccCatalog.sourceKitData?.kind == .doccCatalog)
         }
     }
+
+    @Test
+    func manifestPrepareIsNotForwardedToUnderlyingBuildServer() async throws {
+        try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, notificationCollector, _ in
+            let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            let manifestTarget = try #require(targetResponse.targets.first(where: { $0.displayName == "Package Manifest" }))
+            let logsBefore = notificationCollector.notifications(of: OnBuildLogMessageNotification.self).count
+            _ = try await connection.send(BuildTargetPrepareRequest(targets: [manifestTarget.id]))
+            let logsAfter = notificationCollector.notifications(of: OnBuildLogMessageNotification.self)
+            #expect(logsAfter.count == logsBefore)
+        }
+    }
 }
 #endif


### PR DESCRIPTION
This avoids unnecessary work / logging which could be misinterpreted by clients like sourcekit-lsp