### PR TITLE
Don't pass -warnings-as-errors to remote packages when specified on the command line

### DIFF
--- a/Fixtures/Miscellaneous/WarningsAsErrorsInLocalPackage/downstream/Package.swift
+++ b/Fixtures/Miscellaneous/WarningsAsErrorsInLocalPackage/downstream/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "downstream",
+    dependencies: [
+        .package(url: "../upstream", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "Downstream",
+            dependencies: [
+                .product(name: "Upstream", package: "upstream"),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/WarningsAsErrorsInLocalPackage/downstream/Sources/Downstream/Downstream.swift
+++ b/Fixtures/Miscellaneous/WarningsAsErrorsInLocalPackage/downstream/Sources/Downstream/Downstream.swift
@@ -1,0 +1,10 @@
+import Upstream
+
+@available(*, deprecated, renamed: "newGreet")
+public func greet() -> String {
+    Upstream.NewAPI()
+}
+
+public func newGreet() -> String {
+    greet()
+}

--- a/Fixtures/Miscellaneous/WarningsAsErrorsInLocalPackage/upstream/Package.swift
+++ b/Fixtures/Miscellaneous/WarningsAsErrorsInLocalPackage/upstream/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "upstream",
+    products: [
+        .library(name: "Upstream", targets: ["Upstream"]),
+    ],
+    targets: [
+        .target(name: "Upstream"),
+    ]
+)

--- a/Fixtures/Miscellaneous/WarningsAsErrorsInLocalPackage/upstream/Sources/Upstream/Upstream.swift
+++ b/Fixtures/Miscellaneous/WarningsAsErrorsInLocalPackage/upstream/Sources/Upstream/Upstream.swift
@@ -1,0 +1,8 @@
+@available(*, deprecated, renamed: "NewAPI")
+public func deprecatedFunction() -> String {
+    "hello from upstream"
+}
+
+public func NewAPI() -> String {
+    deprecatedFunction()
+}

--- a/Fixtures/Miscellaneous/WarningsAsErrorsWithRemoteDep/downstream/Package.swift
+++ b/Fixtures/Miscellaneous/WarningsAsErrorsWithRemoteDep/downstream/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "downstream",
+    dependencies: [
+        .package(url: "../upstream", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "Downstream",
+            dependencies: [
+                .product(name: "Upstream", package: "upstream"),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/WarningsAsErrorsWithRemoteDep/downstream/Sources/Downstream/Downstream.swift
+++ b/Fixtures/Miscellaneous/WarningsAsErrorsWithRemoteDep/downstream/Sources/Downstream/Downstream.swift
@@ -1,0 +1,5 @@
+import Upstream
+
+public func greet() -> String {
+    Upstream.NewAPI()
+}

--- a/Fixtures/Miscellaneous/WarningsAsErrorsWithRemoteDep/upstream/Package.swift
+++ b/Fixtures/Miscellaneous/WarningsAsErrorsWithRemoteDep/upstream/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "upstream",
+    products: [
+        .library(name: "Upstream", targets: ["Upstream"]),
+    ],
+    targets: [
+        .target(name: "Upstream"),
+    ]
+)

--- a/Fixtures/Miscellaneous/WarningsAsErrorsWithRemoteDep/upstream/Sources/Upstream/Upstream.swift
+++ b/Fixtures/Miscellaneous/WarningsAsErrorsWithRemoteDep/upstream/Sources/Upstream/Upstream.swift
@@ -1,0 +1,8 @@
+@available(*, deprecated, renamed: "NewAPI")
+public func deprecatedFunction() -> String {
+    "hello from upstream"
+}
+
+public func NewAPI() -> String {
+    deprecatedFunction()
+}

--- a/Sources/SPMBuildCore/WarningControlFlags.swift
+++ b/Sources/SPMBuildCore/WarningControlFlags.swift
@@ -11,6 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 package enum WarningControlFlags {
+    package static func containsWarningsAsErrors(_ args: [String]) -> Bool {
+        args.contains("-warnings-as-errors")
+    }
+
     package static func filterSwiftWarningControlFlags(_ args: [String]) -> [String] {
         var filtered: [String] = []
         var skipNextArg = false

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -248,6 +248,7 @@ public final class PIFBuilder {
     ) async throws -> [(ResolvedPackage, PackagePIFBuilder, any PackagePIFBuilder.BuildDelegate)] {
         let pluginScriptRunner = self.parameters.pluginScriptRunner
         let outputDir = self.parameters.pluginWorkingDirectory.appending("outputs")
+        let treatWarningsAsErrors = WarningControlFlags.containsWarningsAsErrors(buildParameters.flags.swiftCompilerFlags.map(\.value))
 
         let pluginsPerModule = graph.pluginsPerModule(
             satisfying: buildParameters.buildEnvironment // .buildEnvironment(for: .host)
@@ -470,7 +471,7 @@ public final class PIFBuilder {
                 addLocalRpaths: self.parameters.addLocalRpaths,
                 packageDisplayVersion: package.manifest.displayName,
                 pkgConfigDirectories: self.parameters.pkgConfigDirectories,
-                treatWarningsAsErrors: WarningControlFlags.containsWarningsAsErrors(buildParameters.flags.swiftCompilerFlags.map(\.value)),
+                treatWarningsAsErrors: treatWarningsAsErrors,
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,
             )

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -470,6 +470,7 @@ public final class PIFBuilder {
                 addLocalRpaths: self.parameters.addLocalRpaths,
                 packageDisplayVersion: package.manifest.displayName,
                 pkgConfigDirectories: self.parameters.pkgConfigDirectories,
+                treatWarningsAsErrors: WarningControlFlags.containsWarningsAsErrors(buildParameters.flags.swiftCompilerFlags.map(\.value)),
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,
             )

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -207,6 +207,9 @@ public final class PackagePIFBuilder {
 
     let pkgConfigDirectories: [AbsolutePath]
 
+    /// True if the user passed -warnings-as-errors on the command line, false otherwise.
+    let treatWarningsAsErrors: Bool
+
     /// The file system to read from.
     let fileSystem: FileSystem
 
@@ -236,6 +239,7 @@ public final class PackagePIFBuilder {
         addLocalRpaths: AddLocalRpaths = .always,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
+        treatWarningsAsErrors: Bool = false,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
     ) {
@@ -252,6 +256,7 @@ public final class PackagePIFBuilder {
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.addLocalRpaths = addLocalRpaths
+        self.treatWarningsAsErrors = treatWarningsAsErrors
     }
 
     public init(
@@ -266,6 +271,7 @@ public final class PackagePIFBuilder {
         addLocalRpaths: AddLocalRpaths = .always,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
+        treatWarningsAsErrors: Bool = false,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
     ) {
@@ -280,6 +286,7 @@ public final class PackagePIFBuilder {
         self.addLocalRpaths = addLocalRpaths
         self.packageDisplayVersion = packageDisplayVersion
         self.pkgConfigDirectories = pkgConfigDirectories
+        self.treatWarningsAsErrors = treatWarningsAsErrors
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
     }
@@ -622,7 +629,10 @@ public final class PackagePIFBuilder {
             if self.skipStaticAnalyzerForPackageDependencies {
                 settings[.SKIP_CLANG_STATIC_ANALYZER] = "YES"
             }
+        } else if self.treatWarningsAsErrors {
+            settings[.SWIFT_TREAT_WARNINGS_AS_ERRORS] = "YES"
         }
+
         settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS]
             .lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) { $0.append("SWIFT_PACKAGE") }
         settings[.GCC_PREPROCESSOR_DEFINITIONS] = ["$(inherited)", "SWIFT_PACKAGE"]

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1142,10 +1142,9 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         swiftCompilerFlags += buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
         // User arguments (from -Xcc) should follow generated arguments to allow user overrides
         swiftCompilerFlags += buildParameters.flags.cCompilerFlags.asSwiftcCCompilerFlags()
-        // We strip warning control flags (-warnings-as-errors) from the user supplied swift compiler flags.  Per-package toggling of this flag is handled with  SWIFT_TREAT_WARNINGS_AS_ERRORS in the PIF.
-        swiftCompilerFlags = swiftCompilerFlags.filter {
-            !WarningControlFlags.filterSwiftWarningControlFlags([$0.value]).isEmpty
-        }
+        // We strip warning control flags (-warnings-as-errors) from the user supplied swift compiler flags.
+        // Per-package toggling of this flag is handled with  SWIFT_TREAT_WARNINGS_AS_ERRORS in the PIF.
+        swiftCompilerFlags = swiftCompilerFlags.filter { !WarningControlFlags.containsWarningsAsErrors([$0.value]) }
         // TODO: Pass -Xcxx flags to swiftc (#6491)
         // Uncomment when downstream support arrives.
         // swiftCompilerFlags += buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1142,6 +1142,10 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         swiftCompilerFlags += buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
         // User arguments (from -Xcc) should follow generated arguments to allow user overrides
         swiftCompilerFlags += buildParameters.flags.cCompilerFlags.asSwiftcCCompilerFlags()
+        // We strip warning control flags (-warnings-as-errors) from the user supplied swift compiler flags.  Per-package toggling of this flag is handled with  SWIFT_TREAT_WARNINGS_AS_ERRORS in the PIF.
+        swiftCompilerFlags = swiftCompilerFlags.filter {
+            !WarningControlFlags.filterSwiftWarningControlFlags([$0.value]).isEmpty
+        }
         // TODO: Pass -Xcxx flags to swiftc (#6491)
         // Uncomment when downstream support arrives.
         // swiftCompilerFlags += buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1319,6 +1319,62 @@ struct MiscellaneousTestCase {
         .tags(
             .Feature.Command.Build,
         ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10192", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func warningsAsErrorsFlagDoesNotReachRemoteDependencies(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/WarningsAsErrorsWithRemoteDep") { path in
+            let upstreamPath = path.appending("upstream")
+            initGitRepo(upstreamPath, tag: "1.0.0")
+
+            let downstreamPath = path.appending("downstream")
+            let (stdout, stderr) = try await executeSwiftBuild(
+                downstreamPath,
+                Xswiftc: ["-warnings-as-errors"],
+                buildSystem: .swiftbuild,
+            )
+            let combined = stdout + stderr
+            print(combined)
+            #expect(!combined.contains("conflicting options"))
+            #expect(!combined.contains("'deprecatedFunction' is deprecated"))
+        }
+    }
+
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10192", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func warningsAsErrorsStillApplyToLocalPackage(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/WarningsAsErrorsInLocalPackage") { path in
+            let upstreamPath = path.appending("upstream")
+            initGitRepo(upstreamPath, tag: "1.0.0")
+
+            let downstreamPath = path.appending("downstream")
+            await expectThrowsCommandExecutionError(
+                try await executeSwiftBuild(
+                    downstreamPath,
+                    Xswiftc: ["-warnings-as-errors"],
+                    buildSystem: buildSystem,
+                )
+            ) { error in
+                #expect((error.stdout + error.stderr).contains("'greet()' is deprecated:"))
+            }
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func rootPackageWithConditionals(
@@ -1370,7 +1426,6 @@ struct MiscellaneousTestCase {
             ProcessInfo.isHostAmazonLinux2() // libFuzzer link issues occur on AL2
         }
     }
-}
 
 @Suite
 struct MiscellaneousSwiftTestingTests {


### PR DESCRIPTION
Don't pass -warnings-as-errors to remote packages when specified on the command line

### Motivation:

Addresses:
https://github.com/swiftlang/swift-package-manager/issues/10192

When passing -Xswiftc -warnings-as-errors on the command line, this bypassed existing filtering of this flag that is in place if it is included in the Package manifest.  Passing on the command line causes a conflicting flag error to occur that results in a build failure. 

### Modifications:

Filter out -warnings-as-errors when passed from the command line.  Use the new SWIFT_TREAT_WARNINGS_AS_ERRORS setting to toggle this flag on local packages only.

Depends on:
https://github.com/swiftlang/swift-build/pull/1456


