### PR TITLE
[Build] Clear progress animation before printing verbose command description

### DIFF
--- a/Sources/Build/LLBuildProgressTracker.swift
+++ b/Sources/Build/LLBuildProgressTracker.swift
@@ -265,6 +265,12 @@ final class LLBuildProgressTracker: LLBuildBuildSystemDelegate, SwiftCompilerOut
         self.queue.async {
             self.delegate?.buildSystem(self.buildSystem, didStartCommand: BuildSystemCommand(command))
             if self.logLevel.isVerbose {
+                // Preparation steps and other progress updates can still be emitted while in verbose
+                // mode (e.g. `preparationStepStarted`/`preparationStepFinished` do not gate on
+                // `isVerbose`), which leaves the progress animation's cursor mid-line without a
+                // trailing newline. Clear it before writing the raw verbose description so the two
+                // don't get concatenated onto the same terminal line.
+                self.progressAnimation.clear()
                 self.outputStream.send("\(command.verboseDescription)\n")
                 self.outputStream.flush()
             }


### PR DESCRIPTION
Fixes verbose build log lines getting mushed together without newlines (#10238).

### Motivation:

`swift build -v` can print log lines that are unpredictably concatenated onto the same terminal line, e.g.:

```
Emitting module for NewlinesDiscovering Swift tasks after 'Emitting module for Newlines'Unblock downstream dependents of Newlines (arm64)
```

`preparationStepStarted`/`preparationStepFinished` in `LLBuildProgressTracker` are not gated on `logLevel.isVerbose` (unlike `commandStatusChanged`/`commandFinished`), so they still call `updateProgress()`, which writes a partial status line through the TTY progress animation (`RedrawingNinjaProgressAnimation.update`). That write ends without a trailing newline, since it is designed to be overwritten in place on the next redraw.

`commandStarted`'s verbose branch then writes the raw `command.verboseDescription` directly to the output stream, but unlike every other direct-write call site in this file (`preparationStepHadOutput`, the non-parseable-output branch of `swiftCompilerOutputParser`, `buildStart`, `buildComplete`), it never calls `self.progressAnimation.clear()` first. If a preparation-step-driven progress update just wrote to the line, the verbose description gets appended right after it with no separation, producing the garbled output from the issue.

### Modifications:

- Call `self.progressAnimation.clear()` in `commandStarted` before writing the verbose command description, matching the pattern already used by the other direct-write call sites in `LLBuildProgressTracker.swift`.

### Result:

Verbose build (`-v`) output no longer risks getting concatenated with a pending, uncommitted progress-animation line.

### Testing:

- `swift build --product swift-build` builds cleanly with this change.
- I was unable to run the full `swift test` suite in this environment, since the local CommandLineTools-only toolchain doesn't ship `XCTest` (no Xcode installed) required by `swift-tools-support-core`'s test-support module; I relied on CI for full test validation.

Made with [Cursor](https://cursor.com)