### PR TITLE
[6.4] Update DiagnosticsChecker to support Swift Testing

### DIFF
--- a/Sources/_InternalTestSupport/Observability.swift
+++ b/Sources/_InternalTestSupport/Observability.swift
@@ -125,7 +125,7 @@ public func XCTAssertNoDiagnostics(
 ) {
     let diagnostics = problemsOnly ? diagnostics.filter { $0.severity >= .warning } : diagnostics
     if diagnostics.isEmpty { return }
-    
+
     let description = diagnostics.map { "- " + $0.description }.joined(separator: "\n")
     XCTFail("Found unexpected diagnostics: \n\(description)", file: file, line: line)
 }
@@ -198,7 +198,7 @@ public func expectDiagnostics(
     _ diagnostics: [Basics.Diagnostic],
     minSeverity: Basics.Diagnostic.Severity,
     sourceLocation: SourceLocation = #_sourceLocation,
-    handler: (DiagnosticsTestResult) throws -> Void
+    handler: (DiagnosticsTestResult) throws -> Void,
 ) throws {
     let diagnostics = diagnostics.filter { $0.severity >= minSeverity }
     let testResult = DiagnosticsTestResult(diagnostics)
@@ -209,7 +209,7 @@ public func expectDiagnostics(
         Issue.record("unchecked diagnostics \(testResult.uncheckedDiagnostics)", sourceLocation: sourceLocation)
      }
 }
- 
+
 public func testPartialDiagnostics(
     _ diagnostics: [Basics.Diagnostic],
     minSeverity: Basics.Diagnostic.Severity,
@@ -237,9 +237,17 @@ public class DiagnosticsTestResult {
 
     package func checkIsEmpty(
         file: StaticString = #file,
-        line: UInt = #line
+        line: UInt = #line,
+        sourceLocation: SourceLocation = #_sourceLocation,
     ) {
-        XCTAssertTrue(self.uncheckedDiagnostics.isEmpty, file: file, line: line)
+        if Test.current != nil {
+            #expect(
+                self.uncheckedDiagnostics.isEmpty == true,
+                sourceLocation: sourceLocation,
+            )
+        } else {
+            XCTAssertTrue(self.uncheckedDiagnostics.isEmpty, file: file, line: line)
+        }
     }
 
     @discardableResult
@@ -248,20 +256,40 @@ public class DiagnosticsTestResult {
         severity: Basics.Diagnostic.Severity,
         //metadata: ObservabilityMetadata? = .none,
         file: StaticString = #file,
-        line: UInt = #line
+        line: UInt = #line,
+        sourceLocation: SourceLocation = #_sourceLocation,
     ) -> Basics.Diagnostic? {
         guard !self.uncheckedDiagnostics.isEmpty else {
-            XCTFail("No diagnostics left to check", file: file, line: line)
+            let error = "No diagnostics left to check"
+            if Test.current != nil {
+                Issue.record(
+                    "\(error)",
+                    sourceLocation: sourceLocation,
+                )
+            } else {
+                XCTFail(error, file: file, line: line)
+            }
             return nil
         }
 
         let diagnostic: Basics.Diagnostic = self.uncheckedDiagnostics.removeFirst()
-
-        XCTAssertMatch(diagnostic.message, message, file: file, line: line)
-        XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
-        // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed
-        //XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
-        //XCTAssertEqual(diagnostic.metadata?.droppingLegacyKeys(), metadata?.droppingLegacyKeys(), file: file, line: line)
+        if Test.current != nil {
+            expectMatch(
+                diagnostic.message,
+                message,
+                sourceLocation: sourceLocation,
+            )
+            #expect(diagnostic.severity == severity, sourceLocation: sourceLocation)
+            // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed
+            //XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
+            //XCTAssertEqual(diagnostic.metadata?.droppingLegacyKeys(), metadata?.droppingLegacyKeys(), file: file, line: line)
+        } else {
+            XCTAssertMatch(diagnostic.message, message, file: file, line: line)
+            XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
+            // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed
+            //XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
+            //XCTAssertEqual(diagnostic.metadata?.droppingLegacyKeys(), metadata?.droppingLegacyKeys(), file: file, line: line)
+        }
 
         return diagnostic
     }
@@ -272,24 +300,42 @@ public class DiagnosticsTestResult {
         severity: Basics.Diagnostic.Severity,
         //metadata: ObservabilityMetadata? = .none,
         file: StaticString = #file,
-        line: UInt = #line
+        line: UInt = #line,
+        sourceLocation: SourceLocation = #_sourceLocation,
     ) -> Basics.Diagnostic? {
         guard !self.uncheckedDiagnostics.isEmpty else {
-            XCTFail("No diagnostics left to check", file: file, line: line)
+            let error = "No diagnostics left to check"
+            if Test.current != nil {
+                Issue.record("\(error)", sourceLocation: sourceLocation)
+            } else {
+                XCTFail(error, file: file, line: line)
+            }
             return nil
         }
 
         let matching = self.uncheckedDiagnostics.indices
             .filter { diagnosticPattern ~= self.uncheckedDiagnostics[$0].message }
         if matching.isEmpty {
-            XCTFail("No diagnostics match \(diagnosticPattern)", file: file, line: line)
+            let error = "No diagnostics match \(diagnosticPattern)"
+            if Test.current != nil {
+                Issue.record("\(error)", sourceLocation: sourceLocation)
+            } else {
+                XCTFail(error, file: file, line: line)
+            }
             return nil
         } else if matching.count == 1, let index = matching.first {
             let diagnostic = self.uncheckedDiagnostics[index]
-            XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
-            // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed
-            //XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
-            //XCTAssertEqual(diagnostic.metadata?.droppingLegacyKeys(), metadata?.droppingLegacyKeys(), file: file, line: line)
+            if Test.current != nil {
+                #expect(diagnostic.severity == severity, sourceLocation: sourceLocation)
+                // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed
+                //XCTAssertEqual(diagnostic.metadata == metadata, sourceLocation: sourceLocation)
+                //XCTAssertEqual(diagnostic.metadata.droppingLegacyKeys() == metadata?.droppingLegacyKeys(), sourceLocation: sourceLocation)
+            } else {
+                XCTAssertEqual(diagnostic.severity, severity, file: file, line: line)
+                // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed
+                //XCTAssertEqual(diagnostic.metadata, metadata, file: file, line: line)
+                //XCTAssertEqual(diagnostic.metadata?.droppingLegacyKeys(), metadata?.droppingLegacyKeys(), file: file, line: line)
+            }
             self.uncheckedDiagnostics.remove(at: index)
             return diagnostic
         // FIXME: (diagnostics) compare complete metadata when legacy bridge is removed

--- a/Sources/_InternalTestSupport/SwiftTesting+ExpectMatch.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+ExpectMatch.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+import TSCTestSupport
+
+private func expectMatchImpl<Pattern, Value>(
+    _ result: Bool,
+    _ value: Value,
+    _ pattern: Pattern,
+    negativeMatch: Bool = false,
+    sourceLocation: SourceLocation = #_sourceLocation,
+) {
+    let message: Comment
+    if negativeMatch {
+        message = "did not expect '\(value)' to match pattern \(pattern)"
+    } else {
+        message = "unexpected failure matching '\(value)' against pattern \(pattern)"
+    }
+    #expect(
+        result,
+        message,
+        sourceLocation: sourceLocation,
+    )
+}
+
+public func expectMatch(
+    _ value: String,
+    _ pattern: StringPattern,
+    sourceLocation: SourceLocation = #_sourceLocation,
+) {
+    expectMatchImpl(
+        pattern ~= value.trimmingCharacters(in: .whitespacesAndNewlines),
+        value,
+        pattern,
+        sourceLocation: sourceLocation,
+    )
+}
+
+public func expectNoMatch(
+    _ value: String,
+    _ pattern: StringPattern,
+    sourceLocation: SourceLocation = #_sourceLocation,
+) {
+    expectMatchImpl(
+        !(pattern ~= value.trimmingCharacters(in: .whitespacesAndNewlines)),
+        value,
+        pattern,
+        negativeMatch: true,
+        sourceLocation: sourceLocation,
+    )
+}

--- a/Tests/BasicsTests/CancellatorTests.swift
+++ b/Tests/BasicsTests/CancellatorTests.swift
@@ -13,6 +13,7 @@
 @testable import Basics
 import _InternalTestSupport
 import XCTest
+import Testing
 
 import class Basics.AsyncProcess
 
@@ -230,7 +231,6 @@ final class CancellatorTests: XCTestCase {
 
             XCTAssertEqual(.success, finishSemaphore.wait(timeout: .now() + .seconds(5)), "timeout finishing tasks")
             print(startSemaphore.output)
-            
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
 #else

--- a/Tests/BasicsTests/ObservabilitySystemTests.swift
+++ b/Tests/BasicsTests/ObservabilitySystemTests.swift
@@ -178,7 +178,7 @@ struct ObservabilitySystemTest {
                 #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
             do {
-                let diagnostic = try #require(result.check(diagnostic: "debug", severity: .error))
+                let diagnostic = try #require(result.check(diagnostic: "debug", severity: .debug))
                 let diagnostic_metadata = try #require(diagnostic.metadata)
                 #expect(diagnostic_metadata.testKey1 == metadata.testKey1)
             }
@@ -291,6 +291,56 @@ struct ObservabilitySystemTest {
                 #expect(diagnostic_metadata.testKey3 == diagnosticMergedMetadata.testKey3)
             }
         }
+    }
+
+    @Suite(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10061", relationship: .verifies),
+    )
+    struct DiagnosticsReportingCheckerTests {
+
+        @Test
+        func reportsMismatchedMessage() throws {
+            let collector = Collector()
+            let observabilitySystem = ObservabilitySystem(collector)
+            observabilitySystem.topScope.emit(error: "actual error message")
+
+            try expectDiagnostics(collector.diagnostics) { result in
+                withKnownIssue("a mismatched diagnostic severity must be reported") {
+                    // The result.check is expcted to fail, but Swift Testing doesn't offer API to ensure an expectation
+                    // failed, so we wrap the call in a "withKnownIssue"
+                    result.check(diagnostic: "this message does not match", severity: .error)
+                }
+            }
+        }
+
+        @Test
+        func reportsMismatchedSeverity() throws {
+            let collector = Collector()
+            let observabilitySystem = ObservabilitySystem(collector)
+            observabilitySystem.topScope.emit(error: "actual error message")
+
+            try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+                withKnownIssue("a mismatched diagnostic severity must be reported") {
+                    // The result.check is expcted to fail, but Swift Testing doesn't offer API to ensure an expectation
+                    // failed, so we wrap the call in a "withKnownIssue"
+                    result.check(diagnostic: "actual error message", severity: .warning)
+                }
+            }
+        }
+
+        @Test
+        func diagnosticsCheckUnorderedReportsMismatchedSeverity() throws {
+            let collector = Collector()
+            let observabilitySystem = ObservabilitySystem(collector)
+            observabilitySystem.topScope.emit(error: "actual error message")
+
+            withKnownIssue("a mismatched diagnostic severity must be reported") {
+                try expectDiagnostics(collector.diagnostics, problemsOnly: false) { result in
+                    result.checkUnordered(diagnostic: "actual error message", severity: .warning)
+                }
+            }
+        }
+
     }
 
     struct Collector: ObservabilityHandlerProvider, DiagnosticsHandler {

--- a/Tests/PackageLoadingTests/BinaryTargetExecutableTests.swift
+++ b/Tests/PackageLoadingTests/BinaryTargetExecutableTests.swift
@@ -81,7 +81,7 @@ struct BinaryTargetExecutableTests {
         )
 
         let binaryArtifacts = [
-            "BinaryTarget": BinaryArtifact(kind: .xcframework, originURL: nil, path: "/binary.xcframework"),
+            "BinaryTarget": BinaryArtifact(kind: .artifactsArchive(types: [.executable]), originURL: nil, path: "/binary.artifactbundle"),
         ]
 
         try PackageBuilderTester(manifest, binaryArtifacts: binaryArtifacts, in: fs) { package, diagnostics in
@@ -94,7 +94,6 @@ struct BinaryTargetExecutableTests {
             // Check all modules even when there are errors
             try package.checkModule("SwiftTarget") { _ in }
             try package.checkModule("BinaryTarget") { _ in }
-            package.checkProduct("MyExecutable") { _ in }
         }
     }
 

--- a/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
+++ b/Tests/PackageLoadingTests/ManifestLoaderCacheTests.swift
@@ -15,6 +15,7 @@
 import PackageModel
 import _InternalTestSupport
 import XCTest
+import Testing
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
 final class ManifestLoaderCacheTests: XCTestCase {

--- a/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
+++ b/Tests/PackageLoadingTests/ModuleMapGenerationTests.swift
@@ -15,6 +15,7 @@ import PackageLoading
 import PackageModel
 import _InternalTestSupport
 import XCTest
+import Testing
 
 final class ModuleMapGeneration: XCTestCase {
     func testModuleNameHeaderInInclude() throws {
@@ -182,7 +183,7 @@ func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fi
     // Create a module map generator, and determine the type of module map to use for the header directory.  This may emit diagnostics.
     let moduleMapGenerator = ModuleMapGenerator(targetName: targetName, moduleName: targetName.spm_mangledToC99ExtendedIdentifier(), publicHeadersDir: AbsolutePath.root.appending(component: includeDir), fileSystem: fileSystem)
     let moduleMapType = moduleMapGenerator.determineModuleMapType(observabilityScope: observability.topScope)
-    
+
     // Generate a module map and capture any emitted diagnostics.
     let generatedModuleMapPath = AbsolutePath.root.appending(components: "module.modulemap")
     observability.topScope.trap {
@@ -190,11 +191,11 @@ func ModuleMapTester(_ targetName: String, includeDir: String = "include", in fi
             try moduleMapGenerator.generateModuleMap(type: generatedModuleMapType, at: generatedModuleMapPath)
         }
     }
-    
+
     // Invoke the closure to check the results.
     let result = ModuleMapResult(diagnostics: observability.diagnostics, path: generatedModuleMapPath, fs: fileSystem)
     body(result)
-    
+
     // Check for any unexpected diagnostics (the ones the closure didn't check for).
     result.validateDiagnostics()
 }

--- a/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_0_LoadingTests.swift
@@ -15,6 +15,7 @@ import PackageLoading
 import PackageModel
 import _InternalTestSupport
 import XCTest
+import Testing
 
 final class PackageDescription4_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {

--- a/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_4_2_LoadingTests.swift
@@ -16,6 +16,7 @@ import PackageLoading
 import PackageModel
 import _InternalTestSupport
 import XCTest
+import Testing
 
 import enum TSCBasic.PathValidationError
 

--- a/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_0_LoadingTests.swift
@@ -15,6 +15,7 @@ import PackageLoading
 import PackageModel
 import _InternalTestSupport
 import XCTest
+import Testing
 
 import struct TSCBasic.ByteString
 

--- a/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_2_LoadingTests.swift
@@ -15,6 +15,7 @@ import PackageLoading
 import PackageModel
 import _InternalTestSupport
 import XCTest
+import Testing
 
 final class PackageDescription5_2LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {

--- a/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_3_LoadingTests.swift
@@ -15,6 +15,7 @@ import PackageModel
 import PackageLoading
 import _InternalTestSupport
 import XCTest
+import Testing
 
 import enum TSCBasic.PathValidationError
 

--- a/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_5_7_LoadingTests.swift
@@ -15,6 +15,7 @@ import PackageLoading
 import PackageModel
 import _InternalTestSupport
 import XCTest
+import Testing
 
 final class PackageDescription5_7LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {

--- a/Tests/PackageLoadingTests/PD_6_0_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_6_0_LoadingTests.swift
@@ -15,6 +15,7 @@ import PackageModel
 import SourceControl
 import _InternalTestSupport
 import XCTest
+import Testing
 
 final class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
     override var toolsVersion: ToolsVersion {
@@ -93,7 +94,7 @@ final class PackageDescription6_0LoadingTests: PackageDescriptionLoadingTests {
     }
 
     private func loadRootManifestWithBasicGitRepository(
-        manifestContent: String, 
+        manifestContent: String,
         validator: (Manifest, TestingObservability) throws -> ()
     ) async throws {
         let observability = ObservabilitySystem.makeForTesting()

--- a/Tests/PackageLoadingTests/PkgConfigParserTests.swift
+++ b/Tests/PackageLoadingTests/PkgConfigParserTests.swift
@@ -14,6 +14,7 @@ import Basics
 @testable import PackageLoading
 import _InternalTestSupport
 import XCTest
+import Testing
 
 import struct TSCBasic.ByteString
 

--- a/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
+++ b/Tests/PackageLoadingTests/TargetSourcesBuilderTests.swift
@@ -16,6 +16,7 @@ import PackageModel
 import PackageLoading
 import _InternalTestSupport
 import XCTest
+import Testing
 
 final class TargetSourcesBuilderTests: XCTestCase {
     func testBasicFileContentsComputation() throws {
@@ -729,7 +730,7 @@ final class TargetSourcesBuilderTests: XCTestCase {
             XCTAssertNoDiagnostics(observability.diagnostics)
         }
     }
-    
+
     func testMissingResource() throws {
         let target = try TargetDescription(
             name: "Foo",
@@ -797,7 +798,7 @@ final class TargetSourcesBuilderTests: XCTestCase {
         }
     }
 
-    
+
     func testMissingSource() throws {
         let target = try TargetDescription(
             name: "Foo",

--- a/Tests/PackageModelTests/PackageModelTests.swift
+++ b/Tests/PackageModelTests/PackageModelTests.swift
@@ -18,6 +18,7 @@ import Basics
 import _InternalTestSupport
 import func TSCBasic.withTemporaryFile
 import XCTest
+import Testing
 
 import struct TSCBasic.ByteString
 

--- a/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageSigningEntityTOFUTests.swift
@@ -18,6 +18,7 @@ import PackageModel
 @testable import PackageSigning
 import _InternalTestSupport
 import XCTest
+import Testing
 
 import struct TSCUtility.Version
 

--- a/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
+++ b/Tests/PackageRegistryTests/PackageVersionChecksumTOFUTests.swift
@@ -18,6 +18,7 @@ import PackageModel
 @testable import PackageRegistry
 import _InternalTestSupport
 import XCTest
+import Testing
 
 import struct TSCUtility.Version
 

--- a/Tests/PackageRegistryTests/SignatureValidationTests.swift
+++ b/Tests/PackageRegistryTests/SignatureValidationTests.swift
@@ -18,6 +18,7 @@ import PackageSigning
 import _InternalTestSupport
 import X509 // FIXME: need this import or else SwiftSigningIdentity init crashes
 import XCTest
+import Testing
 
 import struct TSCUtility.Version
 

--- a/Tests/SourceControlTests/RepositoryManagerTests.swift
+++ b/Tests/SourceControlTests/RepositoryManagerTests.swift
@@ -16,6 +16,7 @@ import PackageModel
 import _InternalTestSupport
 @testable import SourceControl
 import XCTest
+import Testing
 
 final class RepositoryManagerTests: XCTestCase {
     func testBasics() async throws {

--- a/Tests/SwiftBuildSupportTests/FileSystemUtilsTests.swift
+++ b/Tests/SwiftBuildSupportTests/FileSystemUtilsTests.swift
@@ -69,18 +69,18 @@ struct CreateBuildSymbolicLinkFunction {
         // Arrange
         struct FileSystemDouble: FileSystem {
             func createSymbolicLink(_ path: TSCBasic.AbsolutePath, pointingAt destination: TSCBasic.AbsolutePath, relative: Bool) throws {
-                throw StringError("Purposely failing in \(#function)")
+                throw StringError("Purposely failing in the test in function \(#function)")
             }
 
             func removeFileTree(_ path: TSCBasic.AbsolutePath) throws {
-                throw StringError("Purposely failing in \(#function)")
+                throw StringError("Purposely failing in the test in function \(#function)")
             }
 
             func removeFileTree(_ path: AbsolutePath) throws {
-                throw StringError("Purposely failing in \(#function)")
+                throw StringError("Purposely failing in the test in function \(#function)")
             }
             func createSymbolicLink( source: AbsolutePath, pointingAt target: AbsolutePath ) throws {
-                throw StringError("Purposely failing in \(#function)")
+                throw StringError("Purposely failing in the test in function \(#function)")
             }
 
             func move(from sourcePath: TSCBasic.AbsolutePath, to destinationPath: TSCBasic.AbsolutePath) throws {}
@@ -105,8 +105,8 @@ struct CreateBuildSymbolicLinkFunction {
             func isExecutableFile(_ path: TSCBasic.AbsolutePath) -> Bool { false }
             func isFile(_ path: TSCBasic.AbsolutePath) -> Bool { false }
             func isDirectory(_ path: TSCBasic.AbsolutePath) -> Bool { false }
-            func exists(_ path: TSCBasic.AbsolutePath, followSymlink: Bool) -> Bool { false }
-            func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool { false }
+            func exists(_ path: TSCBasic.AbsolutePath, followSymlink: Bool) -> Bool { true }
+            func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool { true }
         }
 
         let fs = FileSystemDouble(
@@ -135,7 +135,6 @@ struct CreateBuildSymbolicLinkFunction {
                 diagnostic: .contains("unable to create symbolic link"),
                 severity: .warning
             )
-
         }
     }
 

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemMessageHandlerTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemMessageHandlerTests.swift
@@ -174,16 +174,18 @@ struct SwiftBuildSystemMessageHandlerTests {
         let messageHandler = self.messageHandler.warning
 
         let events: [SwiftBuildMessage] = [
-            .taskStartedInfo(taskID: 1, taskSignature: "simple-diagnostic"),
+            .taskStartedInfo(taskID: 1, taskSignature: "simple-diagnostic", ruleInfo: "started-simple-diag"),
             .diagnostic(
+                locationContext: .task(taskID: 1, targetID: 1),
                 locationContext2: .init(taskSignature: "simple-diagnostic"),
                 message: "Simple diagnostic",
                 appendToOutputStream: true
             ),
-            .taskStartedInfo(taskID: 2, taskSignature: "another-diagnostic"),
-            .taskStartedInfo(taskID: 3, taskSignature: "warning-diagnostic"),
+            .taskStartedInfo(taskID: 2, taskSignature: "another-diagnostic", ruleInfo: "started-another-diag"),
+            .taskStartedInfo(taskID: 3, taskSignature: "warning-diagnostic", ruleInfo: "started-warning-diag"),
             .diagnostic(
                 kind: .warning,
+                locationContext: .task(taskID: 3, targetID: 1),
                 locationContext2: .init(taskSignature: "warning-diagnostic"),
                 message: "Warning diagnostic",
                 appendToOutputStream: true
@@ -191,6 +193,7 @@ struct SwiftBuildSystemMessageHandlerTests {
             .taskCompleteInfo(taskID: 1, taskSignature: "simple-diagnostic", result: .failed),
             .diagnostic(
                 kind: .warning,
+                locationContext: .task(taskID: 3, targetID: 1),
                 locationContext2: .init(taskSignature: "warning-diagnostic"),
                 message: "Another warning diagnostic",
                 appendToOutputStream: true
@@ -198,6 +201,7 @@ struct SwiftBuildSystemMessageHandlerTests {
             .taskCompleteInfo(taskID: 3, taskSignature: "warning-diagnostic", result: .success),
             .diagnostic(
                 kind: .note,
+                locationContext: .task(taskID: 2, targetID: 1),
                 locationContext2: .init(taskSignature: "another-diagnostic"),
                 message: "Another diagnostic",
                 appendToOutputStream: true
@@ -209,13 +213,18 @@ struct SwiftBuildSystemMessageHandlerTests {
             _ = try messageHandler.emitEvent(event)
         }
 
-        #expect(self.observability.hasErrorDiagnostics)
-
-        try expectDiagnostics(observability.diagnostics) { result in
+        #expect(self.observability.hasErrorDiagnostics, "expected at least 1 error diagnostic")
+        #expect(self.observability.hasWarningDiagnostics, "expected at least 1 warning diagnostic")
+        try expectDiagnostics(
+            observability.diagnostics,
+            problemsOnly: false,
+        ) { result in
             result.check(diagnostic: "Simple diagnostic", severity: .error)
-            result.check(diagnostic: "Another diagnostic", severity: .info)
-            result.check(diagnostic: "Another warning diagnostic", severity: .warning)
+            result.check(diagnostic: .contains("started-simple-diag failed"), severity: .info)
             result.check(diagnostic: "Warning diagnostic", severity: .warning)
+            result.check(diagnostic: "Another warning diagnostic", severity: .warning)
+            result.check(diagnostic: "Another diagnostic", severity: .info)
+            result.check(diagnostic: .contains("started-another-diag failed"), severity: .info)
         }
     }
 
@@ -295,79 +304,79 @@ struct SwiftBuildSystemMessageHandlerTests {
         #expect(outputText.contains("error"))
     }
 
-    @Test
-    func testDiagnosticOutputWhenOnlyWarnings() throws {
-        let messageHandler = self.messageHandler.warning
+    struct DiagnosticsOutputWhenSpeficyDiagnosticIsEmittedData: CustomTestStringConvertible {
 
-        let events: [SwiftBuildMessage] = [
-            .taskStartedInfo(taskID: 1, taskSignature: "simple-warning-diagnostic"),
-            .diagnostic(
-                kind: .warning,
-                locationContext2: .init(taskSignature: "simple-warning-diagnostic"),
-                message: "Simple warning diagnostic",
-                appendToOutputStream: true
-            ),
-            .taskCompleteInfo(taskID: 1, taskSignature: "simple-warning-diagnostic", result: .success)
-        ]
+        let id: String
+        let severity: SwiftBuildMessage.DiagnosticInfo.Kind
+        let expectedHasWarningDiagnostic: Bool
+        let expectedHasErrorDiagnotic: Bool
+        let expectedSwiftPMSeverity: Basics.Diagnostic.Severity
 
-        for event in events {
-            _ = try messageHandler.emitEvent(event)
-        }
-
-        #expect(self.observability.hasWarningDiagnostics)
+        var testDescription: String { id}
     }
-
-    @Test
-    func testDiagnosticOutputWhenOnlyNotes() throws {
+    @Test(
+        arguments: [
+            DiagnosticsOutputWhenSpeficyDiagnosticIsEmittedData(
+                id: "Swift Build error diagnostic emitted by SwiftPM",
+                severity: SwiftBuildMessage.DiagnosticInfo.Kind.error,
+                expectedHasWarningDiagnostic: false,
+                expectedHasErrorDiagnotic: true,
+                expectedSwiftPMSeverity: Basics.Diagnostic.Severity.error,
+            ),
+            DiagnosticsOutputWhenSpeficyDiagnosticIsEmittedData(
+                id: "Swift Build warning diagnostic emitted by SwiftPM",
+                severity: .warning,
+                expectedHasWarningDiagnostic: true,
+                expectedHasErrorDiagnotic: false,
+                expectedSwiftPMSeverity: .warning,
+            ),
+            DiagnosticsOutputWhenSpeficyDiagnosticIsEmittedData(
+                id: "Swift Build note diagnostic emitted by SwiftPM",
+                severity: .note,
+                expectedHasWarningDiagnostic: false,
+                expectedHasErrorDiagnotic: false,
+                expectedSwiftPMSeverity: .info,
+            ),
+            DiagnosticsOutputWhenSpeficyDiagnosticIsEmittedData(
+                id: "Swift Build remark diagnostic emitted by SwiftPM",
+                severity: .remark,
+                expectedHasWarningDiagnostic: false,
+                expectedHasErrorDiagnotic: false,
+                expectedSwiftPMSeverity: .debug,
+            ),
+        ]
+    )
+    func diagnosticsOutputWhenSpeficyDiagnosticIsEmitted(
+        testcase: DiagnosticsOutputWhenSpeficyDiagnosticIsEmittedData
+    ) async throws {
         let messageHandler = self.messageHandler.warning
+        let diagMessage = "Simple \(testcase.severity) diagnostic"
+        let taskSignatureName = "simple-\(testcase.severity)-diagnostic"
 
         let events: [SwiftBuildMessage] = [
-            .taskStartedInfo(taskID: 1, taskSignature: "simple-note-diagnostic"),
+            .taskStartedInfo(taskID: 1, taskSignature: taskSignatureName),
             .diagnostic(
-                kind: .note,
-                locationContext2: .init(taskSignature: "simple-note-diagnostic"),
-                message: "Simple note diagnostic",
+                kind: testcase.severity,
+                locationContext2: .init(taskSignature: taskSignatureName),
+                message: diagMessage,
                 appendToOutputStream: true
             ),
-            .taskCompleteInfo(taskID: 1, taskSignature: "simple-note-diagnostic", result: .success)
+            .taskCompleteInfo(taskID: 1, taskSignature: taskSignatureName, result: .success)
         ]
 
         for event in events {
             _ = try messageHandler.emitEvent(event)
         }
-        
-        #expect(!self.observability.hasWarningDiagnostics)
-        #expect(!self.observability.hasErrorDiagnostics)
+
+        #expect(self.observability.hasWarningDiagnostics == testcase.expectedHasWarningDiagnostic)
+        #expect(self.observability.hasErrorDiagnostics == testcase.expectedHasErrorDiagnotic)
         #expect(self.observability.diagnostics.count == 1)
-        try expectDiagnostics(self.observability.diagnostics) { result in
-            result.check(diagnostic: "Simple note diagnostic", severity: .info)
-        }
-    }
 
-    @Test
-    func testDiagnosticOutputWhenOnlyDebugs() throws {
-        let messageHandler = self.messageHandler.warning
-
-        let events: [SwiftBuildMessage] = [
-            .taskStartedInfo(taskID: 1, taskSignature: "simple-debug-diagnostic"),
-            .diagnostic(
-                kind: .remark,
-                locationContext2: .init(taskSignature: "simple-debug-diagnostic"),
-                message: "Simple debug diagnostic",
-                appendToOutputStream: true
-            ),
-            .taskCompleteInfo(taskID: 1, taskSignature: "simple-debug-diagnostic", result: .success)
-        ]
-
-        for event in events {
-            _ = try messageHandler.emitEvent(event)
-        }
-
-        #expect(!self.observability.hasWarningDiagnostics)
-        #expect(!self.observability.hasErrorDiagnostics)
-        #expect(self.observability.diagnostics.count == 1)
-        try expectDiagnostics(self.observability.diagnostics) { result in
-            result.check(diagnostic: "Simple debug diagnostic", severity: .debug)
+        try expectDiagnostics(
+            self.observability.diagnostics,
+            problemsOnly: false,
+        ) { result in
+            result.check(diagnostic: "\(diagMessage)", severity: testcase.expectedSwiftPMSeverity)
         }
     }
 
@@ -500,7 +509,7 @@ struct SwiftBuildSystemMessageHandlerTests {
         }
 
         let output = self.outputStream.bytes.description
-        #expect(output.contains("Compile Foo\n"))
+        #expect(output.contains("Compile Foo"))
     }
 
     @Test

--- a/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests+Traits.swift
@@ -14,6 +14,7 @@ import _InternalTestSupport
 import Basics
 import PackageModel
 import XCTest
+import Testing
 
 extension WorkspaceTests {
     func testTraitConfigurationExists_NoDefaultTraits() async throws {

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -22,6 +22,7 @@ import SourceControl
 import SPMBuildCore
 @testable import Workspace
 import XCTest
+import Testing
 
 import struct TSCBasic.ByteString
 


### PR DESCRIPTION
The DiagnosticsChecker was only checking XCTest API.  When executing a Swift Testing tests that used this API, the assertions were being silently ignored.  This should be addressed in the 6.4 dev snapshot with the introduction of ST-0021 [1], which provided targets interoperability between Swift Testing and XCTest.

However, the current SwiftPM CI builds runs against older Swift toolchain version. This changes updates the API to support inspect whether the test execution is occurring in Swift Testing.  if so, we call the Swift Testing APIs. Otherwise, fallback to calling the XCTest APIs.

Fixes #10061
Issue: rdar://177069061

1: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0021-targeted-interoperability-swift-testing-and-xctest.md
