### PR TITLE
[SwiftBuild] Add support for `--disable-sandbox`

### DIFF
--- a/Fixtures/TaskLocal/ExecutableTarget/Package.swift
+++ b/Fixtures/TaskLocal/ExecutableTarget/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ExecutableTarget",
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "ExecutableTarget",
+        ),
+    ]
+)

--- a/Fixtures/TaskLocal/ExecutableTarget/Sources/ExecutableTarget.swift
+++ b/Fixtures/TaskLocal/ExecutableTarget/Sources/ExecutableTarget.swift
@@ -1,0 +1,2 @@
+@TaskLocal var number = 42
+print("Hello, \(number)!")

--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -145,6 +145,7 @@ private struct SwiftBuildSystemFactory: BuildSystemFactory {
             ),
             delegate: delegate,
             scratchDirectory: self.swiftCommandState.scratchDirectory,
+            shouldDisableSandbox: self.swiftCommandState.shouldDisableSandbox,
         )
     }
 }

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -266,6 +266,9 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
     /// Additional rules for different file types generated from plugins.
     private let additionalFileRules: [FileRuleDescription]
 
+    /// Whether to disable the use sandbox on external subcommands
+    private let shouldDisableSandbox: Bool
+
     public var builtTestProducts: [BuiltTestProduct] {
         get async {
             do {
@@ -348,6 +351,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         pluginConfiguration: PluginConfiguration,
         delegate: BuildSystemDelegate?,
         scratchDirectory: Basics.AbsolutePath, // currently used to create the symbolic links
+        shouldDisableSandbox: Bool,
     ) throws {
         self.buildParameters = buildParameters
         self.hostBuildParameters = hostBuildParameters
@@ -361,6 +365,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         self.pluginConfiguration = pluginConfiguration
         self.delegate = delegate
         self.scratchDirectory = scratchDirectory
+        self.shouldDisableSandbox = shouldDisableSandbox
     }
 
     private func createREPLArguments(
@@ -683,7 +688,14 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                         throw error
                     }
 
-                    let request = try await self.makeBuildRequest(service: service, session: session, configuredTargets: configuredTargets, derivedDataPath: derivedDataPath, symbolGraphOptions: symbolGraphOptions)
+                    let request = try await self.makeBuildRequest(
+                        service: service,
+                        session: session,
+                        configuredTargets: configuredTargets,
+                        derivedDataPath: derivedDataPath,
+                        symbolGraphOptions: symbolGraphOptions,
+                        shouldDisableSandbox: self.shouldDisableSandbox,
+                    )
 
                     let operation = try await session.createBuildOperation(
                         request: request,
@@ -866,6 +878,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         session: SWBBuildServiceSession,
         symbolGraphOptions: BuildOutput.SymbolGraphOptions?,
         setToolchainSetting: Bool = true,
+        shouldDisableSandbox: Bool,
     ) async throws -> SwiftBuild.SWBBuildParameters {
         // Generate the run destination parameters.
         let runDestination = try await makeRunDestination(session: session)
@@ -895,6 +908,10 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             if !overrideToolchains.isEmpty {
                 settings["TOOLCHAINS"] = (overrideToolchains + ["$(inherited)"]).joined(separator: " ")
             }
+        }
+
+        if shouldDisableSandbox {
+            settings["SWIFTC_DISABLE_SANDBOX"] = "YES"
         }
 
         for sanitizer in buildParameters.sanitizers.sanitizers {
@@ -1097,6 +1114,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         derivedDataPath: Basics.AbsolutePath,
         symbolGraphOptions: BuildOutput.SymbolGraphOptions?,
         setToolchainSetting: Bool = true,
+        shouldDisableSandbox: Bool,
         ) async throws -> SWBBuildRequest {
         var request = SWBBuildRequest()
         request.parameters = try await makeBuildParameters(
@@ -1104,6 +1122,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             session: session,
             symbolGraphOptions: symbolGraphOptions,
             setToolchainSetting: setToolchainSetting,
+            shouldDisableSandbox: shouldDisableSandbox,
         )
         request.configuredTargets = configuredTargets.map { SWBConfiguredTarget(guid: $0.rawValue, parameters: request.parameters) }
         request.useParallelTargets = true

--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -141,7 +141,8 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
             session: session.session,
             configuredTargets: [.init(rawValue: "ALL-INCLUDING-TESTS")],
             derivedDataPath: self.buildSystem.buildParameters.dataPath,
-            symbolGraphOptions: nil
+            symbolGraphOptions: nil,
+            shouldDisableSandbox: false,
         )
         self.underlyingBuildServer = SWBBuildServer(
             session: session.session,

--- a/Sources/_InternalTestSupport/SwiftPMProduct.swift
+++ b/Sources/_InternalTestSupport/SwiftPMProduct.swift
@@ -83,7 +83,8 @@ extension SwiftPM {
         _ args: [String] = [],
         packagePath: AbsolutePath? = nil,
         env: Environment? = nil,
-        throwIfCommandFails: Bool = true
+        throwIfCommandFails: Bool = true,
+        commandPrefix: [String] = [],
     ) async throws -> (stdout: String, stderr: String) {
         // Swift Testing uses Swift concurrency for test execution and creates a task for each test to run in parallel.
         // A single invocation of "swift build" can spawn a large number of subprocesses.
@@ -95,7 +96,8 @@ extension SwiftPM {
             let result = try await executeProcess(
                 args,
                 packagePath: packagePath,
-                env: env
+                env: env,
+                commandPrefix: commandPrefix,
             )
             // Remove /r from stdout/stderr so that tests do not have to deal with them
             let stdout = try String(decoding: result.output.get().filter { $0 != 13 }, as: Unicode.UTF8.self)
@@ -118,7 +120,8 @@ extension SwiftPM {
     private func executeProcess(
         _ args: [String],
         packagePath: AbsolutePath? = nil,
-        env: Environment? = nil
+        env: Environment? = nil,
+        commandPrefix: [String],
     ) async throws -> AsyncProcessResult {
         var environment = Environment.current
 #if !os(Windows)
@@ -143,7 +146,7 @@ extension SwiftPM {
             environment[key] = value
         }
 
-        var completeArgs = [Self.xctestBinaryPath(for: RelativePath(self.executableName)).pathString]
+        var completeArgs = commandPrefix + [Self.xctestBinaryPath(for: RelativePath(self.executableName)).pathString]
         if let packagePath = packagePath {
             completeArgs += ["--package-path", packagePath.pathString]
         }

--- a/Sources/swift-bootstrap/main.swift
+++ b/Sources/swift-bootstrap/main.swift
@@ -452,6 +452,7 @@ struct SwiftBootstrapBuildTool: AsyncParsableCommand {
                     ),
                     delegate: nil,
                     scratchDirectory: scratchDirectory,
+                    shouldDisableSandbox: false,
                 )
             }
         }

--- a/Tests/IntegrationTests/WorkflowTests.swift
+++ b/Tests/IntegrationTests/WorkflowTests.swift
@@ -28,6 +28,59 @@ import Testing
 )
 struct DeveloperWorkflowTests {
 
+    @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/7098", relationship: .verifies),
+        .requireHostOS(.macOS),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func buildTaskLocalInSandboxWithoutSandBox(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await fixture(name: "TaskLocal/ExecutableTarget") { fixturePath in
+            // GIVEN we have a command line that builds a package with `--disable-sanbox`
+            let commandPrefix = [
+                "/usr/bin/sandbox-exec",
+                "-p",
+                "(version 1)(allow default)",
+            ]
+            let cmd = getBuildSystemArgs(for: buildSystem) + configuration.buildArgs + [
+                "--disable-sandbox",
+                "--verbose",
+            ]
+
+            // WHEN we execute the command
+            // THEN we expect it to build successfully.
+            await #expect(throws: Never.self) {
+                let (stdout, stderr) = try await SwiftPM.Build.execute(
+                    cmd,
+                    packagePath: fixturePath,
+                    throwIfCommandFails: true,
+                    commandPrefix: commandPrefix,
+                )
+
+                let swiftcInvocations = (stdout + stderr).split { $0.isNewline }.map(String.init).filter { $0.contains("swiftc") }
+
+                // AND we expect there to be at least 1 swiftc invocation
+                #expect(
+                    swiftcInvocations.isEmpty == false,
+                    "There should be at least 1 swiftc invocation",
+                )
+
+                // AND at least one of the swiftc invocations should contain `-disable-sandbox`
+                let linesContainsExpectedDisableSandboxCompilerFlag = swiftcInvocations.filter { $0.contains("-disable-sandbox") }
+                try #require(
+                    linesContainsExpectedDisableSandboxCompilerFlag.isEmpty == false,
+                    "There should be at least 1 swiftc invocation with `-disable-sandbox`",
+                )
+                // AND the number of invocation that have `-disable-sandbox` should not be more than the total number of `swiftc` invocations
+                #expect(
+                    linesContainsExpectedDisableSandboxCompilerFlag.count <= swiftcInvocations.count,
+                )
+            }
+        }
+    }
+
     @Test
     func scratchPathContainsSentinelFiles() async throws {
         try await withTemporaryDirectory(removeTreeOnDeinit: false) { tmpDir in

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -80,6 +80,7 @@ func withInstantiatedSwiftBuildSystem(
                 ),
                 delegate: nil,
                 scratchDirectory: tmpDir.appending("scratchDirectory"),
+                shouldDisableSandbox: false,
             )
 
             try await SwiftBuildSupport.withService(
@@ -167,6 +168,7 @@ struct SwiftBuildSystemTests {
                     session: session,
                     symbolGraphOptions: nil,
                     setToolchainSetting: false, // Set this to false as SwiftBuild checks the toolchain path
+                    shouldDisableSandbox: false,
                 )
 
                 let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -197,6 +199,7 @@ struct SwiftBuildSystemTests {
                         session: session,
                         symbolGraphOptions: nil,
                         setToolchainSetting: false, // Set this to false as SwiftBuild checks the toolchain path
+                        shouldDisableSandbox: false,
                     )
                 }
             }
@@ -230,6 +233,7 @@ struct SwiftBuildSystemTests {
                     session: session,
                     symbolGraphOptions: nil,
                     setToolchainSetting: false, // Set this to false as SwiftBuild checks the toolchain path
+                    shouldDisableSandbox: false,
                 )
 
                 // THEN we expect a warning to be emitted
@@ -273,6 +277,7 @@ struct SwiftBuildSystemTests {
                     session: session,
                     symbolGraphOptions: nil,
                     setToolchainSetting: false, // Set this to false as SwiftBuild checks the toolchain path
+                    shouldDisableSandbox: false,
                 )
 
                 // THEN we don't expect any warnings to be emitted
@@ -309,6 +314,7 @@ struct SwiftBuildSystemTests {
                 session: session,
                 symbolGraphOptions: nil,
                 setToolchainSetting: false, // Set this to false as SwiftBuild checks the toolchain path
+                shouldDisableSandbox: false,
             )
 
             let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -369,6 +375,7 @@ struct SwiftBuildSystemTests {
                 session: session,
                 symbolGraphOptions: nil,
                 setToolchainSetting: false, // Set this to false as SwiftBuild checks the toolchain path
+                shouldDisableSandbox: false,
             )
 
             let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -405,6 +412,7 @@ struct SwiftBuildSystemTests {
                 session: session,
                 symbolGraphOptions: nil,
                 setToolchainSetting: false, // Set this to false as SwiftBuild checks the toolchain path
+                shouldDisableSandbox: false,
             )
 
             let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -444,7 +452,8 @@ struct SwiftBuildSystemTests {
                     configuredTargets: [],
                     derivedDataPath: tempDir,
                     symbolGraphOptions: nil,
-                    setToolchainSetting: false
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
                 )
 
                 #expect(buildRequest.schedulerLaneWidthOverride == expectedNumberOfWorkers)
@@ -469,7 +478,8 @@ struct SwiftBuildSystemTests {
                     configuredTargets: [],
                     derivedDataPath: tempDir,
                     symbolGraphOptions: nil,
-                    setToolchainSetting: false
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
                 )
 
                 #expect(buildRequest.parameters.overrides.synthesized?.table["OTHER_CFLAGS"]?.contains("-DFoo") == true)
@@ -511,7 +521,8 @@ struct SwiftBuildSystemTests {
                     service: service,
                     session: session,
                     symbolGraphOptions: nil,
-                    setToolchainSetting: false
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
                 )
 
                 let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -547,7 +558,8 @@ struct SwiftBuildSystemTests {
                     service: service,
                     session: session,
                     symbolGraphOptions: nil,
-                    setToolchainSetting: false
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
                 )
 
                 let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -571,7 +583,8 @@ struct SwiftBuildSystemTests {
                     service: service,
                     session: session,
                     symbolGraphOptions: nil,
-                    setToolchainSetting: false
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
                 )
 
                 let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -601,7 +614,8 @@ struct SwiftBuildSystemTests {
                     service: service,
                     session: session,
                     symbolGraphOptions: nil,
-                    setToolchainSetting: false
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
                 )
 
                 let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -624,7 +638,8 @@ struct SwiftBuildSystemTests {
                     service: service,
                     session: session,
                     symbolGraphOptions: nil,
-                    setToolchainSetting: false
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
                 )
 
                 let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -658,7 +673,8 @@ struct SwiftBuildSystemTests {
                     service: service,
                     session: session,
                     symbolGraphOptions: nil,
-                    setToolchainSetting: false
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
                 )
 
                 let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -715,7 +731,8 @@ struct SwiftBuildSystemTests {
                     service: service,
                     session: session,
                     symbolGraphOptions: nil,
-                    setToolchainSetting: false
+                    setToolchainSetting: false,
+                    shouldDisableSandbox: false,
                 )
 
                 let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -789,7 +806,8 @@ struct SwiftBuildSystemTests {
                 service: service,
                 session: session,
                 symbolGraphOptions: nil,
-                setToolchainSetting: false
+                setToolchainSetting: false,
+                shouldDisableSandbox: false,
             )
 
             let synthesizedArgs = try #require(buildSettings.overrides.synthesized)
@@ -818,6 +836,7 @@ struct SwiftBuildSystemTests {
                 session: session,
                 symbolGraphOptions: nil,
                 setToolchainSetting: false,
+                shouldDisableSandbox: false,
             )
 
             let runDestination = try #require(buildSettings.activeRunDestination)


### PR DESCRIPTION
Some package systems (e.g: HomeBrew, Nix) use a custom build sandbox.
Within the outer sandbox, Swift Toolchain should not create their own
sandbox, which is why SwiftPM offers a `--disable-sandbox` options.

The option is inneffective in Swift toolchain included with Xcode Beta
(Xcode 27A5194q, Swift 6.4.0.20.104).

Add a test to ensure the issues does not regress.

Relates to: #7098
Depends on: https://github.com/swiftlang/swift-build/pull/1498
Issue: rdar://179641209
Issue: rdar://FB23149934 (Customer Feedback)