### PR TITLE
Respect customProductType when deciding whether to install the Swift module

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -527,6 +527,23 @@ extension PackagePIFProjectBuilder {
 
                 // on windows modules are libraries, so we need to add a search path so the linker finds them
                 impartedSettings[.LIBRARY_SEARCH_PATHS, .windows] = ["$(inherited)", "$(TARGET_BUILD_DIR)/ExecutableModules"]
+
+                // If the executable is promoted to a non-executable PIF product (e.g. a Swift Playgrounds
+                // application), the product target installs the Swift module itself, so suppress this testable
+                // variant's copy to avoid both writing BUILT_PRODUCTS_DIR/<module>.swiftmodule, which produces
+                // a build error of "Multiple commands produce...".
+                let productInstallsOwnModule = self.package.products.contains { product in
+                    guard product.isMainModuleProduct,
+                          product.mainModule?.name == sourceModule.name,
+                          [.executable, .snippet].contains(product.type) else {
+                        return false
+                    }
+                    let pifType = pifBuilder.delegate.customProductType(forExecutable: product.underlying) ?? .executable
+                    return pifType != .executable
+                }
+                if productInstallsOwnModule {
+                    settings[.SWIFT_INSTALL_MODULE] = "NO"
+                }
             }
 
             if let aliases = sourceModule.moduleAliases {

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -125,7 +125,7 @@ extension PackagePIFProjectBuilder {
             settings[.SWIFT_MODULE_ALIASES] = list.isEmpty ? nil : list
         }
 
-        if product.type == .executable {
+        if pifProductType == .executable {
             // Don't install the Swift module of the executable product, lest it conflict with the testable variant.
             // The contents of the testable variant's module will exactly match the binary linked by dependencies (test targets).
             // Also, multiple executable products may incorporate sources from the same executable target, while the testable

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1882,3 +1882,218 @@ extension ProjectModel.Group {
         return nil
     }
 }
+
+// MARK: - Promoted Executable Product Tests
+
+/// A `PackagePIFBuilder.BuildDelegate` that lets a test control `customProductType(forExecutable:)`
+/// while returning the same defaults as the production delegate for everything else.
+private final class PromotingBuildDelegate: PackagePIFBuilder.BuildDelegate {
+    let package: ResolvedPackage
+    let promotedProductType: ProjectModel.Target.ProductType?
+
+    init(package: ResolvedPackage, promotedProductType: ProjectModel.Target.ProductType?) {
+        self.package = package
+        self.promotedProductType = promotedProductType
+    }
+
+    var isRootPackage: Bool { self.package.manifest.packageKind.isRoot }
+    var isRemote: Bool { self.package.manifest.packageKind.isRemote }
+    var hostsOnlyPackages: Bool { false }
+    var isUserManaged: Bool { true }
+    var isBranchOrRevisionBased: Bool { false }
+    var isPluginExecutionSandboxingDisabled: Bool { false }
+
+    func customProductType(forExecutable product: PackageModel.Product) -> ProjectModel.Target.ProductType? {
+        self.promotedProductType
+    }
+
+    func deviceFamilyIDs() -> Set<Int> { [] }
+    func shouldPackagesBuildForARM64e(platform: PackageModel.Platform) -> Bool { false }
+    func configureProjectBuildSettings(_ buildSettings: inout ProjectModel.BuildSettings) {}
+    func configureSourceModuleBuildSettings(sourceModule: ResolvedModule, settings: inout ProjectModel.BuildSettings) {}
+    func customInstallPath(product: PackageModel.Product) -> String? { nil }
+    func customProductName(forFramework product: PackageModel.Product) -> String? { nil }
+    func customBundleIdentifierPrefix(forFramework product: PackageModel.Product) -> String? { nil }
+    func customLibraryType(product: PackageModel.Product) -> PackageModel.ProductType.LibraryType? { nil }
+    func customSDKOptions(forPlatform: PackageModel.Platform) -> [String] { [] }
+
+    func addCustomTargets(pifProject: inout ProjectModel.Project) throws -> [PackagePIFBuilder.ModuleOrProduct] { [] }
+
+    func shouldSuppressProductDependency(
+        product: PackageModel.Product,
+        buildSettings: inout ProjectModel.BuildSettings
+    ) -> Bool { false }
+
+    func shouldSetInstallPathForDynamicLib(productName: String) -> Bool { false }
+
+    func configureLibraryProduct(
+        product: PackageModel.Product,
+        project: inout ProjectModel.Project,
+        target: WritableKeyPath<ProjectModel.Project, ProjectModel.Target>,
+        additionalFiles: WritableKeyPath<ProjectModel.Group, ProjectModel.Group>
+    ) {}
+
+    func suggestAlignedPlatformVersionGiveniOSVersion(
+        platform: PackageModel.Platform,
+        iOSVersion: PackageModel.PlatformVersion
+    ) -> String? { nil }
+
+    func validateMacroFingerprint(for macroModule: ResolvedModule) -> Bool { true }
+}
+
+/// Builds the PIF project for a package that has an executable product (module `AppModule`) and a unit
+/// test target that depends on it, promoting the executable to `promotedProductType` via the delegate.
+private func buildAppProject(
+    promotedProductType: ProjectModel.Target.ProductType?
+) async throws -> ProjectModel.Project {
+    let observability = ObservabilitySystem.makeForTesting()
+
+    let fs = InMemoryFileSystem(emptyFiles: [
+        "/App/Sources/AppModule/main.swift",
+        "/App/Tests/AppTests/AppTests.swift",
+    ])
+
+    let graph = try loadModulesGraph(
+        fileSystem: fs,
+        manifests: [
+            Manifest.createRootManifest(
+                displayName: "App",
+                path: "/App",
+                toolsVersion: .v5_9,
+                products: [
+                    ProductDescription(name: "App", type: .executable, targets: ["AppModule"]),
+                ],
+                targets: [
+                    TargetDescription(name: "AppModule", type: .executable),
+                    TargetDescription(name: "AppTests", dependencies: ["AppModule"], type: .test),
+                ]
+            ),
+        ],
+        observabilityScope: observability.topScope
+    )
+
+    let rootPackage = try #require(graph.rootPackages.first)
+
+    let delegate = PromotingBuildDelegate(package: rootPackage, promotedProductType: promotedProductType)
+    let builder = PackagePIFBuilder(
+        modulesGraph: graph,
+        resolvedPackage: rootPackage,
+        packageManifest: rootPackage.manifest,
+        delegate: delegate,
+        buildToolPluginResultsByTargetName: [String: [PackagePIFBuilder.BuildToolPluginInvocationResult]](),
+        packageDisplayVersion: rootPackage.manifest.displayName,
+        pkgConfigDirectories: [],
+        fileSystem: fs,
+        observabilityScope: observability.topScope
+    )
+    _ = try builder.build()
+
+    #expect(!observability.hasErrorDiagnostics, "Unexpected errors: \(observability.errors)")
+
+    // Keep the delegate alive for the duration of the build (`PackagePIFBuilder` holds it `unowned`).
+    withExtendedLifetime(delegate) {}
+
+    return builder.pifProject
+}
+
+extension ProjectModel.Project {
+    /// The main-module product target for a product, e.g. `App-product`.
+    fileprivate func productTarget(named name: String) throws -> ProjectModel.Target {
+        try self.onlyTarget {
+            guard case .target(let t) = $0 else { return false }
+            return t.common.name == name
+        }
+    }
+
+    /// The testable variant target for an executable module, e.g. `PACKAGE-TARGET:AppModule-<hash>-testable`.
+    fileprivate func testableVariantTarget(forModule moduleName: String) throws -> ProjectModel.Target {
+        try self.onlyTarget {
+            guard case .target(let t) = $0 else { return false }
+            return t.id.value.hasPrefix("PACKAGE-TARGET:\(moduleName)") && t.id.value.hasSuffix("-testable")
+        }
+    }
+
+    private func onlyTarget(where predicate: (ProjectModel.BaseTarget) -> Bool) throws -> ProjectModel.Target {
+        let matches = self.targets.filter(predicate)
+        guard let match = matches.only, case .target(let target) = match else {
+            throw StringError("Expected exactly one matching target, found \(matches.count)")
+        }
+        return target
+    }
+}
+
+extension ProjectModel.Target {
+    fileprivate func debugSettings() throws -> ProjectModel.BuildSettings {
+        guard let config = self.common.buildConfigs.first(where: { $0.name == "Debug" }) else {
+            throw StringError("No Debug build config in target \(self.id.value)")
+        }
+        return config.settings
+    }
+}
+
+@Suite(
+    .tags(
+        .TestSize.medium,
+        .FunctionalArea.PIF
+    )
+)
+struct PromotedExecutableProductPIFTests {
+    @Test
+    func promotedAppProductInstallsItsOwnSwiftModule() async throws {
+        // When an executable product is promoted to a non-executable PIF product (e.g. a mac catalyst app),
+        // the product target must install its own Swift module so downstream tooling (Previews)
+        // can find `<module>.swiftmodule`. A genuine executable product suppresses module installation to avoid
+        // conflicting with its testable variant.
+
+        // Promoted to an application: the product installs its module (setting is left unset).
+        let promotedProject = try await buildAppProject(promotedProductType: .application)
+        let promotedProductSettings = try promotedProject.productTarget(named: "App-product").debugSettings()
+        #expect(
+            promotedProductSettings[.SWIFT_INSTALL_MODULE] != "NO",
+            "A promoted (non-executable) product must install its own Swift module"
+        )
+
+        // A genuine executable product does not install its module — the testable variant does.
+        let executableProject = try await buildAppProject(promotedProductType: nil)
+        let executableProductSettings = try executableProject.productTarget(named: "App-product").debugSettings()
+        #expect(
+            executableProductSettings[.SWIFT_INSTALL_MODULE] == "NO",
+            "A genuine executable product must not install its Swift module"
+        )
+    }
+
+    @Test
+    func promotedAppWithUnitTestsInstallsModuleExactlyOnce() async throws {
+        // When a promoted app also has unit tests, the executable gains a testable variant that would install a
+        // module of the same name to the same location as the product target — producing a "Multiple commands
+        // produce <module>.swiftmodule" build error. The testable variant's module installation must be suppressed
+        // so exactly one target installs the module.
+        let project = try await buildAppProject(promotedProductType: .application)
+
+        let productSettings = try project.productTarget(named: "App-product").debugSettings()
+        let testableVariantSettings = try project.testableVariantTarget(forModule: "AppModule").debugSettings()
+
+        // The product installs the module; the testable variant is suppressed. Exactly one installer, no collision.
+        #expect(
+            productSettings[.SWIFT_INSTALL_MODULE] != "NO",
+            "The promoted product target must remain the sole module installer"
+        )
+        #expect(
+            testableVariantSettings[.SWIFT_INSTALL_MODULE] == "NO",
+            "The testable variant must suppress module installation when the product installs its own"
+        )
+    }
+
+    @Test
+    func genuineExecutableTestableVariantStillInstallsModule() async throws {
+        // A genuine executable's testable variant keeps installing its module. Multiple executable products can
+        // share one executable target, so the per-target testable variant remains the installer. This guards against
+        // over-suppressing the fix above.
+        let project = try await buildAppProject(promotedProductType: nil)
+        let testableVariantSettings = try project.testableVariantTarget(forModule: "AppModule").debugSettings()
+        #expect(
+            testableVariantSettings[.SWIFT_INSTALL_MODULE] != "NO",
+            "A genuine executable's testable variant must still install its Swift module"
+        )
+    }
+}


### PR DESCRIPTION
### Motivation:

`makeMainModuleProduct` suppressed Swift module installation for any product whose SwiftPM type is .executable. However, a delegate can promote an executable to a different PIF product type via `customProductType(forExecutable:)`.

The `SWIFT_INSTALL_MODULE` was being set to "NO" for any executable, regardless of what the customProductType returned.
