### PR TITLE
Fix verbose build log output being emitted twice

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystemMessageHandler.swift
@@ -151,7 +151,6 @@ public final class SwiftBuildSystemMessageHandler {
             if logLevel.isVerbose {
                 self.outputStream.send(started + "\n")
             }
-            self.observabilityScope.print(started, condition: .onlyWhenVerbose)
         }
 
         guard info.result == .success else {

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -1642,7 +1642,7 @@ struct PluginTests {
                 #expect(stdout.contains("Build of product 'MyLocalTool' complete!"), "stdout:\n\(stdout)")
             case .swiftbuild:
                 #expect(stdout.contains("MySourceGenBuildTool-product"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
-                #expect(stderr.contains("Creating foo.swift from foo.dat"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
+                #expect(stdout.contains("Creating foo.swift from foo.dat"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
                 #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)\nstderr:\n\(stderr)")
             case .xcode:
                 Issue.record("Test expected have not been considered")

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemMessageHandlerTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemMessageHandlerTests.swift
@@ -502,6 +502,24 @@ struct SwiftBuildSystemMessageHandlerTests {
         let output = self.outputStream.bytes.description
         #expect(output.contains("Compile Foo\n"))
     }
+
+    @Test
+    func testVerboseTaskOutputIsNotDuplicated() throws {
+        let messageHandler = self.messageHandler.debug
+
+        let events: [SwiftBuildMessage] = [
+            .taskStartedInfo(executionDescription: "Compile Foo"),
+            .taskCompleteInfo(result: .success)
+        ]
+
+        for event in events {
+            _ = try messageHandler.emitEvent(event)
+        }
+
+        let output = self.outputStream.bytes.description
+        let occurrences = output.components(separatedBy: "Compile Foo").count - 1
+        #expect(occurrences == 1)
+    }
 }
 
 private func data(_ message: String) -> Data {


### PR DESCRIPTION
Resolves #10278 
Fix verbose build log output being emitted twice

### Motivation:
When verbose logging is enabled (`-v`), each task description was being written to the output stream twice. This is because both `outputStream.send()` and `observabilityScope.print(_:condition:)` were called in `handleTaskOutput`, both writing to the same underlying stream.

For example:
<img width="600" height="400" alt="스크린샷 2026-07-09 오후 2 50 15" src="https://github.com/user-attachments/assets/c2d3af40-cea5-4ea9-bd02-238fe6c3b8dc" />

### Modifications:
Remove the redundant `observabilityScope.print(started, condition: .onlyWhenVerbose)` call in `SwiftBuildSystemMessageHandler.handleTaskOutput`, since `outputStream.send(started + "\n")` already handles the output.

While both calls write to the same underlying stream, they differ in how they do so:
- `outputStream.send()` writes synchronously and directly.
- `observabilityScope.print()` dispatches asynchronously via a `DispatchQueue` through `SwiftCommandObservabilityHandler`, which caused the duplicate output to appear as a separate batch after the synchronous writes.

`outputStream.send()` is retained as it is consistent with other direct output calls in this file (e.g. `"Planning build"`, `"Planning complete"`) and provides predictable ordering.

### Result:
<img width="600" height="400" alt="스크린샷 2026-07-09 오후 2 48 20" src="https://github.com/user-attachments/assets/b0bff36d-4d35-4e5b-a232-663c297bbbd8" />

### Test:
Added `testVerboseTaskOutputIsNotDuplicated` in `SwiftBuildSystemMessageHandlerTests` to verify that each verbose task description appears exactly once in the output.
