### PR TITLE
[docs] Update completion documentation to add instructions for fish shell

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/UsingShellCompletion.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/UsingShellCompletion.md
@@ -38,3 +38,13 @@ swift package completion-tool generate-zsh-script > ~/.zsh/_swift
 echo -e "fpath=(~/.zsh \$fpath)\n" >> ~/.zshrc
 compinit
 ```
+
+### Fish
+
+Use the following command to install the Fish completions to `~/.config/fish/completions/swift.fish`.
+It just needs to be in your `$fish_completion_path` environment variable. `~/.config/fish/completions` 
+is a typical value of that environment variable.
+
+```bash
+swift package completion-tool generate-fish-script > ~/.config/fish/completions/swift.fish
+```


### PR DESCRIPTION
Add instructions for installing fish shell completions.


### Motivation:

There are already docs for bash & zsh, but no docs for fish even though `completion-tool` actually supports fish already. I figure this deserves to be in the official documentation, not just a forums post.

### Modifications:

Added a section for fish cribbed from https://swiftpackageindex.com/apple/swift-argument-parser/1.5.0/documentation/argumentparser/installingcompletionscripts and https://forums.swift.org/t/shell-completions-for-the-swift-command/75043

### Result:

There will be docs for fish and fish users will rejoice 🎉 
