### PR TITLE
[6.4] Ensure targets merged into products by the build system can still be selected using --target

### DIFF
--- a/Sources/SwiftBuildSupport/BuildSystem.swift
+++ b/Sources/SwiftBuildSupport/BuildSystem.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SPMBuildCore
+import PackageGraph
 import PackageModel
 
 extension BuildConfiguration {
@@ -23,12 +24,22 @@ extension BuildConfiguration {
 }
 
 extension BuildSubset {
-    var pifTargetName: String {
+    func pifTargetName(for graph: ModulesGraph) -> String {
         switch self {
         case .product(let name, _):
             PackagePIFBuilder.targetName(forProductName: name)
         case .target(let name, _):
-            name
+            // If the named target is the main module of a main-module product (e.g. a test or
+            // executable target), it is represented in the PIF by that product's target.
+            if let product = graph.allProducts.first(where: {
+                $0.isMainModuleProduct
+                    && $0.mainModule?.name == name
+                    && !($0.mainModule?.isTestSupportModule ?? false)
+            }) {
+                PackagePIFBuilder.targetName(forProductName: product.name)
+            } else {
+                name
+            }
         case .allExcludingTests:
             PIFBuilder.allExcludingTestsTargetName
         case .allIncludingTests:

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -479,8 +479,9 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             throw Diagnostics.fatalError
         }
 
+        let graph = try await getPackageGraph()
         return try await startSWBuildOperation(
-            pifTargetName: subset.pifTargetName,
+            pifTargetName: subset.pifTargetName(for: graph),
             buildOutputs: buildOutputs,
         )
     }

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -528,7 +528,7 @@ struct BuildCommandTestCases {
     }
 
     @Test(
-        .issue("https://github.com/swiftlang/swift-package-manager/issues/9138", relationship: .defect),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9138", relationship: .verifies),
         .tags(
             .Feature.CommandLineArguments.Target,
         ),
@@ -539,24 +539,56 @@ struct BuildCommandTestCases {
         data: BuildData,
     ) async throws {
         let buildSystem = data.buildSystem
-        try await withKnownIssue("Could not find target named 'exec2'") {
-            try await fixture(name: "Miscellaneous/MultipleExecutables") { fixturePath in
-                let fullPath = try resolveSymlinks(fixturePath)
+        try await fixture(name: "Miscellaneous/MultipleExecutables") { fixturePath in
+            let fullPath = try resolveSymlinks(fixturePath)
 
-                let result = try await build(
-                    ["--target", "exec2"],
+            let result = try await build(
+                ["--target", "exec2"],
+                packagePath: fullPath,
+                configuration: data.config,
+                buildSystem: buildSystem,
+            )
+            switch buildSystem {
+            case .native:
+                #expect(result.binContents.contains("exec2.build"))
+                #expect(!result.binContents.contains("exec1.build"))
+            case .swiftbuild, .xcode:
+                #expect(result.binContents.contains(executableName("exec2")))
+                #expect(!result.binContents.contains(executableName("exec1")))
+            }
+
+            await expectThrowsCommandExecutionError(
+                try await build(
+                    ["--target", "notarealtarget"],
                     packagePath: fullPath,
                     configuration: data.config,
                     buildSystem: buildSystem,
                 )
-                #expect(result.binContents.contains("exec2.build"))
-                #expect(!result.binContents.contains(executableName("exec1")))
+            ) { error in
+                #expect(error.stderr.contains("Could not find target named 'notarealtarget'") ||
+                        error.stderr.contains("no target named 'notarealtarget'"))
             }
-        } when: {
-            [
-                .swiftbuild,
-                .xcode,
-            ].contains(buildSystem)
+        }
+    }
+
+    @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10275", relationship: .verifies),
+        .tags(
+            .Feature.CommandLineArguments.Target,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func buildExistingTestTargetIsSuccessful(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/EmptyTestsPkg") { fixturePath in
+            let fullPath = try resolveSymlinks(fixturePath)
+            _ = try await execute(
+                ["--target", "EmptyTestsPkgTests"],
+                packagePath: fullPath,
+                configuration: .debug,
+                buildSystem: buildSystem,
+            )
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/swiftlang/swift-package-manager/issues/10275
Closes https://github.com/swiftlang/swift-package-manager/issues/9138

When generating PIF, a package target representing an executable or test target may be merged into a product. These remain targets in the user-facing model, and should be selectable using --target on the CLI. Update BuildSubset.pifTargetName to account for this case, fixup an existing test for executables, and add a new one for tests.