### PR TITLE
SwiftBuildSupport: hoist remaining per-iteration work in PIF builder

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -61,6 +61,8 @@ extension PackagePIFProjectBuilder {
         var buildSettings: ProjectModel.BuildSettings = self.package.underlying.packageBaseBuildSettings
 
         // Add the dependencies.
+        var pluginTarget = self.project[keyPath: pluginTargetKeyPath]
+        let mainModuleProducts = self.package.products.filter(\.isMainModuleProduct)
         pluginModule.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: false) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
@@ -75,12 +77,11 @@ extension PackagePIFProjectBuilder {
                 case .executable, .snippet:
                     // For executable targets, add a build time dependency on the product.
                     // FIXME: Maybe we should we do this at the libSwiftPM level.
-                    let moduleProducts = self.package.products.filter(\.isMainModuleProduct)
                     let productDependency = moduleDependency
-                        .productRepresentingDependencyOfBuildPlugin(in: moduleProducts)
+                        .productRepresentingDependencyOfBuildPlugin(in: mainModuleProducts)
 
                     if let productDependency {
-                        self.project[keyPath: pluginTargetKeyPath].common.addDependency(
+                        pluginTarget.common.addDependency(
                             on: productDependency.pifTargetGUID,
                             platformFilters: dependencyPlatformFilters
                         )
@@ -95,7 +96,7 @@ extension PackagePIFProjectBuilder {
 
                 case .library, .systemModule, .test, .binary, .plugin, .macro:
                     let dependencyGUID = moduleDependency.pifTargetGUID
-                    self.project[keyPath: pluginTargetKeyPath].common.addDependency(
+                    pluginTarget.common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters
                     )
@@ -116,7 +117,7 @@ extension PackagePIFProjectBuilder {
                     let dependencyPlatformFilters = packageConditions
                         .toPlatformFilter(toolsVersion: self.package.manifest.toolsVersion)
 
-                    self.project[keyPath: pluginTargetKeyPath].common.addDependency(
+                    pluginTarget.common.addDependency(
                         on: dependencyGUID,
                         platformFilters: dependencyPlatformFilters
                     )
@@ -128,12 +129,13 @@ extension PackagePIFProjectBuilder {
         // Any dependencies of plugin targets need to be built for the host.
         buildSettings[.SUPPORTED_PLATFORMS] = ["$(HOST_PLATFORM)"]
 
-        self.project[keyPath: pluginTargetKeyPath].common.addBuildConfig { id in
+        pluginTarget.common.addBuildConfig { id in
             BuildConfig(id: id, name: "Debug", settings: buildSettings)
         }
-        self.project[keyPath: pluginTargetKeyPath].common.addBuildConfig { id in
+        pluginTarget.common.addBuildConfig { id in
             BuildConfig(id: id, name: "Release", settings: buildSettings)
         }
+        self.project[keyPath: pluginTargetKeyPath] = pluginTarget
 
         let pluginModuleMetadata = PackagePIFBuilder.ModuleOrProduct(
             type: .plugin,
@@ -731,6 +733,7 @@ extension PackagePIFProjectBuilder {
         // Handle the target's dependencies (but only link against them if needed).
         let shouldLinkProduct = (desiredModuleType == .dynamicLibrary) || (desiredModuleType == .macro)
         var moduleTarget = self.project[keyPath: sourceModuleTargetKeyPath]
+        let moduleMainProducts = self.package.products.filter(\.isMainModuleProduct)
         sourceModule.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: false) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
@@ -745,7 +748,6 @@ extension PackagePIFProjectBuilder {
                 case .executable, .snippet:
                     // Always depend on product of executable targets (if available).
                     // FIXME: Maybe we should we do this at the libSwiftPM level.
-                    let moduleMainProducts = self.package.products.filter(\.isMainModuleProduct)
                     if let product = moduleDependency
                         .productRepresentingDependencyOfBuildPlugin(in: moduleMainProducts)
                     {

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -769,6 +769,7 @@ extension PackagePIFProjectBuilder {
         // (and link against them, which in the case of a package product, really just means that clients should link
         // against them).
         var libraryUmbrellaTarget = self.project[keyPath: libraryUmbrellaTargetKeyPath]
+        let mainModuleProducts = package.products.filter(\.isMainModuleProduct)
         product.modules.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: false) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
@@ -817,8 +818,6 @@ extension PackagePIFProjectBuilder {
                 // For executable targets, add a build time dependency on the product.
                 // FIXME: Maybe we should we do this at the libSwiftPM level.
                 if moduleDependency.isExecutable {
-                    let mainModuleProducts = package.products.filter(\.isMainModuleProduct)
-
                     if let product = moduleDependency
                         .productRepresentingDependencyOfBuildPlugin(in: mainModuleProducts)
                     {


### PR DESCRIPTION
Hoist the plugin target and the products.filter(\.isMainModuleProduct) calls out of the PIF builder's dependency recursion loops.

rdar://178073760

