### PR TITLE
The "unhandled files" warning does not respect the "-warnings-as-errors" flag

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -439,7 +439,8 @@ public final class PIFBuilder {
                     self.diagnoseUnhandledFiles(
                         package: package,
                         module: module,
-                        buildToolPluginInvocationResults: buildToolPluginResults
+                        buildToolPluginInvocationResults: buildToolPluginResults,
+                        treatWarningsAsErrors: treatWarningsAsErrors
                     )
                 }
 
@@ -623,7 +624,8 @@ public final class PIFBuilder {
     private func diagnoseUnhandledFiles(
         package: ResolvedPackage,
         module: ResolvedModule,
-        buildToolPluginInvocationResults: [BuildToolPluginInvocationResult]
+        buildToolPluginInvocationResults: [BuildToolPluginInvocationResult],
+        treatWarningsAsErrors: Bool
     ) {
         guard package.manifest.toolsVersion >= .v5_3 else {
             return
@@ -649,7 +651,8 @@ public final class PIFBuilder {
             return metadata
         }
 
-        diagnosticsEmitter.emit(.unhandledFiles(unhandledFiles))
+        let diagnostic = Basics.Diagnostic.unhandledFiles(unhandledFiles)
+        diagnosticsEmitter.emit(severity: treatWarningsAsErrors ? .error : .warning, message: diagnostic.message)
     }
 }
 

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -470,6 +470,10 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
         try await writePIF(buildParameters: self.buildParameters)
 
+        guard !self.observabilityScope.errorsReported else {
+            throw Diagnostics.fatalError
+        }
+
         return try await startSWBuildOperation(
             pifTargetName: subset.pifTargetName,
             buildOutputs: buildOutputs,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -457,6 +457,46 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test
+    func emitUnhandledFilesAsErrorWhenWarningsAsErrors() async throws {
+        try await withGeneratedPIF(
+            fromFixture: "PIFBuilder/UnhandledFiled",
+            withPackage: "App",
+            buildParameters: mockBuildParameters(
+                destination: .host,
+                flags: BuildFlags(swiftCompilerFlags: [BuildFlag(value: "-warnings-as-errors", source: nil)]),
+                buildSystemKind: .swiftbuild,
+            ),
+        ) { pif, observabilitySystem, fixturePath in
+
+            let expected: [Basics.Diagnostic] = [
+                Basics.Diagnostic.unhandledFiles([
+                    fixturePath.appending(components: ["Sources", "App", "Foo.txt"]),
+                    fixturePath.appending(components: ["Sources", "App", "README.md"]),
+                ])
+            ]
+
+            // With `-warnings-as-errors`, the unhandled files diagnostic should be
+            // emitted as an error rather than a warning.
+            let actualUnhandledFilesErrors = observabilitySystem.errors.filter {
+                $0.message.contains("which are unhandled;")
+            }
+            #expect(
+                actualUnhandledFilesErrors.count == expected.count,
+                "Expected the unhandled files diagnostic to be emitted as an error... actual: \(observabilitySystem.errors)",
+            )
+
+            // It should no longer be emitted as a warning.
+            let actualUnhandledFilesWarnings = observabilitySystem.warnings.filter {
+                $0.message.contains("which are unhandled;")
+            }
+            #expect(
+                actualUnhandledFilesWarnings.isEmpty,
+                "Did not expect the unhandled files diagnostic to be emitted as a warning... actual: \(actualUnhandledFilesWarnings)",
+            )
+        }
+    }
+
     @Test func platformConditionBasics() async throws {
         try await withGeneratedPIF(fromFixture: "PIFBuilder/UnknownPlatforms") { pif, observabilitySystem, fixturePath in
             // We should emit a warning to the PIF log about the unknown platform

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -482,7 +482,7 @@ struct PIFBuilderTests {
                 $0.message.contains("which are unhandled;")
             }
             #expect(
-                actualUnhandledFilesErrors.count == expected.count,
+                actualUnhandledFilesErrors.map(\.message) == expected.map(\.message),
                 "Expected the unhandled files diagnostic to be emitted as an error... actual: \(observabilitySystem.errors)",
             )
 


### PR DESCRIPTION
### Motivation:

The "unhandled files" warning does not respect the "-warnings-as-errors" flag

### Result:

Emit errors when unhandled files are detected and -warnings-as-errors is passed from the command line