### PR TITLE
Add an option for BSP clients to skip package symlink resolution

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -168,6 +168,13 @@ public struct LocationOptions: ParsableArguments {
 
     @Flag(name: .customLong("experimental-skip-acquiring-lock"), help: .hidden)
     public var skipAcquiringLock: Bool = false
+
+    /// When set, an explicitly provided `--package-path` is used as the package root verbatim,
+    /// without resolving symbolic links, and sources paths are not resolved. Intended for BSP clients
+    /// like SourceKit-LSP which want to independently reference a symlinked source file and its
+    /// original path.
+    @Flag(name: .customLong("experimental-skip-resolving-package-paths"), help: .hidden)
+    public var skipResolvingPackagePaths: Bool = false
 }
 
 public struct CachingOptions: ParsableArguments {

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -457,7 +457,20 @@ public final class SwiftCommandState {
         self.cancellator = cancellator
 
         // Create local variables to use while finding build path to avoid capture self before init error.
-        let packageRoot = findPackageRoot(fileSystem: fileSystem)
+        let packageRoot: AbsolutePath?
+        if options.locations.skipResolvingPackagePaths {
+            // Do not use the current working directory to determine the package root, as it will indirectly
+            // cause us to reference its sources via their real instead of symlinked paths.
+            guard let packageDirectory = options.locations.packageDirectory else {
+                self.observabilityScope.emit(
+                    error: "'--experimental-skip-resolving-package-paths' requires an explicit '--package-path'"
+                )
+                throw ExitCode.failure
+            }
+            packageRoot = packageDirectory
+        } else {
+            packageRoot = findPackageRoot(fileSystem: fileSystem)
+        }
 
         self.packageRoot = packageRoot
         self.scratchDirectory =
@@ -1094,6 +1107,7 @@ public final class SwiftCommandState {
                 testEntryPointPath: self.options.build.testEntryPointPath
             ),
             stripProducts: self.options.build.stripProducts,
+            shouldPreserveSymlinks: options.locations.skipResolvingPackagePaths,
         )
     }
 

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -142,6 +142,10 @@ public struct BuildParameters: Encodable {
 
     public var printPIFManifestGraphviz: Bool = false
 
+    /// Whether to preserve symbolic links in package/source file paths instead of resolving them to
+    /// their real path.
+    public var shouldPreserveSymlinks: Bool
+
     /// Do minimal build to prepare for indexing
     public var prepareForIndexing: PrepareForIndexingMode
 
@@ -192,6 +196,7 @@ public struct BuildParameters: Encodable {
         testingParameters: Testing = .init(),
         apiDigesterMode: APIDigesterMode? = nil,
         stripProducts: Bool? = nil,
+        shouldPreserveSymlinks: Bool = false,
     ) throws {
         // Default to the unversioned triple if none is provided so that we defer to the package's requested deployment target, for Darwin platforms. For other platforms, continue to include the version since those don't have the concept of a package-specified version, and the version is meaningful for some platforms including Android and FreeBSD.
         let triple = try triple ?? {
@@ -258,6 +263,7 @@ public struct BuildParameters: Encodable {
         self.testingParameters = testingParameters
         self.apiDigesterMode = apiDigesterMode
         self.stripProducts = stripProducts
+        self.shouldPreserveSymlinks = shouldPreserveSymlinks
     }
 
     /// The path to the build directory (inside the data directory).

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -87,7 +87,11 @@ package struct PIFBuilderParameters {
     /// reported by the build system for the host `BuildParameters`.
     let hostBuildProductsPath: AbsolutePath
 
-    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRpaths: PackagePIFBuilder.AddLocalRpaths, hostBuildProductsPath: AbsolutePath) {
+    /// Whether to preserve symbolic links in source file paths instead of resolving them to their
+    /// real path.
+    let shouldPreserveSymlinks: Bool
+
+    package init(isPackageAccessModifierSupported: Bool, enableTestability: Bool, shouldCreateDylibForDynamicProducts: Bool, materializeStaticArchiveProductsForRootPackages: Bool, createDynamicVariantsForLibraryProducts: Bool, toolchainLibDir: AbsolutePath, pkgConfigDirectories: [AbsolutePath], supportedSwiftVersions: [SwiftLanguageVersion], pluginScriptRunner: PluginScriptRunner, disableSandbox: Bool, pluginWorkingDirectory: AbsolutePath, additionalFileRules: [FileRuleDescription], addLocalRpaths: PackagePIFBuilder.AddLocalRpaths, hostBuildProductsPath: AbsolutePath, shouldPreserveSymlinks: Bool) {
         self.isPackageAccessModifierSupported = isPackageAccessModifierSupported
         self.enableTestability = enableTestability
         self.shouldCreateDylibForDynamicProducts = shouldCreateDylibForDynamicProducts
@@ -102,6 +106,7 @@ package struct PIFBuilderParameters {
         self.additionalFileRules = additionalFileRules
         self.addLocalRpaths = addLocalRpaths
         self.hostBuildProductsPath = hostBuildProductsPath
+        self.shouldPreserveSymlinks = shouldPreserveSymlinks
     }
 }
 
@@ -466,6 +471,7 @@ public final class PIFBuilder {
                 materializeStaticArchiveProductsForRootPackages: self.parameters.materializeStaticArchiveProductsForRootPackages,
                 createDynamicVariantsForLibraryProducts: self.parameters.createDynamicVariantsForLibraryProducts,
                 addLocalRpaths: self.parameters.addLocalRpaths,
+                shouldPreserveSymlinks: self.parameters.shouldPreserveSymlinks,
                 packageDisplayVersion: package.manifest.displayName,
                 pkgConfigDirectories: self.parameters.pkgConfigDirectories,
                 fileSystem: self.fileSystem,
@@ -932,7 +938,8 @@ extension PIFBuilderParameters {
             pluginWorkingDirectory: pluginWorkingDirectory,
             additionalFileRules: additionalFileRules,
             addLocalRpaths: addLocalRpaths,
-            hostBuildProductsPath: hostBuildProductsPath
+            hostBuildProductsPath: hostBuildProductsPath,
+            shouldPreserveSymlinks: buildParameters.shouldPreserveSymlinks
         )
     }
 }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -202,6 +202,10 @@ public final class PackagePIFBuilder {
     /// the build products to a different location or building the release configuration.
     let addLocalRpaths: AddLocalRpaths
 
+    /// Whether to preserve symbolic links in source file paths instead of resolving them to their
+    /// real path.
+    let shouldPreserveSymlinks: Bool
+
     /// Package display version, if any (i.e., it can be a version, branch or a git ref).
     let packageDisplayVersion: String?
 
@@ -234,6 +238,7 @@ public final class PackagePIFBuilder {
         materializeStaticArchiveProductsForRootPackages: Bool = false,
         createDynamicVariantsForLibraryProducts: Bool = true,
         addLocalRpaths: AddLocalRpaths = .always,
+        shouldPreserveSymlinks: Bool,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
         fileSystem: FileSystem,
@@ -252,6 +257,7 @@ public final class PackagePIFBuilder {
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.addLocalRpaths = addLocalRpaths
+        self.shouldPreserveSymlinks = shouldPreserveSymlinks
     }
 
     public init(
@@ -264,6 +270,7 @@ public final class PackagePIFBuilder {
         materializeStaticArchiveProductsForRootPackages: Bool = false,
         createDynamicVariantsForLibraryProducts: Bool = true,
         addLocalRpaths: AddLocalRpaths = .always,
+        shouldPreserveSymlinks: Bool = false,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
         fileSystem: FileSystem,
@@ -282,6 +289,7 @@ public final class PackagePIFBuilder {
         self.pkgConfigDirectories = pkgConfigDirectories
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
+        self.shouldPreserveSymlinks = shouldPreserveSymlinks
     }
 
     /// Build an empty PIF project.

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -618,14 +618,27 @@ extension PackagePIFProjectBuilder {
         // Create a group for the target's source files.
         //
         // For now we use an absolute path for it, but we should really make it be container-relative,
-        // since it's always inside the package directory. Resolve symbolic links otherwise there will
-        // be a mismatch between the paths that the index service is using for Swift Build queries,
-        // and what paths Swift Build uses in its build description; such a mismatch would result
-        // in the index service failing to get compiler arguments for source files of the target.
+        // since it's always inside the package directory.
+        //
+        // By default (for historical reasons) we resolve symbolic links,
+        // otherwise there will be a mismatch between the paths some indexing clients are using for
+        // Swift Build queries, and what paths Swift Build uses in its build description; such a
+        // mismatch would result in the index service failing to get compiler arguments for source
+        // files of the target.
+        //
+        // If a client is using `--experimental-skip-resolving-package-paths`, the path is used
+        // as-is.
+        //
+        // Ideally, we could get all known clients to use one mode or the other, but the migration story
+        // is tricky.
+        let sourceDirGroupPath =
+            pifBuilder.shouldPreserveSymlinks
+            ? sourceModule.sourceDirAbsolutePath
+            : (try! resolveSymlinks(sourceModule.sourceDirAbsolutePath))
         let targetSourceFileGroupKeyPath = self.project.mainGroup.addGroup { id in
             ProjectModel.Group(
                 id: id,
-                path: try! resolveSymlinks(sourceModule.sourceDirAbsolutePath).pathString,
+                path: sourceDirGroupPath.pathString,
                 pathBase: .absolute
             )
         }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -52,7 +52,8 @@ extension PIFBuilderParameters {
             pluginWorkingDirectory: temporaryDirectory.appending(component: "plugin-working-dir"),
             additionalFileRules: [],
             addLocalRpaths: addLocalRpaths,
-            hostBuildProductsPath: hostBuildProductsPath ?? temporaryDirectory.appending(component: "host-build-products")
+            hostBuildProductsPath: hostBuildProductsPath ?? temporaryDirectory.appending(component: "host-build-products"),
+            shouldPreserveSymlinks: false
         )
     }
 }

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -35,45 +35,52 @@ final fileprivate class NotificationCollectingMessageHandler: MessageHandler, @u
     }
 }
 
-fileprivate func withSwiftPMBSP(fixtureName: String, extraBSPArgs: [String] = [], body: (Connection, NotificationCollectingMessageHandler, AbsolutePath) async throws -> Void) async throws {
+fileprivate func withSwiftPMBSP(packagePath: AbsolutePath, extraBSPArgs: [String] = [], body: (Connection, NotificationCollectingMessageHandler) async throws -> Void) async throws {
     await withKnownIssue("Tests occasionally fail to load build description in CI", isIntermittent: true) {
-        try await fixture(name: fixtureName) { fixture in
-            let inPipe = Pipe()
-            let outPipe = Pipe()
-            let connection = JSONRPCConnection(
-                name: "bsp-connection",
-                protocol: MessageRegistry.bspProtocol,
-                receiveFD: inPipe.fileHandleForReading,
-                sendFD: outPipe.fileHandleForWriting
-            )
-            defer {
-                connection.close()
-            }
-            let bspProcess = Process()
-            bspProcess.standardOutputPipe = inPipe
-            bspProcess.standardInput = outPipe
-            let execPath = SwiftPM.xctestBinaryPath(for: "swift-package").pathString
-            bspProcess.executableURL = URL(filePath: execPath)
-            bspProcess.arguments = ["--package-path", fixture.pathString] + ["experimental-build-server", "--build-system", "swiftbuild"] + extraBSPArgs
-            async let terminationPromise: Void = try await bspProcess.run()
-            let notificationCollector = NotificationCollectingMessageHandler()
-            connection.start(receiveHandler: notificationCollector)
-            _ = try await connection.send(
-                InitializeBuildRequest(
-                    displayName: "test-bsp-client",
-                    version: "1.0.0",
-                    bspVersion: "2.2.0",
-                    rootUri: URI(URL(filePath: fixture.pathString)),
-                    capabilities: .init(languageIds: [.swift, .c, .objective_c, .cpp, .objective_cpp])
-                )
-            )
-            connection.send(OnBuildInitializedNotification())
-            _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
-            try await body(connection, notificationCollector, fixture)
-            _ = try await connection.send(BuildShutdownRequest())
-            connection.send(OnBuildExitNotification())
-            try await terminationPromise
+        let inPipe = Pipe()
+        let outPipe = Pipe()
+        let connection = JSONRPCConnection(
+            name: "bsp-connection",
+            protocol: MessageRegistry.bspProtocol,
+            receiveFD: inPipe.fileHandleForReading,
+            sendFD: outPipe.fileHandleForWriting
+        )
+        defer {
+            connection.close()
         }
+        let bspProcess = Process()
+        bspProcess.standardOutputPipe = inPipe
+        bspProcess.standardInput = outPipe
+        let execPath = SwiftPM.xctestBinaryPath(for: "swift-package").pathString
+        bspProcess.executableURL = URL(filePath: execPath)
+        bspProcess.arguments = ["--package-path", packagePath.pathString] + ["experimental-build-server", "--build-system", "swiftbuild"] + extraBSPArgs
+        async let terminationPromise: Void = try await bspProcess.run()
+        let notificationCollector = NotificationCollectingMessageHandler()
+        connection.start(receiveHandler: notificationCollector)
+        _ = try await connection.send(
+            InitializeBuildRequest(
+                displayName: "test-bsp-client",
+                version: "1.0.0",
+                bspVersion: "2.2.0",
+                rootUri: URI(URL(filePath: packagePath.pathString)),
+                capabilities: .init(languageIds: [.swift, .c, .objective_c, .cpp, .objective_cpp])
+            )
+        )
+        connection.send(OnBuildInitializedNotification())
+        _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
+        try await body(connection, notificationCollector)
+        _ = try await connection.send(BuildShutdownRequest())
+        connection.send(OnBuildExitNotification())
+        try await terminationPromise
+    }
+}
+
+fileprivate func withSwiftPMBSP(fixtureName: String, extraBSPArgs: [String] = [], body: (Connection, NotificationCollectingMessageHandler, AbsolutePath) async throws -> Void) async throws {
+    try await fixture(name: fixtureName) { fixture in
+        try await withSwiftPMBSP(packagePath: fixture, extraBSPArgs: extraBSPArgs) { connection, notificationCollector in
+            try await body(connection, notificationCollector, fixture)
+        }
+
     }
 }
 
@@ -466,6 +473,47 @@ struct SwiftPMBuildServerTests {
             _ = try await connection.send(BuildTargetPrepareRequest(targets: [manifestTarget.id]))
             let logsAfter = notificationCollector.notifications(of: OnBuildLogMessageNotification.self)
             #expect(logsAfter.count == logsBefore)
+        }
+    }
+
+    @Test
+    func skipResolvingPackagePathsPreservesSymlinkedSourcePaths() async throws {
+        func testSourcePath(_ connection: Connection) async throws -> AbsolutePath {
+            let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+            let fooID = try #require(targetResponse.targets.first(where: { $0.displayName == "Foo" })).id
+            let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [fooID]))
+            let item = try #require(sourcesResponse.items.only?.sources.only)
+            let fileURL = try #require(item.uri.fileURL)
+            return try AbsolutePath(validating: fileURL.path)
+        }
+
+        try await fixture(name: "Miscellaneous/Simple") { fixture in
+            let resolvedPackagePath = try resolveSymlinks(fixture)
+
+            let symlinkPath = resolvedPackagePath.parentDirectory
+                .appending(component: resolvedPackagePath.basename + "-symlink")
+            try localFileSystem.createSymbolicLink(symlinkPath, pointingAt: resolvedPackagePath, relative: false)
+
+            // With `--experimental-skip-resolving-package-paths`, the source path should be
+            // reported under the symlinked path the package was opened with.
+            try await withSwiftPMBSP(
+                packagePath: symlinkPath,
+                extraBSPArgs: ["--experimental-skip-resolving-package-paths"]
+            ) { connection, _ in
+                let path = try await testSourcePath(connection)
+                #expect(path.basename == "Foo.swift")
+                #expect(path.isDescendant(of: symlinkPath))
+                #expect(!path.isDescendant(of: resolvedPackagePath))
+            }
+
+            // Without the flag, the symlink is resolved and the source path is reported under
+            // the real package path.
+            try await withSwiftPMBSP(packagePath: symlinkPath) { connection, _ in
+                let path = try await testSourcePath(connection)
+                #expect(path.basename == "Foo.swift")
+                #expect(path.isDescendant(of: resolvedPackagePath))
+                #expect(!path.isDescendant(of: symlinkPath))
+            }
         }
     }
 }


### PR DESCRIPTION
Add an experimental flag BSP clients can use to skip symlink resolution for package roots and sources. This ensures that if an entire package or some sources belonging to it are symlinked, the client can fetch args corresponding to the location used to open the document rather than always using the realpath. Fixes some tests in SourceKit-LSP when using `swift package experimental-build-server`