### PR TITLE
[BSP] Adding/removing files in the scratch path should not reload the package

### DIFF
--- a/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
+++ b/Sources/SwiftPMBuildServer/SwiftPMBuildServer.swift
@@ -103,6 +103,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
     private let packageRoot: Basics.AbsolutePath
     private let buildSystem: SwiftBuildSystem
     private let workspace: Workspace
+    private let defaultScratchDirectory: Basics.AbsolutePath
 
     public let messageHandlingHelper = QueueBasedMessageHandlerHelper(
         signpostLoggingCategory: "build-server-message-handling",
@@ -154,6 +155,7 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         self.packageRoot = packageRoot
         self.buildSystem = buildSystem
         self.workspace = workspace
+        self.defaultScratchDirectory = Workspace.DefaultLocations.scratchDirectory(forRootPackage: packageRoot)
         self.connectionToClient = connectionToClient
         self.exitHandler = exitHandler
         let session = try await buildSystem.createLongLivedSession(name: "swiftpm-build-server")
@@ -595,9 +597,22 @@ public actor SwiftPMBuildServer: QueueBasedMessageHandler {
         return VoidResponse()
     }
 
+    private func isInScratchDirectory(_ url: URL) -> Bool {
+        guard let filePath = try? url.filePath else {
+            return false
+        }
+        if filePath.isDescendantOfOrEqual(to: self.workspace.location.scratchDirectory) || filePath.isDescendantOfOrEqual(to: self.defaultScratchDirectory) {
+            return true
+        }
+        return false
+    }
+
     /// An event is relevant if it modifies a file that matches one of the file rules used by the SwiftPM workspace.
     private func fileEventShouldTriggerPackageReload(event: FileEvent) -> Bool {
         guard let fileURL = event.uri.fileURL else {
+            return false
+        }
+        if isInScratchDirectory(fileURL) {
             return false
         }
         switch event.type {

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -222,6 +222,39 @@ struct SwiftPMBuildServerTests {
     }
 
     @Test
+    func fileEventsInScratchDirectoryDoNotTriggerPackageReload() async throws {
+        try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, notificationCollector, fixturePath in
+            func packageReloadCount() -> Int {
+                notificationCollector.notifications(of: TaskStartNotification.self)
+                    .filter { $0.taskId.id == "package-reloading" }
+                    .count
+            }
+
+            // The initial package load triggers one reload task.
+            #expect(packageReloadCount() == 1)
+
+            // Simulate build output being created inside the '.build' scratch directory. The package should not reload.
+            let resolvedPackagePath = try resolveSymlinks(fixturePath)
+            let scratchFile = resolvedPackagePath.appending(component: ".build").appending(component: "some-build-output.o")
+            connection.send(OnWatchedFilesDidChangeNotification(changes: [
+                .init(uri: .init(.init(filePath: scratchFile.pathString)), type: .created)
+            ]))
+            _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
+            #expect(packageReloadCount() == 1)
+
+            // A change to a source file should still trigger a reload.
+            try localFileSystem.writeFileContents(fixturePath.appending(component: "Bar.swift"), body: {
+                $0.write("public let baz = \"hello\"")
+            })
+            connection.send(OnWatchedFilesDidChangeNotification(changes: [
+                .init(uri: .init(.init(filePath: fixturePath.appending(component: "Bar.swift").pathString)), type: .created)
+            ]))
+            _ = try await connection.send(WorkspaceWaitForBuildSystemUpdatesRequest())
+            #expect(packageReloadCount() == 2)
+        }
+    }
+
+    @Test
     func underlyingBuildServerNotificationsAreForwarded() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, notificationCollector, fixturePath in
             let initialChangeCount = notificationCollector.notifications(of: OnBuildTargetDidChangeNotification.self).count


### PR DESCRIPTION
Otherwise, index preparation may trigger build description regeneration in a loop, leading an LSP to constantly re-index the package.