### PR TITLE
Fix containsAtMain to detect @main after block comment close on same …

### DIFF
--- a/Sources/SPMBuildCore/MainAttrDetection.swift
+++ b/Sources/SPMBuildCore/MainAttrDetection.swift
@@ -28,10 +28,14 @@ package func containsAtMain(fileSystem: FileSystem, path: AbsolutePath) throws -
         if line.hasPrefix("/*") {
             multilineComment = true
         }
-        if line.hasSuffix("*/") {
-            multilineComment = false
-        }
         if multilineComment {
+            if let closeRange = line.range(of: "*/") {
+                multilineComment = false
+                let afterComment = String(line[closeRange.upperBound...]).trimmingCharacters(in: .whitespaces)
+                if afterComment.hasPrefix("@main") {
+                    return true
+                }
+            }
             continue
         }
         if line.hasPrefix("@main") {

--- a/Tests/SPMBuildCoreTests/MainAttrDetectionTests.swift
+++ b/Tests/SPMBuildCoreTests/MainAttrDetectionTests.swift
@@ -220,6 +220,20 @@ struct MainAttrDetectionTests {
                 fileContent: """
                 /*
                 This is a multi-line comment
+                */ @main
+                struct MyApp {
+                    static func main() {
+                        print("Hello, World!")
+                    }
+                }
+                """,
+                expected: true,
+                id: "Multi-line comment end on a line containing @main",
+            ),
+            ContainsAtMainReturnsExpectedValueTestData(
+                fileContent: """
+                /*
+                This is a multi-line comment
                 that spans multiple lines
                 @main should be ignored here
                 */
@@ -240,34 +254,6 @@ struct MainAttrDetectionTests {
         data: ContainsAtMainReturnsExpectedValueTestData,
     ) async throws {
         try await self._testImplementation_containsAtMainReturnsExpectedValue(data: data)
-    }
-
-    @Test(
-        .issue("https://github.com/swiftlang/swift-package-manager/issues/9685", relationship: .defect),
-        arguments: [
-            ContainsAtMainReturnsExpectedValueTestData(
-                fileContent: """
-                /*
-                This is a multi-line comment
-                /* @main
-                struct MyApp {
-                    static func main() {
-                        print("Hello, World!")
-                    }
-                }
-                """,
-                expected: true,
-                id: "Multi-line comment end on a line containing @main",
-            )
-
-        ],
-    )
-    func containsAtMainReturnsExpectedValueCurrentlyFails(
-        data: ContainsAtMainReturnsExpectedValueTestData,
-    ) async throws {
-        await withKnownIssue {
-            try await self._testImplementation_containsAtMainReturnsExpectedValue(data: data)
-        }
     }
 
     fileprivate func _testImplementation_containsAtMainReturnsExpectedValue(


### PR DESCRIPTION
Fix `containsAtMain` to detect `@main` after block comment close on same line

The function used `hasSuffix("*/")` to detect the end of a multi-line comment, which failed when `*/` appeared mid-line (e.g. `*/ @main`). Replace it with `range(of: "*/"`) so the comment is closed at the correct position and any trailing `@main` on the same line is recognised.

Also fix a typo in the existing known-issue test (`/* @main` → `*/ @main`) and promote the corrected test case into the main passing test suite, removing the `withKnownIssue` wrapper.

Resolves #9685

### Motivation:

`containsAtMain` is used by SPM to determine whether a Swift source file declares an entry point via the `@main` attribute. When a file contains a block comment whose closing `*/` appears on the same line as `@main` (e.g. `*/ @main`), the function incorrectly returns false, causing SPM to miss the entry point declaration. This is a parsing edge case that was already tracked and confirmed by a `withKnownIssue` test in the test suite.

### Modifications:

- `Sources/SPMBuildCore/MainAttrDetection.swift`: Replaced the `hasSuffix("*/")` check with a `range(of: "*/")` search inside the `multilineComment` guard. When `*/` is found anywhere on the line, the comment is marked closed and the text following `*/` is trimmed and checked for `@main`
- `Tests/SPMBuildCoreTests/MainAttrDetectionTests.swift`: Fixed a typo in the known-issue test case (file content had `/* @main` — an opening delimiter — where `*/ @main` — a closing delimiter — was intended). Moved the corrected test case into the main parameterised test `containsAtMainReturnsExpectedValue` and removed the now-unnecessary `containsAtMainReturnsExpectedValueCurrentlyFails` / `withKnownIssue` wrapper.

### Result:

`containsAtMain` now correctly returns `true` when `@main` appears on the same line as a closing block comment delimiter. All 16 test cases in `MainAttrDetectionTests` pass with no known issues.
