### PR TITLE
[6.4] Generate all xUnit Test suite in XML

### DIFF
--- a/Sources/Commands/CMakeLists.txt
+++ b/Sources/Commands/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(Commands
   SwiftRunCommand.swift
   SwiftTestCommand.swift
   CommandWorkspaceDelegate.swift
+  XUnitXMLMerger.swift
   Utilities/APIDigester.swift
   Utilities/DependenciesSerializer.swift
   Utilities/DescribedPackage.swift

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -41,6 +41,7 @@ import enum TSCBasic.JSON
 import var TSCBasic.stdoutStream
 import class TSCBasic.SynchronizedQueue
 import class TSCBasic.Thread
+import func TSCBasic.withTemporaryDirectory
 
 #if os(Windows)
 import WinSDK // for ERROR_NOT_FOUND
@@ -718,6 +719,67 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
         library: TestingLibrary,
         buildSystem: any BuildSystem
     ) async throws -> [TestProductResult] {
+        // Each Swift Testing binary opens the `--xunit-output` file with `fopen(path, "wb")`,
+        // which truncates any previous content. With multiple test products, the last product
+        // to run would wipe every prior product's results. Route each product's output to a
+        // distinct per-product path in a temp dir, then merge into the caller-specified path.
+        if library == .swiftTesting,
+           let xUnitOutput = options.xUnitOutput,
+           testProducts.count > 1
+        {
+            let destination = swiftTestingXUnitDestinationPath(
+                from: xUnitOutput,
+                swiftCommandState: swiftCommandState,
+            )
+            return try await withTemporaryDirectory(
+                prefix: "swiftpm-xunit-",
+                removeTreeOnDeinit: true,
+            ) { tempDir in
+                var results: [TestProductResult] = []
+                var perProductPaths: [AbsolutePath] = []
+                for (index, product) in testProducts.enumerated() {
+                    let perProductPath = tempDir.appending("xunit-\(index)-\(product.productName).xml")
+                    perProductPaths.append(perProductPath)
+                    let productResults = try await self.runTestProductsInSingleInvocation(
+                        [product],
+                        additionalArguments: additionalArguments,
+                        productsBuildParameters: productsBuildParameters,
+                        swiftCommandState: swiftCommandState,
+                        library: library,
+                        buildSystem: buildSystem,
+                        xUnitOutputOverride: perProductPath,
+                    )
+                    results.append(contentsOf: productResults)
+                }
+                try XUnitXMLMerger.merge(
+                    sources: perProductPaths,
+                    into: destination,
+                    fileSystem: localFileSystem,
+                )
+                return results
+            }
+        }
+
+        return try await runTestProductsInSingleInvocation(
+            testProducts,
+            additionalArguments: additionalArguments,
+            productsBuildParameters: productsBuildParameters,
+            swiftCommandState: swiftCommandState,
+            library: library,
+            buildSystem: buildSystem,
+            xUnitOutputOverride: nil,
+        )
+    }
+
+    private func runTestProductsInSingleInvocation(
+        _ testProducts: [BuiltTestProduct],
+        additionalArguments: [String],
+        productsBuildParameters: BuildParameters,
+        swiftCommandState: SwiftCommandState,
+        library: TestingLibrary,
+        buildSystem: any BuildSystem,
+        xUnitOutputOverride: AbsolutePath?,
+    ) async throws -> [TestProductResult] {
         // Pass through all arguments from the command line to Swift Testing.
         var additionalArguments = additionalArguments
         if library == .swiftTesting {
@@ -735,18 +797,10 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             }
             additionalArguments += commandLineArguments
 
-            if var xunitPath = options.xUnitOutput {
-                if options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) {
-                    // You are running Swift Testing, XCTest is also running in this session, and an xUnit path
-                    // was specified. Make sure you don't stomp on XCTest's XML output by having Swift Testing
-                    // write to a different path.
-                    var xunitFileName = "\(xunitPath.basenameWithoutExt)-swift-testing"
-                    if let ext = xunitPath.extension {
-                        xunitFileName = "\(xunitFileName).\(ext)"
-                    }
-                    xunitPath = xunitPath.parentDirectory.appending(xunitFileName)
-                }
-                additionalArguments += ["--xunit-output", xunitPath.pathString]
+            let effectiveXUnitPath = xUnitOutputOverride
+                ?? options.xUnitOutput.map { swiftTestingXUnitDestinationPath(from: $0, swiftCommandState: swiftCommandState) }
+            if let effectiveXUnitPath {
+                additionalArguments += ["--xunit-output", effectiveXUnitPath.pathString]
             }
 
             // Forward along --maximum-repetitions as --repetitions
@@ -783,6 +837,23 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             // ie "swift test" should output to stdout
             print($0, terminator: "")
         })
+    }
+
+    private func swiftTestingXUnitDestinationPath(
+        from xUnitOutput: AbsolutePath,
+        swiftCommandState: SwiftCommandState,
+    ) -> AbsolutePath {
+        guard options.testLibraryOptions.isEnabled(.xctest, swiftCommandState: swiftCommandState) else {
+            return xUnitOutput
+        }
+        // You are running Swift Testing, XCTest is also running in this session, and an xUnit path
+        // was specified. Make sure you don't stomp on XCTest's XML output by having Swift Testing
+        // write to a different path.
+        var xunitFileName = "\(xUnitOutput.basenameWithoutExt)-swift-testing"
+        if let ext = xUnitOutput.extension {
+            xunitFileName = "\(xunitFileName).\(ext)"
+        }
+        return xUnitOutput.parentDirectory.appending(xunitFileName)
     }
 
     private static func handleTestOutput(productsBuildParameters: BuildParameters, packagePath: AbsolutePath, buildSystem: any BuildSystem) async throws {

--- a/Sources/Commands/XUnitXMLMerger.swift
+++ b/Sources/Commands/XUnitXMLMerger.swift
@@ -13,8 +13,12 @@
 import Basics
 import Foundation
 
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
+
 /// Combines xUnit XML files produced by individual test binaries into a single
-/// output file. Each source file's `<testsuite>` elements are preserved verbatim
+/// output file. Each source file's `<testsuite>` elements are preserved
 /// and placed under one `<testsuites>` root in the destination.
 ///
 /// Multiple Swift Testing binaries (one per test product) each write their own
@@ -26,41 +30,31 @@ enum XUnitXMLMerger {
         into destination: AbsolutePath,
         fileSystem: FileSystem = localFileSystem,
     ) throws {
-        var output = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n"
+        let root = XMLElement(name: "testsuites")
+        let document = XMLDocument(rootElement: root)
+        document.version = "1.0"
+        document.characterEncoding = "UTF-8"
 
         for source in sources {
             guard fileSystem.exists(source) else { continue }
             let contents: String = try fileSystem.readFileContents(source)
-            for block in extractTestsuiteBlocks(from: contents) {
-                output += block
-                output += "\n"
+            for testsuite in try extractTestsuites(from: contents) {
+                root.addChild(testsuite)
             }
         }
 
-        output += "</testsuites>\n"
-        try fileSystem.writeFileContents(destination, string: output)
+        try fileSystem.writeFileContents(
+            destination,
+            string: document.xmlString(options: [.nodePrettyPrint, .nodeCompactEmptyElement]),
+        )
     }
 
-    private static let openMarker = "<testsuite"
-    private static let closeMarker = "</testsuite>"
-
-    private static func extractTestsuiteBlocks(from xml: String) -> [Substring] {
-        var results: [Substring] = []
-        var searchStart = xml.startIndex
-        while let openRange = xml.range(of: openMarker, range: searchStart..<xml.endIndex) {
-            let afterOpen = openRange.upperBound
-            guard afterOpen < xml.endIndex else { break }
-            let nextChar = xml[afterOpen]
-            guard nextChar == " " || nextChar == ">" else {
-                searchStart = afterOpen
-                continue
-            }
-            guard let closeRange = xml.range(of: closeMarker, range: afterOpen..<xml.endIndex) else {
-                break
-            }
-            results.append(xml[openRange.lowerBound..<closeRange.upperBound])
-            searchStart = closeRange.upperBound
+    private static func extractTestsuites(from xml: String) throws -> [XMLElement] {
+        let document = try XMLDocument(xmlString: xml, options: [])
+        guard let root = document.rootElement() else { return [] }
+        return root.elements(forName: "testsuite").map { element in
+            element.detach()
+            return element
         }
-        return results
     }
 }

--- a/Sources/Commands/XUnitXMLMerger.swift
+++ b/Sources/Commands/XUnitXMLMerger.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+
+/// Combines xUnit XML files produced by individual test binaries into a single
+/// output file. Each source file's `<testsuite>` elements are preserved verbatim
+/// and placed under one `<testsuites>` root in the destination.
+///
+/// Multiple Swift Testing binaries (one per test product) each write their own
+/// xUnit output; without merging, later invocations would truncate earlier ones
+/// via `fopen(path, "wb")`. This type aggregates those outputs.
+enum XUnitXMLMerger {
+    static func merge(
+        sources: [AbsolutePath],
+        into destination: AbsolutePath,
+        fileSystem: FileSystem = localFileSystem,
+    ) throws {
+        var output = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n"
+
+        for source in sources {
+            guard fileSystem.exists(source) else { continue }
+            let contents: String = try fileSystem.readFileContents(source)
+            for block in extractTestsuiteBlocks(from: contents) {
+                output += block
+                output += "\n"
+            }
+        }
+
+        output += "</testsuites>\n"
+        try fileSystem.writeFileContents(destination, string: output)
+    }
+
+    private static let openMarker = "<testsuite"
+    private static let closeMarker = "</testsuite>"
+
+    private static func extractTestsuiteBlocks(from xml: String) -> [Substring] {
+        var results: [Substring] = []
+        var searchStart = xml.startIndex
+        while let openRange = xml.range(of: openMarker, range: searchStart..<xml.endIndex) {
+            let afterOpen = openRange.upperBound
+            guard afterOpen < xml.endIndex else { break }
+            let nextChar = xml[afterOpen]
+            guard nextChar == " " || nextChar == ">" else {
+                searchStart = afterOpen
+                continue
+            }
+            guard let closeRange = xml.range(of: closeMarker, range: afterOpen..<xml.endIndex) else {
+                break
+            }
+            results.append(xml[openRange.lowerBound..<closeRange.upperBound])
+            searchStart = closeRange.upperBound
+        }
+        return results
+    }
+}

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -536,7 +536,7 @@ struct TestCommandTests {
     }
 
     /// Regression: `--xunit-output=PATH` must be stripped when forwarding argv to Swift Testing so only
-    /// SPM's suffixed path is passed; otherwise the helper receives duplicate `--xunit-output` flags and
+    /// SwiftPM's suffixed path is passed; otherwise the helper receives duplicate `--xunit-output` flags and
     /// overwrites the XCTest JUnit file. See discussion in swift-package-manager around combined forms.
     @Test(
         .tags(
@@ -592,6 +592,199 @@ struct TestCommandTests {
             }
         } when: {
             ProcessInfo.hostOperatingSystem == .windows
+        }
+    }
+
+    /// Regression: when a package has multiple test products, each Swift Testing binary opens the
+    /// `--xunit-output` path in truncating mode (`fopen(path, "wb")`), so the last product to run
+    /// wipes every prior product's results. All products' Swift Testing results must survive.
+    @Test(
+        .tags(
+            .Feature.CommandLineArguments.TestOutputXunit,
+            .Feature.CommandLineArguments.TestDisableXCTest,
+            .Feature.CommandLineArguments.TestEnableSwiftTesting,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10261", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func swiftTestXunitOutputAggregatesResultsAcrossMultipleTestProducts(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/TestDebuggingMultiProduct") { fixturePath in
+            let xUnitOutput = fixturePath.appending("result.xml")
+
+            _ = try await execute(
+                [
+                    "--disable-xctest",
+                    "--enable-swift-testing",
+                    "--xunit-output",
+                    xUnitOutput.pathString,
+                ],
+                packagePath: fixturePath,
+                configuration: configuration,
+                buildSystem: buildSystem,
+            )
+
+            try requireFileExists(at: xUnitOutput, "\(xUnitOutput) does not exist")
+            let contents: String = try localFileSystem.readFileContents(xUnitOutput)
+
+            #expect(
+                contents.contains("libAGreeting"),
+                "Swift Testing test from LibATests product must survive the merge; got:\n\(contents)",
+            )
+            #expect(
+                contents.contains("libBGreeting"),
+                "Swift Testing test from LibBTests product must survive the merge; got:\n\(contents)",
+            )
+            let testsuiteCount = contents.components(separatedBy: "<testsuite ").count - 1
+            let expectedMinTestSuites: Int
+            switch buildSystem {
+                case .native: expectedMinTestSuites = 1
+                case .swiftbuild: expectedMinTestSuites = 2
+                case .xcode:
+                    Issue.record("Test exepectation is not set.")
+                    expectedMinTestSuites = -1
+            }
+            #expect(
+                testsuiteCount >= expectedMinTestSuites,
+                "Expected at least \(expectedMinTestSuites) <testsuite> per test product; got \(testsuiteCount) in:\n\(contents)",
+            )
+        }
+    }
+
+    /// Multi-product companion to `swiftTestParallelXunitOutputCombinedEqualsForm`: with both
+    /// XCTest and Swift Testing enabled on a package that has multiple test products, the base
+    /// `--xunit-output` file must contain XCTest results from every product and the
+    /// `-swift-testing` suffixed file must contain Swift Testing results from every product.
+    @Test(
+        .tags(
+            .Feature.CommandLineArguments.TestParallel,
+            .Feature.CommandLineArguments.TestOutputXunit,
+            .Feature.CommandLineArguments.TestEnableXCTest,
+            .Feature.CommandLineArguments.TestEnableSwiftTesting,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10261", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func swiftTestXunitOutputAggregatesXCTestAndSwiftTestingAcrossMultipleTestProducts(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/TestDebuggingMultiProduct") { fixturePath in
+            let xUnitOutput = fixturePath.appending("result.xml")
+            let swiftTestingXUnitOutput = fixturePath.appending("result-swift-testing.xml")
+
+            _ = try await execute(
+                [
+                    "--parallel",
+                    "--enable-xctest",
+                    "--enable-swift-testing",
+                    "--xunit-output",
+                    xUnitOutput.pathString,
+                ],
+                packagePath: fixturePath,
+                configuration: configuration,
+                buildSystem: buildSystem,
+            )
+
+            try requireFileExists(at: xUnitOutput, "\(xUnitOutput) does not exist")
+            try requireFileExists(at: swiftTestingXUnitOutput, "\(swiftTestingXUnitOutput) does not exist")
+
+            // XCTest side: SwiftPM's ParallelTestRunner accumulates results across all products
+            // in memory and writes them to the base xUnit file via XUnitGenerator. Both
+            // products' XCTest cases must land there.
+            let xctestContents: String = try localFileSystem.readFileContents(xUnitOutput)
+            #expect(
+                xctestContents.contains(#"classname="LibATests.LibAXCTests""#),
+                "XCTest case from LibATests product must appear in base xUnit file; got:\n\(xctestContents)",
+            )
+            #expect(
+                xctestContents.contains(#"classname="LibBTests.LibBXCTests""#),
+                "XCTest case from LibBTests product must appear in base xUnit file; got:\n\(xctestContents)",
+            )
+
+            // Swift Testing side: per-product-path + merge must produce a `-swift-testing`
+            // file containing results from every test product.
+            let swiftTestingContents: String = try localFileSystem.readFileContents(swiftTestingXUnitOutput)
+            #expect(
+                swiftTestingContents.contains("libAGreeting"),
+                "Swift Testing test from LibATests product must appear in suffixed xUnit file; got:\n\(swiftTestingContents)",
+            )
+            #expect(
+                swiftTestingContents.contains("libBGreeting"),
+                "Swift Testing test from LibBTests product must appear in suffixed xUnit file; got:\n\(swiftTestingContents)",
+            )
+            let swiftTestingSuiteCount = swiftTestingContents.components(separatedBy: "<testsuite ").count - 1
+            let expectedMinSwiftTestingSuites: Int
+            switch buildSystem {
+                case .native: expectedMinSwiftTestingSuites = 1
+                case .swiftbuild: expectedMinSwiftTestingSuites = 2
+                case .xcode:
+                    Issue.record("Test expectation is not set.")
+                    expectedMinSwiftTestingSuites = -1
+            }
+            #expect(
+                swiftTestingSuiteCount >= expectedMinSwiftTestingSuites,
+                "Expected at least \(expectedMinSwiftTestingSuites) <testsuite> per test product in the Swift Testing merged file; got \(swiftTestingSuiteCount) in:\n\(swiftTestingContents)",
+            )
+        }
+    }
+
+    /// XCTest-only multi-product coverage. SwiftPM's `ParallelTestRunner` collects XCTest results
+    /// across every test product in memory and hands them to `XUnitGenerator` for a single
+    /// write, so all products' XCTest cases must appear in the base xUnit file.
+    @Test(
+        .tags(
+            .Feature.CommandLineArguments.TestParallel,
+            .Feature.CommandLineArguments.TestOutputXunit,
+            .Feature.CommandLineArguments.TestEnableXCTest,
+            .Feature.CommandLineArguments.TestDisableSwiftTesting,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10261", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func swiftTestXunitOutputAggregatesXCTestOnlyAcrossMultipleTestProducts(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/TestDebuggingMultiProduct") { fixturePath in
+            let xUnitOutput = fixturePath.appending("result.xml")
+            let swiftTestingXUnitOutput = fixturePath.appending("result-swift-testing.xml")
+
+            _ = try await execute(
+                [
+                    "--parallel",
+                    "--enable-xctest",
+                    "--disable-swift-testing",
+                    "--xunit-output",
+                    xUnitOutput.pathString,
+                ],
+                packagePath: fixturePath,
+                configuration: configuration,
+                buildSystem: buildSystem,
+            )
+
+            try requireFileExists(at: xUnitOutput, "\(xUnitOutput) does not exist")
+            // With Swift Testing disabled there should be no `-swift-testing` sibling file.
+            expectFileDoesNotExist(
+                at: swiftTestingXUnitOutput,
+                "\(swiftTestingXUnitOutput) should not exist when --disable-swift-testing is set",
+            )
+            // #expect(
+            //     !localFileSystem.exists(swiftTestingXUnitOutput),
+            //     "\(swiftTestingXUnitOutput) should not exist when --disable-swift-testing is set",
+            // )
+
+            let contents: String = try localFileSystem.readFileContents(xUnitOutput)
+            #expect(
+                contents.contains(#"classname="LibATests.LibAXCTests""#),
+                "XCTest case from LibATests product must appear in xUnit file; got:\n\(contents)",
+            )
+            #expect(
+                contents.contains(#"classname="LibBTests.LibBXCTests""#),
+                "XCTest case from LibBTests product must appear in xUnit file; got:\n\(contents)",
+            )
         }
     }
 

--- a/Tests/CommandsTests/XUnitXMLMergerTests.swift
+++ b/Tests/CommandsTests/XUnitXMLMergerTests.swift
@@ -13,7 +13,24 @@
 @testable import Commands
 
 import Basics
+import Foundation
 import Testing
+
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
+
+
+private func parseTestsuites(_ xml: String) throws -> (root: XMLElement?, suites: [XMLElement]) {
+    let document = try XMLDocument(xmlString: xml, options: [])
+    let root = document.rootElement()
+    let suites = (root?.name == "testsuites" ? root?.elements(forName: "testsuite") : nil) ?? []
+    return (root: root, suites: suites)
+}
+
+private func testsuiteName(_ element: XMLElement) -> String? {
+    element.attribute(forName: "name")?.stringValue
+}
 
 @Suite(
     .tags(
@@ -75,17 +92,22 @@ struct XUnitXMLMergerTests {
         try XUnitXMLMerger.merge(sources: [a, b], into: dest, fileSystem: fs)
 
         let merged: String = try fs.readFileContents(dest)
-        #expect(merged.contains("<?xml"))
-        #expect(merged.contains("<testsuites>"))
-        #expect(merged.contains("</testsuites>"))
-        #expect(merged.contains(#"<testsuite name="TestResultsSampleA""#))
-        #expect(merged.contains(#"<testsuite name="TestResultsSampleB""#))
-        #expect(merged.contains(#"name="testA""#))
-        #expect(merged.contains(#"name="testB""#))
-        #expect(merged.contains(#"name="testC""#))
-        #expect(merged.contains(#"<failure message="boom">"#))
-        let testsuiteCount = merged.components(separatedBy: "<testsuite ").count - 1
-        #expect(testsuiteCount == 2, "expected 2 <testsuite> elements in merged output, got \(testsuiteCount)")
+        let (_, suites) = try parseTestsuites(merged)
+        #expect(suites.count == 2, "expected 2 <testsuite> elements in merged output, got \(suites.count)")
+        #expect(testsuiteName(suites[0]) == "TestResultsSampleA")
+        #expect(testsuiteName(suites[1]) == "TestResultsSampleB")
+
+        let sampleATestcases = suites[0].elements(forName: "testcase")
+            .compactMap { $0.attribute(forName: "name")?.stringValue }
+        #expect(sampleATestcases == ["testA", "testB"])
+
+        let sampleBTestcases = suites[1].elements(forName: "testcase")
+            .compactMap { $0.attribute(forName: "name")?.stringValue }
+        #expect(sampleBTestcases == ["testC"])
+
+        let failures = suites[1].elements(forName: "testcase")
+            .flatMap { $0.elements(forName: "failure") }
+        #expect(failures.first?.attribute(forName: "message")?.stringValue == "boom")
     }
 
     @Test
@@ -98,11 +120,13 @@ struct XUnitXMLMergerTests {
         try XUnitXMLMerger.merge(sources: [a], into: dest, fileSystem: fs)
 
         let merged: String = try fs.readFileContents(dest)
-        #expect(merged.contains(#"<testsuite name="TestResultsSampleA""#))
-        #expect(merged.contains(#"name="testA""#))
-        #expect(merged.contains(#"name="testB""#))
-        let testsuiteCount = merged.components(separatedBy: "<testsuite ").count - 1
-        #expect(testsuiteCount == 1)
+        let (_, suites) = try parseTestsuites(merged)
+        #expect(suites.count == 1)
+        #expect(testsuiteName(suites[0]) == "TestResultsSampleA")
+
+        let testcaseNames = suites[0].elements(forName: "testcase")
+            .compactMap { $0.attribute(forName: "name")?.stringValue }
+        #expect(testcaseNames == ["testA", "testB"])
     }
 
     @Test
@@ -113,9 +137,13 @@ struct XUnitXMLMergerTests {
         try XUnitXMLMerger.merge(sources: [], into: dest, fileSystem: fs)
 
         let merged: String = try fs.readFileContents(dest)
-        #expect(merged.contains("<testsuites>"))
-        #expect(merged.contains("</testsuites>"))
-        #expect(!merged.contains("<testsuite "))
+        let (root, suites) = try parseTestsuites(merged)
+        let rootName = try #require(
+            root?.name,
+            "Root element name is not set.  XML contents:\n\(merged)"
+        )
+        #expect(rootName == "testsuites")
+        #expect(suites.isEmpty)
     }
 
     @Test
@@ -129,10 +157,9 @@ struct XUnitXMLMergerTests {
         try XUnitXMLMerger.merge(sources: [missing, present], into: dest, fileSystem: fs)
 
         let merged: String = try fs.readFileContents(dest)
-        #expect(merged.contains(#"<testsuite name="TestResultsSampleA""#))
-        #expect(merged.contains(#"name="testA""#))
-        let testsuiteCount = merged.components(separatedBy: "<testsuite ").count - 1
-        #expect(testsuiteCount == 1)
+        let (_, suites) = try parseTestsuites(merged)
+        #expect(suites.count == 1)
+        #expect(testsuiteName(suites[0]) == "TestResultsSampleA")
     }
 
     @Test
@@ -145,14 +172,15 @@ struct XUnitXMLMergerTests {
         try XUnitXMLMerger.merge(sources: [a], into: dest, fileSystem: fs)
 
         let merged: String = try fs.readFileContents(dest)
-        let testsuiteCount = merged.components(separatedBy: "<testsuite ").count - 1
-        #expect(testsuiteCount == 1, "empty testsuite should still be preserved for accurate reporting")
-        #expect(merged.contains(#"<testsuite name="TestResultsEmpty""#))
-        #expect(merged.contains(#"errors="1""#))
-        #expect(merged.contains(#"tests="10""#))
-        #expect(merged.contains(#"failures="4""#))
-        #expect(merged.contains(#"skipped="5""#))
-        #expect(merged.contains(#"time="0.000279""#))
+        let (_, suites) = try parseTestsuites(merged)
+        #expect(suites.count == 1, "empty testsuite should still be preserved for accurate reporting")
+        let suite = suites[0]
+        #expect(testsuiteName(suite) == "TestResultsEmpty")
+        #expect(suite.attribute(forName: "errors")?.stringValue == "1")
+        #expect(suite.attribute(forName: "tests")?.stringValue == "10")
+        #expect(suite.attribute(forName: "failures")?.stringValue == "4")
+        #expect(suite.attribute(forName: "skipped")?.stringValue == "5")
+        #expect(suite.attribute(forName: "time")?.stringValue == "0.000279")
     }
 
     @Test
@@ -307,6 +335,45 @@ struct XUnitXMLMergerTests {
     func mergeSourcesReturnsExpectedxUnitContents(
         data: (contents: [String], expected: String, id: String),
     ) async throws {
+
+        func canonicalizeXML(_ xml: String) throws -> String {
+            let document = try XMLDocument(xmlString: xml, options: [])
+            guard let root = document.rootElement() else { return "" }
+            return canonicalizeElement(root)
+        }
+
+        func canonicalizeElement(_ element: XMLElement) -> String {
+            let name = element.name ?? ""
+            let attributes = (element.attributes ?? [])
+                .compactMap { attribute -> String? in
+                    guard let attributeName = attribute.name else { return nil }
+                    let value = (attribute.stringValue ?? "")
+                        .replacingOccurrences(of: "&", with: "&amp;")
+                        .replacingOccurrences(of: "<", with: "&lt;")
+                        .replacingOccurrences(of: "\"", with: "&quot;")
+                    return "\(attributeName)=\"\(value)\""
+                }
+                .sorted()
+                .joined(separator: " ")
+            let attributesPart = attributes.isEmpty ? "" : " \(attributes)"
+
+            let children = (element.children ?? []).compactMap { node -> String? in
+                if let childElement = node as? XMLElement {
+                    return canonicalizeElement(childElement)
+                }
+                if node.kind == .text {
+                    let text = (node.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                    return text.isEmpty ? nil : text
+                }
+                return nil
+            }.joined()
+
+            if children.isEmpty {
+                return "<\(name)\(attributesPart)/>"
+            }
+            return "<\(name)\(attributesPart)>\(children)</\(name)>"
+        }
+
         let fs = InMemoryFileSystem()
         var inputs = [AbsolutePath]()
         // GIVEN we have a few xUnit XML contents
@@ -322,10 +389,12 @@ struct XUnitXMLMergerTests {
         // AND we read the merged XML contents
         let actual: String = try fs.readFileContents(output)
 
-        // THEN we expect the contents to match what we expect
+        // THEN we expect the contents to be semantically equal to what we expect
+        let actualCanonical = try canonicalizeXML(actual)
+        let expectedCanonical = try canonicalizeXML(data.expected)
         #expect(
-            actual == data.expected,
-            "actual is not as expected. id: \(data.id)",
+            actualCanonical == expectedCanonical,
+            "actual is not semantically equal to expected. id: \(data.id)\nactual canonical:   \(actualCanonical)\nexpected canonical: \(expectedCanonical)",
         )
 
     }

--- a/Tests/CommandsTests/XUnitXMLMergerTests.swift
+++ b/Tests/CommandsTests/XUnitXMLMergerTests.swift
@@ -1,0 +1,333 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@testable import Commands
+
+import Basics
+import Testing
+
+@Suite(
+    .tags(
+        Tag.TestSize.small,
+    )
+)
+struct XUnitXMLMergerTests {
+    private static let sampleA_testSuite = """
+        <testsuite name="TestResultsSampleA" errors="0" tests="2" failures="0" skipped="0" time="1.0">
+        <testcase classname="Foo" name="testA" time="0.5" />
+        <testcase classname="Foo" name="testB" time="0.5" />
+        </testsuite>
+        """
+    private let sampleA = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+        \(Self.sampleA_testSuite)
+        </testsuites>
+
+        """
+
+    private static let sampleB_testSuite = """
+        <testsuite name="TestResultsSampleB" errors="0" tests="1" failures="1" skipped="0" time="0.3">
+        <testcase classname="Bar" name="testC" time="0.3">
+        <failure message="boom"></failure>
+        </testcase>
+        </testsuite>
+        """
+    private let sampleB = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+        \(Self.sampleB_testSuite)
+        </testsuites>
+
+        """
+
+    private static let emptyResult_testSuite = """
+        <testsuite name="TestResultsEmpty" errors="1" tests="10" failures="4" skipped="5" time="0.000279">
+
+        </testsuite>
+        """
+    private let emptyResult = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+        \(Self.emptyResult_testSuite)
+        </testsuites>
+
+        """
+
+    @Test
+    func mergesTwoSourcesPreservingBothTestsuites() throws {
+        let fs = InMemoryFileSystem()
+        let a = AbsolutePath("/a.xml")
+        let b = AbsolutePath("/b.xml")
+        let dest = AbsolutePath("/merged.xml")
+        try fs.writeFileContents(a, string: sampleA)
+        try fs.writeFileContents(b, string: sampleB)
+
+        try XUnitXMLMerger.merge(sources: [a, b], into: dest, fileSystem: fs)
+
+        let merged: String = try fs.readFileContents(dest)
+        #expect(merged.contains("<?xml"))
+        #expect(merged.contains("<testsuites>"))
+        #expect(merged.contains("</testsuites>"))
+        #expect(merged.contains(#"<testsuite name="TestResultsSampleA""#))
+        #expect(merged.contains(#"<testsuite name="TestResultsSampleB""#))
+        #expect(merged.contains(#"name="testA""#))
+        #expect(merged.contains(#"name="testB""#))
+        #expect(merged.contains(#"name="testC""#))
+        #expect(merged.contains(#"<failure message="boom">"#))
+        let testsuiteCount = merged.components(separatedBy: "<testsuite ").count - 1
+        #expect(testsuiteCount == 2, "expected 2 <testsuite> elements in merged output, got \(testsuiteCount)")
+    }
+
+    @Test
+    func mergesSingleSource() throws {
+        let fs = InMemoryFileSystem()
+        let a = AbsolutePath("/a.xml")
+        let dest = AbsolutePath("/merged.xml")
+        try fs.writeFileContents(a, string: sampleA)
+
+        try XUnitXMLMerger.merge(sources: [a], into: dest, fileSystem: fs)
+
+        let merged: String = try fs.readFileContents(dest)
+        #expect(merged.contains(#"<testsuite name="TestResultsSampleA""#))
+        #expect(merged.contains(#"name="testA""#))
+        #expect(merged.contains(#"name="testB""#))
+        let testsuiteCount = merged.components(separatedBy: "<testsuite ").count - 1
+        #expect(testsuiteCount == 1)
+    }
+
+    @Test
+    func mergingWithNoSourcesProducesEmptyTestsuites() throws {
+        let fs = InMemoryFileSystem()
+        let dest = AbsolutePath("/merged.xml")
+
+        try XUnitXMLMerger.merge(sources: [], into: dest, fileSystem: fs)
+
+        let merged: String = try fs.readFileContents(dest)
+        #expect(merged.contains("<testsuites>"))
+        #expect(merged.contains("</testsuites>"))
+        #expect(!merged.contains("<testsuite "))
+    }
+
+    @Test
+    func skipsMissingSourceFiles() throws {
+        let fs = InMemoryFileSystem()
+        let present = AbsolutePath("/present.xml")
+        let missing = AbsolutePath("/missing.xml")
+        let dest = AbsolutePath("/merged.xml")
+        try fs.writeFileContents(present, string: sampleA)
+
+        try XUnitXMLMerger.merge(sources: [missing, present], into: dest, fileSystem: fs)
+
+        let merged: String = try fs.readFileContents(dest)
+        #expect(merged.contains(#"<testsuite name="TestResultsSampleA""#))
+        #expect(merged.contains(#"name="testA""#))
+        let testsuiteCount = merged.components(separatedBy: "<testsuite ").count - 1
+        #expect(testsuiteCount == 1)
+    }
+
+    @Test
+    func preservesEmptyTestsuiteMetadata() throws {
+        let fs = InMemoryFileSystem()
+        let a = AbsolutePath("/empty.xml")
+        let dest = AbsolutePath("/merged.xml")
+        try fs.writeFileContents(a, string: emptyResult)
+
+        try XUnitXMLMerger.merge(sources: [a], into: dest, fileSystem: fs)
+
+        let merged: String = try fs.readFileContents(dest)
+        let testsuiteCount = merged.components(separatedBy: "<testsuite ").count - 1
+        #expect(testsuiteCount == 1, "empty testsuite should still be preserved for accurate reporting")
+        #expect(merged.contains(#"<testsuite name="TestResultsEmpty""#))
+        #expect(merged.contains(#"errors="1""#))
+        #expect(merged.contains(#"tests="10""#))
+        #expect(merged.contains(#"failures="4""#))
+        #expect(merged.contains(#"skipped="5""#))
+        #expect(merged.contains(#"time="0.000279""#))
+    }
+
+    @Test
+    func doesNotEmitDuplicateXMLHeader() throws {
+        let fs = InMemoryFileSystem()
+        let a = AbsolutePath("/a.xml")
+        let b = AbsolutePath("/b.xml")
+        let dest = AbsolutePath("/merged.xml")
+        try fs.writeFileContents(a, string: sampleA)
+        try fs.writeFileContents(b, string: sampleB)
+
+        try XUnitXMLMerger.merge(sources: [a, b], into: dest, fileSystem: fs)
+
+        let merged: String = try fs.readFileContents(dest)
+        let headerCount = merged.components(separatedBy: "<?xml").count - 1
+        #expect(headerCount == 1)
+    }
+
+    @Test(
+        arguments: [
+            (
+                contents: [],
+                expected: """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    </testsuites>
+
+                    """,
+                    id: "No inputs",
+            ),
+            (
+                contents: [
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    </testsuites>
+
+                    """,
+
+                ],
+                expected: """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    </testsuites>
+
+                    """,
+                id: "Single input without any <testsuite>",
+            ),
+            (
+                contents: [
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleA_testSuite)
+                    </testsuites>
+                    """,
+                ],
+                expected: """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleA_testSuite)
+                    </testsuites>
+
+                    """,
+                id: "Single input with a single <testsuite>",
+            ),
+            (
+                contents: [
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleB_testSuite)
+                    \(Self.sampleA_testSuite)
+                    </testsuites>
+                    """,
+
+                ],
+                expected: """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleB_testSuite)
+                    \(Self.sampleA_testSuite)
+                    </testsuites>
+
+                    """,
+                id: "Single input with a two <testsuite>",
+            ),
+            (
+                contents: [
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleA_testSuite)
+                    </testsuites>
+                    """,
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleB_testSuite)
+                    </testsuites>
+                    """,
+
+                ],
+                expected: """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleA_testSuite)
+                    \(Self.sampleB_testSuite)
+                    </testsuites>
+
+                    """,
+                id: "Two inputs each with a single <testsuite>",
+            ),
+            (
+                contents: [
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleA_testSuite)
+                    </testsuites>
+
+                    """,
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleB_testSuite)
+                    </testsuites>
+
+                    """,
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.emptyResult_testSuite)
+                    </testsuites>
+                    """,
+
+                ],
+                expected: """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <testsuites>
+                    \(Self.sampleA_testSuite)
+                    \(Self.sampleB_testSuite)
+                    \(Self.emptyResult_testSuite)
+                    </testsuites>
+
+                    """,
+                id: "Multiple inputs each with a single <testsuite>",
+            ),
+        ],
+
+    )
+    func mergeSourcesReturnsExpectedxUnitContents(
+        data: (contents: [String], expected: String, id: String),
+    ) async throws {
+        let fs = InMemoryFileSystem()
+        var inputs = [AbsolutePath]()
+        // GIVEN we have a few xUnit XML contents
+        for (index, value) in data.contents.enumerated() {
+            let filename = AbsolutePath("/input_\(index).xml")
+            try fs.writeFileContents(filename, string: value)
+            inputs.append(filename)
+        }
+
+        let output = AbsolutePath("/merged.xml")
+        // WHEN we merge them together
+        try XUnitXMLMerger.merge(sources: inputs, into: output, fileSystem: fs)
+        // AND we read the merged XML contents
+        let actual: String = try fs.readFileContents(output)
+
+        // THEN we expect the contents to match what we expect
+        #expect(
+            actual == data.expected,
+            "actual is not as expected. id: \(data.id)",
+        )
+
+    }
+
+}


### PR DESCRIPTION
Swift Build generated multiple test products, one per test targets. When executing the Swift Testing tests and requesting an xUnit XML output, the last test products was overwritting the contents of the XML file.

Update the Swift Test XML generation by merging the XML results when multiple test products are created.

Fixes: #10261
Issue: rdar://181348522