### PR TITLE
[NFC] Add missing "to" in "Setting the Swift tools version" article

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/SettingSwiftToolsVersion.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SettingSwiftToolsVersion.md
@@ -5,7 +5,7 @@ Define the minimum version of the swift compiler required for your package.
 ## Overview
 
 The tools version declares the minimum version of the Swift compiler required to
-use the package, as well as how parse the `Package.swift` manifest.
+use the package, as well as how to parse the `Package.swift` manifest.
 When you create a new package using <doc:PackageInit>, the minimum version is set automatically to the current version.
 The version is specified on the first line of the manifest with the comment `// swift-tools-version:` and the version for the Swift compiler.
 The version is a semantic version, with the exception that a patch version is inferred to be `0` if you don't specify it.


### PR DESCRIPTION
Fix a typo in the first sentence of the article.