### PR TITLE
SwiftBuild: Pass module alias on product dependencies

### DIFF
--- a/Fixtures/ModuleAliasing/Executable/App/Package.swift
+++ b/Fixtures/ModuleAliasing/Executable/App/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(path: "../Utils"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "App",
+            dependencies: [
+                .product(
+                    name: "Utils",
+                    package: "Utils",
+                    moduleAliases: ["Utils": "AppUtils"]
+                ),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/ModuleAliasing/Executable/App/Sources/App/main.swift
+++ b/Fixtures/ModuleAliasing/Executable/App/Sources/App/main.swift
@@ -1,0 +1,8 @@
+import AppUtils
+
+@main
+struct App {
+    static func main() {
+        print(AppUtils.greet())
+    }
+}

--- a/Fixtures/ModuleAliasing/Executable/Utils/Package.swift
+++ b/Fixtures/ModuleAliasing/Executable/Utils/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "Utils",
+    products: [
+        .library(name: "Utils", targets: ["Utils"]),
+    ],
+    targets: [
+        .target(name: "Utils"),
+    ]
+)

--- a/Fixtures/ModuleAliasing/Executable/Utils/Sources/Utils/Utils.swift
+++ b/Fixtures/ModuleAliasing/Executable/Utils/Sources/Utils/Utils.swift
@@ -1,0 +1,5 @@
+public enum Utils {
+    public static func greet() -> String {
+        "hello from Utils"
+    }
+}

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -119,6 +119,12 @@ extension PackagePIFProjectBuilder {
         settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
         // We must use the main module name here instead of the product name, because they're not guranteed to be the same, and the users may have authored e.g. tests which rely on an executable's module name.
         settings[.PRODUCT_MODULE_NAME] = mainModule.c99name
+
+        if let aliases = mainModule.moduleAliases {
+            let list = aliases.map { $0.0 + "=" + $0.1 }
+            settings[.SWIFT_MODULE_ALIASES] = list.isEmpty ? nil : list
+        }
+
         if product.type == .executable {
             // Don't install the Swift module of the executable product, lest it conflict with the testable variant.
             // The contents of the testable variant's module will exactly match the binary linked by dependencies (test targets).

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -430,6 +430,124 @@ struct PIFBuilderTests {
         }
     }
 
+    struct ModuleAliasTestData {
+        let fixtureName: String
+        let packageName: String
+        let projectName: String
+        let verify: [Verify]
+
+        struct Verify {
+            let targetName: String
+            let expectedAliases: [String]
+        }
+    }
+    @Test(
+        arguments: [
+            ModuleAliasTestData(
+                fixtureName: "ModuleAliasing/Executable",
+                packageName: "App",
+                projectName: "App",
+                verify: [
+                    ModuleAliasTestData.Verify(
+                        targetName: "App-product",
+                        expectedAliases: ["Utils=AppUtils"],
+                    ),
+                ],
+            ),
+        ]
+    )
+    func moduleAliasesPropagateToExecutableProduct(
+        data: ModuleAliasTestData,
+    ) async throws {
+        try await withGeneratedPIF(
+            fromFixture: data.fixtureName,
+            withPackage: data.packageName,
+        ) { pif, observabilitySystem, fixturePath in
+            let project = try pif.workspace.project(named: data.projectName)
+            for v in data.verify {
+                let productConfig = try project
+                    .target(named: v.targetName)
+                    .buildConfig(named: .debug)
+
+                #expect(
+                    productConfig.settings[.SWIFT_MODULE_ALIASES] == v.expectedAliases,
+                    "Project name \(data.projectName) and target name \(v.targetName) does not have expected module aliases",
+                )
+            }
+        }
+    }
+
+    struct ModuleAliasTargetTestData {
+        let fixtureName: String
+        let packageName: String
+        /// Expected `SWIFT_MODULE_ALIASES` entries (formatted as `"OriginalName=AliasName"`)
+        /// that must appear across the union of every `PACKAGE-TARGET:` target in the generated PIF.
+        let expectedAliasEntries: Set<String>
+    }
+    @Test(
+        arguments: [
+            ModuleAliasTargetTestData(
+                fixtureName: "ModuleAliasing/DirectDeps1",
+                packageName: "AppPkg",
+                expectedAliasEntries: ["Utils=GameUtils"],
+            ),
+            ModuleAliasTargetTestData(
+                fixtureName: "ModuleAliasing/DirectDeps2",
+                packageName: "AppPkg",
+                expectedAliasEntries: ["Utils=AUtils", "Utils=BUtils"],
+            ),
+            ModuleAliasTargetTestData(
+                fixtureName: "ModuleAliasing/Executable",
+                packageName: "App",
+                expectedAliasEntries: ["Utils=AppUtils"],
+            ),
+            ModuleAliasTargetTestData(
+                fixtureName: "ModuleAliasing/NestedDeps1",
+                packageName: "AppPkg",
+                expectedAliasEntries: [
+                    "FooUtils=AFooUtils",
+                    "FooUtils=XFooUtils",
+                    "Utils=CarUtils",
+                    "Utils=XUtils",
+                ],
+            ),
+            ModuleAliasTargetTestData(
+                fixtureName: "ModuleAliasing/NestedDeps2",
+                packageName: "AppPkg",
+                expectedAliasEntries: [
+                    "Utils=BUtils",
+                    "Utils=CUtils",
+                    "Utils=XUtils",
+                ],
+            ),
+        ]
+    )
+    func moduleAliasesPropagateToPackageTargets(
+        data: ModuleAliasTargetTestData,
+    ) async throws {
+        try await withGeneratedPIF(
+            fromFixture: data.fixtureName,
+            withPackage: data.packageName,
+        ) { pif, _, _ in
+            var seenAliasEntries: Set<String> = []
+            for project in pif.workspace.projects {
+                for target in project.underlying.targets {
+                    guard target.common.id.value.hasPrefix("PACKAGE-TARGET:") else { continue }
+                    for config in target.common.buildConfigs {
+                        guard let aliases = config.settings[.SWIFT_MODULE_ALIASES] else { continue }
+                        for entry in aliases {
+                            seenAliasEntries.insert(entry)
+                        }
+                    }
+                }
+            }
+            #expect(
+                seenAliasEntries.isSuperset(of: data.expectedAliasEntries),
+                "\(data.fixtureName): PACKAGE-TARGET SWIFT_MODULE_ALIASES missing expected entries; expected superset of \(data.expectedAliasEntries), got \(seenAliasEntries)",
+            )
+        }
+    }
+
     @Test
     func emitUnhandledFilesOnlyForRootPackages() async throws {
         try await withGeneratedPIF(


### PR DESCRIPTION
The SwiftBuild PIF builder did not handle setting module aliases on products.  Update the PIF builder to set such module aliases.

Fixes #10270
Issue: rdar://181597887