### PR TITLE
Fix download race condition when multiple targets reference the same binary artifact

### DIFF
--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -637,34 +637,36 @@ extension Workspace {
             let cacheKey = artifact.url.absoluteString.spm_mangledToC99ExtendedIdentifier()
             let cachedArtifactPath = cachePath.appending(cacheKey)
 
-            if self.fileSystem.exists(cachedArtifactPath) {
+            return try await self.fileSystem.withLock(on: cachedArtifactPath, type: .exclusive) {
+                if self.fileSystem.exists(cachedArtifactPath) {
+                    observabilityScope
+                        .emit(debug: "copying cached binary artifact for \(artifact.url) from \(cachedArtifactPath)")
+                    self.delegate?.willDownloadBinaryArtifact(from: artifact.url.absoluteString, fromCache: true)
+
+                    // copy from cache to destination
+                    try self.fileSystem.copy(from: cachedArtifactPath, to: destination)
+                    return true // fetched from cache
+                }
+
+                // download to the cache
                 observabilityScope
-                    .emit(debug: "copying cached binary artifact for \(artifact.url) from \(cachedArtifactPath)")
-                self.delegate?.willDownloadBinaryArtifact(from: artifact.url.absoluteString, fromCache: true)
+                    .emit(debug: "downloading binary artifact for \(artifact.url) to cache at \(cachedArtifactPath)")
 
-                // copy from cache to destination
-                try self.fileSystem.copy(from: cachedArtifactPath, to: destination)
-                return true // fetched from cache
-            }
+                self.delegate?.willDownloadBinaryArtifact(from: artifact.url.absoluteString, fromCache: false)
 
-            // download to the cache
-            observabilityScope
-                .emit(debug: "downloading binary artifact for \(artifact.url) to cache at \(cachedArtifactPath)")
-
-            self.delegate?.willDownloadBinaryArtifact(from: artifact.url.absoluteString, fromCache: false)
-
-            do {
-                try await self.download(
-                    artifact: artifact,
-                    destination: cachedArtifactPath,
-                    observabilityScope: observabilityScope,
-                    progress: progress
-                )
-                try self.fileSystem.copy(from: cachedArtifactPath, to: destination)
-                return false // not fetched from cache
-            } catch {
-                try? self.fileSystem.removeFileTree(cachedArtifactPath)
-                throw error
+                do {
+                    try await self.download(
+                        artifact: artifact,
+                        destination: cachedArtifactPath,
+                        observabilityScope: observabilityScope,
+                        progress: progress
+                    )
+                    try self.fileSystem.copy(from: cachedArtifactPath, to: destination)
+                    return false // not fetched from cache
+                } catch {
+                    try? self.fileSystem.removeFileTree(cachedArtifactPath)
+                    throw error
+                }
             }
         }
 

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -7891,6 +7891,105 @@ final class WorkspaceTests: XCTestCase {
         )
     }
 
+    func testConcurrentArtifactDownloadsWithSameURLUsingSharedCache() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+        let downloads = ThreadSafeArrayStore<(URL, AbsolutePath)>()
+
+        let httpClient = HTTPClient { request, _ in
+            guard case .download(let fileSystem, let destination) = request.kind else {
+                throw StringError("invalid request \(request.kind)")
+            }
+            guard request.url.absoluteString == "https://a.com/same.zip" else {
+                throw StringError("unexpected url \(request.url)")
+            }
+
+            if downloads.append((request.url, destination)) == 1 {
+                // Keep the first cache download in flight long enough for the second artifact with the
+                // same URL to contend for the same cache entry.
+                try await Task.sleep(nanoseconds: 100_000_000)
+            }
+
+            try fileSystem.writeFileContents(
+                destination,
+                bytes: ByteString([0xA1]),
+                atomically: true
+            )
+            return .okay()
+        }
+
+        let archiver = MockArchiver(handler: { archiver, archivePath, destinationPath, completion in
+            do {
+                guard archivePath.basename == "same.zip" else {
+                    throw StringError("unexpected archivePath \(archivePath)")
+                }
+                try createDummyXCFramework(fileSystem: fs, path: destinationPath, name: "Same")
+                archiver.extractions
+                    .append(MockArchiver.Extraction(archivePath: archivePath, destinationPath: destinationPath))
+                completion(.success(()))
+            } catch {
+                completion(.failure(error))
+            }
+        })
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "A1",
+                            type: .binary,
+                            url: "https://a.com/same.zip",
+                            checksum: "a1"
+                        ),
+                        MockTarget(
+                            name: "A2",
+                            type: .binary,
+                            url: "https://a.com/same.zip",
+                            checksum: "a1"
+                        ),
+                    ]
+                ),
+            ],
+            binaryArtifactsManager: .init(
+                httpClient: httpClient,
+                archiver: archiver
+            )
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+
+        XCTAssertEqual(downloads.count, 1)
+        XCTAssertEqual(downloads.map(\.0.absoluteString), ["https://a.com/same.zip"])
+        XCTAssertEqual(archiver.extractions.count, 2)
+
+        await workspace.checkManagedArtifacts { result in
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A1",
+                source: .remote(
+                    url: "https://a.com/same.zip",
+                    checksum: "a1"
+                ),
+                path: workspace.artifactsDir.appending(components: "root", "A1", "Same.xcframework")
+            )
+            result.check(
+                packageIdentity: .plain("root"),
+                targetName: "A2",
+                source: .remote(
+                    url: "https://a.com/same.zip",
+                    checksum: "a1"
+                ),
+                path: workspace.artifactsDir.appending(components: "root", "A2", "Same.xcframework")
+            )
+        }
+    }
+
     func testArtifactDownloadServerError() async throws {
         let fs = InMemoryFileSystem()
         let sandbox = AbsolutePath("/tmp/ws/")


### PR DESCRIPTION
Fix download race condition when multiple targets reference the same binary artifact. This issue is only present when the cache is empty.

### Motivation:

When 2 or more SPM targets in the graph reference the same binary artifact, and the artifact cache is empty, actions like resolving packages are likely to fail. Here's example output when running`swift package resolve` on a project that has 2 targets referencing the same Sourcery binary:

```
Downloading binary artifact https://github.com/krzysztofzablocki/Sourcery/releases/download/2.3.0/sourcery-2.3.0.artifactbundle.zip
Downloading binary artifact https://github.com/krzysztofzablocki/Sourcery/releases/download/2.3.0/sourcery-2.3.0.artifactbundle.zip
error: failed downloading 'https://github.com/krzysztofzablocki/Sourcery/releases/download/2.3.0/sourcery-2.3.0.artifactbundle.zip' which is required by binary target 'SourceryToolA': /Users/**********/Library/Caches/org.swift.swiftpm/artifacts/https___github_com_krzysztofzablocki_Sourcery_releases_download_2_3_0_sourcery_2_3_0_artifactbundle_zip already exists in file system
error: failed downloading 'https://github.com/krzysztofzablocki/Sourcery/releases/download/2.3.0/sourcery-2.3.0.artifactbundle.zip' which is required by binary target 'SourceryToolB': The file “https___github_com_krzysztofzablocki_Sourcery_releases_download_2_3_0_sourcery_2_3_0_artifactbundle_zip” doesn’t exist.
error: fatalError
```

Users can workaround this issue by repeatedly resolving packages, eventually it will succeed, but the issue will reappear if the user clears their artifact cache.

I created a reproduction project for this bug [here](https://github.com/rayray/SPMDupeBinaryRepro), that resembles the project layout where I've most encountered this issue.

### Modifications:

- Serialize access to each shared binary artifact cache entry using an exclusive file lock
- Preserve concurrent downloads for different artifact URLs
- Add a test covering two distinct binary targets that use the same URL:
  - one cache download occurs
  - both targets still get separate extracted managed artifacts

### Result:

Binary artifact downloads will no longer fail when the artifact is not already in cache, and 2 or more targets reference it
