### PR TITLE
Introduce support for Clang/Swift compilation caching

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(Commands
   PackageCommands/AuditBinaryArtifact.swift
   PackageCommands/BuildServer.swift
   PackageCommands/CompletionCommand.swift
+  PackageCommands/BuildCacheCommand.swift
   PackageCommands/ComputeChecksum.swift
   PackageCommands/Config.swift
   PackageCommands/Describe.swift

--- a/Sources/Commands/PackageCommands/BuildCacheCommand.swift
+++ b/Sources/Commands/PackageCommands/BuildCacheCommand.swift
@@ -1,0 +1,278 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import CoreCommands
+import class Foundation.ByteCountFormatter
+import PackageModel
+import SPMBuildCore
+import SwiftBuildSupport
+import struct SwiftBuild.SWBBuildCacheInfo
+import Workspace
+
+extension SwiftPackageCommand {
+    struct BuildCache: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "build-cache",
+            abstract: "Configure the build cache.",
+            subcommands: [Configure.self, ResetConfiguration.self, GetConfiguration.self, Info.self, Clean.self],
+            helpNames: [.short, .long, .customLong("help", withSingleDash: true)]
+        )
+    }
+}
+
+extension SwiftPackageCommand.BuildCache {
+    /// Whether to read/write the local (per-package) or shared (global) configuration.
+    fileprivate struct ScopeOptions: ParsableArguments {
+        @Flag(
+            name: .customLong("global"),
+            help: "Apply to the shared global configuration instead of the local package configuration."
+        )
+        var global: Bool = false
+    }
+
+    /// Apply a mutation to the local or shared configuration, depending on `scope`.
+    fileprivate static func update(
+        _ config: Workspace.Configuration.BuildCache,
+        scope: ScopeOptions,
+        handler: (inout BuildCacheConfiguration) throws -> Void
+    ) throws {
+        if scope.global {
+            try config.updateShared(handler: handler)
+        } else {
+            try config.updateLocal(handler: handler)
+        }
+    }
+
+    struct Configure: SwiftCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "configure",
+            abstract: "Configure build cache options."
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        @Flag(
+            name: .customLong("caching"),
+            inversion: .prefixedEnableDisable,
+            help: "Enable or disable the build cache."
+        )
+        var enabled: Bool?
+
+        @Option(help: "The path to the build cache.", completion: .directory)
+        var path: AbsolutePath?
+
+        @Option(help: "Limit the build cache size, either as an absolute size (e.g. '10G') or as a percentage of available disk space (e.g. '50%').")
+        var sizeLimit: BuildCacheConfiguration.SizeLimit?
+
+        @Flag(
+            name: .customLong("diagnostic-remarks"),
+            inversion: .prefixedEnableDisable,
+            help: "Enable or disable diagnostic remarks about build cache hits and misses."
+        )
+        var diagnosticRemarks: Bool?
+
+        @Option(help: "The path to an LLVM-compatible build cache plugin.", completion: .directory)
+        var pluginPath: AbsolutePath?
+
+        @Option(help: "The path to a remote build cache service.", completion: .directory)
+        var remoteServicePath: AbsolutePath?
+
+        @Flag(
+            name: .customLong("prefix-mapping"),
+            inversion: .prefixedEnableDisable,
+            help: "Enable or disable prefix mapping, allowing copies of a package at different paths to share cached outputs."
+        )
+        var prefixMapping: Bool?
+
+        @OptionGroup
+        fileprivate var scope: ScopeOptions
+
+        func run(_ swiftCommandState: SwiftCommandState) throws {
+            if self.enabled == nil, self.path == nil, self.sizeLimit == nil, self.diagnosticRemarks == nil,
+               self.remoteServicePath == nil, self.pluginPath == nil, self.prefixMapping == nil {
+                swiftCommandState.observabilityScope.emit(.error("no configuration options were provided"))
+                throw ExitCode.validationFailure
+            }
+
+            let config = try getBuildCacheConfig(swiftCommandState)
+            try update(config, scope: self.scope) { configuration in
+                if let enabled = self.enabled {
+                    configuration.enabled = enabled
+                }
+                if let path = self.path {
+                    configuration.casPath = path
+                }
+                if let sizeLimit = self.sizeLimit {
+                    configuration.sizeLimit = sizeLimit
+                }
+                if let diagnosticRemarks = self.diagnosticRemarks {
+                    configuration.enableDiagnosticRemarks = diagnosticRemarks
+                }
+                if let remoteServicePath = self.remoteServicePath {
+                    configuration.remoteServicePath = remoteServicePath
+                }
+                if let pluginPath = self.pluginPath {
+                    configuration.pluginPath = pluginPath
+                }
+                if let prefixMapping = self.prefixMapping {
+                    configuration.enablePrefixMapping = prefixMapping
+                }
+            }
+        }
+    }
+
+    struct ResetConfiguration: SwiftCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "reset-configuration",
+            abstract: "Remove all build cache configuration options."
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        @OptionGroup
+        fileprivate var scope: ScopeOptions
+
+        func run(_ swiftCommandState: SwiftCommandState) throws {
+            let config = try getBuildCacheConfig(swiftCommandState)
+            try update(config, scope: self.scope) { configuration in
+                configuration = .none
+            }
+        }
+    }
+
+    struct GetConfiguration: SwiftCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "get-configuration",
+            abstract: "Print the effective build cache configuration."
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        func run(_ swiftCommandState: SwiftCommandState) throws {
+            let configuration = try getBuildCacheConfig(swiftCommandState).configuration
+
+            let enabled = configuration.enabled.map { $0 ? "enabled" : "disabled" } ?? "disabled (default)"
+            print("build cache: \(enabled)")
+
+            // The remaining parameters only apply when caching is enabled, and
+            // caching is disabled by default.
+            if configuration.enabled != true {
+                return
+            }
+
+            print("path: \(configuration.casPath?.pathString ?? swiftCommandState.defaultBuildCacheDirectory.pathString)")
+
+            switch configuration.sizeLimit {
+            case .size(let value):
+                print("size limit: \(value)")
+            case .percent(let value):
+                print("size limit: \(value)% of available disk space")
+            case .none:
+                print("size limit: default")
+            }
+
+            let remarks = configuration.enableDiagnosticRemarks
+                .map { $0 ? "enabled" : "disabled" } ?? "disabled (default)"
+            print("diagnostic remarks: \(remarks)")
+
+            if let pluginPath = configuration.pluginPath {
+                print("plugin path: \(pluginPath.pathString)")
+            }
+
+            if let remoteServicePath = configuration.remoteServicePath {
+                print("remote service path: \(remoteServicePath.pathString)")
+            }
+
+            let prefixMapping = configuration.enablePrefixMapping
+                .map { $0 ? "enabled" : "disabled" } ?? "enabled (default)"
+            print("prefix mapping: \(prefixMapping)")
+        }
+    }
+
+    struct Info: AsyncSwiftCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "info",
+            abstract: "Report information about the build cache."
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        func run(_ swiftCommandState: SwiftCommandState) async throws {
+            let configuration = try swiftCommandState.resolveBuildCacheConfiguration()
+            let cachePath = configuration.casPath ?? swiftCommandState.defaultBuildCacheDirectory
+
+            guard swiftCommandState.fileSystem.exists(cachePath) else {
+                print("No build cache found at \(cachePath.pathString)")
+                return
+            }
+
+            let info: SWBBuildCacheInfo
+            do {
+                info = try await queryBuildCacheInfo(
+                    casPath: cachePath,
+                    pluginPath: configuration.pluginPath,
+                    remoteServicePath: configuration.remoteServicePath,
+                    toolchain: try swiftCommandState.productsBuildParameters.toolchain,
+                    packageManagerResourcesDirectory: swiftCommandState.packageManagerResourcesDirectory
+                )
+            } catch {
+                swiftCommandState.observabilityScope.emit(
+                    error: "failed to get build cache info: \(error.interpolationDescription)"
+                )
+                throw ExitCode.failure
+            }
+
+            print("path: \(cachePath.pathString)")
+            print("size: \(ByteCountFormatter.string(fromByteCount: Int64(info.onDiskSize), countStyle: .file))")
+        }
+    }
+
+    struct Clean: SwiftCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "clean",
+            abstract: "Delete the on-disk build cache."
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        func run(_ swiftCommandState: SwiftCommandState) throws {
+            let configuration = try swiftCommandState.resolveBuildCacheConfiguration()
+            let cachePath = configuration.casPath ?? swiftCommandState.defaultBuildCacheDirectory
+
+            let fileSystem = swiftCommandState.fileSystem
+            guard fileSystem.exists(cachePath) else {
+                print("No build cache found at \(cachePath.pathString)")
+                return
+            }
+            try fileSystem.removeFileTree(cachePath)
+            print("Cleaned build cache at \(cachePath.pathString)")
+        }
+    }
+
+    static func getBuildCacheConfig(
+        _ swiftCommandState: SwiftCommandState
+    ) throws -> Workspace.Configuration.BuildCache {
+        let workspace = try swiftCommandState.getActiveWorkspace()
+        return try .init(
+            fileSystem: swiftCommandState.fileSystem,
+            localBuildCacheFile: workspace.location.localBuildCacheConfigurationFile,
+            sharedBuildCacheFile: workspace.location.sharedBuildCacheConfigurationFile
+        )
+    }
+}

--- a/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
+++ b/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
@@ -58,6 +58,7 @@ public struct SwiftPackageCommand: AsyncParsableCommand {
             Unedit.self,
 
             Config.self,
+            BuildCache.self,
             Resolve.self,
             Fetch.self,
 

--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -23,6 +23,7 @@ import struct Foundation.URL
 
 import enum PackageModel.BuildConfiguration
 import struct PackageModel.BuildFlags
+import struct PackageModel.BuildCacheConfiguration
 import struct PackageModel.EnabledSanitizers
 import class PackageModel.Manifest
 import struct PackageModel.PackageIdentity
@@ -54,6 +55,9 @@ public struct GlobalOptions: ParsableArguments {
 
     @OptionGroup(title: "Caching")
     public var caching: CachingOptions
+
+    @OptionGroup(title: "Build Caching")
+    public var buildCaching: BuildCachingOptions
 
     @OptionGroup(title: "Logging")
     public var logging: LoggingOptions
@@ -230,6 +234,70 @@ public struct CachingOptions: ParsableArguments {
         help: .hidden
     )
     public var prebuiltsRootCertPath: String?
+}
+
+public struct BuildCachingOptions: ParsableArguments {
+    public init() {}
+
+    @Flag(
+        name: .customLong("build-caching"),
+        inversion: .prefixedEnableDisable,
+        help: "Enable or disable the build cache."
+    )
+    public var enableBuildCache: Bool?
+
+    @Option(
+        name: .customLong("build-cache-path"),
+        help: "The path to the build cache.",
+        completion: .directory
+    )
+    public var path: AbsolutePath?
+
+    @Option(
+        name: .customLong("build-cache-size-limit"),
+        help: "Limit the build cache size, either as an absolute size (e.g. '10G') or as a percentage of available disk space (e.g. '50%')."
+    )
+    public var sizeLimit: BuildCacheConfiguration.SizeLimit?
+
+    @Flag(
+        name: .customLong("build-cache-diagnostic-remarks"),
+        inversion: .prefixedEnableDisable,
+        help: "Enable or disable diagnostic remarks about build cache hits and misses."
+    )
+    public var enableDiagnosticRemarks: Bool?
+
+    @Option(
+        name: .customLong("build-cache-plugin-path"),
+        help: "The path to an LLVM-compatible build cache plugin.",
+        completion: .directory
+    )
+    public var pluginPath: AbsolutePath?
+
+    @Option(
+        name: .customLong("build-cache-remote-service-path"),
+        help: "The path to a remote build cache service.",
+        completion: .directory
+    )
+    public var remoteServicePath: AbsolutePath?
+
+    @Flag(
+        name: .customLong("build-cache-prefix-mapping"),
+        inversion: .prefixedEnableDisable,
+        help: "Enable or disable prefix mapping, allowing copies of a package at different paths to share cached outputs."
+    )
+    public var enablePrefixMapping: Bool?
+
+    public func resolved() throws -> BuildCacheConfiguration {
+        .init(
+            enabled: self.enableBuildCache,
+            casPath: self.path,
+            sizeLimit: self.sizeLimit,
+            enableDiagnosticRemarks: self.enableDiagnosticRemarks,
+            remoteServicePath: self.remoteServicePath,
+            pluginPath: self.pluginPath,
+            enablePrefixMapping: self.enablePrefixMapping
+        )
+    }
 }
 
 public struct LoggingOptions: ParsableArguments {
@@ -960,8 +1028,18 @@ extension URL {
     }
 }
 
+extension BuildCacheConfiguration.SizeLimit {
+    public init?(argument: String) {
+        guard let sizeLimit = try? BuildCacheConfiguration.SizeLimit.parse(argument) else {
+            return nil
+        }
+        self = sizeLimit
+    }
+}
+
 extension BuildConfiguration: ExpressibleByArgument {}
 extension AbsolutePath: ExpressibleByArgument {}
+extension BuildCacheConfiguration.SizeLimit: ExpressibleByArgument {}
 extension WorkspaceConfiguration.CheckingMode: ExpressibleByArgument {}
 extension Sanitizer: ExpressibleByArgument {}
 extension BuildSystemProvider.Kind: ExpressibleByArgument {}

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -783,6 +783,41 @@ public final class SwiftCommandState {
         }
     }
 
+    /// The default on-disk location for the build cache, used when caching
+    /// is enabled but no explicit cache path is configured.
+    public var defaultBuildCacheDirectory: AbsolutePath {
+        self.sharedCacheDirectory.appending("build-cache")
+    }
+
+    /// Resolve the effective build cache configuration by merging, in
+    /// decreasing order of precedence: command-line flags, the local (per
+    /// package) configuration, and the shared (global) configuration.
+    public func resolveBuildCacheConfiguration() throws -> BuildCacheConfiguration {
+        try self._buildCacheConfiguration.get()
+    }
+
+    private lazy var _buildCacheConfiguration: Result<BuildCacheConfiguration, Swift.Error> = Result(catching: {
+        let cliConfiguration = try self.options.buildCaching.resolved()
+
+        let localBuildCacheFile = (try? self.getLocalConfigurationDirectory())
+            .map { Workspace.DefaultLocations.buildCacheConfigurationFile(at: $0) }
+
+        let configuration = try Workspace.Configuration.BuildCache(
+            fileSystem: self.fileSystem,
+            localBuildCacheFile: localBuildCacheFile,
+            sharedBuildCacheFile: Workspace.DefaultLocations
+                .buildCacheConfigurationFile(at: self.sharedConfigurationDirectory)
+        )
+
+        var resolved = cliConfiguration.merging(over: configuration.configuration)
+
+        if resolved.enabled == true, resolved.casPath == nil {
+            resolved.casPath = self.defaultBuildCacheDirectory
+        }
+
+        return resolved
+    })
+
     public func getAuthorizationProvider() throws -> AuthorizationProvider? {
         var authorization = Workspace.Configuration.Authorization.default
         if !self.options.security.netrc {
@@ -1043,6 +1078,18 @@ public final class SwiftCommandState {
             case (true, true): .noLazy
             }
 
+        let buildCaching = try self.resolveBuildCacheConfiguration()
+        // Build caching is only honored by the swiftbuild build system. Warn
+        // once (for the target destination) if it is requested with another one.
+        if destination == .target,
+           self.options.build.buildSystem != .swiftbuild,
+           !buildCaching.isEmpty
+        {
+            self.observabilityScope.emit(
+                warning: "build caching is only supported by the 'swiftbuild' build system and will be ignored"
+            )
+        }
+
         return try BuildParameters(
             destination: destination,
             dataPath: dataPath,
@@ -1108,6 +1155,7 @@ public final class SwiftCommandState {
             ),
             stripProducts: self.options.build.stripProducts,
             shouldPreserveSymlinks: options.locations.skipResolvingPackagePaths,
+            buildCaching: buildCaching,
         )
     }
 

--- a/Sources/PackageModel/BuildCacheConfiguration.swift
+++ b/Sources/PackageModel/BuildCacheConfiguration.swift
@@ -1,0 +1,120 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+
+public struct BuildCacheConfiguration: Equatable, Sendable, Encodable {
+    public enum SizeLimit: Equatable, Sendable, Encodable {
+        case size(String)
+
+        case percent(Int)
+
+        public static func make(size: String?, percent: Int?) throws -> Self? {
+            if size != nil, percent != nil {
+                throw InvalidSizeLimitError.conflictingSizeAndPercentage
+            }
+            if let percent {
+                return .percent(percent)
+            }
+            if let size {
+                return .size(size)
+            }
+            return nil
+        }
+
+        public static func parse(_ string: String) throws -> Self {
+            if string.hasSuffix("%") {
+                let digits = String(string.dropLast())
+                guard let percent = Int(digits), (0...100).contains(percent) else {
+                    throw InvalidSizeLimitError.invalidPercentage(string)
+                }
+                return .percent(percent)
+            }
+            return .size(string)
+        }
+    }
+
+    public var enabled: Bool?
+
+    public var casPath: Basics.AbsolutePath?
+
+    public var sizeLimit: SizeLimit?
+
+    public var enableDiagnosticRemarks: Bool?
+
+    public var remoteServicePath: Basics.AbsolutePath?
+
+    public var pluginPath: Basics.AbsolutePath?
+
+    public var enablePrefixMapping: Bool?
+
+    public init(
+        enabled: Bool? = nil,
+        casPath: Basics.AbsolutePath? = nil,
+        sizeLimit: SizeLimit? = nil,
+        enableDiagnosticRemarks: Bool? = nil,
+        remoteServicePath: Basics.AbsolutePath? = nil,
+        pluginPath: Basics.AbsolutePath? = nil,
+        enablePrefixMapping: Bool? = nil
+    ) {
+        self.enabled = enabled
+        self.casPath = casPath
+        self.sizeLimit = sizeLimit
+        self.enableDiagnosticRemarks = enableDiagnosticRemarks
+        self.remoteServicePath = remoteServicePath
+        self.pluginPath = pluginPath
+        self.enablePrefixMapping = enablePrefixMapping
+    }
+
+    /// An empty configuration where nothing is set.
+    public static var none: Self { .init() }
+
+    public var isEmpty: Bool {
+        self.enabled == nil
+            && self.casPath == nil
+            && self.sizeLimit == nil
+            && self.enableDiagnosticRemarks == nil
+            && self.remoteServicePath == nil
+            && self.pluginPath == nil
+            && self.enablePrefixMapping == nil
+    }
+
+    /// Returns a new configuration where the values in `self` take precedence
+    /// over the corresponding values in `lower`, merged field-by-field.
+    public func merging(over lower: BuildCacheConfiguration) -> BuildCacheConfiguration {
+        .init(
+            enabled: self.enabled ?? lower.enabled,
+            casPath: self.casPath ?? lower.casPath,
+            sizeLimit: self.sizeLimit ?? lower.sizeLimit,
+            enableDiagnosticRemarks: self.enableDiagnosticRemarks ?? lower.enableDiagnosticRemarks,
+            remoteServicePath: self.remoteServicePath ?? lower.remoteServicePath,
+            pluginPath: self.pluginPath ?? lower.pluginPath,
+            enablePrefixMapping: self.enablePrefixMapping ?? lower.enablePrefixMapping
+        )
+    }
+}
+
+/// An error thrown when a build cache size limit string cannot be parsed.
+public enum InvalidSizeLimitError: Error, CustomStringConvertible {
+    case invalidPercentage(String)
+    case conflictingSizeAndPercentage
+
+    public var description: String {
+        switch self {
+        case .invalidPercentage(let string):
+            return "invalid size limit percentage '\(string)'; expected an integer between 0 and 100 followed by '%'"
+        case .conflictingSizeAndPercentage:
+            return "cannot specify both a size and a percentage for the build cache size limit"
+        }
+    }
+}
+

--- a/Sources/PackageModel/CMakeLists.txt
+++ b/Sources/PackageModel/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(PackageModel
   BuildEnvironment.swift
   BuildFlags.swift
   BuildSettings.swift
+  BuildCacheConfiguration.swift
   DependencyMapper.swift
   Diagnostics.swift
   EnabledTrait.swift

--- a/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
+++ b/Sources/SPMBuildCore/BuildParameters/BuildParameters.swift
@@ -170,6 +170,9 @@ public struct BuildParameters: Encodable {
     /// The mode to run the API digester in, if any.
     public var apiDigesterMode: APIDigesterMode?
 
+    /// Build caching configuration.
+    public var buildCaching: BuildCacheConfiguration
+
     public init(
         destination: Destination,
         dataPath: Basics.AbsolutePath,
@@ -197,6 +200,7 @@ public struct BuildParameters: Encodable {
         apiDigesterMode: APIDigesterMode? = nil,
         stripProducts: Bool? = nil,
         shouldPreserveSymlinks: Bool = false,
+        buildCaching: BuildCacheConfiguration = .none,
     ) throws {
         // Default to the unversioned triple if none is provided so that we defer to the package's requested deployment target, for Darwin platforms. For other platforms, continue to include the version since those don't have the concept of a package-specified version, and the version is meaningful for some platforms including Android and FreeBSD.
         let triple = try triple ?? {
@@ -264,6 +268,7 @@ public struct BuildParameters: Encodable {
         self.apiDigesterMode = apiDigesterMode
         self.stripProducts = stripProducts
         self.shouldPreserveSymlinks = shouldPreserveSymlinks
+        self.buildCaching = buildCaching
     }
 
     /// The path to the build directory (inside the data directory).

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -148,6 +148,39 @@ func withSession(
     }
 }
 
+package func queryBuildCacheInfo(
+    casPath: Basics.AbsolutePath,
+    pluginPath: Basics.AbsolutePath?,
+    remoteServicePath: Basics.AbsolutePath?,
+    toolchain: Toolchain,
+    packageManagerResourcesDirectory: Basics.AbsolutePath?
+) async throws -> SWBBuildCacheInfo {
+    let usingXcodeDeveloperDirectory = (try? toolchainDeveloperPathInfo(toolchain: toolchain))?.isEmbeddedInXcode ?? false
+    let pluginEnabled = pluginPath != nil || usingXcodeDeveloperDirectory
+
+    return try await withService(connectionMode: .inProcessStatic(swiftbuildServiceEntryPoint)) { service in
+        let (session, _) = try await createSession(
+            service: service,
+            name: "swiftpm-build-cache-info",
+            toolchain: toolchain,
+            packageManagerResourcesDirectory: packageManagerResourcesDirectory
+        )
+        do {
+            let info = try await session.buildCacheInfo(
+                casPath: casPath.pathString,
+                pluginPath: pluginPath?.pathString,
+                remoteServicePath: remoteServicePath?.pathString,
+                pluginEnabled: pluginEnabled
+            )
+            try await session.close()
+            return info
+        } catch {
+            try? await session.close()
+            throw error
+        }
+    }
+}
+
 package final class SwiftBuildSystemPlanningOperationDelegate: SWBPlanningOperationDelegate, SWBIndexingDelegate, Sendable {
     private let shouldEnableDebuggingEntitlement: Bool
 
@@ -1089,6 +1122,8 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         try settings.merge(Self.constructTestingSettingsOverrides(from: buildParameters.testingParameters), uniquingKeysWith: reportConflict)
         try settings.merge(Self.constructAPIDigesterSettingsOverrides(from: buildParameters.apiDigesterMode), uniquingKeysWith: reportConflict)
         try settings.merge(Self.constructOutputSettingsOverrides(from: buildParameters.outputParameters), uniquingKeysWith: reportConflict)
+        let usingXcodeDeveloperDirectory = (try? toolchainDeveloperPathInfo(toolchain: buildParameters.toolchain))?.isEmbeddedInXcode ?? false
+        try settings.merge(Self.constructBuildCacheSettingsOverrides(from: buildParameters.buildCaching, usingXcodeDeveloperDirectory: usingXcodeDeveloperDirectory), uniquingKeysWith: reportConflict)
 
         if buildParameters.driverParameters.codesizeProfileEnabled {
             // dSYM generation is required to attribute code size to source locations
@@ -1323,12 +1358,70 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         return settings
     }
 
+    package static func constructBuildCacheSettingsOverrides(
+        from configuration: BuildCacheConfiguration,
+        usingXcodeDeveloperDirectory: Bool
+    ) -> [String: String] {
+        var settings: [String: String] = [:]
+
+        // Caching is off by default, so only emit overrides when it's enabled.
+        if configuration.enabled != true {
+            return settings
+        }
+
+        settings["SWIFT_ENABLE_COMPILE_CACHE"] = "YES"
+        settings["CLANG_ENABLE_COMPILE_CACHE"] = "YES"
+        settings["SWIFT_ENABLE_EXPLICIT_MODULES"] = "YES"
+        settings["CLANG_ENABLE_EXPLICIT_MODULES"] = "YES"
+
+        if let casPath = configuration.casPath {
+            settings["COMPILATION_CACHE_CAS_PATH"] = casPath.pathStringWithPosixSlashes
+        }
+
+        switch configuration.sizeLimit {
+        case .size(let value):
+            settings["COMPILATION_CACHE_LIMIT_SIZE"] = value
+        case .percent(let value):
+            settings["COMPILATION_CACHE_LIMIT_PERCENT"] = "\(value)"
+        case .none:
+            break
+        }
+
+        if let enableDiagnosticRemarks = configuration.enableDiagnosticRemarks {
+            settings["COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS"] = enableDiagnosticRemarks ? "YES" : "NO"
+        }
+
+        if let pluginPath = configuration.pluginPath {
+            settings["COMPILATION_CACHE_PLUGIN_PATH"] = pluginPath.pathStringWithPosixSlashes
+        }
+
+        // Enable the CAS plugin when a plugin path is provided, or when building
+        // with an Xcode developer directory, which ships a compatible plugin.
+        if configuration.pluginPath != nil || usingXcodeDeveloperDirectory {
+            settings["COMPILATION_CACHE_ENABLE_PLUGIN"] = "YES"
+        }
+
+        if let remoteServicePath = configuration.remoteServicePath {
+            settings["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] = remoteServicePath.pathStringWithPosixSlashes
+        }
+
+        // Caching is enabled here, so default prefix mapping to on unless the user
+        // expressed a preference.
+        let enablePrefixMapping = configuration.enablePrefixMapping ?? true
+        let prefixMappingValue = enablePrefixMapping ? "YES" : "NO"
+        settings["CLANG_ENABLE_PREFIX_MAPPING"] = prefixMappingValue
+        settings["SWIFT_ENABLE_PREFIX_MAPPING"] = prefixMappingValue
+        settings["CLANG_ENABLE_PROJECT_PREFIX_MAPPING"] = prefixMappingValue
+        settings["SWIFT_ENABLE_PROJECT_PREFIX_MAPPING"] = prefixMappingValue
+
+        return settings
+    }
+
     private static func constructTestingSettingsOverrides(from parameters: BuildParameters.Testing) -> [String: String] {
         var settings: [String: String] = [:]
 
         // Coverage settings
         settings["CLANG_COVERAGE_MAPPING"] = parameters.enableCodeCoverage ? "YES" : "NO"
-
         if let testability = parameters.explicitlyEnabledTestability {
             settings["ENABLE_TESTABILITY"] = testability ? "YES" : "NO"
         }

--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -518,6 +518,7 @@ public final class InitPackage {
                 xcuserdata/
                 DerivedData/
                 .swiftpm/configuration/registries.json
+                .swiftpm/configuration/build-cache-config.json
                 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
                 .netrc
 

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -115,6 +115,16 @@ extension Workspace {
             self.sharedConfigurationDirectory.map { DefaultLocations.registriesConfigurationFile(at: $0) }
         }
 
+        /// Path to the local build cache configuration.
+        public var localBuildCacheConfigurationFile: AbsolutePath {
+            DefaultLocations.buildCacheConfigurationFile(at: self.localConfigurationDirectory)
+        }
+
+        /// Path to the shared build cache configuration.
+        public var sharedBuildCacheConfigurationFile: AbsolutePath? {
+            self.sharedConfigurationDirectory.map { DefaultLocations.buildCacheConfigurationFile(at: $0) }
+        }
+
         // security locations
 
         /// Path to the shared fingerprints directory.
@@ -243,6 +253,14 @@ extension Workspace {
 
         public static func registriesConfigurationFile(at path: AbsolutePath) -> AbsolutePath {
             path.appending("registries.json")
+        }
+
+        public static func buildCacheConfigurationFile(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
+            self.buildCacheConfigurationFile(at: self.configurationDirectory(forRootPackage: rootPath))
+        }
+
+        public static func buildCacheConfigurationFile(at path: AbsolutePath) -> AbsolutePath {
+            path.appending("build-cache-config.json")
         }
 
         public static func manifestsDirectory(at path: AbsolutePath) -> AbsolutePath {
@@ -655,6 +673,200 @@ extension Workspace.Configuration {
             struct Mirror: Codable {
                 var original: String
                 var mirror: String
+            }
+        }
+    }
+}
+
+// MARK: - Build cache
+
+extension Workspace.Configuration {
+    /// Manages the local and shared build cache configuration, merging
+    /// them so that values set locally take precedence over shared ones.
+    public final class BuildCache {
+        private let localCache: BuildCacheStorage?
+        private let sharedCache: BuildCacheStorage?
+        private let fileSystem: FileSystem
+
+        private var _configuration: BuildCacheConfiguration
+        private let lock = NSLock()
+
+        /// The effective, merged build cache configuration.
+        public var configuration: BuildCacheConfiguration {
+            self.lock.withLock {
+                self._configuration
+            }
+        }
+
+        /// Initialize the workspace build cache configuration.
+        ///
+        /// - Parameters:
+        ///   - fileSystem: The file system to use.
+        ///   - localBuildCacheFile: Path to the workspace build cache configuration file.
+        ///   - sharedBuildCacheFile: Path to the shared build cache configuration file, if any.
+        public init(
+            fileSystem: FileSystem,
+            localBuildCacheFile: AbsolutePath?,
+            sharedBuildCacheFile: AbsolutePath?
+        ) throws {
+            self.localCache = localBuildCacheFile.map { .init(path: $0, fileSystem: fileSystem) }
+            self.sharedCache = sharedBuildCacheFile.map { .init(path: $0, fileSystem: fileSystem) }
+            self.fileSystem = fileSystem
+            self._configuration = .none
+            try self.compute()
+        }
+
+        @discardableResult
+        public func updateLocal(
+            handler: (inout BuildCacheConfiguration) throws -> Void
+        ) throws -> BuildCacheConfiguration {
+            guard let localCache else {
+                throw InternalError("local build cache configuration unexpectedly missing")
+            }
+            try localCache.update(handler: handler)
+            try self.compute()
+            return self.configuration
+        }
+
+        @discardableResult
+        public func updateShared(
+            handler: (inout BuildCacheConfiguration) throws -> Void
+        ) throws -> BuildCacheConfiguration {
+            guard let sharedCache else {
+                throw InternalError("shared build cache configuration not configured")
+            }
+            try sharedCache.update(handler: handler)
+            try self.compute()
+            return self.configuration
+        }
+
+        // mutating the state we hold; access should be done using a lock
+        private func compute() throws {
+            try self.lock.withLock {
+                let shared = try self.sharedCache?.load() ?? .none
+                let local = try self.localCache?.load() ?? .none
+                self._configuration = local.merging(over: shared)
+            }
+        }
+    }
+}
+
+extension Workspace.Configuration {
+    struct BuildCacheStorage {
+        private let path: AbsolutePath
+        private let fileSystem: FileSystem
+
+        init(path: AbsolutePath, fileSystem: FileSystem) {
+            self.path = path
+            self.fileSystem = fileSystem
+        }
+
+        func load() throws -> BuildCacheConfiguration {
+            guard self.fileSystem.exists(self.path) else {
+                return .none
+            }
+            return try self.fileSystem.withLock(on: self.path.parentDirectory, type: .shared) {
+                try Self.load(self.path, fileSystem: self.fileSystem)
+            }
+        }
+
+        @discardableResult
+        func update(
+            handler: (inout BuildCacheConfiguration) throws -> Void
+        ) throws -> BuildCacheConfiguration {
+            if !self.fileSystem.exists(self.path.parentDirectory) {
+                try self.fileSystem.createDirectory(self.path.parentDirectory, recursive: true)
+            }
+            return try self.fileSystem.withLock(on: self.path.parentDirectory, type: .exclusive) {
+                let configuration = try Self.load(self.path, fileSystem: self.fileSystem)
+                var updatedConfiguration = configuration
+                try handler(&updatedConfiguration)
+                if updatedConfiguration != configuration {
+                    try Self.save(updatedConfiguration, to: self.path, fileSystem: self.fileSystem)
+                }
+                return updatedConfiguration
+            }
+        }
+
+        private static func load(
+            _ path: AbsolutePath,
+            fileSystem: FileSystem
+        ) throws -> BuildCacheConfiguration {
+            guard fileSystem.exists(path) else {
+                return .none
+            }
+            let decoder = JSONDecoder.makeWithDefaults()
+            let stored = try decoder.decode(path: path, fileSystem: fileSystem, as: StoredBuildCacheConfiguration.self)
+            return try stored.asConfiguration()
+        }
+
+        private static func save(
+            _ configuration: BuildCacheConfiguration,
+            to path: AbsolutePath,
+            fileSystem: FileSystem
+        ) throws {
+            // Remove the file entirely when there is nothing left to persist.
+            if configuration.isEmpty {
+                if fileSystem.exists(path) {
+                    try fileSystem.removeFileTree(path)
+                }
+                return
+            }
+
+            let encoder = JSONEncoder.makeWithDefaults()
+            let data = try encoder.encode(StoredBuildCacheConfiguration(configuration))
+            if !fileSystem.exists(path.parentDirectory) {
+                try fileSystem.createDirectory(path.parentDirectory, recursive: true)
+            }
+            try fileSystem.writeFileContents(path, data: data)
+        }
+
+        /// On-disk representation of ``BuildCacheConfiguration``.
+        private struct StoredBuildCacheConfiguration: Codable {
+            let version: Int
+            let enabled: Bool?
+            let casPath: String?
+            let sizeLimit: String?
+            let sizePercent: Int?
+            let diagnosticRemarks: Bool?
+            let remoteServicePath: String?
+            let pluginPath: String?
+            let prefixMapping: Bool?
+
+            init(_ configuration: BuildCacheConfiguration) {
+                self.version = 1
+                self.enabled = configuration.enabled
+                self.casPath = configuration.casPath?.pathString
+                switch configuration.sizeLimit {
+                case .size(let value):
+                    self.sizeLimit = value
+                    self.sizePercent = nil
+                case .percent(let value):
+                    self.sizePercent = value
+                    self.sizeLimit = nil
+                case .none:
+                    self.sizeLimit = nil
+                    self.sizePercent = nil
+                }
+                self.diagnosticRemarks = configuration.enableDiagnosticRemarks
+                self.remoteServicePath = configuration.remoteServicePath?.pathString
+                self.pluginPath = configuration.pluginPath?.pathString
+                self.prefixMapping = configuration.enablePrefixMapping
+            }
+
+            func asConfiguration() throws -> BuildCacheConfiguration {
+                let casPath = try self.casPath.map { try AbsolutePath(validating: $0) }
+                let remoteServicePath = try self.remoteServicePath.map { try AbsolutePath(validating: $0) }
+                let pluginPath = try self.pluginPath.map { try AbsolutePath(validating: $0) }
+                return .init(
+                    enabled: self.enabled,
+                    casPath: casPath,
+                    sizeLimit: try .make(size: self.sizeLimit, percent: self.sizePercent),
+                    enableDiagnosticRemarks: self.diagnosticRemarks,
+                    remoteServicePath: remoteServicePath,
+                    pluginPath: pluginPath,
+                    enablePrefixMapping: self.prefixMapping
+                )
             }
         }
     }

--- a/Tests/CommandsTests/BuildCacheCommandTests.swift
+++ b/Tests/CommandsTests/BuildCacheCommandTests.swift
@@ -1,0 +1,334 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageModel
+import Testing
+import Workspace
+import _InternalTestSupport
+
+import struct SPMBuildCore.BuildSystemProvider
+
+@discardableResult
+fileprivate func execute(
+    _ args: [String] = [],
+    packagePath: AbsolutePath? = nil,
+) async throws -> (stdout: String, stderr: String) {
+    let env: Environment = ["SWIFTPM_TESTS_PACKAGECACHE": "1"]
+    return try await executeSwiftPackage(
+        packagePath,
+        extraArgs: args,
+        env: env,
+        buildSystem: .swiftbuild
+    )
+}
+
+@Suite(
+    .tags(
+        .TestSize.small,
+    )
+)
+struct BuildCacheCommandTests {
+    @Test
+    func buildCachePackageLocalConfiguration() async throws {
+        try await testWithTemporaryDirectory { fixturePath in
+            let fs = localFileSystem
+            let packageRoot = fixturePath.appending("Foo")
+            let sharedConfig = ["--config-path", fixturePath.appending("shared-config").pathString]
+
+            fs.createEmptyFiles(
+                at: packageRoot,
+                files:
+                "/Package.swift",
+            )
+
+            try await execute(
+                sharedConfig + [
+                    "build-cache", "configure",
+                    "--enable-caching",
+                    "--size-limit", "10G",
+                    "--enable-diagnostic-remarks",
+                    "--remote-service-path", "/tmp/remote-service",
+                    "--plugin-path", "/tmp/plugin",
+                    "--enable-prefix-mapping",
+                ],
+                packagePath: packageRoot,
+            )
+
+            // Capture the first package's effective configuration.
+            let (firstConfig, _) = try await execute(
+                sharedConfig + ["build-cache", "get-configuration"],
+                packagePath: packageRoot,
+            )
+            #expect(firstConfig.contains("build cache: enabled"))
+            #expect(firstConfig.contains("size limit: 10G"))
+            #expect(firstConfig.contains("diagnostic remarks: enabled"))
+            #expect(firstConfig.contains("remote service path: /tmp/remote-service"))
+            #expect(firstConfig.contains("plugin path: /tmp/plugin"))
+            #expect(firstConfig.contains("prefix mapping: enabled"))
+
+            // Configure a second package with different options.
+            let secondPackageRoot = fixturePath.appending("Bar")
+            fs.createEmptyFiles(
+                at: secondPackageRoot,
+                files:
+                "/Package.swift",
+            )
+
+            try await execute(
+                sharedConfig + [
+                    "build-cache", "configure",
+                    "--enable-caching",
+                    "--size-limit", "20%",
+                    "--disable-diagnostic-remarks",
+                    "--disable-prefix-mapping",
+                ],
+                packagePath: secondPackageRoot,
+            )
+
+            let (secondConfig, _) = try await execute(
+                sharedConfig + ["build-cache", "get-configuration"],
+                packagePath: secondPackageRoot,
+            )
+            #expect(secondConfig.contains("build cache: enabled"))
+            #expect(secondConfig.contains("size limit: 20% of available disk space"))
+            #expect(secondConfig.contains("diagnostic remarks: disabled"))
+            #expect(secondConfig.contains("prefix mapping: disabled"))
+            #expect(!secondConfig.contains("remote service path"))
+            #expect(!secondConfig.contains("plugin path"))
+
+            // The first package's configuration should be unaffected by the second.
+            let (firstConfigAgain, _) = try await execute(
+                sharedConfig + ["build-cache", "get-configuration"],
+                packagePath: packageRoot,
+            )
+            #expect(firstConfigAgain.contains("build cache: enabled"))
+            #expect(firstConfigAgain.contains("size limit: 10G"))
+            #expect(firstConfigAgain.contains("diagnostic remarks: enabled"))
+            #expect(firstConfigAgain.contains("remote service path: /tmp/remote-service"))
+            #expect(firstConfigAgain.contains("plugin path: /tmp/plugin"))
+            #expect(firstConfigAgain.contains("prefix mapping: enabled"))
+        }
+    }
+
+    @Test
+    func buildCacheGlobalConfiguration() async throws {
+        try await testWithTemporaryDirectory { fixturePath in
+            let fs = localFileSystem
+            let sharedConfig = ["--config-path", fixturePath.appending("shared-config").pathString]
+
+            let firstPackageRoot = fixturePath.appending("Foo")
+            fs.createEmptyFiles(
+                at: firstPackageRoot,
+                files:
+                "/Package.swift",
+            )
+
+            // Set a global configuration.
+            try await execute(
+                sharedConfig + [
+                    "build-cache", "configure", "--global",
+                    "--enable-caching",
+                    "--size-limit", "10G",
+                    "--enable-diagnostic-remarks",
+                    "--enable-prefix-mapping",
+                ],
+                packagePath: firstPackageRoot,
+            )
+
+            // A package with no local configuration sees the global configuration.
+            let (firstConfig, _) = try await execute(
+                sharedConfig + ["build-cache", "get-configuration"],
+                packagePath: firstPackageRoot,
+            )
+            #expect(firstConfig.contains("build cache: enabled"))
+            #expect(firstConfig.contains("size limit: 10G"))
+            #expect(firstConfig.contains("diagnostic remarks: enabled"))
+            #expect(firstConfig.contains("prefix mapping: enabled"))
+
+            // A second package overrides a single field with a package-local value.
+            let secondPackageRoot = fixturePath.appending("Bar")
+            fs.createEmptyFiles(
+                at: secondPackageRoot,
+                files:
+                "/Package.swift",
+            )
+
+            try await execute(
+                sharedConfig + ["build-cache", "configure", "--size-limit", "50%"],
+                packagePath: secondPackageRoot,
+            )
+
+            let (secondConfig, _) = try await execute(
+                sharedConfig + ["build-cache", "get-configuration"],
+                packagePath: secondPackageRoot,
+            )
+            #expect(secondConfig.contains("size limit: 50% of available disk space"))
+            #expect(secondConfig.contains("build cache: enabled"))
+            #expect(secondConfig.contains("diagnostic remarks: enabled"))
+            #expect(secondConfig.contains("prefix mapping: enabled"))
+
+            let (firstConfigAgain, _) = try await execute(
+                sharedConfig + ["build-cache", "get-configuration"],
+                packagePath: firstPackageRoot,
+            )
+            #expect(firstConfigAgain.contains("size limit: 10G"))
+        }
+    }
+
+    @Test
+    func buildCacheConfigurationFileContentsIsDeterministic() async throws {
+        try await testWithTemporaryDirectory { fixturePath in
+            let fs = localFileSystem
+            let packageRoot = fixturePath.appending("Foo")
+            let sharedConfig = ["--config-path", fixturePath.appending("shared-config").pathString]
+            let configFile = Workspace.DefaultLocations.buildCacheConfigurationFile(
+                forRootPackage: packageRoot
+            )
+
+            fs.createEmptyFiles(
+                at: packageRoot,
+                files:
+                "/Package.swift",
+            )
+
+            let configureArgs = sharedConfig + [
+                "build-cache", "configure",
+                "--enable-caching",
+                "--path", "/tmp/cache",
+                "--size-limit", "10G",
+                "--enable-diagnostic-remarks",
+                "--remote-service-path", "/tmp/remote-service",
+                "--plugin-path", "/tmp/plugin",
+                "--enable-prefix-mapping",
+            ]
+            let resetArgs = sharedConfig + ["build-cache", "reset-configuration"]
+
+            try await execute(configureArgs, packagePath: packageRoot)
+            let expectedContent: String = try fs.readFileContents(configFile)
+            try await execute(resetArgs, packagePath: packageRoot)
+            #expect(!fs.isFile(configFile))
+
+            for _ in 0..<4 {
+                try await execute(configureArgs, packagePath: packageRoot)
+
+                let content: String = try fs.readFileContents(configFile)
+                #expect(content == expectedContent)
+
+                try await execute(resetArgs, packagePath: packageRoot)
+                #expect(!fs.isFile(configFile))
+            }
+        }
+    }
+
+    @Test
+    func buildCacheResetDeletesConfigurationFile() async throws {
+        try await testWithTemporaryDirectory { fixturePath in
+            let fs = localFileSystem
+            let packageRoot = fixturePath.appending("Foo")
+            let sharedConfig = ["--config-path", fixturePath.appending("shared-config").pathString]
+            let configFile = Workspace.DefaultLocations.buildCacheConfigurationFile(
+                forRootPackage: packageRoot
+            )
+
+            fs.createEmptyFiles(
+                at: packageRoot,
+                files:
+                "/Package.swift",
+            )
+
+            try await execute(
+                sharedConfig + ["build-cache", "configure", "--enable-caching"],
+                packagePath: packageRoot,
+            )
+            #expect(fs.isFile(configFile))
+
+            try await execute(
+                sharedConfig + ["build-cache", "reset-configuration"],
+                packagePath: packageRoot,
+            )
+            #expect(!fs.isFile(configFile))
+        }
+    }
+
+    @Test
+    func buildCacheSizeLimitKindsReplaceEachOther() async throws {
+        try await testWithTemporaryDirectory { fixturePath in
+            let fs = localFileSystem
+            let packageRoot = fixturePath.appending("Foo")
+            let sharedConfig = ["--config-path", fixturePath.appending("shared-config").pathString]
+
+            fs.createEmptyFiles(
+                at: packageRoot,
+                files:
+                "/Package.swift",
+            )
+
+            // Start with an absolute size limit.
+            try await execute(
+                sharedConfig + ["build-cache", "configure", "--enable-caching", "--size-limit", "10G"],
+                packagePath: packageRoot,
+            )
+            let (absoluteConfig, _) = try await execute(
+                sharedConfig + ["build-cache", "get-configuration"],
+                packagePath: packageRoot,
+            )
+            #expect(absoluteConfig.contains("size limit: 10G"))
+
+            // Setting a percentage should replace the absolute size limit.
+            try await execute(
+                sharedConfig + ["build-cache", "configure", "--size-limit", "40%"],
+                packagePath: packageRoot,
+            )
+            let (percentConfig, _) = try await execute(
+                sharedConfig + ["build-cache", "get-configuration"],
+                packagePath: packageRoot,
+            )
+            #expect(percentConfig.contains("size limit: 40% of available disk space"))
+
+            // Setting an absolute size limit again should replace the percentage.
+            try await execute(
+                sharedConfig + ["build-cache", "configure", "--size-limit", "20G"],
+                packagePath: packageRoot,
+            )
+            let (absoluteAgainConfig, _) = try await execute(
+                sharedConfig + ["build-cache", "get-configuration"],
+                packagePath: packageRoot,
+            )
+            #expect(absoluteAgainConfig.contains("size limit: 20G"))
+        }
+    }
+
+    @Test
+    func buildCacheInvalidSizeLimitIsRejected() async throws {
+        try await testWithTemporaryDirectory { fixturePath in
+            let fs = localFileSystem
+            let packageRoot = fixturePath.appending("Foo")
+            let sharedConfig = ["--config-path", fixturePath.appending("shared-config").pathString]
+
+            fs.createEmptyFiles(
+                at: packageRoot,
+                files:
+                "/Package.swift",
+            )
+
+            await expectThrowsCommandExecutionError(
+                try await execute(
+                    sharedConfig + ["build-cache", "configure", "--size-limit", "150%"],
+                    packagePath: packageRoot,
+                )
+            ) { error in
+                #expect(error.stderr.contains("The value '150%' is invalid for '--size-limit <size-limit>'"))
+            }
+        }
+    }
+}

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -1104,6 +1104,250 @@ struct BuildCommandTestCases {
     }
 
     @Test(
+        .tags(
+            .Feature.CommandLineArguments.BuildSystem,
+        ),
+    )
+    func buildCacheBasics() async throws {
+        let config = BuildConfiguration.debug
+        let buildSystem = BuildSystemProvider.Kind.swiftbuild
+        let fs = localFileSystem
+
+        try await testWithTemporaryDirectory { tmpDir in
+            let packageRoot = tmpDir.appending("CacheApp")
+            let casPath = tmpDir.appending("build-cache")
+
+            try fs.createDirectory(packageRoot.appending(components: "Sources", "CApp", "include"), recursive: true)
+            try fs.createDirectory(packageRoot.appending(components: "Sources", "App"), recursive: true)
+            try fs.writeFileContents(
+                packageRoot.appending("Package.swift"),
+                string: """
+                // swift-tools-version:5.9
+                import PackageDescription
+                let package = Package(
+                    name: "CacheApp",
+                    targets: [
+                        .executableTarget(name: "App", dependencies: ["CApp"]),
+                        .target(name: "CApp"),
+                    ]
+                )
+                """
+            )
+            try fs.writeFileContents(
+                packageRoot.appending(components: "Sources", "CApp", "add.c"),
+                string: """
+                #include "add.h"
+                int add(int a, int b) { return a + b; }
+                """
+            )
+            try fs.writeFileContents(
+                packageRoot.appending(components: "Sources", "CApp", "include", "add.h"),
+                string: "int add(int a, int b);\n"
+            )
+            try fs.writeFileContents(
+                packageRoot.appending(components: "Sources", "App", "main.swift"),
+                string: """
+                import CApp
+                print(add(2, 3))
+                """
+            )
+
+            func buildWithCaching() async throws -> String {
+                let (stdout, stderr) = try await execute(
+                    [
+                        "--verbose",
+                        "--enable-build-caching",
+                        "--enable-build-cache-diagnostic-remarks",
+                        "--build-cache-path", casPath.pathString,
+                    ],
+                    packagePath: packageRoot,
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                return stdout + stderr
+            }
+
+            // First build: the cache is empty
+            let coldOutput = try await buildWithCaching()
+
+            #expect(coldOutput.contains("cache miss"))
+            #expect(coldOutput.contains("(0%)"))
+
+            try await executeSwiftPackage(packageRoot, extraArgs: ["clean"], buildSystem: buildSystem)
+
+            // Second build: the cache is popilated
+            let warmOutput = try await buildWithCaching()
+            #expect(warmOutput.contains("cache hit"))
+            #expect(warmOutput.contains("(100%)"))
+
+            let (cleanStdout, _) = try await executeSwiftPackage(
+                packageRoot,
+                extraArgs: ["--build-cache-path", casPath.pathString, "build-cache", "clean"],
+                buildSystem: buildSystem,
+            )
+            #expect(cleanStdout.contains("Cleaned build cache"))
+            #expect(!localFileSystem.exists(casPath))
+
+            // Third Build: After clearing, there should be no cache hits
+            try await executeSwiftPackage(packageRoot, extraArgs: ["clean"], buildSystem: buildSystem)
+            let coldAgainOutput = try await buildWithCaching()
+            #expect(coldAgainOutput.contains("cache miss"))
+            #expect(coldAgainOutput.contains("(0%)"))
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.CommandLineArguments.BuildSystem,
+        ),
+    )
+    func buildCachePrefixMapping() async throws {
+        let config = BuildConfiguration.debug
+        let buildSystem = BuildSystemProvider.Kind.swiftbuild
+        let fs = localFileSystem
+
+        func writePackage(at packageRoot: AbsolutePath) throws {
+            try fs.createDirectory(packageRoot.appending(components: "Sources", "CApp", "include"), recursive: true)
+            try fs.createDirectory(packageRoot.appending(components: "Sources", "App"), recursive: true)
+            try fs.writeFileContents(
+                packageRoot.appending("Package.swift"),
+                string: """
+                // swift-tools-version:5.9
+                import PackageDescription
+                let package = Package(
+                    name: "CacheApp",
+                    targets: [
+                        .executableTarget(name: "App", dependencies: ["CApp"]),
+                        .target(name: "CApp"),
+                    ]
+                )
+                """
+            )
+            try fs.writeFileContents(
+                packageRoot.appending(components: "Sources", "CApp", "add.c"),
+                string: """
+                #include "add.h"
+                int add(int a, int b) { return a + b; }
+                """
+            )
+            try fs.writeFileContents(
+                packageRoot.appending(components: "Sources", "CApp", "include", "add.h"),
+                string: "int add(int a, int b);\n"
+            )
+            try fs.writeFileContents(
+                packageRoot.appending(components: "Sources", "App", "main.swift"),
+                string: """
+                import CApp
+                print(add(2, 3))
+                """
+            )
+        }
+
+        try await testWithTemporaryDirectory { tmpDir in
+            // Build the same package at two distinct absolute paths, sharing a
+            // single build cache. With prefix mapping enabled, the source
+            // location differences are canonicalized so that cache entries
+            // populated by building the first copy are reused by the second.
+            let casPath = tmpDir.appending("build-cache")
+            let firstPackage = tmpDir.appending(components: "first", "CacheApp")
+            let secondPackage = tmpDir.appending(components: "second", "CacheApp")
+
+            try writePackage(at: firstPackage)
+            try writePackage(at: secondPackage)
+
+            func buildWithPrefixMapping(at packageRoot: AbsolutePath) async throws -> String {
+                let (stdout, stderr) = try await execute(
+                    [
+                        "--verbose",
+                        "--enable-build-caching",
+                        "--enable-build-cache-prefix-mapping",
+                        "--enable-build-cache-diagnostic-remarks",
+                        "--build-cache-path", casPath.pathString,
+                    ],
+                    packagePath: packageRoot,
+                    configuration: config,
+                    buildSystem: buildSystem,
+                )
+                return stdout + stderr
+            }
+
+            // First build at the first path: the cache is empty.
+            let firstOutput = try await buildWithPrefixMapping(at: firstPackage)
+            #expect(firstOutput.contains("cache miss"))
+            #expect(firstOutput.contains("(0%)"))
+
+            // Second build at a different path: prefix mapping canonicalizes the
+            // build location (including the compiler working directory) so every
+            // compilation reuses the entries populated by the first build. Without
+            // prefix mapping the embedded absolute paths would differ and yield no
+            // hits (0%).
+            let secondOutput = try await buildWithPrefixMapping(at: secondPackage)
+            #expect(secondOutput.contains("cache hit"))
+            #expect(secondOutput.contains("(100%)"))
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.CommandLineArguments.BuildSystem,
+        ),
+    )
+    func buildCacheInfo() async throws {
+        let config = BuildConfiguration.debug
+        let buildSystem = BuildSystemProvider.Kind.swiftbuild
+        let fs = localFileSystem
+
+        try await testWithTemporaryDirectory { tmpDir in
+            let packageRoot = tmpDir.appending("CacheApp")
+            let casPath = tmpDir.appending("build-cache")
+
+            try fs.createDirectory(packageRoot.appending(components: "Sources", "App"), recursive: true)
+            try fs.writeFileContents(
+                packageRoot.appending("Package.swift"),
+                string: """
+                // swift-tools-version:5.9
+                import PackageDescription
+                let package = Package(
+                    name: "CacheApp",
+                    targets: [.executableTarget(name: "App")]
+                )
+                """
+            )
+            try fs.writeFileContents(
+                packageRoot.appending(components: "Sources", "App", "main.swift"),
+                string: "print(1)\n"
+            )
+
+            // Before any build, there is no cache to report on.
+            let (infoBefore, _) = try await executeSwiftPackage(
+                packageRoot,
+                extraArgs: ["--build-cache-path", casPath.pathString, "build-cache", "info"],
+                buildSystem: buildSystem,
+            )
+            #expect(infoBefore.contains("No build cache found"))
+
+            // Populate the cache with a cached build.
+            try await execute(
+                ["--enable-build-caching", "--build-cache-path", casPath.pathString],
+                packagePath: packageRoot,
+                configuration: config,
+                buildSystem: buildSystem,
+            )
+
+            // Now the cache should report its path and a non-zero size queried
+            // from the underlying CAS.
+            let (infoAfter, _) = try await executeSwiftPackage(
+                packageRoot,
+                extraArgs: ["--build-cache-path", casPath.pathString, "build-cache", "info"],
+                buildSystem: buildSystem,
+            )
+            #expect(infoAfter.contains("path: \(casPath.pathString)"))
+            #expect(infoAfter.contains("size:"))
+            #expect(!infoAfter.contains("unavailable"))
+        }
+    }
+
+    @Test(
         .requireHostOS(.macOS),
         .tags(
             .Feature.CommandLineArguments.BuildSystem,

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -844,3 +844,113 @@ struct SwiftBuildSystemTests {
         }
     }
 }
+
+
+@Suite(
+    .tags(
+        .TestSize.small,
+    ),
+)
+struct BuildCacheSettingsTests {
+    @Test
+    func emptyConfigurationProducesNoSettings() {
+        #expect(SwiftBuildSystem.constructBuildCacheSettingsOverrides(from: .none, usingXcodeDeveloperDirectory: false).isEmpty)
+    }
+
+    @Test
+    func enablingCachingAlsoEnablesExplicitModulesAndPrefixMapping() {
+        let result = SwiftBuildSystem.constructBuildCacheSettingsOverrides(
+            from: BuildCacheConfiguration(enabled: true),
+            usingXcodeDeveloperDirectory: false
+        )
+        #expect(result["SWIFT_ENABLE_COMPILE_CACHE"] == "YES")
+        #expect(result["CLANG_ENABLE_COMPILE_CACHE"] == "YES")
+        // Build caching requires explicit modules, so they are turned on implicitly.
+        #expect(result["SWIFT_ENABLE_EXPLICIT_MODULES"] == "YES")
+        #expect(result["CLANG_ENABLE_EXPLICIT_MODULES"] == "YES")
+        // With no explicit preference, prefix mapping follows the caching state.
+        #expect(result["CLANG_ENABLE_PREFIX_MAPPING"] == "YES")
+        #expect(result["SWIFT_ENABLE_PREFIX_MAPPING"] == "YES")
+        #expect(result["CLANG_ENABLE_PROJECT_PREFIX_MAPPING"] == "YES")
+        #expect(result["SWIFT_ENABLE_PROJECT_PREFIX_MAPPING"] == "YES")
+        // No plugin path and not an Xcode developer directory, so the plugin isn't enabled.
+        #expect(result["COMPILATION_CACHE_ENABLE_PLUGIN"] == nil)
+    }
+
+    @Test
+    func disablingCachingSetsNoOverrides() throws {
+        let result = SwiftBuildSystem.constructBuildCacheSettingsOverrides(
+            from: BuildCacheConfiguration(
+                enabled: false,
+                casPath: try AbsolutePath(validating: "/tmp/cache"),
+                sizeLimit: .size("10G"),
+                enableDiagnosticRemarks: true,
+                enablePrefixMapping: true
+            ),
+            usingXcodeDeveloperDirectory: true
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test(arguments: [true, false])
+    func explicitPrefixMappingOverridesCachingDefault(prefixMapping: Bool) {
+        let expected = prefixMapping ? "YES" : "NO"
+        let result = SwiftBuildSystem.constructBuildCacheSettingsOverrides(
+            from: BuildCacheConfiguration(enabled: true, enablePrefixMapping: prefixMapping),
+            usingXcodeDeveloperDirectory: false
+        )
+        #expect(result["CLANG_ENABLE_PREFIX_MAPPING"] == expected)
+        #expect(result["SWIFT_ENABLE_PREFIX_MAPPING"] == expected)
+        #expect(result["CLANG_ENABLE_PROJECT_PREFIX_MAPPING"] == expected)
+        #expect(result["SWIFT_ENABLE_PROJECT_PREFIX_MAPPING"] == expected)
+    }
+
+    @Test
+    func absoluteSizeLimitMapsToLimitSize() {
+        let result = SwiftBuildSystem.constructBuildCacheSettingsOverrides(
+            from: BuildCacheConfiguration(enabled: true, sizeLimit: .size("10G")),
+            usingXcodeDeveloperDirectory: false
+        )
+        #expect(result["COMPILATION_CACHE_LIMIT_SIZE"] == "10G")
+        #expect(result["COMPILATION_CACHE_LIMIT_PERCENT"] == nil)
+    }
+
+    @Test
+    func percentSizeLimitMapsToLimitPercent() {
+        let result = SwiftBuildSystem.constructBuildCacheSettingsOverrides(
+            from: BuildCacheConfiguration(enabled: true, sizeLimit: .percent(50)),
+            usingXcodeDeveloperDirectory: false
+        )
+        #expect(result["COMPILATION_CACHE_LIMIT_PERCENT"] == "50")
+        #expect(result["COMPILATION_CACHE_LIMIT_SIZE"] == nil)
+    }
+
+    @Test(arguments: [true, false])
+    func diagnosticRemarksMapToSetting(diagnosticRemarks: Bool) {
+        let result = SwiftBuildSystem.constructBuildCacheSettingsOverrides(
+            from: BuildCacheConfiguration(enabled: true, enableDiagnosticRemarks: diagnosticRemarks),
+            usingXcodeDeveloperDirectory: false
+        )
+        #expect(result["COMPILATION_CACHE_ENABLE_DIAGNOSTIC_REMARKS"] == (diagnosticRemarks ? "YES" : "NO"))
+    }
+
+    @Test
+    func pluginPathEnablesPlugin() throws {
+        let result = SwiftBuildSystem.constructBuildCacheSettingsOverrides(
+            from: BuildCacheConfiguration(enabled: true, pluginPath: try AbsolutePath(validating: "/tmp/plugin")),
+            usingXcodeDeveloperDirectory: false
+        )
+        #expect(result["COMPILATION_CACHE_PLUGIN_PATH"] == "/tmp/plugin")
+        #expect(result["COMPILATION_CACHE_ENABLE_PLUGIN"] == "YES")
+    }
+
+    @Test
+    func xcodeDeveloperDirectoryEnablesPlugin() {
+        let result = SwiftBuildSystem.constructBuildCacheSettingsOverrides(
+            from: BuildCacheConfiguration(enabled: true),
+            usingXcodeDeveloperDirectory: true
+        )
+        #expect(result["COMPILATION_CACHE_ENABLE_PLUGIN"] == "YES")
+        #expect(result["COMPILATION_CACHE_PLUGIN_PATH"] == nil)
+    }
+}


### PR DESCRIPTION
Implements support for Clang/Swift compilation caching integration as described in the draft evolution proposal at https://gist.github.com/owenv/4d0f48e30df77a418eea1968223e8033

Caching can be configured either via CLI options of package-local/global configuration. Internally, it maps to Swift Build settings overrides which enable the feature in the underlying build system