### PR TITLE
[6.4.x] Fix reporting of builtArtifacts to command plugins when the umbrella test product is requested

### DIFF
--- a/Fixtures/CommandPluginTestProductArtifacts/Package.swift
+++ b/Fixtures/CommandPluginTestProductArtifacts/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CommandPluginTestProductArtifacts",
+    products: [
+        .library(
+            name: "MyLibrary",
+            type: .static,
+            targets: ["MyLibrary"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "MyLibrary"
+        ),
+        .testTarget(
+            name: "FirstTests",
+            dependencies: ["MyLibrary"]
+        ),
+        .testTarget(
+            name: "SecondTests",
+            dependencies: ["MyLibrary"]
+        ),
+        .plugin(
+            name: "dump-artifacts-plugin",
+            capability: .command(
+                intent: .custom(verb: "dump-artifacts-plugin", description: "Dump Artifacts"),
+                permissions: []
+            )
+        ),
+    ]
+)

--- a/Fixtures/CommandPluginTestProductArtifacts/Plugins/dump-artifacts-plugin.swift
+++ b/Fixtures/CommandPluginTestProductArtifacts/Plugins/dump-artifacts-plugin.swift
@@ -1,0 +1,42 @@
+import PackagePlugin
+
+// Builds a subset of the package selected by the command-line arguments and prints the resulting
+// built artifacts so tests can verify how the synthetic umbrella test product and individual test
+// products are reported.
+//
+// Usage:
+//   dump-artifacts-plugin all
+//   dump-artifacts-plugin product <product-name>
+//   dump-artifacts-plugin target <target-name>
+@main
+struct DumpArtifactsPlugin: CommandPlugin {
+    func performCommand(
+        context: PluginContext,
+        arguments: [String]
+    ) throws {
+        do {
+            let subset: PackageManager.BuildSubset
+            switch arguments.first {
+            case "product":
+                subset = .product(arguments[1])
+            case "target":
+                subset = .target(arguments[1])
+            default:
+                subset = .all(includingTests: true)
+            }
+
+            var parameters = PackageManager.BuildParameters()
+            parameters.configuration = .debug
+            parameters.logging = .concise
+            let result = try packageManager.build(subset, parameters: parameters)
+            print("succeeded: \(result.succeeded)")
+            for artifact in result.builtArtifacts {
+                print("artifact-path: \(artifact.path.string)")
+                print("artifact-kind: \(artifact.kind)")
+            }
+        }
+        catch {
+            print("error from the plugin host: \(error)")
+        }
+    }
+}

--- a/Fixtures/CommandPluginTestProductArtifacts/Sources/MyLibrary/MyLibrary.swift
+++ b/Fixtures/CommandPluginTestProductArtifacts/Sources/MyLibrary/MyLibrary.swift
@@ -1,0 +1,3 @@
+public func greeting() -> String {
+    "hello"
+}

--- a/Fixtures/CommandPluginTestProductArtifacts/Tests/FirstTests/FirstTests.swift
+++ b/Fixtures/CommandPluginTestProductArtifacts/Tests/FirstTests/FirstTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+import MyLibrary
+
+final class FirstTests: XCTestCase {
+    func testGreeting() {
+        XCTAssertEqual(greeting(), "hello")
+    }
+}

--- a/Fixtures/CommandPluginTestProductArtifacts/Tests/SecondTests/SecondTests.swift
+++ b/Fixtures/CommandPluginTestProductArtifacts/Tests/SecondTests/SecondTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+import MyLibrary
+
+final class SecondTests: XCTestCase {
+    func testGreeting() {
+        XCTAssertEqual(greeting(), "hello")
+    }
+}

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -502,7 +502,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
         let buildResultBuildPlan = buildOutputs.contains(.buildPlan) ? try buildPlan : nil
         let buildResultReplArgs = buildOutputs.contains(.replArguments) ? try buildPlan.createREPLArguments() : nil
 
-        let artifacts: [(String, PluginInvocationBuildResult.BuiltArtifact)]?
+        let artifacts: [BuildResult.BuiltArtifact]?
         if buildOutputs.contains(.builtArtifacts) {
             let builtProducts = try buildPlan.buildProducts
             artifacts = try builtProducts.compactMap {
@@ -513,12 +513,17 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
                         case .dynamic: artifactKind = .dynamicLibrary
                         case .static, .automatic: artifactKind = .staticLibrary
                     }
-                    return try ($0.product.name, .init(
-                        path: $0.binaryPath.pathString,
-                        kind: artifactKind)
+                    return try BuildResult.BuiltArtifact(
+                        name: $0.product.name,
+                        artifact: .init(path: $0.binaryPath.pathString, kind: artifactKind),
+                        umbrellaTestProductName: nil
                     )
                 case .executable:
-                    return try ($0.product.name, .init(path: $0.binaryPath.pathString, kind: .executable))
+                    return try BuildResult.BuiltArtifact(
+                        name: $0.product.name,
+                        artifact: .init(path: $0.binaryPath.pathString, kind: .executable),
+                        umbrellaTestProductName: nil
+                    )
                 default:
                     return nil
                 }

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -189,16 +189,16 @@ final class PluginDelegate: PluginInvocationDelegate {
 
         _ = try await buildSystem.getPackageGraph()
 
-        let builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = (result?.builtArtifacts ?? []).filter { (name, _) in
+        let builtArtifacts: [PluginInvocationBuildResult.BuiltArtifact] = (result?.builtArtifacts ?? []).filter { artifact in
             switch subset {
             case .all:
                 return true
             case .product(let productName):
-                return name == productName
+                return artifact.name == productName || artifact.umbrellaTestProductName == productName
             case .target(let targetName):
-                return name == targetName
+                return artifact.name == targetName
             }
-        }.map(\.1)
+        }.map(\.artifact)
 
         return PluginInvocationBuildResult(
             succeeded: success,

--- a/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
+++ b/Sources/SPMBuildCore/BuildSystem/BuildSystem.swift
@@ -150,12 +150,30 @@ public struct SymbolGraphResult {
 public typealias CLIArguments = [String]
 
 public struct BuildResult {
+    public struct BuiltArtifact {
+        public let name: String
+
+        public let artifact: PluginInvocationBuildResult.BuiltArtifact
+
+        public let umbrellaTestProductName: String?
+
+        public init(
+            name: String,
+            artifact: PluginInvocationBuildResult.BuiltArtifact,
+            umbrellaTestProductName: String?
+        ) {
+            self.name = name
+            self.artifact = artifact
+            self.umbrellaTestProductName = umbrellaTestProductName
+        }
+    }
+
     package init(
         serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>,
         symbolGraph: SymbolGraphResult? = nil,
         buildPlan: BuildPlan? = nil,
         replArguments: CLIArguments?,
-        builtArtifacts: [(String, PluginInvocationBuildResult.BuiltArtifact)]? = nil,
+        builtArtifacts: [BuiltArtifact]? = nil,
         // TODO: echeng3805, there's probably a better type for this?
         dependencyGraph: [String: [String]]? = nil
     ) {
@@ -173,7 +191,7 @@ public struct BuildResult {
     public let dependencyGraph: [String: [String]]?
 
     public var serializedDiagnosticPathsByTargetName: Result<[String: [AbsolutePath]], Error>
-    public var builtArtifacts: [(String, PluginInvocationBuildResult.BuiltArtifact)]?
+    public var builtArtifacts: [BuiltArtifact]?
 }
 
 public protocol ProductBuildDescription {

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -633,7 +633,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         }
 
         var replArguments: CLIArguments?
-        var artifacts: [(String, PluginInvocationBuildResult.BuiltArtifact)]?
+        var artifacts: [BuildResult.BuiltArtifact]?
         var dependencyGraph: [String: [String]]?
         return try await withService(connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint)) { service in
             let derivedDataPath = self.buildParameters.dataPath
@@ -752,6 +752,16 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
                     if buildOutputs.contains(.builtArtifacts) {
                         if let buildDescriptionID {
+                            let graph = try await self.getPackageGraph()
+                            var umbrellaTestProductNamesByArtifactName: [String: String] = [:]
+                            for package in graph.rootPackages {
+                                let umbrellaName = package.manifest.umbrellaPackageTestsProductName
+                                for product in package.products where product.type == .test {
+                                    umbrellaTestProductNamesByArtifactName[product.name] = umbrellaName
+                                    umbrellaTestProductNamesByArtifactName["\(product.name)-test-runner"] = umbrellaName
+                                }
+                            }
+
                             let targetInfo = try await session.configuredTargets(buildDescription: buildDescriptionID, buildRequest: request)
                             artifacts = targetInfo.compactMap { target in
                                 guard let artifactInfo = target.artifactInfo else {
@@ -770,13 +780,14 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                                 }
                                 var name = target.name
                                 // FIXME: We need a better way to map between SwiftPM target/product names and PIF target names
-                                if pifTargetName.hasSuffix("-product") {
+                                if name.hasSuffix("-product") {
                                     name = String(name.dropLast(8))
                                 }
-                                return (name, .init(
-                                    path: artifactInfo.path,
-                                    kind: kind
-                                ))
+                                return BuildResult.BuiltArtifact(
+                                    name: name,
+                                    artifact: .init(path: artifactInfo.path, kind: kind),
+                                    umbrellaTestProductName: umbrellaTestProductNamesByArtifactName[name]
+                                )
                             }
                         } else {
                             self.observabilityScope.emit(error: "failed to compute built artifacts list")

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -7163,6 +7163,58 @@ struct PackageCommandTests {
         }
 
         @Test(
+            .requireHostOS(.linux),
+            .tags(
+                .Feature.Command.Package.CommandPlugin,
+            ),
+        )
+        func commandPluginBuildingTestProductArtifacts() async throws {
+            try await fixture(name: "CommandPluginTestProductArtifacts") { fixturePath in
+                let umbrellaTestProduct = "CommandPluginTestProductArtifactsPackageTests"
+
+                func expectArtifact(_ stdout: String, named name: String, sourceLocation: SourceLocation = #_sourceLocation) {
+                    #expect(stdout.split(separator: "\n").contains {
+                        $0.hasPrefix("artifact-path:") && $0.contains(name)
+                    }, "output did not reference artifact named '\(name)': \(stdout)")
+                }
+
+                do {
+                    let (stdout, _) = try await execute(
+                        ["dump-artifacts-plugin", "all"],
+                        packagePath: fixturePath,
+                        configuration: .debug,
+                        buildSystem: .swiftbuild
+                    )
+                    #expect(stdout.contains("succeeded: true"))
+                    expectArtifact(stdout, named: "MyLibrary")
+                    expectArtifact(stdout, named: "FirstTests")
+                    expectArtifact(stdout, named: "SecondTests")
+                }
+
+                do {
+                    let (stdout, _) = try await execute(
+                        ["dump-artifacts-plugin", "product", umbrellaTestProduct],
+                        packagePath: fixturePath,
+                        configuration: .debug,
+                        buildSystem: .swiftbuild
+                    )
+                    #expect(stdout.contains("succeeded: true"))
+                    expectArtifact(stdout, named: "FirstTests")
+                    expectArtifact(stdout, named: "SecondTests")
+                }
+
+                let (stdout, _) = try await execute(
+                    ["dump-artifacts-plugin", "product", "FirstTests"],
+                    packagePath: fixturePath,
+                    configuration: .debug,
+                    buildSystem: .swiftbuild
+                )
+                #expect(stdout.contains("succeeded: true"))
+                expectArtifact(stdout, named: "FirstTests")
+            }
+        }
+
+        @Test(
             .requiresSwiftConcurrencySupport,
             // Depending on how the test is running, the `llvm-profdata` and `llvm-cov` tool might be unavailable.
             .requiresLLVMProfData,


### PR DESCRIPTION
Previously, if a command plugin requested the builtArtifacts corresponding to a request to build the <Package Name>PackageTests umbrella product, we would incorrectly report no artifacts when using the Swift Build backend. Track artifacts which correspond to the umbrella test product to ensure they are reported correctly.

Resolves https://github.com/swiftlang/swift-package-manager/issues/10227 (but I need to polish up and land https://github.com/swiftlang/swift-build/pull/1326 to avoid running into a secondary issue)