### PR TITLE
Fix verbose build log lines being concatenated without newlines

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
@@ -149,7 +149,7 @@ public final class SwiftBuildSystemMessageHandler {
         if let started = self.buildState.startedInfo(for: startedInfo) {
             // Emit depending on verbosity level.
             if logLevel.isVerbose {
-                self.outputStream.send(started)
+                self.outputStream.send(started + "\n")
             }
             self.observabilityScope.print(started, condition: .onlyWhenVerbose)
         }

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemMessageHandlerTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemMessageHandlerTests.swift
@@ -485,6 +485,23 @@ struct SwiftBuildSystemMessageHandlerTests {
         #expect(output.contains("[Something useful]"))
         #expect(output.contains("[Complete]"))
     }
+
+    @Test
+    func testVerboseTaskOutputEndsWithNewline() throws {
+        let messageHandler = self.messageHandler.debug
+
+        let events: [SwiftBuildMessage] = [
+            .taskStartedInfo(executionDescription: "Compile Foo"),
+            .taskCompleteInfo(result: .success)
+        ]
+
+        for event in events {
+            _ = try messageHandler.emitEvent(event)
+        }
+
+        let output = self.outputStream.bytes.description
+        #expect(output.contains("Compile Foo\n"))
+    }
 }
 
 private func data(_ message: String) -> Data {


### PR DESCRIPTION
Resolves #10238
Fix verbose build log lines being concatenated without newlines

### Motivation:
In verbose mode (`-v`), build log lines were being printed without trailing newlines, causing consecutive task descriptions to be concatenated on a single line. (#10238)

For example:
<img width="600" height="250" alt="issue_ex1" src="https://github.com/user-attachments/assets/9ff9a55e-46b4-451a-8f21-72619abacd54" />
`Compute target dependency graphGather provisioning inputsPlanning complete` and
<img width="1462" height="183" alt="issue_ex2" src="https://github.com/user-attachments/assets/b64e4b80-98a9-43de-8ca6-efcb924d3307" />
`Discovering version info for clangDiscovering version info for swiftcDiscovering version info for libtoolDiscovering version info for ld[Planning deferred tasks]`

### Modifications:
In `SwiftBuildSystemMessageHandler.handleTaskOutput`, changed `self.outputStream.send(started)` to `self.outputStream.send(started + "\n")` to ensure each task description is terminated with a newline.

### Result:
<img width="350" height="65" alt="result1" src="https://github.com/user-attachments/assets/fafd4f09-39da-4ce2-8035-9c33a7e04bcf" />
<img width="440" height="185" alt="result2" src="https://github.com/user-attachments/assets/2ad3f0a1-dd31-428a-a18a-d3ca14892150" />

Verbose build log lines are now properly separated, each appearing on its own line.

### Test:
Added `testVerboseTaskOutputEndsWithNewline` in `SwiftBuildSystemMessageHandlerTests` to verify that verbose task output is terminated with a newline.

### Notes:
1. **Potential duplicate output**: While investigating this issue, I noticed that each task description appears twice in the verbose output. For example:

   <img width="950" height="100" alt="duplicate_ex1" src="https://github.com/user-attachments/assets/f05f7880-1fea-414f-906f-d182166290b9" />`Discovering Swift tasks after 'Emitting module for Newlines'` appears twice in the verbose output.

   <img width="1400" height="100" alt="duplicate_ex2" src="https://github.com/user-attachments/assets/7afb157f-88b5-4231-9558-4a8d8971b759" /> `Discovering version info for clang Discovering version info for swiftc Discovering version info for libtool Discovering version info for ld` appears twice in the verbose output.

   This appears to be caused by both `outputStream.send(started)` and `observabilityScope.print(started, condition: .onlyWhenVerbose)` being called in `handleTaskOutput`. I'm not sure if this is intentional. Happy to address it in a separate PR if needed.

2. **SwiftFormat**: I applied SwiftFormat as per the contributing guidelines. Please let me know if any formatting changes need to be adjusted.