### PR TITLE
FreeBSD: ZipArchiver `directories` -> `paths`

### DIFF
--- a/Sources/Basics/Archiver/ZipArchiver.swift
+++ b/Sources/Basics/Archiver/ZipArchiver.swift
@@ -96,7 +96,7 @@ public struct ZipArchiver: Archiver, Cancellable {
         let process = AsyncProcess(
                 arguments: [
                     self.tar, "-c", "--format", "zip", "-f", destinationPath.pathString,
-                ] + directories.map(\.pathString),
+                ] + paths.map(\.pathString),
           workingDirectory: parent
         )
         #else


### PR DESCRIPTION
SwiftPM fails to build on FreeBSd because the code references a `directories` variable that is not declared.

### Motivation:

This looks like there was a missed rename while developing that wasn't caught because different platforms. The FreeBSD node has started reporting use of an undeclared `directories` variable. Causes SwiftPM to fail to build.

### Modifications:

Used `paths` instead of `directories`.
