### PR TITLE
Forward `--filter/skip` args to Swift Testing when running w/ `--debugger`

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -669,6 +669,10 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 swiftTestingArgs += ["--filter", pattern]
             }
 
+            for pattern in options._testCaseSkip {
+                swiftTestingArgs += ["--skip", pattern]
+            }
+
             if let separatorIndex = commandLineArguments.firstIndex(of: "--") {
                 let offset = commandLineArguments.distance(from: commandLineArguments.startIndex, to: separatorIndex)
                 swiftTestingArgs += Array(commandLineArguments.dropFirst(offset + 1))

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -665,6 +665,10 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             let commandLineArguments = CommandLine.arguments.dropFirst()
             var swiftTestingArgs = ["--testing-library", "swift-testing", "--enable-swift-testing"]
 
+            for pattern in options.filter {
+                swiftTestingArgs += ["--filter", pattern]
+            }
+
             if let separatorIndex = commandLineArguments.firstIndex(of: "--") {
                 let offset = commandLineArguments.distance(from: commandLineArguments.startIndex, to: separatorIndex)
                 swiftTestingArgs += Array(commandLineArguments.dropFirst(offset + 1))

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -1974,6 +1974,36 @@ struct TestCommandTests {
         @Test(
             arguments: SupportedBuildSystemOnAllPlatforms
         )
+        func debuggerFlagForwardsFilterToSwiftTesting(buildSystem: BuildSystemProvider.Kind) async throws {
+            let configuration = BuildConfiguration.debug
+            try await withKnownIssue {
+                try await fixture(name: "Miscellaneous/TestDebugging") { fixturePath in
+                    let (stdout, stderr) = try await execute(
+                        ["--debugger", "--disable-xctest", "--verbose", "--filter", "calculatorAdditionPasses"],
+                        packagePath: fixturePath,
+                        configuration: configuration,
+                        buildSystem: buildSystem,
+                    )
+
+                    #expect(
+                        !stderr.contains("error: --debugger cannot be used with"),
+                        "got stdout: \(stdout), stderr: \(stderr)",
+                    )
+
+                    #expect(
+                        stdout.contains("settings append target.run-args \"--filter\"") &&
+                        stdout.contains("settings append target.run-args \"calculatorAdditionPasses\""),
+                        "Expected --filter to be forwarded to Swift Testing run-args, got stdout: \(stdout), stderr: \(stderr)",
+                    )
+                }
+            } when: {
+                ProcessInfo.hostOperatingSystem == .windows
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms
+        )
         func debuggerFlagWithBothTestingSuites(buildSystem: BuildSystemProvider.Kind) async throws {
             let configuration = BuildConfiguration.debug
             try await withKnownIssue {

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -1974,6 +1974,36 @@ struct TestCommandTests {
         @Test(
             arguments: SupportedBuildSystemOnAllPlatforms
         )
+        func debuggerFlagForwardsSkipToSwiftTesting(buildSystem: BuildSystemProvider.Kind) async throws {
+            let configuration = BuildConfiguration.debug
+            try await withKnownIssue {
+                try await fixture(name: "Miscellaneous/TestDebugging") { fixturePath in
+                    let (stdout, stderr) = try await execute(
+                        ["--debugger", "--disable-xctest", "--verbose", "--skip", "calculatorAdditionPasses"],
+                        packagePath: fixturePath,
+                        configuration: configuration,
+                        buildSystem: buildSystem,
+                    )
+
+                    #expect(
+                        !stderr.contains("error: --debugger cannot be used with"),
+                        "got stdout: \(stdout), stderr: \(stderr)",
+                    )
+
+                    #expect(
+                        stdout.contains("settings append target.run-args \"--skip\"") &&
+                        stdout.contains("settings append target.run-args \"calculatorAdditionPasses\""),
+                        "Expected --skip to be forwarded to Swift Testing run-args, got stdout: \(stdout), stderr: \(stderr)",
+                    )
+                }
+            } when: {
+                ProcessInfo.hostOperatingSystem == .windows
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms
+        )
         func debuggerFlagForwardsFilterToSwiftTesting(buildSystem: BuildSystemProvider.Kind) async throws {
             let configuration = BuildConfiguration.debug
             try await withKnownIssue {


### PR DESCRIPTION
### Motivation:

With https://github.com/swiftlang/swift-package-manager/pull/10158 the filter is not forwarded to the swiftpm-testing-helper and so all tests would run even if you passed a `--filter` with the `--debugger` flag.

### Modifications:

Forward the `--filter` to the testing helper.

### Result:

Only the tests that match the filter are run while in LLDB.