### PR TITLE
Avoid creating build directories for generated completion scripts

### DIFF
--- a/Sources/Commands/PackageCommands/CompletionCommand.swift
+++ b/Sources/Commands/PackageCommands/CompletionCommand.swift
@@ -56,6 +56,15 @@ extension SwiftPackageCommand {
         @Argument(help: "Type of completions to list.")
         var mode: Mode
 
+        var inclueAdditionalScratchPathFiles: Bool {
+            switch mode {
+            case .generateBashScript, .generateZshScript, .generateFishScript:
+                false
+            case .listDependencies, .listExecutables, .listSnippets:
+                true
+            }
+        }
+
         func run(_ swiftCommandState: SwiftCommandState) async throws {
             switch mode {
             case .generateBashScript:

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -1366,6 +1366,31 @@ struct PackageCommandTests {
     )
     struct CompletionToolCommandTests {
         @Test(
+            arguments: [
+                "generate-bash-script",
+                "generate-zsh-script",
+                "generate-fish-script",
+            ]
+        )
+        func generateScriptDoesNotCreateScratchDirectory(mode: String) async throws {
+            try await withTemporaryDirectory { temporaryDirectory in
+                let process = AsyncProcess(
+                    arguments: [
+                        SwiftPM.Package.xctestBinaryPath.pathString,
+                        "completion-tool",
+                        mode,
+                    ],
+                    workingDirectory: temporaryDirectory
+                )
+                try process.launch()
+                let result = try await process.waitUntilExit()
+
+                #expect(result.exitStatus == .terminated(code: 0))
+                #expect(!localFileSystem.exists(temporaryDirectory.appending(".build")))
+            }
+        }
+
+        @Test(
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func completionToolListSnippets(


### PR DESCRIPTION
Avoid creating `.build` directories when generating shell completion scripts.

### Motivation:

The documented `swift package completion-tool generate-*-script` commands may run from shell profiles. Since scratch-directory marker files were added, every invocation creates `.build` in the current directory even though script generation does not use package or build state.

Fixes #10303.

### Modifications:

- Opt the bash, zsh, and fish script generation modes out of additional scratch-path files.
- Keep scratch-path files enabled for the modes that load package data.
- Add a process-level regression test for all three script generators.

### Result:

Generating a completion script from an empty directory no longer creates `.build` there. Package-aware completion modes retain their existing behavior.

### Testing:

- `swiftc -frontend -parse Sources/Commands/PackageCommands/CompletionCommand.swift`
- `swiftc -frontend -parse Tests/CommandsTests/PackageCommandTests.swift`
- `git diff --check`
- Targeted `swift test` attempted, but the installed Swift 6.2.3 toolchain cannot compile current `main`'s `swift-docc-plugin` dependency because it requires `SendableMetatype`.

AI-assisted: OpenAI Codex.
