### PR TITLE
fix(swiftbuild): ignore DocC bundles when loading packages

### DIFF
--- a/Sources/CoreCommands/BuildSystemSupport.swift
+++ b/Sources/CoreCommands/BuildSystemSupport.swift
@@ -133,7 +133,7 @@ private struct SwiftBuildSystemFactory: BuildSystemFactory {
                 )
             },
             packageManagerResourcesDirectory: swiftCommandState.packageManagerResourcesDirectory,
-            additionalFileRules: FileRuleDescription.swiftpmFileTypes + FileRuleDescription.xcbuildFileTypes,
+            additionalFileRules: FileRuleDescription.swiftBuildFileTypes,
             outputStream: outputStream ?? self.swiftCommandState.outputStream,
             logLevel: logLevel ?? self.swiftCommandState.logLevel,
             fileSystem: self.swiftCommandState.fileSystem,

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1350,7 +1350,7 @@ extension BuildSystemProvider.Kind {
         case .xcode:
             FileRuleDescription.xcbuildFileTypes
         case .swiftbuild:
-            FileRuleDescription.xcbuildFileTypes + [.docc]
+            FileRuleDescription.swiftBuildFileTypes
         case .native:
             FileRuleDescription.swiftpmFileTypes
         }

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -1347,10 +1347,12 @@ extension BuildSystemProvider.Kind {
 
     fileprivate var additionalFileRules: [FileRuleDescription] {
         switch self {
-        case .xcode, .swiftbuild:
-            return FileRuleDescription.xcbuildFileTypes
+        case .xcode:
+            FileRuleDescription.xcbuildFileTypes
+        case .swiftbuild:
+            FileRuleDescription.xcbuildFileTypes + [.docc]
         case .native:
-            return FileRuleDescription.swiftpmFileTypes
+            FileRuleDescription.swiftpmFileTypes
         }
     }
 }

--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -870,6 +870,11 @@ public struct FileRuleDescription: Sendable {
         xcprivacyIgnored,
     ]
 
+    /// List of file types that apply to the SwiftBuild build system.
+    public static let swiftBuildFileTypes: [FileRuleDescription] = xcbuildFileTypes + [
+        docc,
+    ]
+
     /// List of file directory extensions that should be treated as opaque, non source, directories.
     public static var opaqueDirectoriesExtensions: Set<String> {
         let types = Self.xcbuildFileTypes + Self.swiftpmFileTypes

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -981,6 +981,23 @@ struct BuildCommandTestCases {
     }
 
     @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10285", relationship: .defect)
+    )
+    func docCBundleDoesNotEmitUnhandledFilesWarning() async throws {
+        try await fixture(name: "Miscellaneous/LibraryWithDocC") { fixturePath in
+            let (_, stderr) = try await executeSwiftBuild(
+                fixturePath,
+                buildSystem: .swiftbuild
+            )
+
+            #expect(
+                stderr.contains("Documentation.docc") == false,
+                "Unexpected warning for the DocC bundle: \(stderr)"
+            )
+        }
+    }
+
+    @Test(
         .tags(
             .Feature.BuildCache,
         ),

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -981,7 +981,7 @@ struct BuildCommandTestCases {
     }
 
     @Test(
-        .issue("https://github.com/swiftlang/swift-package-manager/issues/10285", relationship: .defect)
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10285", relationship: .verifies)
     )
     func docCBundleDoesNotEmitUnhandledFilesWarning() async throws {
         try await fixture(name: "Miscellaneous/LibraryWithDocC") { fixturePath in

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -984,6 +984,49 @@ final class TargetSourcesBuilderTests: XCTestCase {
         XCTAssertNoDiagnostics(observability.diagnostics)
     }
 
+    func testSwiftBuildFileTypesDoNotConflict() throws {
+        let target = try TargetDescription(
+            name: "Foo",
+            path: nil,
+            exclude: [],
+            sources: ["File.swift"],
+            resources: [],
+            publicHeadersPath: nil,
+            type: .regular
+        )
+
+        let fs = InMemoryFileSystem()
+        fs.createEmptyFiles(at: AbsolutePath.root, files: [
+            "/File.swift",
+            "/Foo.docc",
+            "/PrivacyInfo.xcprivacy",
+        ])
+
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let builder = TargetSourcesBuilder(
+            packageIdentity: .plain("test"),
+            packageKind: .root(.root),
+            packagePath: .root,
+            target: target,
+            path: .root,
+            defaultLocalization: nil,
+            additionalFileRules: FileRuleDescription.swiftBuildFileTypes,
+            toolsVersion: .v6_0,
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let outputs = try builder.run()
+        XCTAssertEqual(outputs.sources.paths, ["/File.swift"])
+        XCTAssertEqual(outputs.resources, try [
+            .init(rule: .copy, path: .init(validating: "/PrivacyInfo.xcprivacy")),
+        ])
+        XCTAssertEqual(outputs.ignored, ["/Foo.docc"])
+        XCTAssertEqual(outputs.others, [])
+
+        XCTAssertNoDiagnostics(observability.diagnostics)
+    }
+
     func testResourcesAreSorted() throws {
         let target = try TargetDescription(
             name: "Foo",


### PR DESCRIPTION
Fixes #10285

## Summary

Prevents SwiftBuild from reporting documentation catalogs as unhandled files.

Recent Swift 6.4 toolchains emit a spurious unhandled-files warning when a target contains a `.docc` bundle. SwiftBuild was loading packages with XCBuild file rules but without SwiftPM's existing rule that recognizes `.docc` bundles.

## Changes

- Give SwiftBuild the existing `.docc` ignored-file rule when loading the package graph.
- Keep Xcode and native build-system file rules unchanged.
- Add a command-level regression test using the existing `LibraryWithDocC` fixture.

## Alternatives considered

Reusing all SwiftPM-specific file rules was rejected because they also include an ignored `.xcprivacy` rule that would conflict with SwiftBuild's copied `.xcprivacy` rule. Adding only `.docc` keeps the fix narrow.

## Notes

This restores the behavior from Swift 6.3 and earlier. Genuine unhandled files in root packages continue to produce diagnostics.

## Testing

- `BuildCommandTestCases.docCBundleDoesNotEmitUnhandledFilesWarning`
- `TargetSourcesBuilderTests.testDocCFilesDoNotCauseWarningOutsideXCBuild`
- `PIFBuilderTests.emitUnhandledFilesOnlyForRootPackages`
- SwiftFormat lint on the changed ranges
