### PR TITLE
[6.4] GHA: Update support for Amazon Linux

### DIFF
--- a/.github/scripts/prebuild.sh
+++ b/.github/scripts/prebuild.sh
@@ -73,13 +73,14 @@ elif command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
     else
         echo "Skipping Android NDK installation on $dpkg_architecture" >&2
     fi
-elif command -v dnf >/dev/null 2>&1 ; then # rhel-ubi9
+elif command -v dnf >/dev/null 2>&1 ; then # amazonlinux2023, rhel-ubi9
     $sudo dnf update -y
 
     # Build dependencies
     $sudo dnf install -y sqlite-devel ncurses-devel
 
     # Debug symbols
+    $sudo dnf install -y 'dnf-command(debuginfo-install)'
     $sudo dnf debuginfo-install -y glibc
 elif command -v yum >/dev/null 2>&1 ; then # amazonlinux2
     $sudo yum update -y

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,12 +20,12 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.12
     with:
       enable_cross_pr_testing: true
-      linux_os_versions: '["amazonlinux2", "bookworm", "noble", "jammy", "rhel-ubi9"]'
-      linux_swift_versions: '["nightly-main", "nightly-6.2"]'
+      linux_os_versions: '["amazonlinux2023", "bookworm", "noble", "jammy", "rhel-ubi9"]'
+      linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       linux_pre_build_command: ./.github/scripts/prebuild.sh
       linux_build_command: 'swift run swift-build --build-tests'
       windows_build_timeout: 180
-      windows_swift_versions: '["nightly-main", "nightly-6.2"]'
+      windows_swift_versions: '["nightly-main", "nightly-6.4.x",]'
       windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1'
       windows_build_command: 'Invoke-Program swift run -Xlinker /ignore:4217 --configuration release swift-build --build-tests --scratch-path .tests'
       # enable_android_sdk_build: true


### PR DESCRIPTION
The Swift organization is dropping support for Amazon Linux 2 for 6.4 and main branch, and the Swift project already support Amazon Linux 2023.

In GitHub actions, drop support for Amazon Linux 2 and add support for Amazon Linux 2023.