### PR TITLE
Improve debugger startup experience with LLDB instructions

### DIFF
--- a/Sources/Commands/SwiftRunCommand.swift
+++ b/Sources/Commands/SwiftRunCommand.swift
@@ -190,9 +190,10 @@ public struct SwiftRunCommand: AsyncSwiftCommand {
                 } else {
                     let pathRelativeToWorkingDirectory = productAbsolutePath.relative(to: swiftCommandState.originalWorkingDirectory)
                     let lldbPath = try swiftCommandState.getTargetToolchain().getLLDB()
+                    let lldbMessage = #"script print("LLDB is ready. Type 'run' or 'r' to start execution.")"#
                     try safeExec(
                         path: lldbPath.pathString,
-                        args: ["--", pathRelativeToWorkingDirectory.pathString] + options.arguments,
+                        args: ["lldb", "-o", lldbMessage, "--", pathRelativeToWorkingDirectory.pathString] + options.arguments,
                         observabilityScope: swiftCommandState.observabilityScope
                     )
                 }

--- a/Sources/Commands/Utilities/TestingSupport.swift
+++ b/Sources/Commands/Utilities/TestingSupport.swift
@@ -596,6 +596,8 @@ struct DebugTestRunner {
                     lldbCommands.append("run")
                 }
                 lldbCommands.append("quit")
+            } else {
+                lldbCommands.append(#"script print("LLDB is ready. Type 'run' or 'r' to start test execution.")"#)
             }
 
             let commandScript = lldbCommands.joined(separator: "\n")

--- a/Tests/CommandsTests/RunCommandTests.swift
+++ b/Tests/CommandsTests/RunCommandTests.swift
@@ -526,4 +526,32 @@ struct RunCommandTests {
             #expect(stdout.isEmpty)
         }
     }
+
+    @Test(
+        .tags(
+            .Feature.TargetType.Executable
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms
+    )
+    func debuggerInjectsCustomBanner(
+        buildSystem: BuildSystemProvider.Kind
+    ) async throws {
+        try await withKnownIssue(isIntermittent: true) {
+            try await fixture(name: "Miscellaneous/EchoExecutable") { fixturePath in
+                let (stdout, stderr) = try await execute(
+                    ["--debugger", "secho"],
+                    packagePath: fixturePath,
+                    buildSystem: buildSystem
+                )
+
+                let output = stdout + stderr
+                #expect(
+                    output.contains("LLDB is ready. Type 'run' or 'r' to start execution."),
+                    "Expected custom LLDB banner in output, got stdout:\n \(stdout)\n stderr:\n \(stderr)"
+                )
+            }
+        } when: {
+            ProcessInfo.hostOperatingSystem == .windows || CiEnvironment.runningInSmokeTestPipeline
+        }
+    }
 }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -2340,6 +2340,67 @@ struct TestCommandTests {
             }
         }
 
+        @Test(
+            .tags(.Feature.TargetType.Executable),
+            arguments: SupportedBuildSystemOnAllPlatforms
+        )
+        func debuggerSuppressesCustomBannerInAutomatedEnvironments(
+            buildSystem: BuildSystemProvider.Kind
+        ) async throws {
+            let configuration = BuildConfiguration.debug
+            try await withKnownIssue(isIntermittent: true) {
+                try await fixture(name: "Miscellaneous/TestDiscovery/Simple") { fixturePath in
+                    let fakePythonDir = fixturePath.appending(components: "fake_python")
+                    try localFileSystem.createDirectory(fakePythonDir)
+                    try localFileSystem.writeFileContents(
+                        fakePythonDir.appending(components: "shutil.py"),
+                        string: "def rmtree(*args, **kwargs): pass\n"
+                    )
+
+                    var extraEnv = Environment.current
+                    extraEnv["PYTHONPATH"] = fakePythonDir.pathString
+
+                    let (stdout, stderr) = try await executeSwiftTest(
+                        fixturePath,
+                        configuration: configuration,
+                        extraArgs: ["--debugger", "--verbose"],
+                        env: extraEnv,
+                        buildSystem: buildSystem,
+                        throwIfCommandFails: false
+                    )
+
+                    let output = stdout + stderr
+
+                    guard let markerRange = output.range(of: "info: LLDB will run: ") else {
+                        Issue.record("Expected to find LLDB commands file marker in output. Output:\n\(output)")
+                        return
+                    }
+
+                    let pathLine = output[markerRange.upperBound...].split(whereSeparator: { $0.isNewline }).first ?? ""
+                    guard let pathString = pathLine.split(separator: " ").last.map(String.init), !pathString.isEmpty else {
+                        Issue.record("Failed to parse file path from command line: \(pathLine)")
+                        return
+                    }
+
+                    guard let fileContents = try? String(contentsOf: URL(fileURLWithPath: pathString), encoding: .utf8) else {
+                        Issue.record("Failed to read the generated LLDB commands file at \(pathString).")
+                        return
+                    }
+
+                    #expect(
+                        !fileContents.contains("LLDB is ready"),
+                        "Expected custom LLDB banner to be suppressed in automated mode, but it was found in:\n\(fileContents)"
+                    )
+                    #expect(
+                        fileContents.contains("quit"),
+                        "Expected automated mode to inject 'quit', but it was missing from:\n\(fileContents)"
+                    )
+                }
+            } when: {
+                ProcessInfo.hostOperatingSystem == .windows || CiEnvironment.runningInSmokeTestPipeline || CiEnvironment.runningInSelfHostedPipeline
+            }
+        }
+
         func args(_ args: [String], for buildSystem: BuildSystemProvider.Kind, buildConfiguration: BuildConfiguration = .debug) -> [String] {
             return args + buildConfiguration.buildArgs + getBuildSystemArgs(for: buildSystem)
         }


### PR DESCRIPTION
Display a helpful startup message when launching LLDB via `swift run --debugger` and `swift test --debugger`, informing users how to start the executable or test session.

### Motivation

Fixes #10232 

Currently, `swift run --debugger` and `swift test --debugger` drop users into an LLDB prompt with no indication of what to do next. New users can be left at a `(lldb)` prompt without realizing they need to enter `run` (or `r`) to start execution. This change improves the debugging experience by providing a clear instruction while preserving the existing interactive workflow.

### Modifications

- Added a startup message to interactive LLDB sessions launched by `swift run --debugger` and `swift test --debugger`.
- Ensured the message is only shown for interactive sessions and is suppressed in automated testing environments used by SwiftPM's test suite.
- Added regression tests covering both the presence of the startup message in interactive mode and its suppression in automated mode.

### Result

Users launching LLDB through `swift run --debugger` or `swift test --debugger` now receive a clear instruction explaining that they can type `run` (or `r`) to start execution, making the debugger workflow more discoverable without changing existing behavior.