### PR TITLE
Fix double-space typo in doc comment

### DIFF
--- a/Sources/PackageModel/PackageReference.swift
+++ b/Sources/PackageModel/PackageReference.swift
@@ -31,7 +31,7 @@ public struct PackageReference {
         /// A remote source package.
         case remoteSourceControl(SourceControlURL)
 
-        /// A package from  a registry.
+        /// A package from a registry.
         case registry(PackageIdentity)
 
         // FIXME: we should not need this once we migrate off URLs


### PR DESCRIPTION
Fix a minor double-space typo in doc comment

### Motivation:

There is an accidental double-space (`from  a`) in the documentation comment for `PackageReference.Kind.registry`.

### Modifications:

Changed `/// A package from  a registry.` to `/// A package from a registry.` in `PackageReference.swift`.

### Result:

No source code or logic changes. Just cleaner documentation.