### PR TITLE
Improve diagnostics for local binary archive files

### DIFF
--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -186,6 +186,12 @@ struct BinaryArtifactsManagerError: Error, CustomStringConvertible {
         .init(description: "local binary target '\(targetName)' at '\(artifactPath)' does not contain a binary artifact.")
     }
 
+    static func localArtifactIsFile(artifactPath: AbsolutePath, targetName: String) -> Self {
+        .init(
+            description: "local binary target '\(targetName)' at '\(artifactPath)' is a file, but '.\(artifactPath.extension ?? "")' is only supported for directories; use a '.zip' extension for local binary archives."
+        )
+    }
+
     static func artifactContainsEscapingSymlink(
         targetName: String,
         symlinkPath: AbsolutePath,

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -100,6 +100,13 @@ extension Workspace {
                                     kind: .unknown // an archive, we will extract it later
                                 )
                             )
+                        } else if self.fileSystem.isFile(absolutePath) {
+                            observabilityScope.emit(
+                                BinaryArtifactsManagerError.localArtifactIsFile(
+                                    artifactPath: absolutePath,
+                                    targetName: target.name
+                                )
+                            )
                         } else {
                             guard let (artifactPath, artifactKind) = try Self.deriveBinaryArtifact(
                                 fileSystem: self.fileSystem,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -7228,6 +7228,43 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testLocalArtifactFileWithDirectoryExtension() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "A1",
+                            type: .binary,
+                            path: "ArtifactBundles/A1.artifactbundle"
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        let rootPath = try workspace.pathToRoot(withName: "Root")
+        let artifactBundlesPath = rootPath.appending("ArtifactBundles")
+        try fs.createDirectory(artifactBundlesPath, recursive: true)
+        let artifactPath = artifactBundlesPath.appending("A1.artifactbundle")
+        try fs.writeFileContents(artifactPath, bytes: ByteString([0xA1]))
+
+        await workspace.checkPackageGraphFailure(roots: ["Root"]) { diagnostics in
+            testDiagnostics(diagnostics) { result in
+                result.check(
+                    diagnostic: "local binary target 'A1' at '\(artifactPath)' is a file, but '.artifactbundle' is only supported for directories; use a '.zip' extension for local binary archives.",
+                    severity: .error
+                )
+            }
+        }
+    }
+
     func testLocalArtifactDoesNotExist() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
Improve the diagnostic for a local binary target whose directory-only extension points to a regular file.

### Motivation:

A ZIP archive renamed from `A.artifactbundle.zip` to `A.artifactbundle` passes manifest validation, then SwiftPM tries to traverse it as a directory and surfaces an internal filesystem error. Fixes #10077.

### Modifications:

- Detect regular files that use a directory-only binary artifact extension.
- Emit an actionable diagnostic explaining that local archives must retain the `.zip` extension.
- Add a regression test for an `.artifactbundle` file.

### Result:

SwiftPM now reports that `.artifactbundle` is supported only for directories and tells the user to use `.zip` for a local binary archive.

### Testing:

- `swift build --target Workspace`
- SwiftFormat lint of each changed source and test region
- `git diff --check`

The focused XCTest regression could not run in this Command Line Tools-only environment because it does not provide the `XCTest` module. The modified `Workspace` target builds successfully; please trigger `@swift-ci` for the required full test suite.
