### PR TITLE
Fix AsyncOperationQueue concurrency-limit and deadlock bugs

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -118,13 +118,6 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                 return id
             }
         }
-
-        var continuation: WaitingContinuation? {
-            guard case .waiting(_, let continuation) = self else {
-                return nil
-            }
-            return continuation
-        }
     }
 
     /// Creates an `AsyncOperationQueue` with a specified number of concurrent tasks.
@@ -188,13 +181,20 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                             waitingTasks.remove(at: index)
                             return .cancel(continuation)
                         case .creating, .running, .waiting:
-                            // A task may have completed since we initially checked if we should wait. Check again in this locked
-                            // section and if we can start it, remove it from the waiting tasks and start it immediately.
-                            if waitingTasks.count >= concurrentTasks {
+                            // A task may have completed since we initially checked if we should wait. Re-check here, but
+                            // count only the *running* tasks: this task is currently in `waitingTasks` as `.creating`, so
+                            // counting the whole array would count it against itself and could leave it parked with no
+                            // running task left to ever resume it. If a slot is free, mark this task as running in place
+                            // (keeping it in `waitingTasks` so it continues to occupy a concurrency slot until it
+                            // completes) and start it immediately.
+                            let runningCount = waitingTasks.reduce(into: 0) { count, task in
+                                if case .running = task { count += 1 }
+                            }
+                            if runningCount >= concurrentTasks {
                                 waitingTasks[index] = .waiting(taskId, continuation)
                                 return nil
                             } else {
-                                waitingTasks.remove(at: index)
+                                waitingTasks[index] = .running(taskId)
                                 return .start(continuation)
                             }
                     }
@@ -223,10 +223,15 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                         // continuation for the waiting task with a `CancellationError`. Return the continuation
                         // here so it can be resumed once the `waitingTasksLock` is released.
                         return continuation
-                    case .creating, .running:
+                    case .creating:
                         // If the task was still being created, mark it as cancelled in `waitingTasks` so that
                         // the handler for `withCheckedThrowingContinuation` can immediately cancel it.
                         self.waitingTasks[taskIndex] = .cancelled(taskId)
+                        return nil
+                    case .running:
+                        // The task has already been promoted and started running, so it is no longer waiting on
+                        // its continuation. Leave it in place to keep occupying its slot; it will observe the
+                        // cancellation cooperatively and be removed by `signalCompletion` when it completes.
                         return nil
                     case .cancelled:
                         preconditionFailure("Attempting to cancel a task that was already cancelled")
@@ -244,48 +249,38 @@ public final class AsyncOperationQueue: @unchecked Sendable {
                 return nil
             }
 
-            // Remove the completed task from the list to decrement the active task count.
+            // Remove the completed task from the list to free its concurrency slot.
             if let taskIndex = self.waitingTasks.firstIndex(where: { $0.id == taskId }) {
                 waitingTasks.remove(at: taskIndex)
             }
 
-            // We cannot remove elements from `waitingTasks` while iterating over it, so we make
-            // a pass to collect operations and then apply them after the loop.
-            func createTaskListOperations() -> (CollectionDifference<WorkTask>?, WaitingContinuation?) {
-                var changes: [CollectionDifference<WorkTask>.Change] = []
-                for (index, task) in waitingTasks.enumerated() {
-                    switch task {
-                    case .running:
-                        // Skip tasks that are already running, looking for the first one that is waiting or creating.
-                        continue
-                    case .creating:
-                        // If the next task is in the process of being created, let the
-                        // creation code in the `withCheckedThrowingContinuation` in `waitIfNeeded`
-                        // handle starting the task.
-                        break
-                    case .waiting:
-                        // Begin the next waiting task
-                        changes.append(.remove(offset: index, element: task, associatedWith: nil))
-                        return (CollectionDifference<WorkTask>(changes), task.continuation)
-                    case .cancelled:
-                        // If the next task is cancelled, continue removing cancelled
-                        // tasks until we find one that hasn't run yet, or we exaust the list of waiting tasks.
-                        changes.append(.remove(offset: index, element: task, associatedWith: nil))
-                        continue
-                    }
+            // Find the next task to start, removing any cancelled tombstones we pass along the way.
+            var index = 0
+            while index < waitingTasks.count {
+                switch waitingTasks[index] {
+                case .running:
+                    // Already occupying a slot; keep looking for a task that hasn't started yet.
+                    index += 1
+                case .creating:
+                    // The task is in the process of being created, i.e. it is between reserving its slot and
+                    // registering its continuation. We cannot resume it here (it has no continuation yet), but we
+                    // must keep looking for a waiting task behind it to promote: relying on the creating task to
+                    // start itself would strand those waiting tasks if it is cancelled before it ever runs. It is
+                    // safe to promote a later waiting task because the running-count re-check in `waitIfNeeded` will
+                    // make this creating task park once it observes the slot is taken.
+                    index += 1
+                case .waiting(let id, let continuation):
+                    // Promote the next waiting task to running in place so it keeps occupying a concurrency slot
+                    // until it completes, then resume its continuation once the lock is released.
+                    waitingTasks[index] = .running(id)
+                    return continuation
+                case .cancelled:
+                    // Drop cancelled tasks and keep looking for one that still needs to run.
+                    waitingTasks.remove(at: index)
                 }
-                return (CollectionDifference<WorkTask>(changes), nil)
             }
 
-            let (collectionOperations, continuation) = createTaskListOperations()
-            if let operations = collectionOperations {
-                guard let appliedDiff = waitingTasks.applying(operations) else {
-                    preconditionFailure("Failed to apply changes to waiting tasks")
-                }
-                waitingTasks = appliedDiff
-            }
-
-            return continuation
+            return nil
         }
 
         continuationToResume?.resume()

--- a/Tests/BasicsTests/ConcurrencyHelpersTests.swift
+++ b/Tests/BasicsTests/ConcurrencyHelpersTests.swift
@@ -106,6 +106,159 @@ struct ConcurrencyHelpersTest {
             }
         }
 
+        /// Test-only coordinator that lets the test step operations through the
+        /// queue deterministically: it can wait until a given operation has
+        /// started running, and hold an operation inside the queue until the
+        /// test explicitly releases it.
+        fileprivate actor TaskCoordinator {
+            private var entered: Set<Int> = []
+            private var enteredContinuations: [Int: CheckedContinuation<Void, Never>] = [:]
+            private var released: Set<Int> = []
+            private var releaseContinuations: [Int: CheckedContinuation<Void, Never>] = [:]
+
+            /// Called from inside the operation when it begins running.
+            func markEntered(_ id: Int) {
+                entered.insert(id)
+                enteredContinuations.removeValue(forKey: id)?.resume()
+            }
+
+            /// Suspends the test until the operation with `id` has started running.
+            func waitUntilEntered(_ id: Int) async {
+                if entered.contains(id) { return }
+                await withCheckedContinuation { continuation in
+                    enteredContinuations[id] = continuation
+                }
+            }
+
+            /// Called from inside the operation to block until the test releases it.
+            func waitForRelease(_ id: Int) async {
+                if released.contains(id) { return }
+                await withCheckedContinuation { continuation in
+                    releaseContinuations[id] = continuation
+                }
+            }
+
+            /// Allows the operation with `id` to finish.
+            func release(_ id: Int) {
+                released.insert(id)
+                releaseContinuations.removeValue(forKey: id)?.resume()
+            }
+        }
+
+        // Surfaces the over-subscription bug: when a waiting task is promoted it
+        // is *removed* from `waitingTasks` instead of being marked `.running`, so
+        // the admission gate under-counts running tasks. A new arrival is then
+        // admitted while the promoted task is still running, breaking the limit.
+        // With `concurrentTasks: 1` this breaks the serialization guarantee.
+        @Test
+        func doesNotExceedLimitWhenTaskArrivesAfterPromotion() async throws {
+            let queue = AsyncOperationQueue(concurrentTasks: 1)
+            let tracker = ResultsTracker()
+            let coordinator = TaskCoordinator()
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                func submit(_ id: Int) {
+                    group.addTask {
+                        try await queue.withOperation {
+                            await tracker.incrementConcurrent()
+                            await coordinator.markEntered(id)
+                            await coordinator.waitForRelease(id)
+                            await tracker.decrementConcurrent()
+                        }
+                    }
+                }
+
+                // Task 0 occupies the single slot.
+                submit(0)
+                await coordinator.waitUntilEntered(0)
+
+                // Task 1 arrives while task 0 holds the slot, so it must park.
+                // Give it time to register as a waiting task (no public hook exists).
+                submit(1)
+                try await Task.sleep(nanoseconds: 100_000_000)
+
+                // Releasing task 0 promotes task 1. The buggy promotion removes
+                // task 1 from the accounting array, so the queue now believes no
+                // task is running even though task 1 is.
+                await coordinator.release(0)
+                await coordinator.waitUntilEntered(1)
+
+                // Task 2 arrives after task 1 was promoted. It should wait for
+                // task 1, but the broken accounting admits it immediately. Give
+                // it time to (wrongly) start running concurrently with task 1.
+                submit(2)
+                try await Task.sleep(nanoseconds: 100_000_000)
+
+                await coordinator.release(1)
+                await coordinator.release(2)
+                try await group.waitForAll()
+            }
+
+            let maxConcurrent = await tracker.maxConcurrent
+            // A serial queue must never run two operations at once.
+            #expect(maxConcurrent == 1)
+        }
+
+        // Surfaces the deadlock race: if the running task completes (calling
+        // `signalCompletion`) while a newly-arrived task is between appending
+        // itself as `.creating` and registering its continuation, the completion
+        // scan finds only a `.creating` entry and resumes nobody. The arriving
+        // task's re-check then counts *itself* in `waitingTasks`, so it parks
+        // with no running task left to ever resume it, permanently wedging the
+        // queue. The window is tiny, so drive a high volume of tiny operations
+        // through a serial queue from several producers to provoke it, and fail
+        // via a deadline if the queue wedges.
+        //
+        // NOTE: this is a probabilistic stress test, not a deterministic one. The
+        // race window between the two lock acquisitions in `waitIfNeeded` is
+        // synchronous on a single thread, so the bug only triggers when the kernel
+        // preempts that thread in the window while another thread completes the
+        // running task. It is therefore gated behind an environment variable and
+        // run as multiple high-volume rounds; on the buggy implementation it wedges
+        // roughly once per tens of millions of operations.
+        @Test(.enabled(if: ProcessInfo.processInfo.environment["SWIFTPM_ENABLE_STRESS_TESTS"] != nil))
+        func doesNotDeadlockWhenTaskCompletesWhileNextTaskRegisters() async throws {
+            enum DeadlockDetected: Error { case timedOut }
+
+            let rounds = 50
+            let producers = 16
+            let operationsPerProducer = 50_000
+
+            for round in 0..<rounds {
+                let queue = AsyncOperationQueue(concurrentTasks: 1)
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    group.addTask {
+                        try await withThrowingTaskGroup(of: Void.self) { work in
+                            for _ in 0..<producers {
+                                work.addTask {
+                                    for _ in 0..<operationsPerProducer {
+                                        try await queue.withOperation {
+                                            await Task.yield()
+                                        }
+                                    }
+                                }
+                            }
+                            try await work.waitForAll()
+                        }
+                    }
+                    group.addTask {
+                        try await Task.sleep(nanoseconds: 15_000_000_000)
+                        throw DeadlockDetected.timedOut
+                    }
+                    // Whichever finishes first wins: the work (success) or the
+                    // deadline (the queue wedged, failing the test).
+                    do {
+                        try await group.next()
+                        group.cancelAll()
+                    } catch {
+                        Issue.record("Queue deadlocked in round \(round): \(error)")
+                        group.cancelAll()
+                        throw error
+                    }
+                }
+            }
+        }
+
         @Test
         func limitsConcurrentOperations() async throws {
             let queue = AsyncOperationQueue(concurrentTasks: 5)


### PR DESCRIPTION
AsyncOperationQueue stopped tracking running tasks accurately once a parked task was promoted, breaking its concurrency guarantee (most visible at concurrentTasks: 1).

1. Concurrency limit exceeded: a promoted waiting task was removed from waitingTasks when it started, so the admission gate under-counted running tasks and admitted extra ones.
2. Permanent deadlock: the continuation re-check counted the .creating task against itself; if the running task completed in the registration window, the task parked with nothing left to resume it.

Fixes: promote tasks to .running in place (waitIfNeeded start path + signalCompletion, rewritten as a scan); re-check against running-task count only; stop onCancel from tombstoning an already-running task. Adds a deterministic over-subscription test and an env-gated deadlock stress test.

