### PR TITLE
Fix RepositoryManager caching failed lookups for the process's lifetime

### DIFF
--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -39,8 +39,11 @@ public class RepositoryManager: Cancellable {
     /// The filesystem to operate on.
     private let fileSystem: FileSystem
 
-    // tracks outstanding lookups for de-duping requests
-    private var pendingLookups = [RepositorySpecifier: Task<RepositoryManager.RepositoryHandle, Error>]()
+    // Tracks in-flight lookups so that concurrent requests for the same
+    // repository can be de-duped. Each entry is tagged with a unique id so that
+    // a completing lookup only removes its own entry and never a newer one for
+    // the same repository.
+    private var pendingLookups = [RepositorySpecifier: (id: UUID, task: Task<RepositoryManager.RepositoryHandle, Error>)]()
     private var pendingLookupsLock = NSLock()
 
     // Limits how many concurrent operations can be performed at once.
@@ -131,60 +134,53 @@ public class RepositoryManager: Cancellable {
                 self.pendingLookupsLock.lock()
                 defer { self.pendingLookupsLock.unlock() }
 
-                let lookupTask: Task<RepositoryManager.RepositoryHandle, any Error>
-                if let inFlight = self.pendingLookups[repositorySpecifier] {
-                    lookupTask = Task {
-                        // Let the existing in-flight task finish before queuing up the new one
-                        let _ = try await inFlight.value
+                // Identifies this lookup so that, on completion, it only removes
+                // its own entry from `pendingLookups`.
+                let lookupID = UUID()
+                let inFlight = self.pendingLookups[repositorySpecifier]?.task
 
-                        if Task.isCancelled {
-                            throw CancellationError()
-                        }
+                let lookupTask = Task { () throws -> RepositoryManager.RepositoryHandle in
+                    defer { self.removePendingLookup(for: repositorySpecifier, id: lookupID) }
 
-                        let result = try await self.performLookup(
-                            package: package,
-                            repository: repositorySpecifier,
-                            updateStrategy: updateStrategy,
-                            observabilityScope: observabilityScope
-                        )
-
-                        if Task.isCancelled {
-                            throw CancellationError()
-                        }
-
-                        return result
+                    // Let the existing in-flight task finish before queuing up the new one
+                    if let inFlight {
+                        _ = try? await inFlight.value
                     }
-                } else {
-                    lookupTask = Task {
-                        if Task.isCancelled {
-                            throw CancellationError()
-                        }
 
-                        let result = try await self.performLookup(
-                            package: package,
-                            repository: repositorySpecifier,
-                            updateStrategy: updateStrategy,
-                            observabilityScope: observabilityScope
-                        )
-
-                        if Task.isCancelled {
-                            throw CancellationError()
-                        }
-
-                        return result
+                    if Task.isCancelled {
+                        throw CancellationError()
                     }
+
+                    let result = try await self.performLookup(
+                        package: package,
+                        repository: repositorySpecifier,
+                        updateStrategy: updateStrategy,
+                        observabilityScope: observabilityScope
+                    )
+
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+
+                    return result
                 }
 
-                self.pendingLookups[repositorySpecifier] = lookupTask
+                self.pendingLookups[repositorySpecifier] = (id: lookupID, task: lookupTask)
                 continuation.resume(returning: lookupTask)
             }
 
-            do {
-                let result = try await task.value
-                return result
-            } catch {
-                throw error
-            }
+            return try await task.value
+        }
+    }
+
+    /// Removes the in-flight lookup tracked for `repositorySpecifier`, but only
+    /// if it is still the lookup identified by `id`. A newer in-flight lookup for
+    /// the same repository is left in place.
+    private func removePendingLookup(for repositorySpecifier: RepositorySpecifier, id: UUID) {
+        self.pendingLookupsLock.lock()
+        defer { self.pendingLookupsLock.unlock() }
+        if self.pendingLookups[repositorySpecifier]?.id == id {
+            self.pendingLookups[repositorySpecifier] = nil
         }
     }
 
@@ -271,8 +267,8 @@ public class RepositoryManager: Cancellable {
 
         self.pendingLookupsLock.lock()
         defer { self.pendingLookupsLock.unlock() }
-        for task in self.pendingLookups.values {
-            task.cancel()
+        for entry in self.pendingLookups.values {
+            entry.task.cancel()
         }
         self.pendingLookups = [:]
     }

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -122,6 +122,43 @@ final class RepositoryManagerTests: XCTestCase {
         }
     }
 
+    func testFailedLookupIsNotCached() async throws {
+        // Regression test: a lookup that fails must not be cached.
+        // Subsequent lookups must retry the operation rather than
+        // replaying the previous failure.
+        let fs = localFileSystem
+        let observability = ObservabilitySystem.makeForTesting()
+
+        try await testWithTemporaryDirectory { path in
+            let provider = DummyRepositoryProvider(fileSystem: fs)
+            let delegate = DummyRepositoryManagerDelegate()
+
+            let manager = RepositoryManager(
+                fileSystem: fs,
+                path: path,
+                provider: provider,
+                delegate: delegate
+            )
+
+            let dummyRepo = RepositorySpecifier(path: "/dummy")
+
+            // The host is unreachable: the first lookup fails.
+            provider.nextFetchError = StringError("ssh: connect to host dummy port 22: Operation timed out")
+            delegate.prepare(fetchExpected: true, updateExpected: false)
+            await XCTAssertAsyncThrowsError(
+                try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+            )
+
+            // The host is now reachable: the next lookup must retry and succeed,
+            // not re-throw the cached timeout from the first attempt.
+            provider.nextFetchError = nil
+            delegate.prepare(fetchExpected: true, updateExpected: false)
+            let handle = try await manager.lookup(repository: dummyRepo, observabilityScope: observability.topScope)
+            XCTAssertEqual(handle.repository, dummyRepo)
+            XCTAssertNoDiagnostics(observability.diagnostics)
+        }
+    }
+
     func testCache() async throws {
         let fs = localFileSystem
         let observability = ObservabilitySystem.makeForTesting()
@@ -715,12 +752,24 @@ private class DummyRepositoryProvider: RepositoryProvider, @unchecked Sendable {
     private let lock = NSLock()
     private var _numClones = 0
     private var _numFetches = 0
+    private var _nextFetchError: Error?
 
     init(fileSystem: FileSystem) {
         self.fileSystem = fileSystem
     }
 
+    /// When set, the next `fetch` throws this error instead of cloning. Used to
+    /// simulate a transient failure such as an unreachable host. The test is
+    /// responsible for clearing it to simulate recovery.
+    var nextFetchError: Error? {
+        get { self.lock.withLock { self._nextFetchError } }
+        set { self.lock.withLock { self._nextFetchError = newValue } }
+    }
+
     func fetch(repository: RepositorySpecifier, to path: AbsolutePath, progressHandler: FetchProgress.Handler? = nil) async throws {
+        if let error = self.lock.withLock({ self._nextFetchError }) {
+            throw error
+        }
         assert(!self.fileSystem.exists(path), "\(path) should not exist")
         try self.fileSystem.createDirectory(path, recursive: true)
         try self.fileSystem.writeFileContents(path.appending("readme.md"), string: repository.location.description)


### PR DESCRIPTION
RepositoryManager.lookup de-dupes concurrent fetches by storing one Task per repository in `pendingLookups`, but never removed an entry once the task completed. If a fetch failed every subsequent resolution of that package kept replaying the same error until a new RepositoryManager was created.

Fix by removing each lookup's entry from `pendingLookups` when its task finishes, regardless of outcome.
