### PR TITLE
Support Swift Testing in macro package template

### DIFF
--- a/Sources/Workspace/InitPackage.swift
+++ b/Sources/Workspace/InitPackage.swift
@@ -121,11 +121,6 @@ public final class InitPackage {
         installedSwiftPMConfiguration: InstalledSwiftPMConfiguration,
         fileSystem: FileSystem
     ) throws {
-        if options.packageType == .macro && options.supportedTestingLibraries.contains(.swiftTesting) {
-            // FIXME: https://github.com/swiftlang/swift-syntax/issues/2400
-            throw InitError.unsupportedTestingLibraryForPackageType(.swiftTesting, .macro)
-        }
-
         self.options = options
         self.pkgname = name
         var mangledName = name.spm_mangledToC99ExtendedIdentifier()
@@ -383,32 +378,43 @@ public final class InitPackage {
                     """
                 } else if packageType == .macro {
                     let testTarget: String
+                    var testDependencies = [
+                        "\"\(moduleName)Macros\"",
+                    ]
+
                     if options.supportedTestingLibraries.contains(.swiftTesting) {
+                        testDependencies.append(#".product(name: "SwiftSyntaxMacrosGenericTestSupport", package: "swift-syntax")"#)
+                        testDependencies.append(#".product(name: "Testing", package: "swift-testing")"#)
+                    }
+
+                    if options.supportedTestingLibraries.contains(.xctest) {
+                        testDependencies.append(#".product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")"#)
+                    }
+
+                    if !options.supportedTestingLibraries.isEmpty {
+                        let testDependencies = testDependencies.map { dependency in
+                            "                \(dependency),"
+                        }.joined(separator: "\n")
+
+                        let testSettings: String
+                        if options.supportedTestingLibraries.contains(.xctest) {
+                            testSettings = "\n" + [
+                                "                swiftSettings: [",
+                                "                    .enableUpcomingFeature(\"ApproachableConcurrency\"),",
+                                "                ],",
+                            ].joined(separator: "\n")
+                        } else {
+                            testSettings = ""
+                        }
+
                         testTarget = """
 
                                 // A test target used to develop the macro implementation.
                                 .testTarget(
                                     name: "\(moduleName)Tests",
                                     dependencies: [
-                                        "\(moduleName)Macros",
-                                        .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-                                        .product(name: "Testing", package: "swift-testing"),
-                                    ]
-                                ),
-                        """
-                    } else if options.supportedTestingLibraries.contains(.xctest) {
-                        testTarget = """
-
-                                // A test target used to develop the macro implementation.
-                                .testTarget(
-                                    name: "\(moduleName)Tests",
-                                    dependencies: [
-                                        "\(moduleName)Macros",
-                                        .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-                                    ],
-                                    swiftSettings: [
-                                        .enableUpcomingFeature("ApproachableConcurrency"),
-                                    ],
+                        \(testDependencies)
+                                    ],\(testSettings)
                                 ),
                         """
                     } else {
@@ -809,15 +815,18 @@ public final class InitPackage {
             import SwiftSyntax
             import SwiftSyntaxBuilder
             import SwiftSyntaxMacros
-            import SwiftSyntaxMacrosTestSupport
 
             """##
 
         if options.supportedTestingLibraries.contains(.swiftTesting) {
-            content += "import Testing\n"
+            content += "import SwiftSyntaxMacrosGenericTestSupport\n"
         }
         if options.supportedTestingLibraries.contains(.xctest) {
+            content += "import SwiftSyntaxMacrosTestSupport\n"
             content += "import XCTest\n"
+        }
+        if options.supportedTestingLibraries.contains(.swiftTesting) {
+            content += "import Testing\n"
         }
 
         content += ##"""
@@ -826,8 +835,8 @@ public final class InitPackage {
             #if canImport(\##(moduleName)Macros)
             import \##(moduleName)Macros
 
-            let testMacros: [String: Macro.Type] = [
-                "stringify": StringifyMacro.self,
+            let testMacros: [String: MacroSpec] = [
+                "stringify": MacroSpec(type: StringifyMacro.self),
             ]
             #endif
 
@@ -838,7 +847,58 @@ public final class InitPackage {
         // for it *and* Testing if it is enabled.
 
         if options.supportedTestingLibraries.contains(.swiftTesting) {
-            // FIXME: https://github.com/swiftlang/swift-syntax/issues/2400
+            content += ##"""
+                @Test func testMacro() throws {
+                    #if canImport(\##(moduleName)Macros)
+                    assertMacroExpansion(
+                        """
+                        #stringify(a + b)
+                        """,
+                        expandedSource: """
+                        (a + b, "a + b")
+                        """,
+                        macroSpecs: testMacros,
+                        failureHandler: {
+                            Issue.record(
+                                Comment(rawValue: $0.message),
+                                sourceLocation: SourceLocation(
+                                    fileID: $0.location.fileID,
+                                    filePath: $0.location.filePath,
+                                    line: $0.location.line,
+                                    column: $0.location.column
+                                )
+                            )
+                        }
+                    )
+                    #endif
+                }
+
+                @Test func testMacroWithStringLiteral() throws {
+                    #if canImport(\##(moduleName)Macros)
+                    assertMacroExpansion(
+                        #"""
+                        #stringify("Hello, \(name)")
+                        """#,
+                        expandedSource: #"""
+                        ("Hello, \(name)", #""Hello, \(name)""#)
+                        """#,
+                        macroSpecs: testMacros,
+                        failureHandler: {
+                            Issue.record(
+                                Comment(rawValue: $0.message),
+                                sourceLocation: SourceLocation(
+                                    fileID: $0.location.fileID,
+                                    filePath: $0.location.filePath,
+                                    line: $0.location.line,
+                                    column: $0.location.column
+                                )
+                            )
+                        }
+                    )
+                    #endif
+                }
+
+                """##
         }
 
         if options.supportedTestingLibraries.contains(.xctest) {
@@ -853,7 +913,7 @@ public final class InitPackage {
                             expandedSource: """
                             (a + b, "a + b")
                             """,
-                            macros: testMacros
+                            macroSpecs: testMacros
                         )
                         #else
                         throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -869,7 +929,7 @@ public final class InitPackage {
                             expandedSource: #"""
                             ("Hello, \(name)", #""Hello, \(name)""#)
                             """#,
-                            macros: testMacros
+                            macroSpecs: testMacros
                         )
                         #else
                         throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -972,7 +1032,6 @@ public final class InitPackage {
 
 private enum InitError: Swift.Error {
     case manifestAlreadyExists
-    case unsupportedTestingLibraryForPackageType(_ testingLibrary: TestingLibrary, _ packageType: InitPackage.PackageType)
 }
 
 extension InitError: CustomStringConvertible {
@@ -980,8 +1039,6 @@ extension InitError: CustomStringConvertible {
         switch self {
         case .manifestAlreadyExists:
             return "a manifest file already exists in this directory"
-        case let .unsupportedTestingLibraryForPackageType(library, packageType):
-            return "\(library) cannot be used when initializing a \(packageType) package"
         }
     }
 }

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -588,6 +588,53 @@ struct InitTests {
             .TestSize.medium,
         ),
     )
+    func initPackageMacroWithSwiftTesting() async throws {
+        try withTemporaryDirectory { tmpPath in
+            let fs = localFileSystem
+            let path = tmpPath.appending("Foo")
+            let name = path.basename
+            try fs.createDirectory(path)
+
+            // Create the package
+            let initPackage = try InitPackage(
+                name: name,
+                packageType: .macro,
+                supportedTestingLibraries: [.swiftTesting],
+                destinationPath: path,
+                fileSystem: localFileSystem
+            )
+
+            try initPackage.writePackageStructure()
+
+            // Verify basic file system content that we expect in the package
+            let manifest = path.appending("Package.swift")
+            try requireFileExists(at: manifest)
+
+            let manifestContents: String = try localFileSystem.readFileContents(manifest)
+            #expect(manifestContents.contains(".testTarget("))
+            #expect(manifestContents.contains(#".product(name: "SwiftSyntaxMacrosGenericTestSupport", package: "swift-syntax")"#))
+            #expect(manifestContents.contains(#".product(name: "Testing", package: "swift-testing")"#))
+            #expect(!manifestContents.contains(#".product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")"#))
+
+            let testFile = path.appending("Tests").appending("FooTests").appending("FooTests.swift")
+            let testFileContents: String = try localFileSystem.readFileContents(testFile)
+            #expect(testFileContents.contains(#"import SwiftSyntaxMacrosGenericTestSupport"#))
+            #expect(testFileContents.contains(#"import Testing"#))
+            #expect(!testFileContents.contains(#"import SwiftSyntaxMacrosTestSupport"#))
+            #expect(!testFileContents.contains(#"import XCTest"#))
+            #expect(testFileContents.contains(#"let testMacros: [String: MacroSpec]"#))
+            #expect(testFileContents.contains(#"@Test func testMacro() throws"#))
+            #expect(testFileContents.contains(#"@Test func testMacroWithStringLiteral() throws"#))
+            #expect(testFileContents.contains(#"macroSpecs: testMacros"#))
+            #expect(testFileContents.contains(#"Issue.record("#))
+        }
+    }
+
+    @Test(
+        .tags(
+            .TestSize.medium,
+        ),
+    )
     func initPackageCommandPlugin() throws {
         try withTemporaryDirectory { tmpPath in
             let fs = localFileSystem


### PR DESCRIPTION
Support Swift Testing when initializing macro packages.

### Motivation:

Macro packages initialized with Swift Testing are currently blocked, even though `SwiftSyntaxMacrosGenericTestSupport` now supports macro expansion assertions without depending on XCTest.

This prevents `swift package init` from generating an idiomatic Swift Testing-based macro package template.

Fixes #8890.

### Modifications:

- Allow macro packages to be initialized with Swift Testing.
- Use `SwiftSyntaxMacrosGenericTestSupport` for generated Swift Testing macro tests.
- Keep `SwiftSyntaxMacrosTestSupport` for generated XCTest macro tests.
- Generate Swift Testing macro expansion tests that record failures through `Issue.record(...)`.
- Add coverage for the generated macro package manifest and test file.

### Result:

Macro packages can now be initialized with Swift Testing.

The generated Swift Testing macro package template uses `SwiftSyntaxMacrosGenericTestSupport`, includes Swift Testing macro expansion tests, and records expansion failures through `Issue.record(...)`.

Validation completed locally:

```text
swift test --filter InitTests.initPackageMacroWithSwiftTesting
✔ Test initPackageMacroWithSwiftTesting() passed

swift test --filter InitTests
✔ Test run with 17 tests in 2 suites passed

git diff --check
No whitespace issues reported.