### PR TITLE
Support loading macros from a binary artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Package.resolved
 /stage/
 Utilities/InstalledSwiftPMConfiguration/config.json
 Fixtures/BinaryLibraries/Static/Package1/Simple.artifactbundle/build
+Packages/

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -483,18 +483,15 @@ public final class SwiftModuleBuildDescription {
         #endif
 
         // Prebuilt macro plugins shipped as binary artifact bundles. These are host tools, so
-        // their variants are selected against the host (macro build) triple. The artifact key is
-        // used as the plugin module name, matching the `module:` of the `#externalMacro` decl.
+        // their variants are selected against the host triple. The artifact key is
+        // used as the plugin module name, matching the `module:` of the `#externalMacro` declaration
         try self.requiredBinaryMacros.forEach { binaryMacro in
             let macros = try binaryMacro.parseMacroArtifactArchives(
                 for: macroBuildParameters.triple,
                 fileSystem: self.fileSystem
             )
             for macro in macros where !macro.supportedTriples.isEmpty {
-                args += [
-                    "-Xfrontend", "-load-plugin-executable",
-                    "-Xfrontend", "\(macro.executablePath.pathString)#\(macro.name)",
-                ]
+                args += ["-Xfrontend", "-load-plugin-executable", "-Xfrontend", "\(macro.executablePath.pathString)#\(macro.name)"]
             }
         }
 

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -246,6 +246,18 @@ public final class SwiftModuleBuildDescription {
         }
     }
 
+    /// Binary dependencies that vend prebuilt macro plugin executables (an artifact bundle
+    /// containing a `macro`-typed artifact), as opposed to `.macro` targets built from source.
+    public var requiredBinaryMacros: [BinaryModule] {
+        get throws {
+            try self.target.recursiveModuleDependencies().compactMap {
+                guard $0.type == .binary, let binary = $0.underlying as? BinaryModule,
+                      binary.containsMacro else { return nil }
+                return binary
+            }
+        }
+    }
+
     /// ObservabilityScope with which to emit diagnostics
     private let observabilityScope: ObservabilityScope
 
@@ -469,6 +481,22 @@ public final class SwiftModuleBuildDescription {
             args += ["-Xfrontend", "-load-plugin-executable", "-Xfrontend", "\(executablePath)#\(macro.c99name)"]
         }
         #endif
+
+        // Prebuilt macro plugins shipped as binary artifact bundles. These are host tools, so
+        // their variants are selected against the host (macro build) triple. The artifact key is
+        // used as the plugin module name, matching the `module:` of the `#externalMacro` decl.
+        try self.requiredBinaryMacros.forEach { binaryMacro in
+            let macros = try binaryMacro.parseMacroArtifactArchives(
+                for: macroBuildParameters.triple,
+                fileSystem: self.fileSystem
+            )
+            for macro in macros where !macro.supportedTriples.isEmpty {
+                args += [
+                    "-Xfrontend", "-load-plugin-executable",
+                    "-Xfrontend", "\(macro.executablePath.pathString)#\(macro.name)",
+                ]
+            }
+        }
 
         if self.shouldDisableSandbox {
             let toolchainSupportsDisablingSandbox = DriverSupport.checkSupportedFrontendFlags(

--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -44,6 +44,10 @@ public struct ArtifactsArchiveMetadata: Equatable {
     // 3D models along with associated textures, or fonts, etc.
     public enum ArtifactType: String, RawRepresentable, Decodable {
         case executable
+        /// A compiler plugin executable that implements a Swift macro, to be loaded by the
+        /// compiler via `-load-plugin-executable`. Like `executable`, variants are keyed by
+        /// the host triple (the platform performing the compilation), not the build target.
+        case macro
         case staticLibrary
         case swiftSDK
         // Experimental support for Windows DLLs

--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -44,10 +44,6 @@ public struct ArtifactsArchiveMetadata: Equatable {
     // 3D models along with associated textures, or fonts, etc.
     public enum ArtifactType: String, RawRepresentable, Decodable {
         case executable
-        /// A compiler plugin executable that implements a Swift macro, to be loaded by the
-        /// compiler via `-load-plugin-executable`. Like `executable`, variants are keyed by
-        /// the host triple (the platform performing the compilation), not the build target.
-        case macro
         case staticLibrary
         case swiftSDK
         // Experimental support for Windows DLLs
@@ -55,6 +51,9 @@ public struct ArtifactsArchiveMetadata: Equatable {
 
         // Can't be marked as formally deprecated as we still need to use this value for warning users.
         case crossCompilationDestination
+
+        // Plugin executable that implements a macro, keyed to the host triple, not build target
+        case macro
     }
 
     public struct Variant: Equatable {

--- a/Sources/PackageModel/Module/BinaryModule.swift
+++ b/Sources/PackageModel/Module/BinaryModule.swift
@@ -97,6 +97,18 @@ public final class BinaryModule: Module {
         }
     }
 
+    /// Whether this binary artifact provides one or more prebuilt macro plugin executables.
+    public var containsMacro: Bool {
+        switch self.kind {
+        case .xcframework:
+            return false
+        case .artifactsArchive(let types):
+            return types.contains(.macro)
+        case .unknown:
+            return false
+        }
+    }
+
     public enum Origin: Equatable {
 
         /// Represents an artifact that was downloaded from a remote URL.

--- a/Sources/PackageModel/Module/BinaryModule.swift
+++ b/Sources/PackageModel/Module/BinaryModule.swift
@@ -21,7 +21,7 @@ public final class BinaryModule: Module {
 
     /// The kind of binary artifact.
     public let kind: Kind
-    
+
     /// The original source of the binary artifact.
     public let origin: Origin
 
@@ -97,7 +97,6 @@ public final class BinaryModule: Module {
         }
     }
 
-    /// Whether this binary artifact provides one or more prebuilt macro plugin executables.
     public var containsMacro: Bool {
         switch self.kind {
         case .xcframework:

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -97,10 +97,7 @@ extension BinaryModule {
         }
     }
 
-    /// Parses the prebuilt macro plugin executables in this artifact bundle, selecting the
-    /// variant(s) matching the given host `triple`. Mirrors `parseExecutableArtifactArchives`
-    /// but filters for the `.macro` artifact type. The returned `ExecutableInfo.name` is the
-    /// artifact key, which doubles as the macro plugin module name passed to the compiler.
+    /// Parses the prebuilt macro plugin executables in this artifact bundle, matching the given host `triple`.
     public func parseMacroArtifactArchives(for triple: Triple, fileSystem: any FileSystem) throws -> [ExecutableInfo] {
         // The host triple might contain a version which we don't want to take into account here.
         let versionLessTriple = try triple.withoutVersion()

--- a/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
+++ b/Sources/SPMBuildCore/BinaryTarget+Extensions.swift
@@ -97,6 +97,33 @@ extension BinaryModule {
         }
     }
 
+    /// Parses the prebuilt macro plugin executables in this artifact bundle, selecting the
+    /// variant(s) matching the given host `triple`. Mirrors `parseExecutableArtifactArchives`
+    /// but filters for the `.macro` artifact type. The returned `ExecutableInfo.name` is the
+    /// artifact key, which doubles as the macro plugin module name passed to the compiler.
+    public func parseMacroArtifactArchives(for triple: Triple, fileSystem: any FileSystem) throws -> [ExecutableInfo] {
+        // The host triple might contain a version which we don't want to take into account here.
+        let versionLessTriple = try triple.withoutVersion()
+        let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: self.artifactPath)
+        // Filter out everything except macro plugins.
+        let macros = metadata.artifacts.filter { $0.value.type == .macro }
+        // Construct an ExecutableInfo for each matching variant.
+        return try macros.flatMap { entry in
+            try entry.value.variants.map {
+                guard let supportedTriples = $0.supportedTriples else {
+                    throw StringError("No \"supportedTriples\" found in the artifact metadata for \(entry.key) in \(self.artifactPath)")
+                }
+                let filteredSupportedTriples = try supportedTriples
+                    .filter { try $0.withoutVersion() == versionLessTriple }
+                return ExecutableInfo(
+                    name: entry.key,
+                    executablePath: self.artifactPath.appending($0.path),
+                    supportedTriples: filteredSupportedTriples
+                )
+            }
+        }
+    }
+
     public func parseWindowsDLLArtifactArchives(for triple: Triple, fileSystem: any FileSystem) throws -> [WindowsDLLInfo] {
         // The host triple might contain a version which we don't want to take into account here.
         let versionLessTriple = try triple.withoutVersion()

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -468,6 +468,7 @@ public final class PIFBuilder {
                 addLocalRpaths: self.parameters.addLocalRpaths,
                 packageDisplayVersion: package.manifest.displayName,
                 pkgConfigDirectories: self.parameters.pkgConfigDirectories,
+                hostTriple: try self.parameters.pluginScriptRunner.hostTriple,
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,
             )

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -51,8 +51,6 @@ public final class PackagePIFBuilder {
     let modulesGraph: ModulesGraph
     private let package: ResolvedPackage
 
-    /// The triple of the host performing the build. Used to select the right variant of a
-    /// prebuilt macro plugin shipped as a binary artifact bundle (macros are host tools).
     let hostTriple: Basics.Triple
 
     /// Contains the package declarative specification.

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -16,6 +16,7 @@ import protocol TSCBasic.FileSystem
 
 import struct Basics.AbsolutePath
 import struct Basics.SourceControlURL
+import struct Basics.Triple
 import struct Basics.Diagnostic
 import struct Basics.ObservabilityMetadata
 import class Basics.ObservabilityScope
@@ -49,6 +50,10 @@ typealias FileReference = SwiftBuild.ProjectModel.FileReference
 public final class PackagePIFBuilder {
     let modulesGraph: ModulesGraph
     private let package: ResolvedPackage
+
+    /// The triple of the host performing the build. Used to select the right variant of a
+    /// prebuilt macro plugin shipped as a binary artifact bundle (macros are host tools).
+    let hostTriple: Basics.Triple
 
     /// Contains the package declarative specification.
     let packageManifest: PackageModel.Manifest // FIXME: Can't we just use `package.manifest` instead? —— Paulo
@@ -236,6 +241,7 @@ public final class PackagePIFBuilder {
         addLocalRpaths: AddLocalRpaths = .always,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
+        hostTriple: Basics.Triple,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
     ) {
@@ -249,6 +255,7 @@ public final class PackagePIFBuilder {
         self.createDynamicVariantsForLibraryProducts = createDynamicVariantsForLibraryProducts
         self.packageDisplayVersion = packageDisplayVersion
         self.pkgConfigDirectories = pkgConfigDirectories
+        self.hostTriple = hostTriple
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.addLocalRpaths = addLocalRpaths
@@ -266,6 +273,7 @@ public final class PackagePIFBuilder {
         addLocalRpaths: AddLocalRpaths = .always,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
+        hostTriple: Basics.Triple,
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
     ) {
@@ -280,6 +288,7 @@ public final class PackagePIFBuilder {
         self.addLocalRpaths = addLocalRpaths
         self.packageDisplayVersion = packageDisplayVersion
         self.pkgConfigDirectories = pkgConfigDirectories
+        self.hostTriple = hostTriple
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
     }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -31,6 +31,8 @@ import struct PackageGraph.ResolvedPackage
 
 import struct PackageLoading.GeneratedFiles
 
+import SPMBuildCore
+
 import enum SwiftBuild.ProjectModel
 
 /// Extension to create PIF **modules** for a given package.
@@ -722,6 +724,26 @@ extension PackagePIFProjectBuilder {
             settings[.SKIP_BUILDING_DOCUMENTATION] = "YES"
         }
 
+        // A target that (transitively) depends on a binary artifact bundle vending a prebuilt
+        // macro plugin loads it via SWIFT_LOAD_BINARY_MACROS. Macros are host tools, so we select
+        // the variant matching the build host. The SwiftBuild engine turns each "path#Module"
+        // entry into `-load-plugin-executable`, exactly like a source-built macro.
+        for dependency in try sourceModule.recursiveModuleDependencies() {
+            guard dependency.type == .binary,
+                  let binaryModule = dependency.underlying as? BinaryModule,
+                  binaryModule.containsMacro else { continue }
+            let macros = try binaryModule.parseMacroArtifactArchives(
+                for: pifBuilder.hostTriple,
+                fileSystem: pifBuilder.fileSystem
+            )
+            for macro in macros where !macro.supportedTriples.isEmpty {
+                let entry = "\(macro.executablePath.pathString)#\(macro.name)"
+                var loadBinaryMacros = settings[.SWIFT_LOAD_BINARY_MACROS] ?? []
+                loadBinaryMacros.append(entry)
+                settings[.SWIFT_LOAD_BINARY_MACROS] = loadBinaryMacros
+            }
+        }
+
         sourceModule.addParseAsLibrarySettings(to: &settings, toolsVersion: package.manifest.toolsVersion, fileSystem: pifBuilder.fileSystem)
 
         // Handle the target's dependencies (but only link against them if needed).
@@ -761,6 +783,14 @@ extension PackagePIFProjectBuilder {
                 case .binary:
                     guard let binaryModule = moduleDependency.underlying as? BinaryModule else {
                         log(.error, "'\(moduleDependency.name)' is a binary dependency, but its underlying module was not")
+                        break
+                    }
+                    if binaryModule.containsMacro {
+                        // Prebuilt macro plugin: loaded via SWIFT_LOAD_BINARY_MACROS (set above), not
+                        // linked or embedded. Don't add it as a build file so the SwiftBuild engine does
+                        // not treat the artifact bundle as a linkable/resource artifact (its info.json
+                        // 'macro' type would otherwise be rejected by the engine's artifact parser).
+                        log(.debug, indent: 1, "Loading prebuilt binary macro '\(moduleDependency.name)'")
                         break
                     }
                     let binaryReference = self.binaryGroup.addFileReference { id in

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -724,10 +724,6 @@ extension PackagePIFProjectBuilder {
             settings[.SKIP_BUILDING_DOCUMENTATION] = "YES"
         }
 
-        // A target that (transitively) depends on a binary artifact bundle vending a prebuilt
-        // macro plugin loads it via SWIFT_LOAD_BINARY_MACROS. Macros are host tools, so we select
-        // the variant matching the build host. The SwiftBuild engine turns each "path#Module"
-        // entry into `-load-plugin-executable`, exactly like a source-built macro.
         for dependency in try sourceModule.recursiveModuleDependencies() {
             guard dependency.type == .binary,
                   let binaryModule = dependency.underlying as? BinaryModule,
@@ -786,10 +782,8 @@ extension PackagePIFProjectBuilder {
                         break
                     }
                     if binaryModule.containsMacro {
-                        // Prebuilt macro plugin: loaded via SWIFT_LOAD_BINARY_MACROS (set above), not
-                        // linked or embedded. Don't add it as a build file so the SwiftBuild engine does
-                        // not treat the artifact bundle as a linkable/resource artifact (its info.json
-                        // 'macro' type would otherwise be rejected by the engine's artifact parser).
+                        // Don't add it as a build file so the SwiftBuild engine does
+                        // not treat the artifact bundle as a linkable/resource artifact
                         log(.debug, indent: 1, "Loading prebuilt binary macro '\(moduleDependency.name)'")
                         break
                     }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -204,8 +204,7 @@ extension PackagePIFProjectBuilder {
         settings[.CLANG_CXX_LANGUAGE_STANDARD] = mainModule.cxxLanguageStandard
         settings[.SWIFT_ENABLE_BARE_SLASH_REGEX] = "NO"
 
-        // Load any prebuilt macro plugins that this product's main module (transitively) depends
-        // on, shipped as binary artifact bundles. See the matching logic in `buildSourceModule`.
+        // Load any prebuilt macro plugins
         for dependency in try mainModule.recursiveModuleDependencies() {
             guard dependency.type == .binary,
                   let binaryModule = dependency.underlying as? BinaryModule,
@@ -402,8 +401,7 @@ extension PackagePIFProjectBuilder {
                         break
                     }
                     if binaryModule.containsMacro {
-                        // Prebuilt macro plugin: loaded via SWIFT_LOAD_BINARY_MACROS on the source
-                        // module, not linked/embedded in the product. Skip adding it as a build file.
+                        // Skip adding prebuilt macro plugin as a build file
                         log(.debug, indent: 1, "Loading prebuilt binary macro '\(moduleDependency.name)'")
                         break
                     }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -19,6 +19,7 @@ import class Basics.ObservabilitySystem
 import struct Basics.SourceControlURL
 
 import PackageLoading
+import SPMBuildCore
 
 import class PackageModel.BinaryModule
 import class PackageModel.Manifest
@@ -203,6 +204,23 @@ extension PackagePIFProjectBuilder {
         settings[.CLANG_CXX_LANGUAGE_STANDARD] = mainModule.cxxLanguageStandard
         settings[.SWIFT_ENABLE_BARE_SLASH_REGEX] = "NO"
 
+        // Load any prebuilt macro plugins that this product's main module (transitively) depends
+        // on, shipped as binary artifact bundles. See the matching logic in `buildSourceModule`.
+        for dependency in try mainModule.recursiveModuleDependencies() {
+            guard dependency.type == .binary,
+                  let binaryModule = dependency.underlying as? BinaryModule,
+                  binaryModule.containsMacro else { continue }
+            let macros = try binaryModule.parseMacroArtifactArchives(
+                for: pifBuilder.hostTriple,
+                fileSystem: pifBuilder.fileSystem
+            )
+            for macro in macros where !macro.supportedTriples.isEmpty {
+                var loadBinaryMacros = settings[.SWIFT_LOAD_BINARY_MACROS] ?? []
+                loadBinaryMacros.append("\(macro.executablePath.pathString)#\(macro.name)")
+                settings[.SWIFT_LOAD_BINARY_MACROS] = loadBinaryMacros
+            }
+        }
+
         // Create a group for the source files of the main module
         // For now we use an absolute path for it, but we should really make it
         // container-relative, since it's always inside the package directory.
@@ -381,6 +399,12 @@ extension PackagePIFProjectBuilder {
                 case .binary:
                     guard let binaryModule = moduleDependency.underlying as? BinaryModule else {
                         log(.error, "'\(moduleDependency.name)' is a binary dependency, but its underlying module was not")
+                        break
+                    }
+                    if binaryModule.containsMacro {
+                        // Prebuilt macro plugin: loaded via SWIFT_LOAD_BINARY_MACROS on the source
+                        // module, not linked/embedded in the product. Skip adding it as a build file.
+                        log(.debug, indent: 1, "Loading prebuilt binary macro '\(moduleDependency.name)'")
                         break
                     }
                     let binaryFileRef = self.binaryGroup.addFileReference { id in
@@ -676,6 +700,11 @@ extension PackagePIFProjectBuilder {
         for module in product.modules {
             // Binary targets are special in that they are just linked, not built.
             if let binaryTarget = module.underlying as? BinaryModule {
+                if binaryTarget.containsMacro {
+                    // Prebuilt macro plugin: loaded via SWIFT_LOAD_BINARY_MACROS, not linked.
+                    log(.debug, indent: 1, "Loading prebuilt binary macro '\(binaryTarget.name)'")
+                    continue
+                }
                 let binaryFileRef = self.binaryGroup.addFileReference { id in
                     FileReference(id: id, path: binaryTarget.artifactPath.pathString)
                 }
@@ -793,6 +822,11 @@ extension PackagePIFProjectBuilder {
                 }
 
                 if let binaryTarget = moduleDependency.underlying as? BinaryModule {
+                    if binaryTarget.containsMacro {
+                        // Prebuilt macro plugin: loaded via SWIFT_LOAD_BINARY_MACROS, not linked.
+                        log(.debug, indent: 1, "Loading prebuilt binary macro '\(binaryTarget.name)'")
+                        return
+                    }
                     let binaryFileRef = self.binaryGroup.addFileReference { id in
                         FileReference(id: id, path: binaryTarget.artifactPath.pathString)
                     }

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -6814,6 +6814,80 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
         try await self.sanitizerTest(.address, expectedName: "address")
     }
 
+    func testBinaryMacroLoadsPluginExecutable() async throws {
+        // A Swift module that depends on a `macro`-typed artifact bundle should be compiled
+        // with `-load-plugin-executable <host-variant>#<artifact-name>`, where the artifact
+        // name matches the `module:` of the consumer's `#externalMacro` declaration. This is
+        // the prebuilt counterpart to building a `.macro` target from source.
+        let fs = InMemoryFileSystem(emptyFiles: "/Pkg/Sources/MyLib/MyLib.swift")
+
+        let toolPath = AbsolutePath("/Pkg/MyMacros.artifactbundle")
+        try fs.createDirectory(toolPath, recursive: true)
+        try fs.writeFileContents(
+            toolPath.appending("info.json"),
+            string: """
+                {
+                    "schemaVersion": "1.0",
+                    "artifacts": {
+                        "MyMacros": {
+                            "type": "macro",
+                            "version": "1.0.0",
+                            "variants": [
+                                {
+                                    "path": "x86_64-apple-macosx/MyMacros",
+                                    "supportedTriples": ["x86_64-apple-macosx"]
+                                },
+                                {
+                                    "path": "x86_64-unknown-linux-gnu/MyMacros",
+                                    "supportedTriples": ["x86_64-unknown-linux-gnu"]
+                                }
+                            ]
+                        }
+                    }
+                }
+            """
+        )
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Pkg",
+                    path: "/Pkg",
+                    targets: [
+                        TargetDescription(name: "MyLib", dependencies: ["MyMacros"]),
+                        TargetDescription(name: "MyMacros", path: "MyMacros.artifactbundle", type: .binary),
+                    ]
+                ),
+            ],
+            binaryArtifacts: [
+                .plain("pkg"): [
+                    "MyMacros": .init(kind: .artifactsArchive(types: [.macro]), originURL: nil, path: toolPath),
+                ],
+            ],
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let result = try await BuildPlanResult(plan: mockBuildPlan(
+            triple: .x86_64MacOS,
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        ))
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let lib = try result.moduleBuildDescription(for: "MyLib").swift()
+        let args = try lib.compileArguments().joined(separator: " ")
+
+        // Only the host-matching variant (x86_64-apple-macosx) should be loaded, keyed by the
+        // artifact name; the foreign Linux variant must not be passed to the host compiler.
+        XCTAssertMatch(args, .contains("-load-plugin-executable"))
+        XCTAssertMatch(args, .contains("x86_64-apple-macosx/MyMacros#MyMacros"))
+        XCTAssertNoMatch(args, .contains("x86_64-unknown-linux-gnu/MyMacros"))
+    }
+
     func testThreadSanitizer() async throws {
         try await self.sanitizerTest(.thread, expectedName: "thread")
     }

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -12,6 +12,7 @@
 
 import Basics
 import PackageModel
+import SPMBuildCore
 import Testing
 
 struct ArtifactsArchiveMetadataTests {
@@ -124,5 +125,99 @@ struct ArtifactsArchiveMetadataTests {
                 for: Triple("x86_64-apple-macosx"), fileSystem: fileSystem
             )
         }
+    }
+
+    @Test
+    func parseMacroMetadata() throws {
+        let fileSystem = InMemoryFileSystem()
+        try fileSystem.writeFileContents(
+            "/info.json",
+            string: """
+            {
+                "schemaVersion": "1.0",
+                "artifacts": {
+                    "MyMacros": {
+                        "type": "macro",
+                        "version": "1.0.0",
+                        "variants": [
+                            {
+                                "path": "arm64-apple-macosx/MyMacros",
+                                "supportedTriples": ["arm64-apple-macosx"]
+                            },
+                            {
+                                "path": "aarch64-unknown-linux-gnu/MyMacros",
+                                "supportedTriples": ["aarch64-unknown-linux-gnu"]
+                            }
+                        ]
+                    }
+                }
+            }
+            """
+        )
+
+        let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
+        let expected = try ArtifactsArchiveMetadata(
+            schemaVersion: "1.0",
+            artifacts: [
+                "MyMacros": ArtifactsArchiveMetadata.Artifact(
+                    type: .macro,
+                    version: "1.0.0",
+                    variants: [
+                        ArtifactsArchiveMetadata.Variant(
+                            path: "arm64-apple-macosx/MyMacros",
+                            supportedTriples: [Triple("arm64-apple-macosx")]
+                        ),
+                        ArtifactsArchiveMetadata.Variant(
+                            path: "aarch64-unknown-linux-gnu/MyMacros",
+                            supportedTriples: [Triple("aarch64-unknown-linux-gnu")]
+                        ),
+                    ]
+                ),
+            ]
+        )
+        #expect(metadata == expected, "Actual is not as expected")
+    }
+
+    @Test
+    func parseMacroArtifactArchivesSelectsHostVariant() throws {
+        let fileSystem = InMemoryFileSystem()
+        try fileSystem.writeFileContents(
+            "/info.json",
+            string: """
+            {
+                "schemaVersion": "1.0",
+                "artifacts": {
+                    "MyMacros": {
+                        "type": "macro",
+                        "version": "1.0.0",
+                        "variants": [
+                            {
+                                "path": "arm64-apple-macosx/MyMacros",
+                                "supportedTriples": ["arm64-apple-macosx"]
+                            },
+                            {
+                                "path": "aarch64-unknown-linux-gnu/MyMacros",
+                                "supportedTriples": ["aarch64-unknown-linux-gnu"]
+                            }
+                        ]
+                    }
+                }
+            }
+            """
+        )
+
+        let hostTriple = try Triple("arm64-apple-macosx")
+        let binaryTarget = BinaryModule(
+            name: "MyMacros", kind: .artifactsArchive(types: [.macro]), path: .root, origin: .local
+        )
+        let macros = try binaryTarget.parseMacroArtifactArchives(for: hostTriple, fileSystem: fileSystem)
+
+        // One entry per variant; only the variant matching the host triple keeps a non-empty
+        // `supportedTriples`, which is how the build plan picks the plugin to load.
+        let hostMacros = macros.filter { !$0.supportedTriples.isEmpty }
+        #expect(hostMacros.count == 1)
+        #expect(hostMacros.first?.name == "MyMacros")
+        #expect(hostMacros.first?.executablePath.pathString == "/arm64-apple-macosx/MyMacros")
+        #expect(hostMacros.first?.supportedTriples == [hostTriple])
     }
 }

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -128,57 +128,6 @@ struct ArtifactsArchiveMetadataTests {
     }
 
     @Test
-    func parseMacroMetadata() throws {
-        let fileSystem = InMemoryFileSystem()
-        try fileSystem.writeFileContents(
-            "/info.json",
-            string: """
-            {
-                "schemaVersion": "1.0",
-                "artifacts": {
-                    "MyMacros": {
-                        "type": "macro",
-                        "version": "1.0.0",
-                        "variants": [
-                            {
-                                "path": "arm64-apple-macosx/MyMacros",
-                                "supportedTriples": ["arm64-apple-macosx"]
-                            },
-                            {
-                                "path": "aarch64-unknown-linux-gnu/MyMacros",
-                                "supportedTriples": ["aarch64-unknown-linux-gnu"]
-                            }
-                        ]
-                    }
-                }
-            }
-            """
-        )
-
-        let metadata = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
-        let expected = try ArtifactsArchiveMetadata(
-            schemaVersion: "1.0",
-            artifacts: [
-                "MyMacros": ArtifactsArchiveMetadata.Artifact(
-                    type: .macro,
-                    version: "1.0.0",
-                    variants: [
-                        ArtifactsArchiveMetadata.Variant(
-                            path: "arm64-apple-macosx/MyMacros",
-                            supportedTriples: [Triple("arm64-apple-macosx")]
-                        ),
-                        ArtifactsArchiveMetadata.Variant(
-                            path: "aarch64-unknown-linux-gnu/MyMacros",
-                            supportedTriples: [Triple("aarch64-unknown-linux-gnu")]
-                        ),
-                    ]
-                ),
-            ]
-        )
-        #expect(metadata == expected, "Actual is not as expected")
-    }
-
-    @Test
     func parseMacroArtifactArchivesSelectsHostVariant() throws {
         let fileSystem = InMemoryFileSystem()
         try fileSystem.writeFileContents(

--- a/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
@@ -450,4 +450,87 @@ struct PrebuiltsPIFTests {
             #expect(isHost == false, "\(target.common.name)")
         }
     }
+
+    // A module that depends on a `macro`-typed artifact bundle should have the host-matching
+    // plugin recorded in `SWIFT_LOAD_BINARY_MACROS`, which the build engine turns into
+    // `-load-plugin-executable <path>#<name>`. This is the PIF counterpart of the native
+    // `testBinaryMacroLoadsPluginExecutable` build-plan test.
+    @Test func testBinaryMacroSetsLoadBinaryMacrosSetting() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let fs = InMemoryFileSystem(
+            emptyFiles: [
+                "/MyPackage/Sources/MyLib/MyLib.swift",
+                "/MyPackage/Sources/MyApp/MyApp.swift",
+            ]
+        )
+
+        let bundlePath = AbsolutePath("/MyPackage/MyMacros.artifactbundle")
+        try fs.createDirectory(bundlePath, recursive: true)
+        // Cover every triple the test host might run on so a host variant is always selected.
+        try fs.writeFileContents(
+            bundlePath.appending("info.json"),
+            string: """
+                {
+                    "schemaVersion": "1.0",
+                    "artifacts": {
+                        "MyMacros": {
+                            "type": "macro",
+                            "version": "1.0.0",
+                            "variants": [
+                                { "path": "arm64-apple-macosx/MyMacros", "supportedTriples": ["arm64-apple-macosx"] },
+                                { "path": "x86_64-apple-macosx/MyMacros", "supportedTriples": ["x86_64-apple-macosx"] },
+                                { "path": "aarch64-unknown-linux-gnu/MyMacros", "supportedTriples": ["aarch64-unknown-linux-gnu"] },
+                                { "path": "x86_64-unknown-linux-gnu/MyMacros", "supportedTriples": ["x86_64-unknown-linux-gnu"] }
+                            ]
+                        }
+                    }
+                }
+            """
+        )
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "MyPackage",
+                    path: "/MyPackage",
+                    products: [
+                        ProductDescription(name: "MyApp", type: .executable, targets: ["MyApp"]),
+                    ],
+                    targets: [
+                        TargetDescription(name: "MyApp", dependencies: ["MyLib"], type: .executable),
+                        TargetDescription(name: "MyLib", dependencies: ["MyMacros"]),
+                        TargetDescription(name: "MyMacros", path: "MyMacros.artifactbundle", type: .binary),
+                    ]
+                ),
+            ],
+            binaryArtifacts: [
+                .plain("mypackage"): [
+                    "MyMacros": .init(kind: .artifactsArchive(types: [.macro]), originURL: nil, path: bundlePath),
+                ],
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder: PIFBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root, addLocalRpaths: .always),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let targets = pif.workspace.projects.flatMap { $0.underlying.targets }
+        let myLib = try #require(targets.first { $0.common.name == "MyLib" })
+
+        let loadBinaryMacros = myLib.common.buildConfigs
+            .compactMap { $0.settings[.SWIFT_LOAD_BINARY_MACROS] }
+            .flatMap { $0 }
+        #expect(!loadBinaryMacros.isEmpty, "MyLib should load the prebuilt macro plugin")
+        #expect(loadBinaryMacros.contains { $0.hasSuffix("#MyMacros") })
+    }
 }


### PR DESCRIPTION
Support loading macros from a binary artifact so they can be shipped alongside XCFrameworks. Related PR in Swift Build is [here](https://github.com/swiftlang/swift-build/pull/1460)

Forum pitch: https://forums.swift.org/t/pitch-distributing-swift-macros-as-prebuilt-binaries/87447

### Motivation:

Currently there's no way to ship macros in a binary artifact, which makes using them more difficult than they should be if you're trying to vend them from something like an XCFramework.

### Modifications:

Hooked up the `macro` artifact type using the host variant and pass it through to the `-load-plugin-executable`. Works with both the old and new build systems.

### Result:

You can ship macros in a binary artifact
