### PR TITLE
Hande Swift Testing-specific prefixes

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -250,7 +250,7 @@ struct TestCommandOptions: ParsableArguments {
 }
 
 /// Tests filtering the specifier, which is used to filter tests to run.
-public enum TestCaseSpecifier {
+public enum TestCaseSpecifier: Equatable {
     /// No filtering.
     case none
 
@@ -1827,27 +1827,37 @@ extension SwiftCommandState {
 }
 
 extension TestCaseSpecifier {
-    /// Normalizes the arguments passed to XCTest by processing any prefixes that are Swift Testing-specific.
+    /// Normalizes filter/skip arguments for XCTest, which only understands test ID patterns.
     ///
-    /// In particular, anything prefixed with `id:` should be treated as if the argument to the prefix were passed in
-    /// directly (e.g. `--filter id:foo` becomes `--filter foo`). Any other prefixes indicate behaviors unsupported by
-    /// xctest and so should be dropped (e.g. `--filter tag:integrationTest` will be dropped).
+    /// `id:foo` and bare `foo` match a test ID, so the prefix is stripped and applied normally. Any other prefix
+    /// (e.g. `tag:`) is a Swift Testing-only concept no XCTest can match.
     func normalizedForXCTest() -> TestCaseSpecifier {
         switch self {
         case .none, .specific:
             return self
         case .regex(let array):
-            let normalizedPatterns = array.compactMap(Self.stripPrefixesAndFilterForXCTest(_:))
-            if normalizedPatterns.isEmpty { return .none }
+            // Encountering _any_ prefix other than `id:` (such as `tag:`) means that no XCTest test could match
+            // against it (because, for example, it's impossible for an XCTest to have a tag). Functionally, this means
+            // that if we encounter any such filters, we automatically know that we shouldn't run any XCTests. We
+            // represent this by returning `.regex([])` which no XCTest matches.
+            var normalizedPatterns = [String]()
+            for pattern in array {
+                guard let stripped = Self.strippedIDPatternForXCTest(pattern) else {
+                    return .regex([])
+                }
+                normalizedPatterns.append(stripped)
+            }
             return .regex(normalizedPatterns)
         case .skip(let array):
-            let normalizedPatterns = array.compactMap(Self.stripPrefixesAndFilterForXCTest(_:))
+            let normalizedPatterns = array.compactMap(Self.strippedIDPatternForXCTest(_:))
             if normalizedPatterns.isEmpty { return .none }
             return .skip(normalizedPatterns)
         }
     }
 
-    private static func stripPrefixesAndFilterForXCTest(_ pattern: String) -> String? {
+    /// The XCTest ID pattern for `pattern` (stripping any `id:` prefix), or `nil` if it carries a
+    /// non-`id:` prefix that XCTest can never match.
+    private static func strippedIDPatternForXCTest(_ pattern: String) -> String? {
         let idPrefix = #/^id:/#
         let genericTagPrefix = #/^[a-zA-Z]+:/#
         if pattern.contains(idPrefix) {

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -190,9 +190,9 @@ struct TestCommandOptions: ParsableArguments {
           help: "Print the path of the exported code coverage JSON file.")
     var shouldPrintCodeCovPath: Bool = false
 
-    var testCaseSpecifier: TestCaseSpecifier {
+    var xctestFilterSpecifier: TestCaseSpecifier {
         if !filter.isEmpty {
-            return .regex(filter)
+            return .regex(filter).normalizedForXCTest()
         }
 
         return _testCaseSpecifier.map { .specific($0) } ?? .none
@@ -383,8 +383,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     buildSystem: buildSystem
                 )
                 let tests = try testSuites
-                    .filteredTests(specifier: options.testCaseSpecifier)
-                    .skippedTests(specifier: options.skippedTests(fileSystem: swiftCommandState.fileSystem))
+                    .filteredTests(specifier: options.xctestFilterSpecifier)
+                    .skippedTests(specifier: options.xctestSkippedSpecifier(fileSystem: swiftCommandState.fileSystem))
 
                 let testResults: [ParallelTestRunner.TestResult]
                 if tests.isEmpty {
@@ -470,9 +470,9 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
     }
 
     private func xctestArgs(for testProducts: [BuiltTestProduct], swiftCommandState: SwiftCommandState, buildSystem: any BuildSystem) async throws -> (arguments: [String], testCount: Int?) {
-        switch options.testCaseSpecifier {
+        switch options.xctestFilterSpecifier {
         case .none:
-            if case .skip = options.skippedTests(fileSystem: swiftCommandState.fileSystem) {
+            if case .skip = options.xctestSkippedSpecifier(fileSystem: swiftCommandState.fileSystem) {
                 fallthrough
             } else {
                 return ([], nil)
@@ -480,7 +480,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
 
         case .regex, .specific, .skip:
             // If the previous specifier `-s` option was used, emit the deprecation notice.
-            if case .specific = options.testCaseSpecifier {
+            if case .specific = options.xctestFilterSpecifier {
                 swiftCommandState.observabilityScope.emit(warning: "'--specifier' option is deprecated; use '--filter' instead")
             }
 
@@ -495,8 +495,8 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 buildSystem: buildSystem
             )
             let tests = try testSuites
-                .filteredTests(specifier: options.testCaseSpecifier)
-                .skippedTests(specifier: options.skippedTests(fileSystem: swiftCommandState.fileSystem))
+                .filteredTests(specifier: options.xctestFilterSpecifier)
+                .skippedTests(specifier: options.xctestSkippedSpecifier(fileSystem: swiftCommandState.fileSystem))
 
             return (TestRunner.xctestArguments(forTestSpecifiers: tests.map(\.specifier)), tests.count)
         }
@@ -578,7 +578,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                                  (options.testLibraryOptions.isExplicitlyEnabled(.swiftTesting, swiftCommandState: swiftCommandState) ||
                                   testEntryPointPath == nil)
 
-        let skipSpecifier = options.skippedTests(fileSystem: swiftCommandState.fileSystem)
+        let skipSpecifier = options.xctestSkippedSpecifier(fileSystem: swiftCommandState.fileSystem)
 
         var productsWithXCTests = Set<AbsolutePath>()
         if xctestEnabled {
@@ -592,7 +592,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                 buildSystem: buildSystem
             )
             let matchingTests = try xctestSuites
-                .filteredTests(specifier: options.testCaseSpecifier)
+                .filteredTests(specifier: options.xctestFilterSpecifier)
                 .skippedTests(specifier: skipSpecifier)
             productsWithXCTests = Set(matchingTests.map(\.testProduct.bundlePath))
         }
@@ -1826,16 +1826,51 @@ extension SwiftCommandState {
     }
 }
 
+extension TestCaseSpecifier {
+    /// Normalizes the arguments passed to XCTest by processing any prefixes that are Swift Testing-specific.
+    ///
+    /// In particular, anything prefixed with `id:` should be treated as if the argument to the prefix were passed in
+    /// directly (e.g. `--filter id:foo` becomes `--filter foo`). Any other prefixes indicate behaviors unsupported by
+    /// xctest and so should be dropped (e.g. `--filter tag:integrationTest` will be dropped).
+    func normalizedForXCTest() -> TestCaseSpecifier {
+        switch self {
+        case .none, .specific:
+            return self
+        case .regex(let array):
+            let normalizedPatterns = array.compactMap(Self.stripPrefixesAndFilterForXCTest(_:))
+            if normalizedPatterns.isEmpty { return .none }
+            return .regex(normalizedPatterns)
+        case .skip(let array):
+            let normalizedPatterns = array.compactMap(Self.stripPrefixesAndFilterForXCTest(_:))
+            if normalizedPatterns.isEmpty { return .none }
+            return .skip(normalizedPatterns)
+        }
+    }
+
+    private static func stripPrefixesAndFilterForXCTest(_ pattern: String) -> String? {
+        let idPrefix = #/^id:/#
+        let genericTagPrefix = #/^[a-zA-Z]+:/#
+        if pattern.contains(idPrefix) {
+            return String(pattern.trimmingPrefix(idPrefix))
+        } else if pattern.contains(genericTagPrefix) {
+            return nil
+        } else {
+            return pattern
+        }
+    }
+}
+
 extension TestCommandOptions {
-    func skippedTests(fileSystem: FileSystem) -> TestCaseSpecifier {
+    /// Returns the specifier used for skipping tests, normalized for XCTest.
+    func xctestSkippedSpecifier(fileSystem: FileSystem) -> TestCaseSpecifier {
         // TODO: Remove this once the environment variable is no longer used.
         if let override = skippedTestsOverride(fileSystem: fileSystem) {
-            return override
+            return override.normalizedForXCTest()
         }
 
         return self._testCaseSkip.isEmpty
             ? .none
-            : .skip(self._testCaseSkip)
+            : .skip(self._testCaseSkip).normalizedForXCTest()
     }
 
     /// Returns the test case specifier if overridden in the environment.

--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -190,7 +190,7 @@ struct TestCommandOptions: ParsableArguments {
           help: "Print the path of the exported code coverage JSON file.")
     var shouldPrintCodeCovPath: Bool = false
 
-    var xctestFilterSpecifier: TestCaseSpecifier {
+    var xctestFilterSpecifier: XCTestCaseSpecifier {
         if !filter.isEmpty {
             return .regex(filter).normalizedForXCTest()
         }
@@ -250,7 +250,7 @@ struct TestCommandOptions: ParsableArguments {
 }
 
 /// Tests filtering the specifier, which is used to filter tests to run.
-public enum TestCaseSpecifier: Equatable {
+public enum XCTestCaseSpecifier: Equatable {
     /// No filtering.
     case none
 
@@ -1681,7 +1681,7 @@ fileprivate extension Dictionary where Key == BuiltTestProduct, Value == [TestSu
     }
 
     /// Return tests matching the provided specifier
-    func filteredTests(specifier: TestCaseSpecifier) throws -> [UnitTest] {
+    func filteredTests(specifier: XCTestCaseSpecifier) throws -> [UnitTest] {
         switch specifier {
         case .none:
             return allTests
@@ -1702,7 +1702,7 @@ fileprivate extension Dictionary where Key == BuiltTestProduct, Value == [TestSu
 
 fileprivate extension Array where Element == UnitTest {
     /// Skip tests matching the provided specifier
-    func skippedTests(specifier: TestCaseSpecifier) throws -> [UnitTest] {
+    func skippedTests(specifier: XCTestCaseSpecifier) throws -> [UnitTest] {
         switch specifier {
         case .none:
             return self
@@ -1826,12 +1826,12 @@ extension SwiftCommandState {
     }
 }
 
-extension TestCaseSpecifier {
+extension XCTestCaseSpecifier {
     /// Normalizes filter/skip arguments for XCTest, which only understands test ID patterns.
     ///
     /// `id:foo` and bare `foo` match a test ID, so the prefix is stripped and applied normally. Any other prefix
     /// (e.g. `tag:`) is a Swift Testing-only concept no XCTest can match.
-    func normalizedForXCTest() -> TestCaseSpecifier {
+    func normalizedForXCTest() -> XCTestCaseSpecifier {
         switch self {
         case .none, .specific:
             return self
@@ -1872,7 +1872,7 @@ extension TestCaseSpecifier {
 
 extension TestCommandOptions {
     /// Returns the specifier used for skipping tests, normalized for XCTest.
-    func xctestSkippedSpecifier(fileSystem: FileSystem) -> TestCaseSpecifier {
+    func xctestSkippedSpecifier(fileSystem: FileSystem) -> XCTestCaseSpecifier {
         // TODO: Remove this once the environment variable is no longer used.
         if let override = skippedTestsOverride(fileSystem: fileSystem) {
             return override.normalizedForXCTest()
@@ -1884,7 +1884,7 @@ extension TestCommandOptions {
     }
 
     /// Returns the test case specifier if overridden in the environment.
-    private func skippedTestsOverride(fileSystem: FileSystem) -> TestCaseSpecifier? {
+    private func skippedTestsOverride(fileSystem: FileSystem) -> XCTestCaseSpecifier? {
         guard let override = Environment.current["_SWIFTPM_SKIP_TESTS_LIST"] else {
             return nil
         }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -2370,5 +2370,67 @@ struct TestCommandTests {
             return (state, outputStream)
         }
     }
+    // MARK: - XCTest Filter Normalization Tests
+
+    /// Unit tests for `TestCaseSpecifier.normalizedForXCTest()`, which rewrites Swift Testing
+    /// filter/skip prefixes (e.g. `id:`, `tag:`) for XCTest, which only understands test-ID patterns.
+    @Suite
+    struct XCTestFilterNormalizationTests {
+        @Test
+        func idPrefixIsStrippedWhenFiltering() {
+            #expect(TestCaseSpecifier.regex(["id:SomeTests/testFoo"]).normalizedForXCTest() == .regex(["SomeTests/testFoo"]))
+        }
+
+        @Test
+        func noPrefixIsLeftUnchangedWhenFiltering() {
+            #expect(TestCaseSpecifier.regex(["SomeTests/testFoo"]).normalizedForXCTest() == .regex(["SomeTests/testFoo"]))
+        }
+
+        @Test
+        func tagPrefixFilterMatchesNoXCTests() {
+            #expect(TestCaseSpecifier.regex(["tag:integration"]).normalizedForXCTest() == .regex([]))
+        }
+
+        @Test
+        func arbitraryPrefixFilterMatchesNoXCTests() {
+            #expect(TestCaseSpecifier.regex(["foo:bar"]).normalizedForXCTest() == .regex([]))
+        }
+
+        @Test
+        func mixedIdAndTagFilterMatchesNoXCTests() {
+            #expect(TestCaseSpecifier.regex(["id:SomeTests/testFoo", "tag:integration"]).normalizedForXCTest() == .regex([]))
+        }
+
+        @Test
+        func tagBeforeIdFilterMatchesNoXCTests() {
+            #expect(TestCaseSpecifier.regex(["tag:integration", "id:SomeTests/testFoo"]).normalizedForXCTest() == .regex([]))
+        }
+
+        @Test
+        func barePatternWithTagFilterMatchesNoXCTests() {
+            #expect(TestCaseSpecifier.regex(["SomeTests/testFoo", "tag:integration"]).normalizedForXCTest() == .regex([]))
+        }
+
+        @Test
+        func idPrefixIsStrippedWhenSkipping() {
+            #expect(TestCaseSpecifier.skip(["id:SomeTests/testFoo"]).normalizedForXCTest() == .skip(["SomeTests/testFoo"]))
+        }
+
+        @Test
+        func tagPrefixSkipSkipsNoXCTests() {
+            #expect(TestCaseSpecifier.skip(["tag:integration"]).normalizedForXCTest() == .none)
+        }
+
+        @Test
+        func mixedIdAndTagSkipKeepsOnlyIdPatterns() {
+            #expect(TestCaseSpecifier.skip(["id:SomeTests/testFoo", "tag:integration"]).normalizedForXCTest() == .skip(["SomeTests/testFoo"]))
+        }
+
+        @Test
+        func noneAndSpecificPassThrough() {
+            #expect(TestCaseSpecifier.none.normalizedForXCTest() == .none)
+            #expect(TestCaseSpecifier.specific("SomeTests/testFoo").normalizedForXCTest() == .specific("SomeTests/testFoo"))
+        }
+    }
 }
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -2372,64 +2372,64 @@ struct TestCommandTests {
     }
     // MARK: - XCTest Filter Normalization Tests
 
-    /// Unit tests for `TestCaseSpecifier.normalizedForXCTest()`, which rewrites Swift Testing
+    /// Unit tests for `XCTestCaseSpecifier.normalizedForXCTest()`, which rewrites Swift Testing
     /// filter/skip prefixes (e.g. `id:`, `tag:`) for XCTest, which only understands test-ID patterns.
     @Suite
     struct XCTestFilterNormalizationTests {
         @Test
         func idPrefixIsStrippedWhenFiltering() {
-            #expect(TestCaseSpecifier.regex(["id:SomeTests/testFoo"]).normalizedForXCTest() == .regex(["SomeTests/testFoo"]))
+            #expect(XCTestCaseSpecifier.regex(["id:SomeTests/testFoo"]).normalizedForXCTest() == .regex(["SomeTests/testFoo"]))
         }
 
         @Test
         func noPrefixIsLeftUnchangedWhenFiltering() {
-            #expect(TestCaseSpecifier.regex(["SomeTests/testFoo"]).normalizedForXCTest() == .regex(["SomeTests/testFoo"]))
+            #expect(XCTestCaseSpecifier.regex(["SomeTests/testFoo"]).normalizedForXCTest() == .regex(["SomeTests/testFoo"]))
         }
 
         @Test
         func tagPrefixFilterMatchesNoXCTests() {
-            #expect(TestCaseSpecifier.regex(["tag:integration"]).normalizedForXCTest() == .regex([]))
+            #expect(XCTestCaseSpecifier.regex(["tag:integration"]).normalizedForXCTest() == .regex([]))
         }
 
         @Test
         func arbitraryPrefixFilterMatchesNoXCTests() {
-            #expect(TestCaseSpecifier.regex(["foo:bar"]).normalizedForXCTest() == .regex([]))
+            #expect(XCTestCaseSpecifier.regex(["foo:bar"]).normalizedForXCTest() == .regex([]))
         }
 
         @Test
         func mixedIdAndTagFilterMatchesNoXCTests() {
-            #expect(TestCaseSpecifier.regex(["id:SomeTests/testFoo", "tag:integration"]).normalizedForXCTest() == .regex([]))
+            #expect(XCTestCaseSpecifier.regex(["id:SomeTests/testFoo", "tag:integration"]).normalizedForXCTest() == .regex([]))
         }
 
         @Test
         func tagBeforeIdFilterMatchesNoXCTests() {
-            #expect(TestCaseSpecifier.regex(["tag:integration", "id:SomeTests/testFoo"]).normalizedForXCTest() == .regex([]))
+            #expect(XCTestCaseSpecifier.regex(["tag:integration", "id:SomeTests/testFoo"]).normalizedForXCTest() == .regex([]))
         }
 
         @Test
         func barePatternWithTagFilterMatchesNoXCTests() {
-            #expect(TestCaseSpecifier.regex(["SomeTests/testFoo", "tag:integration"]).normalizedForXCTest() == .regex([]))
+            #expect(XCTestCaseSpecifier.regex(["SomeTests/testFoo", "tag:integration"]).normalizedForXCTest() == .regex([]))
         }
 
         @Test
         func idPrefixIsStrippedWhenSkipping() {
-            #expect(TestCaseSpecifier.skip(["id:SomeTests/testFoo"]).normalizedForXCTest() == .skip(["SomeTests/testFoo"]))
+            #expect(XCTestCaseSpecifier.skip(["id:SomeTests/testFoo"]).normalizedForXCTest() == .skip(["SomeTests/testFoo"]))
         }
 
         @Test
         func tagPrefixSkipSkipsNoXCTests() {
-            #expect(TestCaseSpecifier.skip(["tag:integration"]).normalizedForXCTest() == .none)
+            #expect(XCTestCaseSpecifier.skip(["tag:integration"]).normalizedForXCTest() == .none)
         }
 
         @Test
         func mixedIdAndTagSkipKeepsOnlyIdPatterns() {
-            #expect(TestCaseSpecifier.skip(["id:SomeTests/testFoo", "tag:integration"]).normalizedForXCTest() == .skip(["SomeTests/testFoo"]))
+            #expect(XCTestCaseSpecifier.skip(["id:SomeTests/testFoo", "tag:integration"]).normalizedForXCTest() == .skip(["SomeTests/testFoo"]))
         }
 
         @Test
         func noneAndSpecificPassThrough() {
-            #expect(TestCaseSpecifier.none.normalizedForXCTest() == .none)
-            #expect(TestCaseSpecifier.specific("SomeTests/testFoo").normalizedForXCTest() == .specific("SomeTests/testFoo"))
+            #expect(XCTestCaseSpecifier.none.normalizedForXCTest() == .none)
+            #expect(XCTestCaseSpecifier.specific("SomeTests/testFoo").normalizedForXCTest() == .specific("SomeTests/testFoo"))
         }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/swiftlang/swift-testing/pull/1531
---
This PR accompanies https://github.com/swiftlang/swift-testing/pull/1531 as the implementation for [ST-0025](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0025-tag-based-test-execution-filtering.md), which enables users to pass an argument prefixed with `tag:` to `swift test --filter` in order to filter tests by tag in Swift Testing.


### Motivation:

This particular PR accounts for what happens to XCTests when we pass in such a filter. XCTest doesn't have a concept of tags. Another way of saying this is that every XCTest has an empty set of tags, which means that supplying `--filter tag:foo` should not run _any_ XCTests, since none of them have the appropriate tag. Similarly, supplying `--skip tag:foo` should not skip any XCTests.

We generalize this idea by saying that if any prefix is encountered (with one exception), we shouldn't match _any_ XCTests. The exception is the `id:` prefix which behaves the same as passing no prefix at all. We only introduced the `id:` prefix in https://github.com/swiftlang/swift-testing/pull/1531 in order to allow for disambiguation purposes, which don't apply when dealing with XCTests.

#### Examples

Here's a table of select examples to help illustrate what happens when you pass in various combinations of filter & skip specifiers:

| Argument                       | Swift Testing                          | XCTest                                    |
| ------------------------------ | -------------------------------------- | ----------------------------------------- |
| `--filter id:myTestName`       | runs matching tests                    | runs tests whose ID matches `myTestName`  |
| `--filter tag:integration`     | runs tests tagged `integration`        | runs nothing (XCTest tests have no tags)  |
| `--filter id:… --filter tag:…` | runs tests matching the id **and** tag | runs nothing (the tag can't be satisfied) |
| `--skip id:myTestName`         | skips matching tests                   | skips tests whose ID matches              |
| `--skip tag:integration`       | skips tests tagged `integration`       | skips nothing (all XCTest tests run)      |

### Modifications:

- Renamed `testCaseSpecifier` → `xctestFilterSpecifier`, `skippedTests` → `xctestSkippedSpecifier` to indicate their XCTest-specific nature (for Swift Testing, the arguments are passed directly and parsed over there).
- Added a function that normalizes the specifier for XCTest by stripping `id:` prefixes and deriving the correct behavior for other prefixes.
- Accounted for the slightly different semantics of the `--filter` and `--skip` specifiers.

### Result:

Existing uses won't change, but you will now be able to pass prefixes to `--filter` and `--skip` and have well-defined behavior as described above.
