### PR TITLE
Improve artifact bundle manifest decoding diagnostics

### DIFF
--- a/Sources/PackageModel/ArtifactsArchiveMetadata.swift
+++ b/Sources/PackageModel/ArtifactsArchiveMetadata.swift
@@ -95,6 +95,35 @@ extension ArtifactsArchiveMetadata {
                     "invalid `schemaVersion` of bundle manifest at `\(path)`: \(decodedMetadata.schemaVersion)"
                 )
             }
+        } catch let error as DecodingError {
+          switch error {
+              case .typeMismatch(let type, let context):
+                let keyPath = context.codingPath.map { $0.stringValue }.joined(separator: ".")
+                throw StringError(
+                  "Type mismatch in ArtifactsArchive info.json at '\(path)'. Key '\(keyPath)' expected type '\(type)'."
+                )
+
+              case .keyNotFound(let key, let context):
+                let keyPath = context.codingPath.map { $0.stringValue }.joined(separator: ".")
+                let location = keyPath.isEmpty ? "root" : "'\(keyPath)'"
+                throw StringError(
+                  "Missing required key '\(key.stringValue)' in ArtifactsArchive info.json at '\(path)' in \(location)."
+                )
+
+              case .valueNotFound(let type, let context):
+                let keyPath = context.codingPath.map { $0.stringValue }.joined(separator: ".")
+                throw StringError(
+                  "Expected non-null value of type '\(type)' in ArtifactsArchive info.json at '\(path)'. Key '\(keyPath)' is null."
+                )
+
+              case .dataCorrupted(let context):
+                throw StringError(
+                  "Invalid JSON in ArtifactsArchive info.json at '\(path)': \(context.debugDescription)")
+
+              @unknown default:
+                throw StringError(
+                  "failed parsing ArtifactsArchive info.json at '\(path)': \(error.localizedDescription)")
+              }
         } catch {
             throw StringError(
                 "failed parsing ArtifactsArchive info.json at '\(path)': \(error.interpolationDescription)"

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -13,6 +13,7 @@
 import Basics
 import PackageModel
 import Testing
+import struct TSCBasic.StringError
 
 struct ArtifactsArchiveMetadataTests {
     @Test
@@ -123,6 +124,93 @@ struct ArtifactsArchiveMetadataTests {
             try binaryTarget.parseExecutableArtifactArchives(
                 for: Triple("x86_64-apple-macosx"), fileSystem: fileSystem
             )
+        }
+    }
+
+    @Test
+    func parseMetadataTypeMismatch() throws {
+        let fileSystem = InMemoryFileSystem()
+        try fileSystem.writeFileContents(
+            "/info.json",
+            string: """
+            {
+                "schemaVersion": 1.0, 
+                "artifacts": {}
+            }
+            """
+        )
+
+        do {
+            _ = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
+            Issue.record("Expected an error to be thrown for type mismatch")
+        } catch let error as StringError {
+            let message = error.description
+            #expect(message.contains("Type mismatch"))
+            #expect(message.contains("schemaVersion"))
+            #expect(message.contains("String"))
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test
+    func parseMetadataMissingKey() throws {
+        let fileSystem = InMemoryFileSystem()
+        try fileSystem.writeFileContents(
+            "/info.json",
+            string: """
+            {
+                "schemaVersion": "1.0",
+                "artifacts": {
+                    "my-artifact": {
+                        "type": "executable",
+                        "variants": []
+                    }
+                }
+            }
+            """
+        )
+
+        do {
+            _ = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
+            Issue.record("Expected an error to be thrown for missing key")
+        } catch let error as StringError {
+            let message = error.description
+            #expect(message.contains("Missing required key 'version'"))
+            #expect(message.contains("artifacts.my-artifact"))
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test
+    func parseMetadataValueNotFound() throws {
+        let fileSystem = InMemoryFileSystem()
+        try fileSystem.writeFileContents(
+            "/info.json",
+            string: """
+            {
+                "schemaVersion": "1.0",
+                "artifacts": {
+                    "my-artifact": {
+                        "type": "executable",
+                        "version": null,
+                        "variants": []
+                    }
+                }
+            }
+            """
+        )
+
+        do {
+            _ = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
+            Issue.record("Expected an error to be thrown for null value")
+        } catch let error as StringError {
+            let message = error.description
+            #expect(message.contains("Expected non-null value"))
+            #expect(message.contains("version"))
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
         }
     }
 }

--- a/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
+++ b/Tests/SPMBuildCoreTests/ArtifactsArchiveMetadataTests.swift
@@ -127,90 +127,81 @@ struct ArtifactsArchiveMetadataTests {
         }
     }
 
-    @Test
-    func parseMetadataTypeMismatch() throws {
-        let fileSystem = InMemoryFileSystem()
-        try fileSystem.writeFileContents(
-            "/info.json",
-            string: """
-            {
-                "schemaVersion": 1.0, 
-                "artifacts": {}
-            }
-            """
-        )
-
-        do {
-            _ = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
-            Issue.record("Expected an error to be thrown for type mismatch")
-        } catch let error as StringError {
-            let message = error.description
-            #expect(message.contains("Type mismatch"))
-            #expect(message.contains("schemaVersion"))
-            #expect(message.contains("String"))
-        } catch {
-            Issue.record("Unexpected error type: \(error)")
-        }
-    }
-
-    @Test
-    func parseMetadataMissingKey() throws {
-        let fileSystem = InMemoryFileSystem()
-        try fileSystem.writeFileContents(
-            "/info.json",
-            string: """
-            {
-                "schemaVersion": "1.0",
-                "artifacts": {
-                    "my-artifact": {
-                        "type": "executable",
-                        "variants": []
+    @Test(
+        arguments: [
+            (
+                infoPathName: AbsolutePath("/info.json"),
+                contents: """
+                {
+                    "schemaVersion": 1.0, 
+                    "artifacts": {}
+                }
+                """,
+                expectedError: StringError("Type mismatch in ArtifactsArchive info.json at '/info.json'. Key 'schemaVersion' expected type 'String'."),
+                id: "Type Mismatch",
+            ),
+            (
+                infoPathName: AbsolutePath("/info.json"),
+                contents: """
+                {
+                    "schemaVersion": "1.0",
+                    "artifacts": {
+                        "my-artifact": {
+                            "type": "executable",
+                            "variants": []
                     }
                 }
-            }
-            """
-        )
-
-        do {
-            _ = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
-            Issue.record("Expected an error to be thrown for missing key")
-        } catch let error as StringError {
-            let message = error.description
-            #expect(message.contains("Missing required key 'version'"))
-            #expect(message.contains("artifacts.my-artifact"))
-        } catch {
-            Issue.record("Unexpected error type: \(error)")
-        }
-    }
-
-    @Test
-    func parseMetadataValueNotFound() throws {
-        let fileSystem = InMemoryFileSystem()
-        try fileSystem.writeFileContents(
-            "/info.json",
-            string: """
-            {
-                "schemaVersion": "1.0",
-                "artifacts": {
-                    "my-artifact": {
-                        "type": "executable",
-                        "version": null,
-                        "variants": []
+                """,
+                expectedError: StringError("Invalid JSON in ArtifactsArchive info.json at '/info.json': The given data was not valid JSON."),
+                id: "Invalid JSON",
+            
+            ),
+            (
+                infoPathName: AbsolutePath("/info.json"),
+                contents: """
+                {
+                    "schemaVersion": "1.0",
+                    "artifacts": {
+                        "my-artifact": {
+                            "type": "executable",
+                            "variants": []
+                        }
                     }
                 }
-            }
-            """
+                """,
+                expectedError: StringError("Missing required key 'version' in ArtifactsArchive info.json at '/info.json' in 'artifacts.my-artifact'."),
+                id: "Missing Key",
+            ),
+            (
+                infoPathName: AbsolutePath("/info.json"),
+                contents: """
+                {
+                    "schemaVersion": "1.0",
+                    "artifacts": {
+                        "my-artifact": {
+                            "type": "executable",
+                            "version": null,
+                            "variants": []
+                        }
+                    }
+                }
+                """,
+                expectedError: StringError("Expected non-null value of type 'String' in ArtifactsArchive info.json at '/info.json'. Key 'artifacts.my-artifact.version' is null."),
+                id: "Value not found",
+            ),
+        ],
+    )
+    func parseMetadataErrors(
+        data: (infoPathName: AbsolutePath, contents: String, expectedError: StringError, id: String),
+    ) throws {
+        let fileSystem = InMemoryFileSystem()
+        try fileSystem.writeFileContents(
+            data.infoPathName,
+            string: data.contents,
         )
 
-        do {
+        #expect(throws: data.expectedError) {
             _ = try ArtifactsArchiveMetadata.parse(fileSystem: fileSystem, rootPath: .root)
-            Issue.record("Expected an error to be thrown for null value")
-        } catch let error as StringError {
-            let message = error.description
-            #expect(message.contains("Expected non-null value"))
-            #expect(message.contains("version"))
-        } catch {
-            Issue.record("Unexpected error type: \(error)")
         }
     }
 }


### PR DESCRIPTION
Improve artifact bundle manifest decoding diagnostics

### Motivation:

Fixes #10078 

When parsing .artifactbundle/info.json, SwiftPM reports a generic error message when decoding fails, making it difficult to identify which field in the manifest is invalid. This can make troubleshooting malformed artifact bundle manifests unnecessarily difficult.

### Modifications:

- Added handling for DecodingError cases in ArtifactsArchiveMetadata.parse.
- Included decoding context information, such as the affected key path in emitted diagnostics.
- Added regression tests covering invalid manifest structures, including type mismatches, missing required keys, and null values for non-optional fields.

### Result:

Artifact bundle manifests parsing errors now provide more actionable diagnostics that identify the problematic field, making it easier to diagnose and correct invalid info.json files.