### PR TITLE
[6.4]Only apply standalone toolsets to the target platform

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -950,7 +950,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         }
 
         if !buildParameters.customToolsetPaths.isEmpty {
-            settings["SWIFT_SDK_TOOLSETS"] =
+            settings["SWIFT_SDK_TOOLSETS[__destination_platform=YES]"] =
                 (["$(inherited)"] + buildParameters.customToolsetPaths.map { $0.pathStringWithPosixSlashes })
                 .joined(separator: " ")
         }

--- a/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -128,6 +128,47 @@ private struct WebAssemblyIntegrationTests {
     @Test(
         .requiresWebAssemblySwiftSDK,
         .tags(
+            .Feature.Command.Run,
+            .Feature.CommandLineArguments.Toolset,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func flagOverridesToolset(buildSystem: BuildSystemProvider.Kind) async throws {
+        try await fixture(name: "Miscellaneous/FlagOverrides") { fixturePath in
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndSDKIDForTesting(for: .webassembly))
+
+            var env = Environment()
+            env["SWIFT_EXEC"] = compilerPath.pathString
+
+            // Pass the `-DONE` flag to the Swift compiler via a toolset file instead of `-Xswiftc`.
+            let toolsetPath = fixturePath.appending("toolset.json")
+            try localFileSystem.writeFileContents(
+                toolsetPath,
+                string: """
+                {
+                  "schemaVersion": "1.0",
+                  "swiftCompiler": { "extraCLIOptions": ["-DONE"] }
+                }
+                """
+            )
+
+            let runOutput = try await executeSwiftRun(
+                fixturePath,
+                "FlagOverrides",
+                extraArgs: ["--swift-sdk", sdkID, "--toolset", toolsetPath.pathString],
+                env: env,
+                buildSystem: buildSystem,
+            )
+
+            let lines = runOutput.stdout.split(separator: "\n").map(String.init)
+            #expect(lines.contains("Executable flag: ONE"))
+            #expect(lines.contains("Plugin tool flag: NONE"))
+        }
+    }
+
+    @Test(
+        .requiresWebAssemblySwiftSDK,
+        .tags(
             .Feature.Command.Package.Plugin,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,


### PR DESCRIPTION
Align the behavior of toolset across both build systems with the documented behavior that it only applies to targets which build for the destination platform

Closes https://github.com/swiftlang/swift-package-manager/issues/10206