### PR TITLE
Add HTTP proxy configuration support

### DIFF
--- a/Sources/Basics/HTTPClient/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient/HTTPClient.swift
@@ -48,7 +48,7 @@ public actor HTTPClient {
 
     public init(configuration: HTTPClientConfiguration = .init(), implementation: Implementation? = nil) {
         self.configuration = configuration
-        self.implementation = implementation ?? URLSessionHTTPClient().execute
+        self.implementation = implementation ?? URLSessionHTTPClient(fileSystem: localFileSystem).execute
         self.tokenBucket = TokenBucket(tokens: configuration.maxConcurrentRequests ?? Concurrency.maxOperations)
     }
 

--- a/Sources/Basics/HTTPClient/HTTPProxyConfiguration.swift
+++ b/Sources/Basics/HTTPClient/HTTPProxyConfiguration.swift
@@ -92,7 +92,7 @@ extension HTTPProxyConfiguration {
     /// - Must be a valid URL with a scheme and host
     /// - Must not contain credentials (userinfo)
     /// - Supported schemes: http, https, socks5
-    static func validateProxyURL(_ urlString: String) throws {
+    public static func validateProxyURL(_ urlString: String) throws {
         guard let components = URLComponents(string: urlString) else {
             throw ValidationError.invalidProxyURL(urlString, reason: "not a valid URL")
         }

--- a/Sources/Basics/HTTPClient/HTTPProxyConfiguration.swift
+++ b/Sources/Basics/HTTPClient/HTTPProxyConfiguration.swift
@@ -1,0 +1,233 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Configuration for HTTP/HTTPS proxy routing.
+///
+/// This struct represents the contents of a `proxy.json` configuration file
+/// used by Swift Package Manager to route HTTP traffic through proxy servers.
+public struct HTTPProxyConfiguration: Codable, Equatable, Sendable {
+    /// Schema version. Must be `1`.
+    public var version: Int
+
+    /// Proxy settings for HTTP requests.
+    public var http: ProtocolProxy?
+
+    /// Proxy settings for HTTPS requests.
+    public var https: ProtocolProxy?
+
+    /// Hosts and patterns that should bypass the proxy.
+    public var noProxy: [String]?
+
+    /// Proxy settings for a single protocol.
+    public struct ProtocolProxy: Codable, Equatable, Sendable {
+        /// The proxy URL (scheme://host[:port]).
+        public var proxy: String
+
+        public init(proxy: String) {
+            self.proxy = proxy
+        }
+    }
+
+    public init(version: Int = 1, http: ProtocolProxy? = nil, https: ProtocolProxy? = nil, noProxy: [String]? = nil) {
+        self.version = version
+        self.http = http
+        self.https = https
+        self.noProxy = noProxy
+    }
+
+    /// Returns `true` if the configuration has no meaningful proxy settings.
+    public var isEmpty: Bool {
+        http == nil && https == nil && (noProxy == nil || noProxy!.isEmpty)
+    }
+}
+
+// MARK: - Validation
+
+extension HTTPProxyConfiguration {
+    /// Errors that can occur when validating proxy configuration.
+    public enum ValidationError: Error, CustomStringConvertible, Equatable {
+        case unsupportedVersion(Int)
+        case invalidProxyURL(String, reason: String)
+        case credentialsInProxyURL(String)
+
+        public var description: String {
+            switch self {
+            case .unsupportedVersion(let version):
+                return "unsupported proxy configuration version \(version), expected 1"
+            case .invalidProxyURL(let url, let reason):
+                return "invalid proxy URL '\(url)': \(reason)"
+            case .credentialsInProxyURL(let url):
+                return "proxy URL '\(url)' must not contain credentials; authenticated proxy support is not yet available"
+            }
+        }
+    }
+
+    /// Validates the proxy configuration, throwing an error if invalid.
+    public func validate() throws {
+        if version != 1 {
+            throw ValidationError.unsupportedVersion(version)
+        }
+        if let http {
+            try Self.validateProxyURL(http.proxy)
+        }
+        if let https {
+            try Self.validateProxyURL(https.proxy)
+        }
+    }
+
+    /// Validates a proxy URL string.
+    ///
+    /// Requirements:
+    /// - Must be a valid URL with a scheme and host
+    /// - Must not contain credentials (userinfo)
+    /// - Supported schemes: http, https, socks5
+    static func validateProxyURL(_ urlString: String) throws {
+        guard let components = URLComponents(string: urlString) else {
+            throw ValidationError.invalidProxyURL(urlString, reason: "not a valid URL")
+        }
+
+        // Check for credentials
+        if components.user != nil || components.password != nil {
+            throw ValidationError.credentialsInProxyURL(urlString)
+        }
+
+        // Check for scheme
+        guard let scheme = components.scheme?.lowercased() else {
+            throw ValidationError.invalidProxyURL(urlString, reason: "missing scheme")
+        }
+
+        // Check for supported scheme
+        let supportedSchemes = ["http", "https", "socks5"]
+        guard supportedSchemes.contains(scheme) else {
+            throw ValidationError.invalidProxyURL(urlString, reason: "unsupported scheme '\(scheme)', expected one of: \(supportedSchemes.joined(separator: ", "))")
+        }
+
+        // Check for host
+        guard let host = components.host, !host.isEmpty else {
+            throw ValidationError.invalidProxyURL(urlString, reason: "missing host")
+        }
+    }
+}
+
+// MARK: - noProxy matching
+
+extension HTTPProxyConfiguration {
+    /// Determines whether the given host should bypass the proxy based on the `noProxy` patterns.
+    ///
+    /// Matching rules:
+    /// - `*` matches all hosts
+    /// - `example.com` matches exactly `example.com` and all subdomains
+    /// - `.example.com` matches subdomains of `example.com` but NOT `example.com` itself
+    /// - IP addresses are matched exactly
+    /// - Matching is case-insensitive
+    ///
+    /// - Parameter host: The target hostname to check.
+    /// - Returns: `true` if the host should bypass the proxy (go direct).
+    public func shouldBypassProxy(for host: String) -> Bool {
+        guard let noProxy, !noProxy.isEmpty else {
+            return false
+        }
+
+        let lowercasedHost = host.lowercased()
+
+        for pattern in noProxy {
+            let lowercasedPattern = pattern.lowercased().trimmingCharacters(in: .whitespaces)
+
+            // Wildcard matches everything
+            if lowercasedPattern == "*" {
+                return true
+            }
+
+            // Leading dot: match subdomains only, not the base domain itself
+            if lowercasedPattern.hasPrefix(".") {
+                let suffix = lowercasedPattern // e.g. ".example.com"
+                if lowercasedHost.hasSuffix(suffix) {
+                    return true
+                }
+                continue
+            }
+
+            // Exact match
+            if lowercasedHost == lowercasedPattern {
+                return true
+            }
+
+            // Subdomain match: pattern "example.com" matches "sub.example.com"
+            if lowercasedHost.hasSuffix(".\(lowercasedPattern)") {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    /// Returns the proxy URL to use for the given request URL, or `nil` if the request should go direct.
+    ///
+    /// - Parameter url: The target URL being requested.
+    /// - Returns: The proxy URL string if a proxy should be used, `nil` otherwise.
+    public func proxyURL(for url: URL) -> String? {
+        // Check if the host is in the noProxy list
+        if let host = url.host, shouldBypassProxy(for: host) {
+            return nil
+        }
+
+        // Determine which proxy to use based on the URL scheme
+        switch url.scheme?.lowercased() {
+        case "http":
+            return http?.proxy
+        case "https":
+            return https?.proxy
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: - Parsed proxy URL components
+
+extension HTTPProxyConfiguration {
+    /// Parsed components of a proxy URL for use in URLSession configuration.
+    public struct ParsedProxyURL: Equatable, Sendable {
+        public let scheme: String
+        public let host: String
+        public let port: Int
+
+        /// Default ports per scheme.
+        public static func defaultPort(for scheme: String) -> Int {
+            switch scheme.lowercased() {
+            case "http": return 80
+            case "https": return 443
+            case "socks5": return 1080
+            default: return 80
+            }
+        }
+    }
+
+    /// Parses a proxy URL string into its components.
+    ///
+    /// - Parameter urlString: The proxy URL string.
+    /// - Returns: Parsed proxy URL components.
+    /// - Throws: `ValidationError` if the URL is invalid.
+    public static func parseProxyURL(_ urlString: String) throws -> ParsedProxyURL {
+        guard let components = URLComponents(string: urlString),
+              let scheme = components.scheme?.lowercased(),
+              let host = components.host, !host.isEmpty
+        else {
+            throw ValidationError.invalidProxyURL(urlString, reason: "not a valid URL")
+        }
+
+        let port = components.port ?? ParsedProxyURL.defaultPort(for: scheme)
+        return ParsedProxyURL(scheme: scheme, host: host, port: port)
+    }
+}

--- a/Sources/Basics/HTTPClient/HTTPProxyConfiguration.swift
+++ b/Sources/Basics/HTTPClient/HTTPProxyConfiguration.swift
@@ -194,6 +194,53 @@ extension HTTPProxyConfiguration {
     }
 }
 
+// MARK: - Environment variable loading
+
+extension HTTPProxyConfiguration {
+    /// Loads proxy configuration from environment variables.
+    ///
+    /// Reads the standard proxy environment variables:
+    /// - `http_proxy` / `HTTP_PROXY` — proxy URL for HTTP requests
+    /// - `https_proxy` / `HTTPS_PROXY` — proxy URL for HTTPS requests
+    /// - `no_proxy` / `NO_PROXY` — comma-separated list of hosts to bypass
+    ///
+    /// Lowercase variants take precedence over uppercase (consistent with curl behavior).
+    ///
+    /// - Parameter environment: A dictionary of environment variables (defaults to `ProcessInfo`).
+    /// - Returns: A proxy configuration if any proxy variables are set, `nil` otherwise.
+    public static func loadFromEnvironment(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> HTTPProxyConfiguration? {
+        let httpProxy = environment["http_proxy"] ?? environment["HTTP_PROXY"]
+        let httpsProxy = environment["https_proxy"] ?? environment["HTTPS_PROXY"]
+        let noProxyValue = environment["no_proxy"] ?? environment["NO_PROXY"]
+
+        // If no proxy variables are set, return nil
+        guard httpProxy != nil || httpsProxy != nil else {
+            return nil
+        }
+
+        var config = HTTPProxyConfiguration(version: 1)
+
+        if let httpProxy, !httpProxy.isEmpty {
+            config.http = ProtocolProxy(proxy: httpProxy)
+        }
+
+        if let httpsProxy, !httpsProxy.isEmpty {
+            config.https = ProtocolProxy(proxy: httpsProxy)
+        }
+
+        if let noProxyValue, !noProxyValue.isEmpty {
+            config.noProxy = noProxyValue
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+        }
+
+        return config.isEmpty ? nil : config
+    }
+}
+
 // MARK: - Parsed proxy URL components
 
 extension HTTPProxyConfiguration {

--- a/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
@@ -55,7 +55,7 @@ public final class LegacyHTTPClient: Cancellable {
     public init(configuration: LegacyHTTPClientConfiguration = .init(), handler: Handler? = nil) {
         self.configuration = configuration
         // FIXME: inject platform specific implementation here
-        self.underlying = handler ?? URLSessionHTTPClient().execute
+        self.underlying = handler ?? URLSessionHTTPClient(fileSystem: localFileSystem).execute
 
         // this queue and semaphore is used to limit the amount of concurrent http requests taking place
         // the default max number of request chosen to match Concurrency.maxOperations which is the number of active

--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -24,7 +24,14 @@ final class URLSessionHTTPClient: Sendable {
     private let dataTaskManager: DataTaskManager
     private let downloadTaskManager: DownloadTaskManager
 
-    init(configuration: URLSessionConfiguration = .default) {
+    init(configuration: URLSessionConfiguration = .default, proxyConfiguration: HTTPProxyConfiguration? = nil) {
+        // Apply proxy configuration to the URLSessionConfiguration if provided.
+        // When proxyConfiguration is nil, leave the URLSessionConfiguration untouched
+        // so that macOS system proxy continues to work as a fallback.
+        if let proxyConfiguration {
+            configuration.connectionProxyDictionary = Self.buildProxyDictionary(from: proxyConfiguration)
+        }
+
         let dataDelegateQueue = OperationQueue()
         dataDelegateQueue.name = "org.swift.swiftpm.urlsession-http-client-data-delegate"
         dataDelegateQueue.maxConcurrentOperationCount = 1
@@ -49,6 +56,83 @@ final class URLSessionHTTPClient: Sendable {
     deinit {
         dataSession.finishTasksAndInvalidate()
         downloadSession.finishTasksAndInvalidate()
+    }
+
+    /// Convenience initializer that reads proxy configuration from the filesystem.
+    ///
+    /// Reads from the shared SwiftPM configuration directory (`~/.swiftpm/configuration/proxy.json`).
+    /// If no proxy configuration file exists, falls back to default behavior (no proxy dictionary set,
+    /// allowing macOS system proxy to work).
+    convenience init(configuration: URLSessionConfiguration = .default, fileSystem: FileSystem) {
+        let proxyConfig = Self.loadProxyConfiguration(fileSystem: fileSystem)
+        self.init(configuration: configuration, proxyConfiguration: proxyConfig)
+    }
+
+    /// Loads proxy configuration from the filesystem.
+    ///
+    /// Returns `nil` if no configuration file exists or if it cannot be read.
+    private static func loadProxyConfiguration(fileSystem: FileSystem) -> HTTPProxyConfiguration? {
+        guard let configDir = try? fileSystem.swiftPMConfigurationDirectory else {
+            return nil
+        }
+        let proxyFile = configDir.appending("proxy.json")
+        guard fileSystem.exists(proxyFile) else {
+            return nil
+        }
+        do {
+            let data: Data = try fileSystem.readFileContents(proxyFile)
+            let decoder = JSONDecoder.makeWithDefaults()
+            let config = try decoder.decode(HTTPProxyConfiguration.self, from: data)
+            try config.validate()
+            return config
+        } catch {
+            // If the configuration file is malformed, log and proceed without proxy
+            return nil
+        }
+    }
+
+    /// Builds a `connectionProxyDictionary` from an `HTTPProxyConfiguration`.
+    private static func buildProxyDictionary(from config: HTTPProxyConfiguration) -> [AnyHashable: Any] {
+        var dict = [AnyHashable: Any]()
+
+        if let httpProxy = config.http {
+            if let parsed = try? HTTPProxyConfiguration.parseProxyURL(httpProxy.proxy) {
+                #if canImport(CoreFoundation)
+                dict[kCFNetworkProxiesHTTPEnable] = 1
+                dict[kCFNetworkProxiesHTTPProxy] = parsed.host
+                dict[kCFNetworkProxiesHTTPPort] = parsed.port
+                #else
+                dict["HTTPEnable"] = 1
+                dict["HTTPProxy"] = parsed.host
+                dict["HTTPPort"] = parsed.port
+                #endif
+            }
+        }
+
+        if let httpsProxy = config.https {
+            if let parsed = try? HTTPProxyConfiguration.parseProxyURL(httpsProxy.proxy) {
+                #if canImport(CoreFoundation)
+                dict[kCFStreamPropertyHTTPSProxyHost as String] = parsed.host
+                dict[kCFStreamPropertyHTTPSProxyPort as String] = parsed.port
+                #else
+                dict["HTTPSProxy"] = parsed.host
+                dict["HTTPSPort"] = parsed.port
+                #endif
+            }
+        }
+
+        // Note: noProxy matching is handled per-request by the caller or by URLSession
+        // when using connectionProxyDictionary. For URLSession, we rely on the
+        // kCFNetworkProxiesExceptionsList key for noProxy support.
+        if let noProxy = config.noProxy, !noProxy.isEmpty {
+            #if canImport(CoreFoundation)
+            dict[kCFNetworkProxiesExceptionsList] = noProxy
+            #else
+            dict["ExceptionsList"] = noProxy
+            #endif
+        }
+
+        return dict
     }
 
     @Sendable

--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -68,27 +68,33 @@ final class URLSessionHTTPClient: Sendable {
         self.init(configuration: configuration, proxyConfiguration: proxyConfig)
     }
 
-    /// Loads proxy configuration from the filesystem.
+    /// Loads proxy configuration from the filesystem, falling back to environment variables.
     ///
-    /// Returns `nil` if no configuration file exists or if it cannot be read.
+    /// Priority order:
+    /// 1. `proxy.json` configuration file (explicit per-user/per-project config)
+    /// 2. Environment variables (`http_proxy`, `https_proxy`, `no_proxy`)
+    /// 3. macOS system proxy (implicit URLSession behavior when no dictionary is set)
+    ///
+    /// Returns `nil` if no configuration is found, allowing system proxy fallback.
     private static func loadProxyConfiguration(fileSystem: FileSystem) -> HTTPProxyConfiguration? {
-        guard let configDir = try? fileSystem.swiftPMConfigurationDirectory else {
-            return nil
+        // 1. Try proxy.json file first
+        if let configDir = try? fileSystem.swiftPMConfigurationDirectory {
+            let proxyFile = configDir.appending("proxy.json")
+            if fileSystem.exists(proxyFile) {
+                do {
+                    let data: Data = try fileSystem.readFileContents(proxyFile)
+                    let decoder = JSONDecoder.makeWithDefaults()
+                    let config = try decoder.decode(HTTPProxyConfiguration.self, from: data)
+                    try config.validate()
+                    return config
+                } catch {
+                    // If the configuration file is malformed, log and proceed to env vars
+                }
+            }
         }
-        let proxyFile = configDir.appending("proxy.json")
-        guard fileSystem.exists(proxyFile) else {
-            return nil
-        }
-        do {
-            let data: Data = try fileSystem.readFileContents(proxyFile)
-            let decoder = JSONDecoder.makeWithDefaults()
-            let config = try decoder.decode(HTTPProxyConfiguration.self, from: data)
-            try config.validate()
-            return config
-        } catch {
-            // If the configuration file is malformed, log and proceed without proxy
-            return nil
-        }
+
+        // 2. Fall back to environment variables
+        return HTTPProxyConfiguration.loadFromEnvironment()
     }
 
     /// Builds a `connectionProxyDictionary` from an `HTTPProxyConfiguration`.

--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -68,16 +68,21 @@ final class URLSessionHTTPClient: Sendable {
         self.init(configuration: configuration, proxyConfiguration: proxyConfig)
     }
 
-    /// Loads proxy configuration from the filesystem, falling back to environment variables.
+    /// Loads proxy configuration, checking environment variables first, then the config file.
     ///
     /// Priority order:
-    /// 1. `proxy.json` configuration file (explicit per-user/per-project config)
-    /// 2. Environment variables (`http_proxy`, `https_proxy`, `no_proxy`)
+    /// 1. Environment variables (`http_proxy`, `https_proxy`, `no_proxy`) — highest priority
+    /// 2. `proxy.json` configuration file (per-user/per-project config)
     /// 3. macOS system proxy (implicit URLSession behavior when no dictionary is set)
     ///
     /// Returns `nil` if no configuration is found, allowing system proxy fallback.
     private static func loadProxyConfiguration(fileSystem: FileSystem) -> HTTPProxyConfiguration? {
-        // 1. Try proxy.json file first
+        // 1. Environment variables take highest priority
+        if let envConfig = HTTPProxyConfiguration.loadFromEnvironment() {
+            return envConfig
+        }
+
+        // 2. Fall back to proxy.json file
         if let configDir = try? fileSystem.swiftPMConfigurationDirectory {
             let proxyFile = configDir.appending("proxy.json")
             if fileSystem.exists(proxyFile) {
@@ -88,13 +93,13 @@ final class URLSessionHTTPClient: Sendable {
                     try config.validate()
                     return config
                 } catch {
-                    // If the configuration file is malformed, log and proceed to env vars
+                    // If the configuration file is malformed, proceed without proxy
                 }
             }
         }
 
-        // 2. Fall back to environment variables
-        return HTTPProxyConfiguration.loadFromEnvironment()
+        // 3. Return nil — URLSession will use macOS system proxy
+        return nil
     }
 
     /// Builds a `connectionProxyDictionary` from an `HTTPProxyConfiguration`.

--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -13,6 +13,7 @@
 import ArgumentParser
 import Basics
 import CoreCommands
+import Foundation
 import PackageGraph
 import Workspace
 
@@ -22,7 +23,7 @@ extension SwiftPackageCommand {
     struct Config: ParsableCommand {
         static let configuration = CommandConfiguration(
             abstract: "Manipulate configuration of the package",
-            subcommands: [SetMirror.self, UnsetMirror.self, GetMirror.self],
+            subcommands: [SetMirror.self, UnsetMirror.self, GetMirror.self, SetProxy.self, GetProxy.self, UnsetProxy.self],
             helpNames: [.short, .long, .customLong("help", withSingleDash: true)]
         )
     }
@@ -119,5 +120,136 @@ extension SwiftPackageCommand.Config {
 extension Basics.Diagnostic {
     fileprivate static func missingRequiredArg(_ argument: String) -> Self {
         .error("missing required argument \(argument)")
+    }
+}
+
+// MARK: - Proxy Commands
+
+extension SwiftPackageCommand.Config {
+    struct SetProxy: SwiftCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Set proxy configuration for package manager HTTP operations."
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        @Option(help: "The HTTP proxy URL (e.g., http://proxy:8080).")
+        var http: String?
+
+        @Option(help: "The HTTPS proxy URL (e.g., http://proxy:8080).")
+        var https: String?
+
+        @Option(
+            parsing: .upToNextOption,
+            help: "Hosts that should bypass the proxy (comma-separated or multiple values)."
+        )
+        var noProxy: [String] = []
+
+        func run(_ swiftCommandState: SwiftCommandState) throws {
+            guard http != nil || https != nil || !noProxy.isEmpty else {
+                swiftCommandState.observabilityScope.emit(.missingRequiredArg("--http, --https, or --no-proxy"))
+                throw ExitCode.failure
+            }
+
+            let storage = try getProxyStorage(swiftCommandState)
+
+            // Parse comma-separated noProxy values into individual entries
+            let noProxyPatterns: [String]? = noProxy.isEmpty ? nil : noProxy.flatMap {
+                $0.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+            }
+
+            try storage.set(httpProxy: http, httpsProxy: https, noProxy: noProxyPatterns)
+        }
+    }
+
+    struct GetProxy: SwiftCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Display the current proxy configuration."
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        func run(_ swiftCommandState: SwiftCommandState) throws {
+            let storage = try getProxyStorage(swiftCommandState)
+            let config = try storage.get()
+
+            if let config, !config.isEmpty {
+                let configPath = try getProxyConfigPath(swiftCommandState)
+                if let httpProxy = config.http?.proxy {
+                    print("HTTP proxy:  \(httpProxy) (user: \(configPath))")
+                }
+                if let httpsProxy = config.https?.proxy {
+                    print("HTTPS proxy: \(httpsProxy) (user: \(configPath))")
+                }
+                if let noProxy = config.noProxy, !noProxy.isEmpty {
+                    print("No proxy:    \(noProxy.joined(separator: ", ")) (user: \(configPath))")
+                }
+            } else {
+                // Check for macOS system proxy
+                #if canImport(SystemConfiguration)
+                if let systemProxy = Self.querySystemProxy() {
+                    if let http = systemProxy.http {
+                        print("HTTP proxy:  \(http) (system)")
+                    }
+                    if let https = systemProxy.https {
+                        print("HTTPS proxy: \(https) (system)")
+                    }
+                    if let noProxy = systemProxy.noProxy, !noProxy.isEmpty {
+                        print("No proxy:    \(noProxy) (system)")
+                    }
+                } else {
+                    print("No proxy configuration.")
+                }
+                #else
+                print("No proxy configuration.")
+                #endif
+            }
+        }
+
+        #if canImport(SystemConfiguration)
+        private static func querySystemProxy() -> (http: String?, https: String?, noProxy: String?)? {
+            // Implemented in step 6
+            return nil
+        }
+        #endif
+    }
+
+    struct UnsetProxy: SwiftCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Remove proxy configuration."
+        )
+
+        @OptionGroup(visibility: .hidden)
+        var globalOptions: GlobalOptions
+
+        @Flag(help: "Remove the HTTP proxy setting.")
+        var http: Bool = false
+
+        @Flag(help: "Remove the HTTPS proxy setting.")
+        var https: Bool = false
+
+        @Flag(help: "Remove the no-proxy exclusion list.")
+        var noProxy: Bool = false
+
+        func run(_ swiftCommandState: SwiftCommandState) throws {
+            let storage = try getProxyStorage(swiftCommandState)
+            try storage.unset(http: http, https: https, noProxy: noProxy)
+        }
+    }
+
+    static func getProxyStorage(_ swiftCommandState: SwiftCommandState) throws -> Workspace.Configuration.ProxyStorage {
+        let workspace = try swiftCommandState.getActiveWorkspace()
+        let proxyFile = workspace.location.sharedProxyConfigurationFile
+            ?? workspace.location.localProxyConfigurationFile
+        return .init(path: proxyFile, fileSystem: swiftCommandState.fileSystem)
+    }
+
+    static func getProxyConfigPath(_ swiftCommandState: SwiftCommandState) throws -> String {
+        let workspace = try swiftCommandState.getActiveWorkspace()
+        let proxyFile = workspace.location.sharedProxyConfigurationFile
+            ?? workspace.location.localProxyConfigurationFile
+        return proxyFile.pathString
     }
 }

--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -210,7 +210,18 @@ extension SwiftPackageCommand.Config {
 
         #if canImport(SystemConfiguration)
         private static func querySystemProxy() -> (http: String?, https: String?, noProxy: String?)? {
-            // Implemented in step 6
+            guard let proxySettings = SystemProxyQuery.copySystemProxySettings() else {
+                return nil
+            }
+
+            let http = proxySettings.httpProxy
+            let https = proxySettings.httpsProxy
+            let noProxy = proxySettings.exceptionsList?.joined(separator: ", ")
+
+            // Only return if at least one setting is present
+            if http != nil || https != nil || noProxy != nil {
+                return (http: http, https: https, noProxy: noProxy)
+            }
             return nil
         }
         #endif
@@ -253,3 +264,55 @@ extension SwiftPackageCommand.Config {
         return proxyFile.pathString
     }
 }
+
+// MARK: - System Proxy Query (macOS)
+
+#if canImport(SystemConfiguration)
+import SystemConfiguration
+
+/// Queries macOS system proxy settings via `SCDynamicStoreCopyProxies`.
+///
+/// This is display-only — it is NOT used for actual networking (URLSession handles that automatically).
+enum SystemProxyQuery {
+    struct ProxySettings {
+        var httpProxy: String?
+        var httpsProxy: String?
+        var exceptionsList: [String]?
+    }
+
+    static func copySystemProxySettings() -> ProxySettings? {
+        guard let proxies = SCDynamicStoreCopyProxies(nil) as? [String: Any] else {
+            return nil
+        }
+
+        var settings = ProxySettings()
+
+        // HTTP proxy
+        if let httpEnabled = proxies[kCFNetworkProxiesHTTPEnable as String] as? Int, httpEnabled == 1,
+           let httpHost = proxies[kCFNetworkProxiesHTTPProxy as String] as? String
+        {
+            let httpPort = proxies[kCFNetworkProxiesHTTPPort as String] as? Int ?? 80
+            settings.httpProxy = "http://\(httpHost):\(httpPort)"
+        }
+
+        // HTTPS proxy
+        if let httpsEnabled = proxies[kCFNetworkProxiesHTTPSEnable as String] as? Int, httpsEnabled == 1,
+           let httpsHost = proxies[kCFNetworkProxiesHTTPSProxy as String] as? String
+        {
+            let httpsPort = proxies[kCFNetworkProxiesHTTPSPort as String] as? Int ?? 443
+            settings.httpsProxy = "http://\(httpsHost):\(httpsPort)"
+        }
+
+        // Exceptions list (noProxy)
+        if let exceptions = proxies[kCFNetworkProxiesExceptionsList as String] as? [String], !exceptions.isEmpty {
+            settings.exceptionsList = exceptions
+        }
+
+        // Only return if we found something
+        if settings.httpProxy != nil || settings.httpsProxy != nil || settings.exceptionsList != nil {
+            return settings
+        }
+        return nil
+    }
+}
+#endif

--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -186,6 +186,21 @@ extension SwiftPackageCommand.Config {
                 if let noProxy = config.noProxy, !noProxy.isEmpty {
                     print("No proxy:    \(noProxy.joined(separator: ", ")) (user: \(configPath))")
                 }
+            } else if let envConfig = HTTPProxyConfiguration.loadFromEnvironment(), !envConfig.isEmpty {
+                // Show environment variable configuration
+                let env = ProcessInfo.processInfo.environment
+                if let httpProxy = envConfig.http?.proxy {
+                    let varName = env["http_proxy"] != nil ? "http_proxy" : "HTTP_PROXY"
+                    print("HTTP proxy:  \(httpProxy) (environment: \(varName))")
+                }
+                if let httpsProxy = envConfig.https?.proxy {
+                    let varName = env["https_proxy"] != nil ? "https_proxy" : "HTTPS_PROXY"
+                    print("HTTPS proxy: \(httpsProxy) (environment: \(varName))")
+                }
+                if let noProxy = envConfig.noProxy, !noProxy.isEmpty {
+                    let varName = env["no_proxy"] != nil ? "no_proxy" : "NO_PROXY"
+                    print("No proxy:    \(noProxy.joined(separator: ", ")) (environment: \(varName))")
+                }
             } else {
                 // Check for macOS system proxy
                 #if canImport(SystemConfiguration)

--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -134,6 +134,9 @@ extension SwiftPackageCommand.Config {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
+        @Flag(help: "Apply settings to all projects for this user.")
+        var global: Bool = false
+
         @Option(help: "The HTTP proxy URL (e.g., http://proxy:8080).")
         var http: String?
 
@@ -152,7 +155,7 @@ extension SwiftPackageCommand.Config {
                 throw ExitCode.failure
             }
 
-            let storage = try getProxyStorage(swiftCommandState)
+            let storage = try getProxyStorage(swiftCommandState, global: self.global)
 
             // Parse comma-separated noProxy values into individual entries
             let noProxyPatterns: [String]? = noProxy.isEmpty ? nil : noProxy.flatMap {
@@ -171,8 +174,11 @@ extension SwiftPackageCommand.Config {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
+        @Flag(help: "Read only settings applied to all projects for this user.")
+        var global: Bool = false
+
         func run(_ swiftCommandState: SwiftCommandState) throws {
-            let storage = try getProxyStorage(swiftCommandState)
+            let storage = try getProxyStorage(swiftCommandState, global: self.global)
             let config = try storage.get()
 
             if let envConfig = HTTPProxyConfiguration.loadFromEnvironment(), !envConfig.isEmpty {
@@ -191,7 +197,7 @@ extension SwiftPackageCommand.Config {
                     print("No proxy:    \(noProxy.joined(separator: ", ")) (environment: \(varName))")
                 }
             } else if let config, !config.isEmpty {
-                let configPath = try getProxyConfigPath(swiftCommandState)
+                let configPath = try getProxyConfigPath(swiftCommandState, global: self.global)
                 if let httpProxy = config.http?.proxy {
                     print("HTTP proxy:  \(httpProxy) (user: \(configPath))")
                 }
@@ -250,6 +256,9 @@ extension SwiftPackageCommand.Config {
         @OptionGroup(visibility: .hidden)
         var globalOptions: GlobalOptions
 
+        @Flag(help: "Apply settings to all projects for this user.")
+        var global: Bool = false
+
         @Flag(help: "Remove the HTTP proxy setting.")
         var http: Bool = false
 
@@ -260,22 +269,32 @@ extension SwiftPackageCommand.Config {
         var noProxy: Bool = false
 
         func run(_ swiftCommandState: SwiftCommandState) throws {
-            let storage = try getProxyStorage(swiftCommandState)
+            let storage = try getProxyStorage(swiftCommandState, global: self.global)
             try storage.unset(http: http, https: https, noProxy: noProxy)
         }
     }
 
-    static func getProxyStorage(_ swiftCommandState: SwiftCommandState) throws -> Workspace.Configuration.ProxyStorage {
+    static func getProxyStorage(_ swiftCommandState: SwiftCommandState, global: Bool) throws -> Workspace.Configuration.ProxyStorage {
+        if global {
+            let proxyFile = Workspace.DefaultLocations.proxyConfigurationFile(
+                at: swiftCommandState.sharedConfigurationDirectory
+            )
+            return .init(path: proxyFile, fileSystem: swiftCommandState.fileSystem, deleteWhenEmpty: false)
+        }
         let workspace = try swiftCommandState.getActiveWorkspace()
-        let proxyFile = workspace.location.sharedProxyConfigurationFile
-            ?? workspace.location.localProxyConfigurationFile
+        let proxyFile = workspace.location.localProxyConfigurationFile
         return .init(path: proxyFile, fileSystem: swiftCommandState.fileSystem)
     }
 
-    static func getProxyConfigPath(_ swiftCommandState: SwiftCommandState) throws -> String {
+    static func getProxyConfigPath(_ swiftCommandState: SwiftCommandState, global: Bool) throws -> String {
+        if global {
+            let proxyFile = Workspace.DefaultLocations.proxyConfigurationFile(
+                at: swiftCommandState.sharedConfigurationDirectory
+            )
+            return proxyFile.pathString
+        }
         let workspace = try swiftCommandState.getActiveWorkspace()
-        let proxyFile = workspace.location.sharedProxyConfigurationFile
-            ?? workspace.location.localProxyConfigurationFile
+        let proxyFile = workspace.location.localProxyConfigurationFile
         return proxyFile.pathString
     }
 }

--- a/Sources/Commands/PackageCommands/Config.swift
+++ b/Sources/Commands/PackageCommands/Config.swift
@@ -175,19 +175,8 @@ extension SwiftPackageCommand.Config {
             let storage = try getProxyStorage(swiftCommandState)
             let config = try storage.get()
 
-            if let config, !config.isEmpty {
-                let configPath = try getProxyConfigPath(swiftCommandState)
-                if let httpProxy = config.http?.proxy {
-                    print("HTTP proxy:  \(httpProxy) (user: \(configPath))")
-                }
-                if let httpsProxy = config.https?.proxy {
-                    print("HTTPS proxy: \(httpsProxy) (user: \(configPath))")
-                }
-                if let noProxy = config.noProxy, !noProxy.isEmpty {
-                    print("No proxy:    \(noProxy.joined(separator: ", ")) (user: \(configPath))")
-                }
-            } else if let envConfig = HTTPProxyConfiguration.loadFromEnvironment(), !envConfig.isEmpty {
-                // Show environment variable configuration
+            if let envConfig = HTTPProxyConfiguration.loadFromEnvironment(), !envConfig.isEmpty {
+                // Environment variables take highest priority
                 let env = ProcessInfo.processInfo.environment
                 if let httpProxy = envConfig.http?.proxy {
                     let varName = env["http_proxy"] != nil ? "http_proxy" : "HTTP_PROXY"
@@ -200,6 +189,17 @@ extension SwiftPackageCommand.Config {
                 if let noProxy = envConfig.noProxy, !noProxy.isEmpty {
                     let varName = env["no_proxy"] != nil ? "no_proxy" : "NO_PROXY"
                     print("No proxy:    \(noProxy.joined(separator: ", ")) (environment: \(varName))")
+                }
+            } else if let config, !config.isEmpty {
+                let configPath = try getProxyConfigPath(swiftCommandState)
+                if let httpProxy = config.http?.proxy {
+                    print("HTTP proxy:  \(httpProxy) (user: \(configPath))")
+                }
+                if let httpsProxy = config.https?.proxy {
+                    print("HTTPS proxy: \(httpsProxy) (user: \(configPath))")
+                }
+                if let noProxy = config.noProxy, !noProxy.isEmpty {
+                    print("No proxy:    \(noProxy.joined(separator: ", ")) (user: \(configPath))")
                 }
             } else {
                 // Check for macOS system proxy

--- a/Sources/Workspace/Workspace+Configuration.swift
+++ b/Sources/Workspace/Workspace+Configuration.swift
@@ -115,6 +115,16 @@ extension Workspace {
             self.sharedConfigurationDirectory.map { DefaultLocations.registriesConfigurationFile(at: $0) }
         }
 
+        /// Path to the local proxy configuration.
+        public var localProxyConfigurationFile: AbsolutePath {
+            DefaultLocations.proxyConfigurationFile(at: self.localConfigurationDirectory)
+        }
+
+        /// Path to the shared proxy configuration.
+        public var sharedProxyConfigurationFile: AbsolutePath? {
+            self.sharedConfigurationDirectory.map { DefaultLocations.proxyConfigurationFile(at: $0) }
+        }
+
         // security locations
 
         /// Path to the shared fingerprints directory.
@@ -243,6 +253,14 @@ extension Workspace {
 
         public static func registriesConfigurationFile(at path: AbsolutePath) -> AbsolutePath {
             path.appending("registries.json")
+        }
+
+        public static func proxyConfigurationFile(forRootPackage rootPath: AbsolutePath) -> AbsolutePath {
+            self.proxyConfigurationFile(at: self.configurationDirectory(forRootPackage: rootPath))
+        }
+
+        public static func proxyConfigurationFile(at path: AbsolutePath) -> AbsolutePath {
+            path.appending("proxy.json")
         }
 
         public static func manifestsDirectory(at path: AbsolutePath) -> AbsolutePath {

--- a/Sources/Workspace/Workspace+Proxy.swift
+++ b/Sources/Workspace/Workspace+Proxy.swift
@@ -1,0 +1,169 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+
+import class TSCBasic.FileLock
+
+// MARK: - Proxy Configuration Storage
+
+extension Workspace.Configuration {
+    /// Storage for proxy configuration with file locking.
+    ///
+    /// Follows the same pattern as `MirrorsStorage`: shared locks for reads, exclusive locks for writes.
+    public struct ProxyStorage {
+        private let path: AbsolutePath
+        private let fileSystem: FileSystem
+        private let deleteWhenEmpty: Bool
+
+        public init(path: AbsolutePath, fileSystem: FileSystem, deleteWhenEmpty: Bool = true) {
+            self.path = path
+            self.fileSystem = fileSystem
+            self.deleteWhenEmpty = deleteWhenEmpty
+        }
+
+        /// Load the proxy configuration from disk.
+        ///
+        /// Returns `nil` if the file does not exist.
+        public func get() throws -> HTTPProxyConfiguration? {
+            guard self.fileSystem.exists(self.path) else {
+                return nil
+            }
+            return try self.fileSystem.withLock(on: self.path.parentDirectory, type: .shared) {
+                try Self.load(self.path, fileSystem: self.fileSystem)
+            }
+        }
+
+        /// Apply a mutation to the proxy configuration with exclusive file locking.
+        ///
+        /// The handler receives the current configuration (or a fresh one if no file exists).
+        /// After the handler returns, the updated configuration is saved to disk.
+        @discardableResult
+        public func apply(handler: (inout HTTPProxyConfiguration) throws -> Void) throws -> HTTPProxyConfiguration {
+            if !self.fileSystem.exists(self.path.parentDirectory) {
+                try self.fileSystem.createDirectory(self.path.parentDirectory, recursive: true)
+            }
+            return try self.fileSystem.withLock(on: self.path.parentDirectory, type: .exclusive) {
+                var config = (try? Self.load(self.path, fileSystem: self.fileSystem)) ?? HTTPProxyConfiguration()
+                try handler(&config)
+                try Self.save(config, to: self.path, fileSystem: self.fileSystem, deleteWhenEmpty: self.deleteWhenEmpty)
+                return config
+            }
+        }
+
+        /// Remove the proxy configuration file.
+        public func remove() throws {
+            if self.fileSystem.exists(self.path) {
+                try self.fileSystem.withLock(on: self.path.parentDirectory, type: .exclusive) {
+                    try self.fileSystem.removeFileTree(self.path)
+                }
+            }
+        }
+
+        // MARK: - Private
+
+        private static func load(_ path: AbsolutePath, fileSystem: FileSystem) throws -> HTTPProxyConfiguration? {
+            guard fileSystem.exists(path) else {
+                return nil
+            }
+            let data: Data = try fileSystem.readFileContents(path)
+            let decoder = JSONDecoder.makeWithDefaults()
+            let config = try decoder.decode(HTTPProxyConfiguration.self, from: data)
+            try config.validate()
+            return config
+        }
+
+        private static func save(
+            _ config: HTTPProxyConfiguration,
+            to path: AbsolutePath,
+            fileSystem: FileSystem,
+            deleteWhenEmpty: Bool
+        ) throws {
+            if config.isEmpty {
+                if deleteWhenEmpty && fileSystem.exists(path) {
+                    return try fileSystem.removeFileTree(path)
+                } else if !fileSystem.exists(path) {
+                    return
+                }
+            }
+
+            try config.validate()
+
+            let encoder = JSONEncoder.makeWithDefaults()
+            let data = try encoder.encode(config)
+            if !fileSystem.exists(path.parentDirectory) {
+                try fileSystem.createDirectory(path.parentDirectory, recursive: true)
+            }
+            try fileSystem.writeFileContents(path, data: data)
+        }
+    }
+}
+
+// MARK: - Merge operations
+
+extension Workspace.Configuration.ProxyStorage {
+    /// Sets proxy fields additively — only updates fields that are provided.
+    ///
+    /// - Parameters:
+    ///   - httpProxy: The HTTP proxy URL to set, or `nil` to leave unchanged.
+    ///   - httpsProxy: The HTTPS proxy URL to set, or `nil` to leave unchanged.
+    ///   - noProxy: The noProxy patterns to set, or `nil` to leave unchanged.
+    @discardableResult
+    public func set(httpProxy: String? = nil, httpsProxy: String? = nil, noProxy: [String]? = nil) throws -> HTTPProxyConfiguration {
+        // Validate URLs before writing
+        if let httpProxy {
+            try HTTPProxyConfiguration.validateProxyURL(httpProxy)
+        }
+        if let httpsProxy {
+            try HTTPProxyConfiguration.validateProxyURL(httpsProxy)
+        }
+
+        return try self.apply { config in
+            if let httpProxy {
+                config.http = .init(proxy: httpProxy)
+            }
+            if let httpsProxy {
+                config.https = .init(proxy: httpsProxy)
+            }
+            if let noProxy {
+                config.noProxy = noProxy
+            }
+        }
+    }
+
+    /// Unsets specific proxy fields. If all fields are `false`, removes the entire configuration.
+    ///
+    /// - Parameters:
+    ///   - http: Whether to remove the HTTP proxy setting.
+    ///   - https: Whether to remove the HTTPS proxy setting.
+    ///   - noProxy: Whether to remove the noProxy patterns.
+    public func unset(http: Bool = false, https: Bool = false, noProxy: Bool = false) throws {
+        let removeAll = !http && !https && !noProxy
+
+        if removeAll {
+            try self.remove()
+        } else {
+            try self.apply { config in
+                if http {
+                    config.http = nil
+                }
+                if https {
+                    config.https = nil
+                }
+                if noProxy {
+                    config.noProxy = nil
+                }
+            }
+        }
+    }
+}

--- a/Tests/BasicsTests/HTTPProxyConfigurationTests.swift
+++ b/Tests/BasicsTests/HTTPProxyConfigurationTests.swift
@@ -1,0 +1,305 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+@testable import Basics
+
+final class HTTPProxyConfigurationTests: XCTestCase {
+
+    // MARK: - JSON Parsing
+
+    func testDecodeFullConfiguration() throws {
+        let json = """
+        {
+            "version": 1,
+            "http": { "proxy": "http://proxy.example.com:8080" },
+            "https": { "proxy": "http://proxy.example.com:8443" },
+            "noProxy": ["localhost", "127.0.0.1", ".internal.corp"]
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let config = try JSONDecoder().decode(HTTPProxyConfiguration.self, from: data)
+
+        XCTAssertEqual(config.version, 1)
+        XCTAssertEqual(config.http?.proxy, "http://proxy.example.com:8080")
+        XCTAssertEqual(config.https?.proxy, "http://proxy.example.com:8443")
+        XCTAssertEqual(config.noProxy, ["localhost", "127.0.0.1", ".internal.corp"])
+    }
+
+    func testDecodeHTTPOnly() throws {
+        let json = """
+        {
+            "version": 1,
+            "http": { "proxy": "http://proxy:3128" }
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let config = try JSONDecoder().decode(HTTPProxyConfiguration.self, from: data)
+
+        XCTAssertEqual(config.version, 1)
+        XCTAssertEqual(config.http?.proxy, "http://proxy:3128")
+        XCTAssertNil(config.https)
+        XCTAssertNil(config.noProxy)
+    }
+
+    func testDecodeEmptyConfig() throws {
+        let json = """
+        { "version": 1 }
+        """
+        let data = json.data(using: .utf8)!
+        let config = try JSONDecoder().decode(HTTPProxyConfiguration.self, from: data)
+
+        XCTAssertEqual(config.version, 1)
+        XCTAssertNil(config.http)
+        XCTAssertNil(config.https)
+        XCTAssertNil(config.noProxy)
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    func testRoundTrip() throws {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            http: .init(proxy: "http://proxy:8080"),
+            https: .init(proxy: "http://proxy:8443"),
+            noProxy: ["localhost", "*.local"]
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(config)
+        let decoded = try JSONDecoder().decode(HTTPProxyConfiguration.self, from: data)
+
+        XCTAssertEqual(config, decoded)
+    }
+
+    // MARK: - Validation
+
+    func testValidateAcceptsValidConfig() throws {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            http: .init(proxy: "http://proxy.example.com:8080"),
+            https: .init(proxy: "https://secure-proxy.example.com:443")
+        )
+        XCTAssertNoThrow(try config.validate())
+    }
+
+    func testValidateRejectsUnsupportedVersion() {
+        let config = HTTPProxyConfiguration(version: 2)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard let validationError = error as? HTTPProxyConfiguration.ValidationError else {
+                return XCTFail("Expected ValidationError, got \(error)")
+            }
+            XCTAssertEqual(validationError, .unsupportedVersion(2))
+        }
+    }
+
+    func testValidateRejectsCredentialsInURL() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            http: .init(proxy: "http://user:pass@proxy:8080")
+        )
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard let validationError = error as? HTTPProxyConfiguration.ValidationError else {
+                return XCTFail("Expected ValidationError, got \(error)")
+            }
+            XCTAssertEqual(validationError, .credentialsInProxyURL("http://user:pass@proxy:8080"))
+        }
+    }
+
+    func testValidateRejectsMissingScheme() {
+        XCTAssertThrowsError(try HTTPProxyConfiguration.validateProxyURL("proxy.example.com:8080")) { error in
+            guard let validationError = error as? HTTPProxyConfiguration.ValidationError else {
+                return XCTFail("Expected ValidationError, got \(error)")
+            }
+            if case .invalidProxyURL(_, let reason) = validationError {
+                XCTAssertTrue(reason.contains("scheme"), "Expected reason about scheme, got: \(reason)")
+            } else {
+                XCTFail("Expected invalidProxyURL error")
+            }
+        }
+    }
+
+    func testValidateRejectsUnsupportedScheme() {
+        XCTAssertThrowsError(try HTTPProxyConfiguration.validateProxyURL("ftp://proxy:21")) { error in
+            guard let validationError = error as? HTTPProxyConfiguration.ValidationError else {
+                return XCTFail("Expected ValidationError, got \(error)")
+            }
+            if case .invalidProxyURL(_, let reason) = validationError {
+                XCTAssertTrue(reason.contains("unsupported scheme"), "Expected unsupported scheme, got: \(reason)")
+            } else {
+                XCTFail("Expected invalidProxyURL error")
+            }
+        }
+    }
+
+    func testValidateRejectsMissingHost() {
+        XCTAssertThrowsError(try HTTPProxyConfiguration.validateProxyURL("http://")) { error in
+            guard let validationError = error as? HTTPProxyConfiguration.ValidationError else {
+                return XCTFail("Expected ValidationError, got \(error)")
+            }
+            if case .invalidProxyURL(_, let reason) = validationError {
+                XCTAssertTrue(reason.contains("host"), "Expected reason about host, got: \(reason)")
+            } else {
+                XCTFail("Expected invalidProxyURL error")
+            }
+        }
+    }
+
+    func testValidateAcceptsSocks5() throws {
+        XCTAssertNoThrow(try HTTPProxyConfiguration.validateProxyURL("socks5://proxy:1080"))
+    }
+
+    func testValidateAcceptsHTTPS() throws {
+        XCTAssertNoThrow(try HTTPProxyConfiguration.validateProxyURL("https://secure-proxy:443"))
+    }
+
+    // MARK: - noProxy Matching
+
+    func testNoProxyExactMatch() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            noProxy: ["example.com"]
+        )
+        XCTAssertTrue(config.shouldBypassProxy(for: "example.com"))
+        XCTAssertFalse(config.shouldBypassProxy(for: "other.com"))
+    }
+
+    func testNoProxySubdomainMatch() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            noProxy: ["example.com"]
+        )
+        // "example.com" pattern matches exact and subdomains
+        XCTAssertTrue(config.shouldBypassProxy(for: "example.com"))
+        XCTAssertTrue(config.shouldBypassProxy(for: "sub.example.com"))
+        XCTAssertTrue(config.shouldBypassProxy(for: "deep.sub.example.com"))
+        XCTAssertFalse(config.shouldBypassProxy(for: "notexample.com"))
+    }
+
+    func testNoProxyLeadingDot() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            noProxy: [".example.com"]
+        )
+        // Leading dot matches subdomains only, NOT the base domain
+        XCTAssertFalse(config.shouldBypassProxy(for: "example.com"))
+        XCTAssertTrue(config.shouldBypassProxy(for: "sub.example.com"))
+        XCTAssertTrue(config.shouldBypassProxy(for: "deep.sub.example.com"))
+    }
+
+    func testNoProxyWildcard() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            noProxy: ["*"]
+        )
+        XCTAssertTrue(config.shouldBypassProxy(for: "anything.com"))
+        XCTAssertTrue(config.shouldBypassProxy(for: "localhost"))
+        XCTAssertTrue(config.shouldBypassProxy(for: "192.168.1.1"))
+    }
+
+    func testNoProxyCaseInsensitive() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            noProxy: ["Example.COM"]
+        )
+        XCTAssertTrue(config.shouldBypassProxy(for: "example.com"))
+        XCTAssertTrue(config.shouldBypassProxy(for: "EXAMPLE.COM"))
+        XCTAssertTrue(config.shouldBypassProxy(for: "sub.Example.Com"))
+    }
+
+    func testNoProxyIPAddress() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            noProxy: ["192.168.1.1", "127.0.0.1"]
+        )
+        XCTAssertTrue(config.shouldBypassProxy(for: "192.168.1.1"))
+        XCTAssertTrue(config.shouldBypassProxy(for: "127.0.0.1"))
+        XCTAssertFalse(config.shouldBypassProxy(for: "192.168.1.2"))
+    }
+
+    func testNoProxyLocalhost() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            noProxy: ["localhost"]
+        )
+        XCTAssertTrue(config.shouldBypassProxy(for: "localhost"))
+        XCTAssertFalse(config.shouldBypassProxy(for: "localhostx"))
+    }
+
+    func testNoProxyEmpty() {
+        let config = HTTPProxyConfiguration(version: 1, noProxy: [])
+        XCTAssertFalse(config.shouldBypassProxy(for: "anything.com"))
+    }
+
+    func testNoProxyNil() {
+        let config = HTTPProxyConfiguration(version: 1)
+        XCTAssertFalse(config.shouldBypassProxy(for: "anything.com"))
+    }
+
+    // MARK: - proxyURL(for:)
+
+    func testProxyURLForHTTP() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            http: .init(proxy: "http://http-proxy:8080"),
+            https: .init(proxy: "http://https-proxy:8443")
+        )
+        XCTAssertEqual(config.proxyURL(for: URL(string: "http://example.com")!), "http://http-proxy:8080")
+        XCTAssertEqual(config.proxyURL(for: URL(string: "https://example.com")!), "http://https-proxy:8443")
+    }
+
+    func testProxyURLBypassesNoProxy() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            http: .init(proxy: "http://proxy:8080"),
+            https: .init(proxy: "http://proxy:8080"),
+            noProxy: ["internal.corp"]
+        )
+        XCTAssertNil(config.proxyURL(for: URL(string: "http://internal.corp/path")!))
+        XCTAssertNil(config.proxyURL(for: URL(string: "https://api.internal.corp")!))
+        XCTAssertEqual(config.proxyURL(for: URL(string: "http://external.com")!), "http://proxy:8080")
+    }
+
+    func testProxyURLReturnsNilForHTTPSWhenOnlyHTTPConfigured() {
+        let config = HTTPProxyConfiguration(
+            version: 1,
+            http: .init(proxy: "http://proxy:8080")
+        )
+        XCTAssertEqual(config.proxyURL(for: URL(string: "http://example.com")!), "http://proxy:8080")
+        XCTAssertNil(config.proxyURL(for: URL(string: "https://example.com")!))
+    }
+
+    // MARK: - ParsedProxyURL
+
+    func testParseProxyURLHTTP() throws {
+        let parsed = try HTTPProxyConfiguration.parseProxyURL("http://proxy.example.com:3128")
+        XCTAssertEqual(parsed.scheme, "http")
+        XCTAssertEqual(parsed.host, "proxy.example.com")
+        XCTAssertEqual(parsed.port, 3128)
+    }
+
+    func testParseProxyURLDefaultPort() throws {
+        let parsed = try HTTPProxyConfiguration.parseProxyURL("http://proxy.example.com")
+        XCTAssertEqual(parsed.port, 80)
+
+        let parsedHTTPS = try HTTPProxyConfiguration.parseProxyURL("https://proxy.example.com")
+        XCTAssertEqual(parsedHTTPS.port, 443)
+
+        let parsedSOCKS = try HTTPProxyConfiguration.parseProxyURL("socks5://proxy.example.com")
+        XCTAssertEqual(parsedSOCKS.port, 1080)
+    }
+
+    func testParseProxyURLInvalid() {
+        XCTAssertThrowsError(try HTTPProxyConfiguration.parseProxyURL("not a url"))
+    }
+}

--- a/Tests/BasicsTests/HTTPProxyConfigurationTests.swift
+++ b/Tests/BasicsTests/HTTPProxyConfigurationTests.swift
@@ -302,4 +302,80 @@ final class HTTPProxyConfigurationTests: XCTestCase {
     func testParseProxyURLInvalid() {
         XCTAssertThrowsError(try HTTPProxyConfiguration.parseProxyURL("not a url"))
     }
+
+    // MARK: - Environment Variable Loading
+
+    func testLoadFromEnvironmentHTTPProxy() {
+        let env = ["http_proxy": "http://proxy.corp:3128"]
+        let config = HTTPProxyConfiguration.loadFromEnvironment(env)
+        XCTAssertNotNil(config)
+        XCTAssertEqual(config?.http?.proxy, "http://proxy.corp:3128")
+        XCTAssertNil(config?.https)
+        XCTAssertNil(config?.noProxy)
+    }
+
+    func testLoadFromEnvironmentHTTPSProxy() {
+        let env = ["https_proxy": "http://secure-proxy:8443"]
+        let config = HTTPProxyConfiguration.loadFromEnvironment(env)
+        XCTAssertNotNil(config)
+        XCTAssertNil(config?.http)
+        XCTAssertEqual(config?.https?.proxy, "http://secure-proxy:8443")
+    }
+
+    func testLoadFromEnvironmentBothProxies() {
+        let env = [
+            "http_proxy": "http://proxy:3128",
+            "https_proxy": "http://proxy:3129",
+            "no_proxy": "localhost,127.0.0.1,.internal.corp"
+        ]
+        let config = HTTPProxyConfiguration.loadFromEnvironment(env)
+        XCTAssertNotNil(config)
+        XCTAssertEqual(config?.http?.proxy, "http://proxy:3128")
+        XCTAssertEqual(config?.https?.proxy, "http://proxy:3129")
+        XCTAssertEqual(config?.noProxy, ["localhost", "127.0.0.1", ".internal.corp"])
+    }
+
+    func testLoadFromEnvironmentLowercaseTakesPrecedence() {
+        let env = [
+            "http_proxy": "http://lower:3128",
+            "HTTP_PROXY": "http://upper:3128"
+        ]
+        let config = HTTPProxyConfiguration.loadFromEnvironment(env)
+        XCTAssertEqual(config?.http?.proxy, "http://lower:3128")
+    }
+
+    func testLoadFromEnvironmentUppercaseFallback() {
+        let env = ["HTTP_PROXY": "http://upper:3128", "HTTPS_PROXY": "http://upper:3129"]
+        let config = HTTPProxyConfiguration.loadFromEnvironment(env)
+        XCTAssertEqual(config?.http?.proxy, "http://upper:3128")
+        XCTAssertEqual(config?.https?.proxy, "http://upper:3129")
+    }
+
+    func testLoadFromEnvironmentNoProxyParsing() {
+        let env = [
+            "http_proxy": "http://proxy:3128",
+            "NO_PROXY": "  localhost , .example.com , 10.0.0.0/8  "
+        ]
+        let config = HTTPProxyConfiguration.loadFromEnvironment(env)
+        XCTAssertEqual(config?.noProxy, ["localhost", ".example.com", "10.0.0.0/8"])
+    }
+
+    func testLoadFromEnvironmentEmpty() {
+        let env: [String: String] = [:]
+        let config = HTTPProxyConfiguration.loadFromEnvironment(env)
+        XCTAssertNil(config)
+    }
+
+    func testLoadFromEnvironmentEmptyValues() {
+        let env = ["http_proxy": "", "https_proxy": ""]
+        let config = HTTPProxyConfiguration.loadFromEnvironment(env)
+        XCTAssertNil(config)
+    }
+
+    func testLoadFromEnvironmentOnlyNoProxy() {
+        // no_proxy alone without any proxy URL should return nil
+        let env = ["no_proxy": "localhost"]
+        let config = HTTPProxyConfiguration.loadFromEnvironment(env)
+        XCTAssertNil(config)
+    }
 }

--- a/Tests/WorkspaceTests/ProxyStorageTests.swift
+++ b/Tests/WorkspaceTests/ProxyStorageTests.swift
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Basics
+import Workspace
+import Testing
+
+import _InternalTestSupport
+
+fileprivate struct ProxyStorageTests {
+    @Test
+    func loadValidConfig() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        try fs.createDirectory(configFile.parentDirectory)
+        try fs.writeFileContents(
+            configFile,
+            string: """
+            {
+              "version": 1,
+              "http": { "proxy": "http://proxy.example.com:8080" },
+              "https": { "proxy": "http://proxy.example.com:8443" },
+              "noProxy": ["localhost", "127.0.0.1"]
+            }
+            """
+        )
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs)
+        let config = try storage.get()
+
+        #expect(config != nil)
+        #expect(config?.http?.proxy == "http://proxy.example.com:8080")
+        #expect(config?.https?.proxy == "http://proxy.example.com:8443")
+        #expect(config?.noProxy == ["localhost", "127.0.0.1"])
+    }
+
+    @Test
+    func loadReturnsNilWhenFileDoesNotExist() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs)
+        let config = try storage.get()
+
+        #expect(config == nil)
+    }
+
+    @Test
+    func setHTTPProxy() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs)
+        try storage.set(httpProxy: "http://proxy:8080")
+
+        let config = try storage.get()
+        #expect(config?.http?.proxy == "http://proxy:8080")
+        #expect(config?.https == nil)
+    }
+
+    @Test
+    func setIsAdditive() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs)
+
+        // Set HTTP proxy
+        try storage.set(httpProxy: "http://proxy:8080")
+
+        // Add HTTPS proxy — should preserve HTTP
+        try storage.set(httpsProxy: "http://proxy:8443")
+
+        let config = try storage.get()
+        #expect(config?.http?.proxy == "http://proxy:8080")
+        #expect(config?.https?.proxy == "http://proxy:8443")
+    }
+
+    @Test
+    func setNoProxy() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs)
+        try storage.set(httpProxy: "http://proxy:8080", noProxy: ["localhost", ".internal.corp"])
+
+        let config = try storage.get()
+        #expect(config?.noProxy == ["localhost", ".internal.corp"])
+    }
+
+    @Test
+    func unsetHTTPOnly() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs)
+        try storage.set(httpProxy: "http://proxy:8080", httpsProxy: "http://proxy:8443")
+
+        // Unset only HTTP
+        try storage.unset(http: true)
+
+        let config = try storage.get()
+        #expect(config?.http == nil)
+        #expect(config?.https?.proxy == "http://proxy:8443")
+    }
+
+    @Test
+    func unsetAll() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs)
+        try storage.set(httpProxy: "http://proxy:8080")
+
+        // Unset all (no flags = remove file)
+        try storage.unset()
+
+        #expect(!fs.exists(configFile))
+        let config = try storage.get()
+        #expect(config == nil)
+    }
+
+    @Test
+    func deleteWhenEmpty() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs, deleteWhenEmpty: true)
+
+        // Set then unset everything
+        try storage.set(httpProxy: "http://proxy:8080")
+        #expect(fs.exists(configFile))
+
+        try storage.unset(http: true)
+        // Config is now empty — file should be deleted
+        #expect(!fs.exists(configFile))
+    }
+
+    @Test
+    func rejectsInvalidProxyURL() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs)
+
+        #expect(throws: (any Error).self) {
+            try storage.set(httpProxy: "not-a-valid-url")
+        }
+    }
+
+    @Test
+    func rejectsCredentialsInURL() throws {
+        let fs = InMemoryFileSystem()
+        let configFile = AbsolutePath("/config/proxy.json")
+
+        let storage = Workspace.Configuration.ProxyStorage(path: configFile, fileSystem: fs)
+
+        #expect(throws: (any Error).self) {
+            try storage.set(httpProxy: "http://user:pass@proxy:8080")
+        }
+    }
+}


### PR DESCRIPTION
Implementation of SE-NNNN: Package Manager HTTP Proxy Configuration

Proposal: https://github.com/swiftlang/swift-evolution/pull/3346
Bug: https://github.com/swiftlang/swift-package-manager/issues/7470

## Changes

- **HTTPProxyConfiguration.swift** — Codable config model, URL validation, noProxy matching
- **Workspace+Proxy.swift** — ProxyStorage with file locking (follows MirrorsStorage pattern)
- **URLSessionHTTPClient.swift** — Reads proxy.json and sets connectionProxyDictionary
- **HTTPClient.swift / LegacyHTTPClient.swift** — Pass filesystem for proxy config loading
- **Workspace+Configuration.swift** — DefaultLocations for proxy.json
- **Config.swift** — set-proxy, get-proxy, unset-proxy CLI commands + macOS system proxy query
- **Tests** — 37 tests covering parsing, validation, noProxy matching, storage merge semantics