### PR TITLE
Add regression tests for non-regular file support in readFileContents

### DIFF
--- a/Tests/BasicsTests/FileSystem/FileSystemTests.swift
+++ b/Tests/BasicsTests/FileSystem/FileSystemTests.swift
@@ -16,6 +16,39 @@ import Testing
 @testable import Basics
 
 struct FileSystemTests {
+    // Regression test for https://github.com/swiftlang/swift-package-manager/issues/9915: localFileSystem.readFileContents must accept non-regular
+    // files (FIFOs, /dev/stdin) after TSC switched from fopen/fread to Data(contentsOf:), which
+    // rejects non-regular files on Linux (swift-foundation) and some macOS/Foundation versions.
+    #if !os(Windows)
+    @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9915", relationship: .verifies),
+    )
+    func localFileSystemReadFileContentsAcceptsNonRegularFile() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let fifoPath = tmpDir.appending("token.fifo")
+
+            let rc = mkfifo(fifoPath.pathString, 0o600)
+            guard rc == 0 else {
+                Issue.record("mkfifo failed: \(String(cString: strerror(errno)))")
+                return
+            }
+
+            let expected = "test-secret-token"
+            // FIFOs block open(2) until both ends are open, so write from a concurrent task.
+            let writeTask = Task.detached {
+                let fd = open(fifoPath.pathString, O_WRONLY)
+                guard fd >= 0 else { return }
+                defer { close(fd) }
+                _ = expected.withCString { ptr in write(fd, ptr, strlen(ptr)) }
+            }
+            defer { writeTask.cancel() }
+
+            let contents: String = try localFileSystem.readFileContents(fifoPath)
+            #expect(contents == expected)
+        }
+    }
+    #endif
+
     @Test
     func stripFirstLevelComponent() throws {
         let fileSystem = InMemoryFileSystem()

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -1270,6 +1270,56 @@ struct PackageRegistryCommandTests {
         }
     }
 
+    #if !os(Windows)
+    // Regression test for https://github.com/swiftlang/swift-package-manager/issues/9915: --token-file must accept non-regular files (FIFOs,
+    // /dev/stdin) after TSC switched readFileContents to Data(contentsOf:), which rejects them.
+    @Test(
+        .tags(
+            .TestSize.large,
+            .Feature.Command.PackageRegistry.Login,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9915", relationship: .verifies),
+    )
+    func tokenFileAcceptsNonRegularFile() async throws {
+        try await withTemporaryDirectory { tmpDir in
+            let fifoPath = tmpDir.appending("token.fifo")
+
+            let rc = mkfifo(fifoPath.pathString, 0o600)
+            guard rc == 0 else {
+                Issue.record("mkfifo failed: \(String(cString: strerror(errno)))")
+                return
+            }
+
+            // FIFOs block open(2) until both ends are open, so write from a concurrent task.
+            let token = "test-registry-token"
+            let writeTask = Task.detached {
+                let fd = open(fifoPath.pathString, O_WRONLY)
+                guard fd >= 0 else { return }
+                defer { close(fd) }
+                _ = token.withCString { ptr in write(fd, ptr, strlen(ptr)) }
+            }
+            defer { writeTask.cancel() }
+
+            // The login will fail (no real registry), but must NOT fail reading the FIFO.
+            let result = try await SwiftPM.Registry.execute(
+                [
+                    "login",
+                    "--url", "https://nonexistent.registry.invalid",
+                    "--token-file", fifoPath.pathString,
+                    "--no-confirm",
+                ],
+                throwIfCommandFails: false
+            )
+
+            let combinedOutput = result.stdout + result.stderr
+            #expect(
+                !combinedOutput.contains("invalid access to"),
+                "Login failed reading the FIFO — regression of https://github.com/swiftlang/swift-package-manager/issues/9915. Output: \(combinedOutput)"
+            )
+        }
+    }
+    #endif
+
     struct LogingUrlData {
         let loginApiPath: String?
         let expectedComponent: String


### PR DESCRIPTION
Adds tests to catch a regression (rdar://174417799) where `localFileSystem.readFileContents` broke for FIFOs, named pipes, and `/dev/stdin` after TSC switched from `fopen/fread` to `Data(contentsOf:)`, which rejects non-regular files.

- `FileSystemTests.localFileSystemReadFileContentsAcceptsNonRegularFile`: unit test that calls `localFileSystem.readFileContents` directly on a FIFO and verifies the content is read correctly.
- `PackageRegistryCommandTests.tokenFileAcceptsNonRegularFile`: functional test that runs `swift package-registry login --token-file <fifo>` and verifies the command fails at the network step rather than the file-read step, confirming `--token-file` accepts non-regular files as it did before the regression.

Validates: https://github.com/swiftlang/swift-package-manager/issues/9915
