### PR TITLE
Make the plugin invocation path async

### DIFF
--- a/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
+++ b/Sources/Basics/Concurrency/ConcurrencyHelpers.swift
@@ -40,6 +40,30 @@ public func unsafe_await<T: Sendable>(_ body: @Sendable @escaping () async -> T)
     return box.get()!
 }
 
+/// Runs `body` in an unstructured task that is **not** cancelled when the calling task is cancelled,
+/// and suspends until it finishes.
+///
+/// Use this when an operation must run to completion regardless of the parent task's cancellation —
+/// for example, draining a subprocess's output until the process has actually exited. Awaiting the
+/// returned value is itself not a cancellation point that aborts the work early.
+public func withUncancelledTask<R: Sendable>(
+    returning: R.Type = R.self,
+    _ body: @Sendable @escaping () async throws -> R
+) async throws -> R {
+    try await Task {
+        try await body()
+    }.value
+}
+
+public func withUncancelledTask<R: Sendable>(
+    returning: R.Type = R.self,
+    _ body: @Sendable @escaping () async -> R
+) async -> R {
+    await Task {
+        await body()
+    }.value
+}
+
 extension Task where Failure == Never {
     /// Runs `block` in a new thread and suspends until it finishes execution.
     ///

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -65,17 +65,9 @@ final class PluginDelegate: PluginInvocationDelegate {
 
     func pluginRequestedBuildOperation(
         subset: PluginInvocationBuildSubset,
-        parameters: PluginInvocationBuildParameters,
-        completion: @escaping (Result<PluginInvocationBuildResult, Error>) -> Void
-    ) {
-        // Run the build in the background and call the completion handler when done.
-        Task {
-            do {
-                try await completion(.success(self.performBuildForPlugin(subset: subset, parameters: parameters)))
-            } catch {
-                completion(.failure(error))
-            }
-        }
+        parameters: PluginInvocationBuildParameters
+    ) async throws -> PluginInvocationBuildResult {
+        try await self.performBuildForPlugin(subset: subset, parameters: parameters)
     }
 
     class TeeOutputByteStream: OutputByteStream {
@@ -208,17 +200,9 @@ final class PluginDelegate: PluginInvocationDelegate {
 
     func pluginRequestedTestOperation(
         subset: PluginInvocationTestSubset,
-        parameters: PluginInvocationTestParameters,
-        completion: @escaping (Result<PluginInvocationTestResult, Error>
-        ) -> Void) {
-        // Run the test in the background and call the completion handler when done.
-        Task {
-            do {
-                try await completion(.success(self.performTestsForPlugin(subset: subset, parameters: parameters)))
-            } catch {
-                completion(.failure(error))
-            }
-        }
+        parameters: PluginInvocationTestParameters
+    ) async throws -> PluginInvocationTestResult {
+        try await self.performTestsForPlugin(subset: subset, parameters: parameters)
     }
 
     func performTestsForPlugin(
@@ -378,17 +362,9 @@ final class PluginDelegate: PluginInvocationDelegate {
 
     func pluginRequestedSymbolGraph(
         forTarget targetName: String,
-        options: PluginInvocationSymbolGraphOptions,
-        completion: @escaping (Result<PluginInvocationSymbolGraphResult, Error>) -> Void
-    ) {
-        // Extract the symbol graph in the background and call the completion handler when done.
-        Task {
-            do {
-                try await completion(.success(self.createSymbolGraphForPlugin(forTarget: targetName, options: options)))
-            } catch {
-                completion(.failure(error))
-            }
-        }
+        options: PluginInvocationSymbolGraphOptions
+    ) async throws -> PluginInvocationSymbolGraphResult {
+        try await self.createSymbolGraphForPlugin(forTarget: targetName, options: options)
     }
 
     private func createSymbolGraphForPlugin(

--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -70,45 +70,34 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        delegate: PluginScriptCompilerDelegate & PluginScriptRunnerDelegate,
-        completion: @escaping (Result<Int32, Error>) -> Void
-    ) {
-        // If needed, compile the plugin script to an executable (asynchronously). Compilation is skipped if the plugin hasn't changed since it was last compiled.
-        self.compilePluginScript(
+        delegate: PluginScriptCompilerDelegate & PluginScriptRunnerDelegate
+    ) async throws -> Int32 {
+        // If needed, compile the plugin script to an executable. Compilation is skipped if the plugin hasn't changed since it was last compiled.
+        let result = try await self.compilePluginScript(
             sourceFiles: sourceFiles,
             pluginName: pluginName,
             toolsVersion: toolsVersion,
             workers: workers,
             observabilityScope: observabilityScope,
             callbackQueue: DispatchQueue.sharedConcurrent,
-            delegate: delegate,
-            completion: {
-                dispatchPrecondition(condition: .onQueue(DispatchQueue.sharedConcurrent))
-                switch $0 {
-                case .success(let result):
-                    if result.succeeded {
-                        // Compilation succeeded, so run the executable. We are already running on an asynchronous queue.
-                        self.invoke(
-                            compiledExec: result.executableFile,
-                            workingDirectory: workingDirectory,
-                            writableDirectories: writableDirectories,
-                            readOnlyDirectories: readOnlyDirectories,
-                            allowNetworkConnections: allowNetworkConnections,
-                            initialMessage: initialMessage,
-                            observabilityScope: observabilityScope,
-                            callbackQueue: callbackQueue,
-                            delegate: delegate,
-                            completion: completion)
-                    }
-                    else {
-                        // Compilation failed, so throw an error.
-                        callbackQueue.async { completion(.failure(DefaultPluginScriptRunnerError.compilationFailed(result))) }
-                    }
-                case .failure(let error):
-                    // Compilation failed, so just call the callback block on the appropriate queue.
-                    callbackQueue.async { completion(.failure(error)) }
-                }
-            }
+            delegate: delegate
+        )
+        guard result.succeeded else {
+            // Compilation failed, so throw an error.
+            throw DefaultPluginScriptRunnerError.compilationFailed(result)
+        }
+
+        // Compilation succeeded, so run the executable.
+        return try await self.invoke(
+            compiledExec: result.executableFile,
+            workingDirectory: workingDirectory,
+            writableDirectories: writableDirectories,
+            readOnlyDirectories: readOnlyDirectories,
+            allowNetworkConnections: allowNetworkConnections,
+            initialMessage: initialMessage,
+            observabilityScope: observabilityScope,
+            callbackQueue: callbackQueue,
+            delegate: delegate
         )
     }
 
@@ -455,33 +444,24 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         initialMessage: Data,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        delegate: PluginScriptRunnerDelegate,
-        completion: @escaping (Result<Int32, Error>) -> Void
-    ) {
+        delegate: PluginScriptRunnerDelegate
+    ) async throws -> Int32 {
 #if canImport(Darwin) && !os(macOS)
-        callbackQueue.async {
-            completion(.failure(DefaultPluginScriptRunnerError.pluginUnavailable(reason: "subprocess invocations are unavailable on this platform")))
-        }
+        throw DefaultPluginScriptRunnerError.pluginUnavailable(reason: "subprocess invocations are unavailable on this platform")
 #else
         // Construct the command line. Currently we just invoke the executable built from the plugin without any parameters.
         var command = [compiledExec.pathString]
 
         // Optionally wrap the command in a sandbox, which places some limits on what it can do. In particular, it blocks network access and restricts the paths to which the plugin can make file system changes. It does allow writing to temporary directories.
         if self.enableSandbox {
-            do {
-                command = try Sandbox.apply(
-                    command: command,
-                    fileSystem: self.fileSystem,
-                    strictness: .writableTemporaryDirectory,
-                    writableDirectories: writableDirectories + [self.cacheDir],
-                    readOnlyDirectories: readOnlyDirectories,
-                    allowNetworkConnections: allowNetworkConnections
-                )
-            } catch {
-                return callbackQueue.async {
-                    completion(.failure(error))
-                }
-            }
+            command = try Sandbox.apply(
+                command: command,
+                fileSystem: self.fileSystem,
+                strictness: .writableTemporaryDirectory,
+                writableDirectories: writableDirectories + [self.cacheDir],
+                readOnlyDirectories: readOnlyDirectories,
+                allowNetworkConnections: allowNetworkConnections
+            )
         }
 
         // Create and configure a Process. We set the working directory to the cache directory, so that relative paths end up there.
@@ -519,35 +499,17 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
         let outputQueue = DispatchQueue(label: "plugin-send-queue")
         process.standardInput = stdinPipe
 
-        // Set up a pipe for receiving messages from the plugin on its stdout.
+        // Set up a pipe for receiving messages from the plugin on its stdout, bridging each
+        // length-delimited message into an async stream that we consume below.
         let stdoutPipe = Pipe()
         let stdoutLock = NSLock()
+        let (messages, messagesContinuation) = AsyncStream.makeStream(of: Data.self)
         stdoutPipe.fileHandleForReading.readabilityHandler = { fileHandle in
-            // Receive the next message and pass it on to the delegate.
+            // Receive the next message and pass it on to the consumer.
             stdoutLock.withLock {
                 do {
                     while let message = try fileHandle.readPluginMessage() {
-                        // FIXME: We should handle errors here.
-                        callbackQueue.async {
-                            do {
-                                try delegate.handleMessage(data: message, responder: { data in
-                                    outputQueue.async {
-                                        do {
-                                            try outputHandle.writePluginMessage(data)
-                                        }
-                                        catch {
-                                            print("error while trying to send message to plugin: \(error.interpolationDescription)")
-                                        }
-                                    }
-                                })
-                            }
-                            catch DecodingError.keyNotFound(let key, _) where key.stringValue == "version" {
-                                print("message from plugin did not contain a 'version' key, likely an incompatible plugin library is being loaded by the plugin")
-                            }
-                            catch {
-                                print("error while trying to handle message from plugin: \(error.interpolationDescription)")
-                            }
-                        }
+                        messagesContinuation.yield(message)
                     }
                 }
                 catch {
@@ -573,64 +535,99 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             stderrLock.withLock { stderrHandler(fileHandle.availableData) }
         }
         process.standardError = stderrPipe
-        
+
         // Add it to the list of currently running plugin processes, so it can be cancelled if the host is interrupted.
         guard let cancellationKey = self.cancellator.register(process) else {
-            return callbackQueue.async {
-                completion(.failure(CancellationError()))
-            }
+            throw CancellationError()
         }
 
-        // Set up a handler to deal with the exit of the plugin process.
-        process.terminationHandler = { process in
-            // Remove the process from the list of currently running ones.
-            self.cancellator.deregister(cancellationKey)
-
-            // Close the output handle through which we talked to the plugin.
-            try? outputHandle.close()
-
-            // Read and pass on any remaining free-form text output from the plugin.
-            // We need the lock since we could run concurrently with the readability handler.
-            stderrLock.withLock {
-                try? stderrPipe.fileHandleForReading.readToEnd().map{ stderrHandler($0) }
-            }
-
-            // Read and pass on any remaining messages from the plugin.
-            let handle = stdoutPipe.fileHandleForReading
-            if let handler = handle.readabilityHandler {
-                handler(handle)
-            }
-
-            // Call the completion block with a result that depends on how the process ended.
-            callbackQueue.async {
-                completion(Result {
-                    // We throw an error if the plugin ended with a signal.
-                    if process.terminationReason == .uncaughtSignal {
-                        throw DefaultPluginScriptRunnerError.invocationEndedBySignal(
-                            signal: process.terminationStatus,
-                            command: command,
-                            output: String(decoding: stderrData, as: UTF8.self))
+        // Drain plugin messages on a task that is not cancelled with the caller. Doing this on the
+        // calling task would mean that cancelling the caller ends the `for await` early (an
+        // `AsyncStream` iterator is cancellation aware), after which reading
+        // `terminationReason`/`terminationStatus` on a process that is still running traps in
+        // Foundation. Instead this lives until the termination handler finishes the stream — i.e. until
+        // the process has actually exited.
+        async let consumer: Void = withUncancelledTask {
+            for await message in messages {
+                do {
+                    if let reply = try await delegate.handleMessage(data: message) {
+                        outputQueue.async {
+                            do {
+                                try outputHandle.writePluginMessage(reply)
+                            }
+                            catch {
+                                print("error while trying to send message to plugin: \(error.interpolationDescription)")
+                            }
+                        }
                     }
-                    // Otherwise return the termination satatus.
-                    return process.terminationStatus
-                })
-            }
-        }
- 
-        // Start the plugin process.
-        do {
-            try process.run()
-        }
-        catch {
-            callbackQueue.async {
-                completion(.failure(DefaultPluginScriptRunnerError.invocationFailed(error: error, command: command)))
+                }
+                catch DecodingError.keyNotFound(let key, _) where key.stringValue == "version" {
+                    print("message from plugin did not contain a 'version' key, likely an incompatible plugin library is being loaded by the plugin")
+                }
+                catch {
+                    print("error while trying to handle message from plugin: \(error.interpolationDescription)")
+                }
             }
         }
 
-        /// Send the initial message to the plugin.
-        outputQueue.async {
-            try? outputHandle.writePluginMessage(initialMessage)
+        // Run the process and wait for it to terminate. The termination handler reads the exit status —
+        // which is only valid once the process has actually terminated — and resumes the continuation, so
+        // we never touch `terminationReason`/`terminationStatus` on a running process. This await is not
+        // cancellation sensitive: on cancellation we still wait for the cancellator to terminate the
+        // process and fire the handler.
+        let result: Result<Int32, Error> = await withCheckedContinuation { continuation in
+            process.terminationHandler = { process in
+                // Remove the process from the list of currently running ones.
+                self.cancellator.deregister(cancellationKey)
+
+                // Close the output handle through which we talked to the plugin.
+                try? outputHandle.close()
+
+                // Read and pass on any remaining free-form text output from the plugin.
+                // We need the lock since we could run concurrently with the readability handler.
+                stderrLock.withLock {
+                    try? stderrPipe.fileHandleForReading.readToEnd().map { stderrHandler($0) }
+                }
+
+                // Read and pass on any remaining messages from the plugin.
+                let handle = stdoutPipe.fileHandleForReading
+                if let handler = handle.readabilityHandler {
+                    handler(handle)
+                }
+                messagesContinuation.finish()
+
+                // Compute a result based on how the process ended. We report an error if it ended with a signal.
+                if process.terminationReason == .uncaughtSignal {
+                    continuation.resume(returning: .failure(DefaultPluginScriptRunnerError.invocationEndedBySignal(
+                        signal: process.terminationStatus,
+                        command: command,
+                        output: String(decoding: stderrLock.withLock { stderrData }, as: UTF8.self))))
+                } else {
+                    continuation.resume(returning: .success(process.terminationStatus))
+                }
+            }
+
+            // Start the plugin process.
+            do {
+                try process.run()
+            }
+            catch {
+                self.cancellator.deregister(cancellationKey)
+                messagesContinuation.finish()
+                continuation.resume(returning: .failure(DefaultPluginScriptRunnerError.invocationFailed(error: error, command: command)))
+                return
+            }
+
+            // Send the initial message to the plugin.
+            outputQueue.async {
+                try? outputHandle.writePluginMessage(initialMessage)
+            }
         }
+
+        // Make sure every message has been handled before returning.
+        await consumer
+
+        return try result.get()
 #endif
     }
 

--- a/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginInvocation.swift
@@ -60,53 +60,6 @@ public struct PluginTool {
 }
 
 extension PluginModule {
-    public func invoke(
-        action: PluginAction,
-        buildEnvironment: BuildEnvironment,
-        workers: UInt32,
-        scriptRunner: PluginScriptRunner,
-        workingDirectory: AbsolutePath,
-        outputDirectory: AbsolutePath,
-        toolSearchDirectories: [AbsolutePath],
-        accessibleTools: [String: PluginTool],
-        writableDirectories: [AbsolutePath],
-        readOnlyDirectories: [AbsolutePath],
-        allowNetworkConnections: [SandboxNetworkPermission],
-        pkgConfigDirectories: [AbsolutePath],
-        sdkRootPath: AbsolutePath?,
-        fileSystem: FileSystem,
-        modulesGraph: ModulesGraph,
-        observabilityScope: ObservabilityScope,
-        callbackQueue: DispatchQueue,
-        delegate: PluginInvocationDelegate
-    ) async throws -> Bool {
-        try await withCheckedThrowingContinuation { continuation in
-            self.invoke(
-                action: action,
-                buildEnvironment: buildEnvironment,
-                workers: workers,
-                scriptRunner: scriptRunner,
-                workingDirectory: workingDirectory,
-                outputDirectory: outputDirectory,
-                toolSearchDirectories: toolSearchDirectories,
-                accessibleTools: accessibleTools,
-                writableDirectories: writableDirectories,
-                readOnlyDirectories: readOnlyDirectories,
-                allowNetworkConnections: allowNetworkConnections,
-                pkgConfigDirectories: pkgConfigDirectories,
-                sdkRootPath: sdkRootPath,
-                fileSystem: fileSystem,
-                modulesGraph: modulesGraph,
-                observabilityScope: observabilityScope,
-                callbackQueue: callbackQueue,
-                delegate: delegate,
-                completion: {
-                    continuation.resume(with: $0)
-                }
-            )
-        }
-    }
-
     /// Invokes the plugin by compiling its source code (if needed) and then running it as a subprocess. The specified
     /// plugin action determines which entry point is called in the subprocess, and the package and the tool mapping
     /// determine the context that is available to the plugin.
@@ -130,7 +83,6 @@ extension PluginModule {
     ///   - fileSystem: The file system to which all of the paths refers.
     ///
     /// - Returns: A PluginInvocationResult that contains the results of invoking the plugin.
-    @available(*, noasync, message: "Use the async alternative")
     public func invoke(
         action: PluginAction,
         buildEnvironment: BuildEnvironment,
@@ -149,15 +101,14 @@ extension PluginModule {
         modulesGraph: ModulesGraph,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        delegate: PluginInvocationDelegate,
-        completion: @escaping (Result<Bool, Error>) -> Void
-    ) {
+        delegate: PluginInvocationDelegate
+    ) async throws -> Bool {
         // Create the plugin's output directory if needed (but don't do anything with it if it already exists).
         do {
             try fileSystem.createDirectory(outputDirectory, recursive: true)
         }
         catch {
-            return callbackQueue.async { completion(.failure(PluginEvaluationError.couldNotCreateOuputDirectory(path: outputDirectory, underlyingError: error))) }
+            throw PluginEvaluationError.couldNotCreateOuputDirectory(path: outputDirectory, underlyingError: error)
         }
 
         // Serialize the plugin action to send as the initial message.
@@ -266,7 +217,7 @@ extension PluginModule {
             initialMessage = try actionMessage.toData()
         }
         catch {
-            return callbackQueue.async { completion(.failure(PluginEvaluationError.couldNotSerializePluginInput(underlyingError: error))) }
+            throw PluginEvaluationError.couldNotSerializePluginInput(underlyingError: error)
         }
 
         // Handle messages and output from the plugin.
@@ -283,9 +234,15 @@ extension PluginModule {
             /// If this is true, we exited early with an error.
             var exitEarly = false
 
-            init(invocationDelegate: PluginInvocationDelegate, observabilityScope: ObservabilityScope) {
+            /// Queue on which the invocation delegate expects to be called. The synchronous portions of
+            /// `handleMessage` hop onto it so they observe the same serialization as `handleOutput`, which
+            /// the caller already dispatches on this queue.
+            let callbackQueue: DispatchQueue
+
+            init(invocationDelegate: PluginInvocationDelegate, observabilityScope: ObservabilityScope, callbackQueue: DispatchQueue) {
                 self.invocationDelegate = invocationDelegate
                 self.observabilityScope = observabilityScope
+                self.callbackQueue = callbackQueue
             }
 
             func willCompilePlugin(commandLine: [String], environment: [String: String]) {
@@ -300,120 +257,114 @@ extension PluginModule {
                 invocationDelegate.pluginCompilationWasSkipped(cachedResult: cachedResult)
             }
 
-            /// Invoked when the plugin emits arbitrary data on its stdout/stderr. There is no guarantee that the data is split on UTF-8 character encoding boundaries etc.  The script runner delegate just passes it on to the invocation delegate.
+            /// Invoked when the plugin emits arbitrary data on its stdout/stderr. There is no guarantee that the data is split on UTF-8 character encoding boundaries etc.  The script runner delegate just passes it on to the invocation delegate. Callers dispatch this on `callbackQueue`.
             func handleOutput(data: Data) {
                 invocationDelegate.pluginEmittedOutput(data)
             }
 
-            /// Invoked when the plugin emits a message. The `responder` closure can be used to send any reply messages.
-            func handleMessage(data: Data, responder: @escaping (Data) -> Void) throws {
+            /// Invoked when the plugin emits a message. Returns an optional reply message to send back to the plugin.
+            func handleMessage(data: Data) async throws -> Data? {
                 let message = try PluginToHostMessage(data)
                 switch message {
 
                 case .emitDiagnostic(let severity, let message, let file, let line):
-                    let metadata: ObservabilityMetadata? = file.map {
-                        var metadata = ObservabilityMetadata()
-                        // FIXME: We should probably report some kind of protocol error if the path isn't valid.
-                        metadata.fileLocation = try? .init(.init(validating: $0), line: line)
-                        return metadata
+                    callbackQueue.sync {
+                        let metadata: ObservabilityMetadata? = file.map {
+                            var metadata = ObservabilityMetadata()
+                            // FIXME: We should probably report some kind of protocol error if the path isn't valid.
+                            metadata.fileLocation = try? .init(.init(validating: $0), line: line)
+                            return metadata
+                        }
+                        let diagnostic: Basics.Diagnostic
+                        switch severity {
+                        case .error:
+                            diagnostic = .error(message, metadata: metadata)
+                            hasReportedError = true
+                        case .warning:
+                            diagnostic = .warning(message, metadata: metadata)
+                        case .remark:
+                            diagnostic = .info(message, metadata: metadata)
+                        }
+                        self.invocationDelegate.pluginEmittedDiagnostic(diagnostic)
                     }
-                    let diagnostic: Basics.Diagnostic
-                    switch severity {
-                    case .error:
-                        diagnostic = .error(message, metadata: metadata)
-                        hasReportedError = true
-                    case .warning:
-                        diagnostic = .warning(message, metadata: metadata)
-                    case .remark:
-                        diagnostic = .info(message, metadata: metadata)
-                    }
-                    self.invocationDelegate.pluginEmittedDiagnostic(diagnostic)
+                    return nil
 
                 case .emitProgress(let message):
-                    self.invocationDelegate.pluginEmittedProgress(message)
+                    callbackQueue.sync {
+                        self.invocationDelegate.pluginEmittedProgress(message)
+                    }
+                    return nil
 
                 case .defineBuildCommand(let config, let inputFiles, let outputFiles):
                     if config.version != 2 {
                         throw PluginEvaluationError.pluginUsesIncompatibleVersion(expected: 2, actual: config.version)
                     }
-                    self.invocationDelegate.pluginDefinedBuildCommand(
-                        displayName: config.displayName,
-                        executable: try config.executable.filePath,
-                        arguments: config.arguments,
-                        environment: config.environment,
-                        workingDirectory: try config.workingDirectory.map{ try $0.filePath },
-                        inputFiles: try inputFiles.map{ try $0.filePath },
-                        outputFiles: try outputFiles.map{ try $0.filePath })
+                    try callbackQueue.sync {
+                        self.invocationDelegate.pluginDefinedBuildCommand(
+                            displayName: config.displayName,
+                            executable: try config.executable.filePath,
+                            arguments: config.arguments,
+                            environment: config.environment,
+                            workingDirectory: try config.workingDirectory.map{ try $0.filePath },
+                            inputFiles: try inputFiles.map{ try $0.filePath },
+                            outputFiles: try outputFiles.map{ try $0.filePath })
+                    }
+                    return nil
 
                 case .definePrebuildCommand(let config, let outputFilesDir):
                     if config.version != 2 {
                         throw PluginEvaluationError.pluginUsesIncompatibleVersion(expected: 2, actual: config.version)
                     }
-                    let success = self.invocationDelegate.pluginDefinedPrebuildCommand(
-                        displayName: config.displayName,
-                        executable: try config.executable.filePath,
-                        arguments: config.arguments,
-                        environment: config.environment,
-                        workingDirectory: try config.workingDirectory.map{ try $0.filePath },
-                        outputFilesDirectory: try outputFilesDir.filePath)
+                    try callbackQueue.sync {
+                        let success = self.invocationDelegate.pluginDefinedPrebuildCommand(
+                            displayName: config.displayName,
+                            executable: try config.executable.filePath,
+                            arguments: config.arguments,
+                            environment: config.environment,
+                            workingDirectory: try config.workingDirectory.map{ try $0.filePath },
+                            outputFilesDirectory: try outputFilesDir.filePath)
 
-                    if !success {
-                        exitEarly = true
-                        hasReportedError = true
+                        if !success {
+                            exitEarly = true
+                            hasReportedError = true
+                        }
                     }
+                    return nil
 
                 case .buildOperationRequest(let subset, let parameters):
-                    self.invocationDelegate.pluginRequestedBuildOperation(subset: .init(subset), parameters: .init(parameters)) {
-                        do {
-                            switch $0 {
-                            case .success(let result):
-                                responder(try HostToPluginMessage.buildOperationResponse(result: .init(result)).toData())
-                            case .failure(let error):
-                                responder(try HostToPluginMessage.errorResponse(error: String(describing: error)).toData())
-                            }
-                        }
-                        catch {
-                            self.observabilityScope.emit(debug: "couldn't send reply to plugin", underlyingError: error)
-                        }
+                    do {
+                        let result = try await self.invocationDelegate.pluginRequestedBuildOperation(
+                            subset: .init(subset), parameters: .init(parameters))
+                        return try HostToPluginMessage.buildOperationResponse(result: .init(result)).toData()
+                    } catch {
+                        return try HostToPluginMessage.errorResponse(error: String(describing: error)).toData()
                     }
 
                 case .testOperationRequest(let subset, let parameters):
-                    self.invocationDelegate.pluginRequestedTestOperation(subset: .init(subset), parameters: .init(parameters)) {
-                        do {
-                            switch $0 {
-                            case .success(let result):
-                                responder(try HostToPluginMessage.testOperationResponse(result: .init(result)).toData())
-                            case .failure(let error):
-                                responder(try HostToPluginMessage.errorResponse(error: String(describing: error)).toData())
-                            }
-                        }
-                        catch {
-                            self.observabilityScope.emit(debug: "couldn't send reply to plugin", underlyingError: error)
-                        }
+                    do {
+                        let result = try await self.invocationDelegate.pluginRequestedTestOperation(
+                            subset: .init(subset), parameters: .init(parameters))
+                        return try HostToPluginMessage.testOperationResponse(result: .init(result)).toData()
+                    } catch {
+                        return try HostToPluginMessage.errorResponse(error: String(describing: error)).toData()
                     }
 
                 case .symbolGraphRequest(let targetName, let options):
                     // The plugin requested symbol graph information for a target. We ask the delegate and then send a response.
-                    self.invocationDelegate.pluginRequestedSymbolGraph(forTarget: .init(targetName), options: .init(options)) {
-                        do {
-                            switch $0 {
-                            case .success(let result):
-                                responder(try HostToPluginMessage.symbolGraphResponse(result: .init(result)).toData())
-                            case .failure(let error):
-                                responder(try HostToPluginMessage.errorResponse(error: String(describing: error)).toData())
-                            }
-                        }
-                        catch {
-                            self.observabilityScope.emit(debug: "couldn't send reply to plugin", underlyingError: error)
-                        }
+                    do {
+                        let result = try await self.invocationDelegate.pluginRequestedSymbolGraph(
+                            forTarget: .init(targetName), options: .init(options))
+                        return try HostToPluginMessage.symbolGraphResponse(result: .init(result)).toData()
+                    } catch {
+                        return try HostToPluginMessage.errorResponse(error: String(describing: error)).toData()
                     }
                 }
             }
         }
-        let runnerDelegate = ScriptRunnerDelegate(invocationDelegate: delegate, observabilityScope: observabilityScope)
+        let runnerDelegate = ScriptRunnerDelegate(invocationDelegate: delegate, observabilityScope: observabilityScope, callbackQueue: callbackQueue)
 
         // Call the plugin script runner to actually invoke the plugin.
-        scriptRunner.runPluginScript(
+        let exitCode = try await scriptRunner.runPluginScript(
             sourceFiles: sources.paths,
             pluginName: self.name,
             initialMessage: initialMessage,
@@ -426,22 +377,22 @@ extension PluginModule {
             fileSystem: fileSystem,
             observabilityScope: observabilityScope,
             callbackQueue: callbackQueue,
-            delegate: runnerDelegate) { result in
-                dispatchPrecondition(condition: .onQueue(callbackQueue))
-                completion(result.map { exitCode in
-                    // Return a result based on the exit code or the `exitEarly` parameter. If the plugin
-                    // exits with an error but hasn't already emitted an error, we do so for it.
-                    let exitedCleanly = (exitCode == 0) && !runnerDelegate.exitEarly
-                    if !exitedCleanly && !runnerDelegate.hasReportedError {
-                        delegate.pluginEmittedDiagnostic(
-                            .error("Plugin ended with exit code \(exitCode)")
-                        )
-                    }
-                    return exitedCleanly
-                })
+            delegate: runnerDelegate
+        )
+
+        // Return a result based on the exit code or the `exitEarly` parameter. If the plugin
+        // exits with an error but hasn't already emitted an error, we do so for it.
+        let exitedCleanly = (exitCode == 0) && !runnerDelegate.exitEarly
+        if !exitedCleanly && !runnerDelegate.hasReportedError {
+            delegate.pluginEmittedDiagnostic(
+                .error("Plugin ended with exit code \(exitCode)")
+            )
         }
+        return exitedCleanly
     }
 
+    /// This is a convenient way to get results of the plugin invocation without having
+    /// to deal with delegates and other internal details.
     package func invoke(
         module: ResolvedModule,
         action: PluginAction,
@@ -461,59 +412,9 @@ extension PluginModule {
         modulesGraph: ModulesGraph,
         observabilityScope: ObservabilityScope
     ) async throws -> BuildToolPluginInvocationResult {
-        try await withCheckedThrowingContinuation { continuation in
-            self.invoke(
-                module: module,
-                action: action,
-                buildEnvironment: buildEnvironment,
-                workers: workers,
-                scriptRunner: scriptRunner,
-                workingDirectory: workingDirectory,
-                outputDirectory: outputDirectory,
-                toolSearchDirectories: toolSearchDirectories,
-                accessibleTools: accessibleTools,
-                writableDirectories: writableDirectories,
-                readOnlyDirectories: readOnlyDirectories,
-                allowNetworkConnections: allowNetworkConnections,
-                pkgConfigDirectories: pkgConfigDirectories,
-                sdkRootPath: sdkRootPath,
-                fileSystem: fileSystem,
-                modulesGraph: modulesGraph,
-                observabilityScope: observabilityScope,
-                completion: {
-                    continuation.resume(with: $0)
-                }
-            )
-        }
-    }
-
-    /// This is a convenient way to get results of the plugin invocation without having
-    /// to deal with delegates and other internal details.
-    @available(*, noasync, message: "Use the async alternative")
-    package func invoke(
-        module: ResolvedModule,
-        action: PluginAction,
-        buildEnvironment: BuildEnvironment,
-        workers: UInt32,
-        scriptRunner: PluginScriptRunner,
-        workingDirectory: AbsolutePath,
-        outputDirectory: AbsolutePath,
-        toolSearchDirectories: [AbsolutePath],
-        accessibleTools: [String: PluginTool],
-        writableDirectories: [AbsolutePath],
-        readOnlyDirectories: [AbsolutePath],
-        allowNetworkConnections: [SandboxNetworkPermission],
-        pkgConfigDirectories: [AbsolutePath],
-        sdkRootPath: AbsolutePath?,
-        fileSystem: FileSystem,
-        modulesGraph: ModulesGraph,
-        observabilityScope: ObservabilityScope,
-        completion: @escaping (Result<BuildToolPluginInvocationResult, Error>) -> Void
-    ) {
         /// Determine the package that contains the target.
         guard let package = modulesGraph.package(for: module) else {
-            completion(.failure(InternalError("Could not find package for \(self)")))
-            return
+            throw InternalError("Could not find package for \(self)")
         }
 
         // Set up a delegate to handle callbacks from the build tool plugin.
@@ -535,50 +436,44 @@ extension PluginModule {
 
         let startTime = DispatchTime.now()
 
-        self.invoke(
-            action: action,
-            buildEnvironment: buildEnvironment,
-            workers: workers,
-            scriptRunner: scriptRunner,
-            workingDirectory: workingDirectory,
-            outputDirectory: outputDirectory,
-            toolSearchDirectories: toolSearchDirectories,
-            accessibleTools: accessibleTools,
-            writableDirectories: writableDirectories,
-            readOnlyDirectories: readOnlyDirectories,
-            allowNetworkConnections: allowNetworkConnections,
-            pkgConfigDirectories: pkgConfigDirectories,
-            sdkRootPath: sdkRootPath,
-            fileSystem: fileSystem,
-            modulesGraph: modulesGraph,
-            observabilityScope: observabilityScope,
-            callbackQueue: delegateQueue,
-            delegate: delegate,
-            completion: {
-                let duration = startTime.distance(to: .now())
+        let success: Bool
+        do {
+            success = try await self.invoke(
+                action: action,
+                buildEnvironment: buildEnvironment,
+                workers: workers,
+                scriptRunner: scriptRunner,
+                workingDirectory: workingDirectory,
+                outputDirectory: outputDirectory,
+                toolSearchDirectories: toolSearchDirectories,
+                accessibleTools: accessibleTools,
+                writableDirectories: writableDirectories,
+                readOnlyDirectories: readOnlyDirectories,
+                allowNetworkConnections: allowNetworkConnections,
+                pkgConfigDirectories: pkgConfigDirectories,
+                sdkRootPath: sdkRootPath,
+                fileSystem: fileSystem,
+                modulesGraph: modulesGraph,
+                observabilityScope: observabilityScope,
+                callbackQueue: delegateQueue,
+                delegate: delegate
+            )
+        } catch {
+            success = false
+        }
+        let duration = startTime.distance(to: .now())
 
-                let success: Bool = switch $0 {
-                case .success(let result):
-                    result
-                case .failure:
-                    false
-                }
-
-                let invocationResult = BuildToolPluginInvocationResult(
-                    plugin: self,
-                    pluginOutputDirectory: outputDirectory,
-                    package: package,
-                    target: module,
-                    succeeded: success,
-                    duration: duration,
-                    diagnostics: delegate.diagnostics,
-                    textOutput: String(decoding: delegate.outputData, as: UTF8.self),
-                    buildCommands: delegate.buildCommands,
-                    prebuildCommands: delegate.prebuildCommands
-                )
-
-                completion(.success(invocationResult))
-            }
+        return BuildToolPluginInvocationResult(
+            plugin: self,
+            pluginOutputDirectory: outputDirectory,
+            package: package,
+            target: module,
+            succeeded: success,
+            duration: duration,
+            diagnostics: delegate.diagnostics,
+            textOutput: String(decoding: delegate.outputData, as: UTF8.self),
+            buildCommands: delegate.buildCommands,
+            prebuildCommands: delegate.prebuildCommands
         )
     }
 }
@@ -864,13 +759,13 @@ public protocol PluginInvocationDelegate {
     func pluginDefinedPrebuildCommand(displayName: String?, executable: AbsolutePath, arguments: [String], environment: [String: String], workingDirectory: AbsolutePath?, outputFilesDirectory: AbsolutePath) -> Bool
 
     /// Called when a plugin requests a build operation through the PackagePlugin APIs.
-    func pluginRequestedBuildOperation(subset: PluginInvocationBuildSubset, parameters: PluginInvocationBuildParameters, completion: @escaping (Result<PluginInvocationBuildResult, Error>) -> Void)
+    func pluginRequestedBuildOperation(subset: PluginInvocationBuildSubset, parameters: PluginInvocationBuildParameters) async throws -> PluginInvocationBuildResult
 
     /// Called when a plugin requests a test operation through the PackagePlugin APIs.
-    func pluginRequestedTestOperation(subset: PluginInvocationTestSubset, parameters: PluginInvocationTestParameters, completion: @escaping (Result<PluginInvocationTestResult, Error>) -> Void)
+    func pluginRequestedTestOperation(subset: PluginInvocationTestSubset, parameters: PluginInvocationTestParameters) async throws -> PluginInvocationTestResult
 
     /// Called when a plugin requests that the host computes and returns symbol graph information for a particular target.
-    func pluginRequestedSymbolGraph(forTarget name: String, options: PluginInvocationSymbolGraphOptions, completion: @escaping (Result<PluginInvocationSymbolGraphResult, Error>) -> Void)
+    func pluginRequestedSymbolGraph(forTarget name: String, options: PluginInvocationSymbolGraphOptions) async throws -> PluginInvocationSymbolGraphResult
 }
 
 final class DefaultPluginInvocationDelegate: PluginInvocationDelegate {
@@ -1087,14 +982,14 @@ public extension PluginInvocationDelegate {
     func pluginDefinedPrebuildCommand(displayName: String?, executable: AbsolutePath, arguments: [String], environment: [String: String], workingDirectory: AbsolutePath?, outputFilesDirectory: AbsolutePath) -> Bool {
         return true
     }
-    func pluginRequestedBuildOperation(subset: PluginInvocationBuildSubset, parameters: PluginInvocationBuildParameters, completion: @escaping (Result<PluginInvocationBuildResult, Error>) -> Void) {
-        DispatchQueue.sharedConcurrent.async { completion(Result.failure(StringError("unimplemented"))) }
+    func pluginRequestedBuildOperation(subset: PluginInvocationBuildSubset, parameters: PluginInvocationBuildParameters) async throws -> PluginInvocationBuildResult {
+        throw StringError("unimplemented")
     }
-    func pluginRequestedTestOperation(subset: PluginInvocationTestSubset, parameters: PluginInvocationTestParameters, completion: @escaping (Result<PluginInvocationTestResult, Error>) -> Void) {
-        DispatchQueue.sharedConcurrent.async { completion(Result.failure(StringError("unimplemented"))) }
+    func pluginRequestedTestOperation(subset: PluginInvocationTestSubset, parameters: PluginInvocationTestParameters) async throws -> PluginInvocationTestResult {
+        throw StringError("unimplemented")
     }
-    func pluginRequestedSymbolGraph(forTarget name: String, options: PluginInvocationSymbolGraphOptions, completion: @escaping (Result<PluginInvocationSymbolGraphResult, Error>) -> Void) {
-        DispatchQueue.sharedConcurrent.async { completion(Result.failure(StringError("unimplemented"))) }
+    func pluginRequestedSymbolGraph(forTarget name: String, options: PluginInvocationSymbolGraphOptions) async throws -> PluginInvocationSymbolGraphResult {
+        throw StringError("unimplemented")
     }
 }
 

--- a/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/PluginScriptRunner.swift
@@ -66,9 +66,8 @@ public protocol PluginScriptRunner {
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        delegate: PluginScriptCompilerDelegate & PluginScriptRunnerDelegate,
-        completion: @escaping (Result<Int32, Error>) -> Void
-    )
+        delegate: PluginScriptCompilerDelegate & PluginScriptRunnerDelegate
+    ) async throws -> Int32
 
     /// Returns the Triple that represents the host for which plugin script tools should be built, or for which binary
     /// tools should be selected.
@@ -119,8 +118,8 @@ public protocol PluginScriptRunnerDelegate {
     /// Called for each piece of textual output data emitted by the plugin. Note that there is no guarantee that the data begins and ends on a UTF-8 byte sequence boundary (much less on a line boundary) so the delegate should buffer partial data as appropriate.
     func handleOutput(data: Data)
     
-    /// Called for each length-delimited message received from the plugin. The `responder` is closure that can be used to send one or more messages in reply.
-    func handleMessage(data: Data, responder: @escaping (Data) -> Void) throws
+    /// Called for each length-delimited message received from the plugin. Returns an optional reply message to send back to the plugin.
+    func handleMessage(data: Data) async throws -> Data?
 }
 
 /// The result of compiling a plugin. The executable path will only be present if the compilation succeeds, while the other properties are present in all cases.

--- a/Tests/BuildTests/CGenPluginsBuildPlanTests.swift
+++ b/Tests/BuildTests/CGenPluginsBuildPlanTests.swift
@@ -145,30 +145,22 @@ import Build
                 fileSystem: any Basics.FileSystem,
                 observabilityScope: Basics.ObservabilityScope,
                 callbackQueue: DispatchQueue,
-                delegate: any SPMBuildCore.PluginScriptCompilerDelegate & SPMBuildCore.PluginScriptRunnerDelegate,
-                completion: @escaping (Result<Int32, any Error>) -> Void)
-            {
-                callbackQueue.sync {
-                    do {
-                        let decoder = JSONDecoder.makeWithDefaults()
-                        let encoder = JSONEncoder(outputFormatting: .prettyPrinted)
+                delegate: any SPMBuildCore.PluginScriptCompilerDelegate & SPMBuildCore.PluginScriptRunnerDelegate
+            ) async throws -> Int32 {
+                let decoder = JSONDecoder.makeWithDefaults()
+                let encoder = JSONEncoder(outputFormatting: .prettyPrinted)
 
-                        let initial = try decoder.decode(HostToPluginMessage.self, from: initialMessage)
-                        guard case let .createBuildToolCommands(context: context, rootPackageId: _, targetId: _, pluginGeneratedSources: _, pluginGeneratedResources: _) = initial else {
-                            completion(.failure(StringError("Invalid initial message")))
-                            return
-                        }
-                        let workDir = try context.url(for: context.pluginWorkDirId)
-
-                        for message in genMessages(sourceFiles, workDir) {
-                            let data = try encoder.encode(message)
-                            try delegate.handleMessage(data: data, responder: { _ in })
-                        }
-                        completion(.success(0))
-                    } catch {
-                        completion(.failure(error))
-                    }
+                let initial = try decoder.decode(HostToPluginMessage.self, from: initialMessage)
+                guard case let .createBuildToolCommands(context: context, rootPackageId: _, targetId: _, pluginGeneratedSources: _, pluginGeneratedResources: _) = initial else {
+                    throw StringError("Invalid initial message")
                 }
+                let workDir = try context.url(for: context.pluginWorkDirId)
+
+                for message in genMessages(sourceFiles, workDir) {
+                    let data = try encoder.encode(message)
+                    _ = try await delegate.handleMessage(data: data)
+                }
+                return 0
             }
 
             var hostTriple: Triple {

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -174,69 +174,54 @@ final class PluginInvocationTests: XCTestCase {
                 fileSystem: FileSystem,
                 observabilityScope: ObservabilityScope,
                 callbackQueue: DispatchQueue,
-                delegate: PluginScriptCompilerDelegate & PluginScriptRunnerDelegate,
-                completion: @escaping (Result<Int32, Error>) -> Void
-            ) {
+                delegate: PluginScriptCompilerDelegate & PluginScriptRunnerDelegate
+            ) async throws -> Int32 {
                 // Check that we were given the right sources.
                 XCTAssertEqual(sourceFiles, ["/Foo/Plugins/FooPlugin/source.swift"])
 
-                do {
-                    // Pretend the plugin emitted some output.
-                    callbackQueue.sync {
-                        delegate.handleOutput(data: Data("Hello Plugin!".utf8))
-                    }
-
-                    // Pretend it emitted a warning.
-                    try callbackQueue.sync {
-                        let message = Data("""
-                        {   "emitDiagnostic": {
-                                "severity": "warning",
-                                "message": "A warning",
-                                "file": "/Foo/Sources/Foo/SomeFile.abc",
-                                "line": 42
-                            }
-                        }
-                        """.utf8)
-                        try delegate.handleMessage(data: message, responder: { _ in })
-                    }
-
-                    // Pretend it defined a build command.
-                    try callbackQueue.sync {
-                        let message = Data("""
-                        {   "defineBuildCommand": {
-                                "configuration": {
-                                    "version": 2,
-                                    "displayName": "Do something",
-                                    "executable": "file:///bin/FooTool",
-                                    "arguments": [
-                                        "-c", "/Foo/Sources/Foo/SomeFile.abc"
-                                    ],
-                                    "workingDirectory": "file:///Foo/Sources/Foo",
-                                    "environment": {
-                                        "X": "Y"
-                                    },
-                                },
-                                "inputFiles": [
-                                ],
-                                "outputFiles": [
-                                ]
-                            }
-                        }
-                        """.utf8)
-                        try delegate.handleMessage(data: message, responder: { _ in })
-                    }
-                }
-                catch {
-                    callbackQueue.sync {
-                        completion(.failure(error))
-                    }
-                    return
-                }
-
-                // If we get this far we succeeded, so invoke the completion handler.
+                // Pretend the plugin emitted some output.
                 callbackQueue.sync {
-                    completion(.success(0))
+                    delegate.handleOutput(data: Data("Hello Plugin!".utf8))
                 }
+
+                // Pretend it emitted a warning.
+                let warning = Data("""
+                    {   "emitDiagnostic": {
+                            "severity": "warning",
+                            "message": "A warning",
+                            "file": "/Foo/Sources/Foo/SomeFile.abc",
+                            "line": 42
+                        }
+                    }
+                    """.utf8)
+                _ = try await delegate.handleMessage(data: warning)
+
+                // Pretend it defined a build command.
+                let buildCommand = Data("""
+                    {   "defineBuildCommand": {
+                            "configuration": {
+                                "version": 2,
+                                "displayName": "Do something",
+                                "executable": "file:///bin/FooTool",
+                                "arguments": [
+                                    "-c", "/Foo/Sources/Foo/SomeFile.abc"
+                                ],
+                                "workingDirectory": "file:///Foo/Sources/Foo",
+                                "environment": {
+                                    "X": "Y"
+                                },
+                            },
+                            "inputFiles": [
+                            ],
+                            "outputFiles": [
+                            ]
+                        }
+                    }
+                    """.utf8)
+                _ = try await delegate.handleMessage(data: buildCommand)
+
+                // If we get this far we succeeded.
+                return 0
             }
         }
 
@@ -285,6 +270,229 @@ final class PluginInvocationTests: XCTestCase {
         XCTAssertEqual(evalFirstDiagnostic.metadata?.fileLocation, FileLocation("/Foo/Sources/Foo/SomeFile.abc", line: 42))
 
         XCTAssertEqual(evalFirstResult.textOutput, "Hello Plugin!")
+    }
+
+    /// Constructs the same canned package graph used by `testBasics`: a library `Foo` that uses a
+    /// build tool plugin `FooPlugin`, which depends on an executable `FooTool`.
+    private func makeFooPluginGraph(
+        observabilityScope: ObservabilityScope
+    ) throws -> (fileSystem: InMemoryFileSystem, graph: ModulesGraph) {
+        let fileSystem = InMemoryFileSystem(emptyFiles:
+            "/Foo/Plugins/FooPlugin/source.swift",
+            "/Foo/Sources/FooTool/source.swift",
+            "/Foo/Sources/FooToolLib/source.swift",
+            "/Foo/Sources/Foo/source.swift",
+            "/Foo/Sources/Foo/SomeFile.abc"
+        )
+        let graph = try loadModulesGraph(
+            fileSystem: fileSystem,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Foo",
+                    path: "/Foo",
+                    products: [
+                        ProductDescription(name: "Foo", type: .library(.dynamic), targets: ["Foo"]),
+                    ],
+                    targets: [
+                        TargetDescription(
+                            name: "Foo",
+                            type: .regular,
+                            pluginUsages: [.plugin(name: "FooPlugin", package: nil)]
+                        ),
+                        TargetDescription(
+                            name: "FooPlugin",
+                            dependencies: ["FooTool"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                        TargetDescription(name: "FooTool", dependencies: ["FooToolLib"], type: .executable),
+                        TargetDescription(name: "FooToolLib", dependencies: [], type: .regular),
+                    ]
+                ),
+            ],
+            observabilityScope: observabilityScope
+        )
+        return (fileSystem, graph)
+    }
+
+    /// Verifies that a `definePrebuildCommand` message is handled and surfaced as a prebuild command.
+    ///
+    /// This exercises the `callbackQueue.sync` hop in `ScriptRunnerDelegate.handleMessage` that must run
+    /// on the invocation delegate's queue to satisfy its `dispatchPrecondition(.onQueue(delegateQueue))` —
+    /// `testBasics` only covers that hop for `emitDiagnostic`/`defineBuildCommand`, not the prebuild path.
+    func testPrebuildCommand() async throws {
+        struct MockPluginScriptRunner: PluginScriptRunner {
+            var hostTriple: Triple {
+                get throws { try UserToolchain.default.targetTriple }
+            }
+
+            func compilePluginScript(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                toolsVersion: ToolsVersion,
+                workers: UInt32,
+                observabilityScope: ObservabilityScope,
+                callbackQueue: DispatchQueue,
+                delegate: PluginScriptCompilerDelegate,
+                completion: @escaping (Result<PluginCompilationResult, Error>) -> Void
+            ) {
+                callbackQueue.sync { completion(.failure(StringError("unimplemented"))) }
+            }
+
+            func buildCommandLine(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                toolsVersion: ToolsVersion,
+                workers: UInt32,
+                observabilityScope: ObservabilityScope?
+            ) -> (commandLine: [String], execName: String, execFilePath: Basics.AbsolutePath, diagFilePath: Basics.AbsolutePath) {
+                fatalError("Not implemented")
+            }
+
+            func runPluginScript(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                initialMessage: Data,
+                toolsVersion: ToolsVersion,
+                workingDirectory: AbsolutePath,
+                writableDirectories: [AbsolutePath],
+                readOnlyDirectories: [AbsolutePath],
+                allowNetworkConnections: [SandboxNetworkPermission],
+                workers: UInt32,
+                fileSystem: FileSystem,
+                observabilityScope: ObservabilityScope,
+                callbackQueue: DispatchQueue,
+                delegate: PluginScriptCompilerDelegate & PluginScriptRunnerDelegate
+            ) async throws -> Int32 {
+                let message = PluginToHostMessage.definePrebuildCommand(
+                    configuration: .init(
+                        displayName: "Generate Code",
+                        executable: URL(fileURLWithPath: "/bin/FooTool"),
+                        arguments: ["-o", "out"],
+                        environment: [:],
+                        workingDirectory: nil
+                    ),
+                    outputFilesDirectory: URL(fileURLWithPath: "/Foo/.build/prebuild-outputs")
+                )
+                _ = try await delegate.handleMessage(data: JSONEncoder.makeWithDefaults().encode(message))
+                return 0
+            }
+        }
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (fileSystem, graph) = try makeFooPluginGraph(observabilityScope: observability.topScope)
+        let buildParameters = mockBuildParameters(
+            destination: .host,
+            environment: BuildEnvironment(platform: .macOS, configuration: .debug),
+            buildSystem: .native
+        )
+
+        let results = try await invokeBuildToolPlugins(
+            graph: graph,
+            buildParameters: buildParameters,
+            fileSystem: fileSystem,
+            outputDir: AbsolutePath("/Foo/.build"),
+            pluginScriptRunner: MockPluginScriptRunner(),
+            observabilityScope: observability.topScope
+        )
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        let (_, (_, evalResults)) = try XCTUnwrap(results.first)
+        let evalFirstResult = try XCTUnwrap(evalResults.first)
+        XCTAssertTrue(evalFirstResult.succeeded)
+        XCTAssertEqual(evalFirstResult.buildCommands.count, 0)
+        XCTAssertEqual(evalFirstResult.prebuildCommands.count, 1)
+        XCTAssertEqual(evalFirstResult.prebuildCommands.first?.configuration.displayName, "Generate Code")
+    }
+
+    /// Verifies the request/response path: when the plugin sends a `buildOperationRequest` that the host
+    /// delegate cannot service, `handleMessage` returns a well-formed `errorResponse` reply rather than
+    /// throwing. The reply bytes are captured and decoded inside the mock runner.
+    func testPluginRequestErrorResponse() async throws {
+        struct MockPluginScriptRunner: PluginScriptRunner {
+            var hostTriple: Triple {
+                get throws { try UserToolchain.default.targetTriple }
+            }
+
+            func compilePluginScript(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                toolsVersion: ToolsVersion,
+                workers: UInt32,
+                observabilityScope: ObservabilityScope,
+                callbackQueue: DispatchQueue,
+                delegate: PluginScriptCompilerDelegate,
+                completion: @escaping (Result<PluginCompilationResult, Error>) -> Void
+            ) {
+                callbackQueue.sync { completion(.failure(StringError("unimplemented"))) }
+            }
+
+            func buildCommandLine(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                toolsVersion: ToolsVersion,
+                workers: UInt32,
+                observabilityScope: ObservabilityScope?
+            ) -> (commandLine: [String], execName: String, execFilePath: Basics.AbsolutePath, diagFilePath: Basics.AbsolutePath) {
+                fatalError("Not implemented")
+            }
+
+            func runPluginScript(
+                sourceFiles: [AbsolutePath],
+                pluginName: String,
+                initialMessage: Data,
+                toolsVersion: ToolsVersion,
+                workingDirectory: AbsolutePath,
+                writableDirectories: [AbsolutePath],
+                readOnlyDirectories: [AbsolutePath],
+                allowNetworkConnections: [SandboxNetworkPermission],
+                workers: UInt32,
+                fileSystem: FileSystem,
+                observabilityScope: ObservabilityScope,
+                callbackQueue: DispatchQueue,
+                delegate: PluginScriptCompilerDelegate & PluginScriptRunnerDelegate
+            ) async throws -> Int32 {
+                // The default `PluginInvocationDelegate.pluginRequestedBuildOperation` throws, so the
+                // host should answer with an `errorResponse` reply (not propagate the error).
+                let request = PluginToHostMessage.buildOperationRequest(
+                    subset: .all(includingTests: false),
+                    parameters: .init(
+                        configuration: .debug,
+                        logging: .concise,
+                        echoLogs: false,
+                        otherCFlags: [],
+                        otherCxxFlags: [],
+                        otherSwiftcFlags: [],
+                        otherLinkerFlags: []
+                    )
+                )
+                let reply = try await delegate.handleMessage(data: JSONEncoder.makeWithDefaults().encode(request))
+                let replyData = try XCTUnwrap(reply, "expected a reply to buildOperationRequest")
+                let decoded = try JSONDecoder.makeWithDefaults().decode(HostToPluginMessage.self, from: replyData)
+                guard case .errorResponse = decoded else {
+                    XCTFail("expected an errorResponse reply, got \(decoded)")
+                    return 0
+                }
+                return 0
+            }
+        }
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (fileSystem, graph) = try makeFooPluginGraph(observabilityScope: observability.topScope)
+        let buildParameters = mockBuildParameters(
+            destination: .host,
+            environment: BuildEnvironment(platform: .macOS, configuration: .debug),
+            buildSystem: .native
+        )
+
+        _ = try await invokeBuildToolPlugins(
+            graph: graph,
+            buildParameters: buildParameters,
+            fileSystem: fileSystem,
+            outputDir: AbsolutePath("/Foo/.build"),
+            pluginScriptRunner: MockPluginScriptRunner(),
+            observabilityScope: observability.topScope
+        )
     }
 
     func testCompilationDiagnostics() async throws {

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -759,8 +759,7 @@ struct PluginTests {
                     )
 
                     let toolSearchDirectories = [try UserToolchain.default.swiftCompilerPath.parentDirectory]
-                    let success = try await withCheckedThrowingContinuation { continuation in
-                      plugin.invoke(
+                    let success = try await plugin.invoke(
                         action: .performCommand(package: package, arguments: arguments),
                         buildEnvironment: BuildEnvironment(platform: .macOS, configuration: .debug),
                         workers: 1,
@@ -778,12 +777,8 @@ struct PluginTests {
                         modulesGraph: packageGraph,
                         observabilityScope: observability.topScope,
                         callbackQueue: delegateQueue,
-                        delegate: delegate,
-                        completion: {
-                          continuation.resume(with: $0)
-                        }
-                      )
-                    }
+                        delegate: delegate
+                    )
                     if expectFailure {
                         #expect(!success, "expected command to fail, but it succeeded")
                     }

--- a/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/CGenPIFTests.swift
@@ -139,30 +139,22 @@ import SwiftBuild
                 fileSystem: any Basics.FileSystem,
                 observabilityScope: Basics.ObservabilityScope,
                 callbackQueue: DispatchQueue,
-                delegate: any SPMBuildCore.PluginScriptCompilerDelegate & SPMBuildCore.PluginScriptRunnerDelegate,
-                completion: @escaping (Result<Int32, any Error>) -> Void)
-            {
-                callbackQueue.sync {
-                    do {
-                        let decoder = JSONDecoder.makeWithDefaults()
-                        let encoder = JSONEncoder(outputFormatting: .prettyPrinted)
+                delegate: any SPMBuildCore.PluginScriptCompilerDelegate & SPMBuildCore.PluginScriptRunnerDelegate
+            ) async throws -> Int32 {
+                let decoder = JSONDecoder.makeWithDefaults()
+                let encoder = JSONEncoder(outputFormatting: .prettyPrinted)
 
-                        let initial = try decoder.decode(HostToPluginMessage.self, from: initialMessage)
-                        guard case let .createBuildToolCommands(context: context, rootPackageId: _, targetId: _, pluginGeneratedSources: _, pluginGeneratedResources: _) = initial else {
-                            completion(.failure(StringError("Invalid initial message")))
-                            return
-                        }
-                        let workDir = try context.url(for: context.pluginWorkDirId)
-
-                        for message in genMessages(sourceFiles, workDir) {
-                            let data = try encoder.encode(message)
-                            try delegate.handleMessage(data: data, responder: { _ in })
-                        }
-                        completion(.success(0))
-                    } catch {
-                        completion(.failure(error))
-                    }
+                let initial = try decoder.decode(HostToPluginMessage.self, from: initialMessage)
+                guard case let .createBuildToolCommands(context: context, rootPackageId: _, targetId: _, pluginGeneratedSources: _, pluginGeneratedResources: _) = initial else {
+                    throw StringError("Invalid initial message")
                 }
+                let workDir = try context.url(for: context.pluginWorkDirId)
+
+                for message in genMessages(sourceFiles, workDir) {
+                    let data = try encoder.encode(message)
+                    _ = try await delegate.handleMessage(data: data)
+                }
+                return 0
             }
 
             var hostTriple: Triple {

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1613,10 +1613,9 @@ private struct NoOpPluginScriptRunner: PluginScriptRunner {
         fileSystem: any FileSystem,
         observabilityScope: ObservabilityScope,
         callbackQueue: DispatchQueue,
-        delegate: any PluginScriptCompilerDelegate & PluginScriptRunnerDelegate,
-        completion: @escaping (Result<Int32, any Error>) -> Void
-    ) {
-        callbackQueue.sync { completion(.success(0)) }
+        delegate: any PluginScriptCompilerDelegate & PluginScriptRunnerDelegate
+    ) async throws -> Int32 {
+        return 0
     }
 
     var hostTriple: Triple {

--- a/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
+++ b/Tests/SwiftBuildSupportTests/PrebuiltsPIFTests.swift
@@ -406,12 +406,9 @@ struct PrebuiltsPIFTests {
                 fileSystem: any FileSystem,
                 observabilityScope: ObservabilityScope,
                 callbackQueue: DispatchQueue,
-                delegate: any PluginScriptCompilerDelegate & PluginScriptRunnerDelegate,
-                completion: @escaping (Result<Int32, any Error>) -> Void
-            ) {
-                callbackQueue.sync {
-                    completion(.success(0))
-                }
+                delegate: any PluginScriptCompilerDelegate & PluginScriptRunnerDelegate
+            ) async throws -> Int32 {
+                return 0
             }
 
             var hostTriple: Triple {


### PR DESCRIPTION
Behavior-preserving callback→async/await refactor of PluginScriptRunner, its delegates, and PluginModule.invoke, this is in preparation of using swift-subprocess for plugin invocation. Adds unit tests for the pre-build and errorResponse paths.

