### PR TITLE
[6.4.x] Fix product name for package targets promoted to dynamic frameworks

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -269,6 +269,7 @@ extension PackagePIFProjectBuilder {
         precondition(sourceModule.isSourceModule)
 
         let productType: ProjectModel.Target.ProductType
+        var productName = "$(EXECUTABLE_NAME)"
 
         switch desiredModuleType {
         case .dynamicLibrary:
@@ -276,6 +277,7 @@ extension PackagePIFProjectBuilder {
             if pifBuilder.createDylibForDynamicProducts {
                 productType = .dynamicLibrary
             } else {
+                productName = "$(WRAPPER_NAME)"
                 productType = .framework
             }
 
@@ -305,7 +307,7 @@ extension PackagePIFProjectBuilder {
                 id: sourceModule.pifTargetGUID(suffix: targetSuffix),
                 productType: productType,
                 name: sourceModule.name,
-                productName: "$(EXECUTABLE_NAME)",
+                productName: productName,
                 approvedByUser: approvedByUser
             )
         }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -645,6 +645,83 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test(arguments: [true, false])
+    func dynamicVariantProductName(createDylibForDynamicProducts: Bool) async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let fs = InMemoryFileSystem(
+            emptyFiles: [
+                "/MyPkg/Sources/MyLib/MyLib.swift",
+            ]
+        )
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                .createRootManifest(
+                    displayName: "MyPkg",
+                    path: "/MyPkg",
+                    toolsVersion: .v6_2,
+                    products: [
+                        .init(name: "MyLibDynamic", type: .library(.dynamic), targets: ["MyLib"]),
+                    ],
+                    targets: [
+                        .init(name: "MyLib"),
+                    ]
+                )
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root,
+                addLocalRpaths: .always,
+                shouldCreateDylibForDynamicProducts: createDylibForDynamicProducts
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        let project = try pif.workspace.project(named: "MyPkg")
+
+        let moduleVariant = try #require(
+            project.underlying.targets.first {
+                $0.common.name == "MyLib" && $0.common.id.value.hasSuffix("-dynamic")
+            }
+        )
+        guard case .target(let moduleTarget) = moduleVariant else {
+            Issue.record("Expected a regular target for the dynamic module variant, got \(moduleVariant)")
+            return
+        }
+
+        let productVariant = try project.target(named: "MyLibDynamic-product")
+        guard case .target(let productTarget) = productVariant else {
+            Issue.record("Expected a regular target for the dynamic product, got \(productVariant)")
+            return
+        }
+
+        if createDylibForDynamicProducts {
+            #expect(moduleTarget.productType == .dynamicLibrary)
+            #expect(moduleTarget.productName == "$(EXECUTABLE_NAME)")
+
+            #expect(productTarget.productType == .dynamicLibrary)
+            #expect(productTarget.productName == "$(EXECUTABLE_NAME)")
+        } else {
+            #expect(moduleTarget.productType == .framework)
+            #expect(moduleTarget.productName == "$(WRAPPER_NAME)")
+
+            #expect(productTarget.productType == .framework)
+            #expect(productTarget.productName == "$(WRAPPER_NAME)")
+        }
+    }
+
     @Test(
         arguments: BuildConfiguration.allCases,
     )


### PR DESCRIPTION
For framework targets, the product reference name should be the wrapper name as opposed to the name of the embedded image. This was handled correctly for the dynamic variant of library products, but not the dynamic variant of individual targets. Fix the PIF generation so the cases match