### PR TITLE
Warn and confirm when publish package name doesn't match the manifest

### DIFF
--- a/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
+++ b/Sources/PackageRegistryCommand/PackageRegistryCommand+Publish.swift
@@ -104,6 +104,32 @@ extension PackageRegistryCommand {
                 throw ValidationError.invalidPackageIdentity(self.packageIdentity)
             }
 
+            // warn if the name component of the package identity does not match the
+            // name declared in the package manifest, and confirm before continuing if they differ.
+            // This compares against the manifest the current toolchain resolves, which may be a
+            // version-specific variant (e.g. Package@swift-6.1.swift).
+            let workspace = try swiftCommandState.getActiveWorkspace()
+            let rootManifests = try await workspace.loadRootManifests(
+                packages: [packageDirectory],
+                observabilityScope: swiftCommandState.observabilityScope
+            )
+            if let manifest = rootManifests[packageDirectory],
+               registryIdentity.name.description.caseInsensitiveCompare(manifest.displayName) != .orderedSame
+            {
+                swiftCommandState.observabilityScope.emit(
+                    warning: "the package name '\(registryIdentity.name)' does not match the name '\(manifest.displayName)' declared in \(manifest.path.basename)"
+                )
+
+                if swiftCommandState.outputStream.isTTY {
+                    swiftCommandState.outputStream.write("Publish anyway? (yes/no): ".utf8)
+                    swiftCommandState.outputStream.flush()
+                    let answer = readLine(strippingNewline: true)?.lowercased()
+                    guard answer == "yes" || answer == "y" else {
+                        throw StringError("Publishing cancelled.")
+                    }
+                }
+            }
+
             // compute and validate registry URL
             let registryURL = self.registryURL ?? configuration.registry(for: registryIdentity.scope)?.url
             guard let registryURL else {

--- a/Tests/CommandsTests/PackageRegistryCommandTests.swift
+++ b/Tests/CommandsTests/PackageRegistryCommandTests.swift
@@ -911,6 +911,99 @@ struct PackageRegistryCommandTests {
 
     @Test(
         .requiresWorkingDirectorySupport,
+        .tags(
+            .TestSize.large,
+            .Feature.Command.PackageRegistry.Publish,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func publishingWarnsWhenIdentityNameDoesNotMatchManifestName(
+        buildSystem: BuildSystemProvider.Kind,
+    ) throws {
+        let config = BuildConfiguration.debug
+        let version = "0.1.0"
+        let registryURL = "https://packages.example.com"
+        let mismatchMarker = "does not match the name"
+
+        // The name component of the package identity does not match the manifest
+        // name: a warning is emitted (and, non-interactively, publishing proceeds).
+        _ = try withTemporaryDirectory { temporaryDirectory in
+            let packageDirectory = temporaryDirectory.appending("MyPackage")
+            try localFileSystem.createDirectory(packageDirectory)
+
+            let initPackage = try InitPackage(
+                name: "MyPackage",
+                packageType: .executable,
+                destinationPath: packageDirectory,
+                fileSystem: localFileSystem
+            )
+            try initPackage.writePackageStructure()
+            expectFileExists(at: packageDirectory.appending("Package.swift"))
+
+            let workingDirectory = temporaryDirectory.appending(component: UUID().uuidString)
+            try localFileSystem.createDirectory(workingDirectory)
+
+            let (stdout, stderr) = try await executeSwiftPackageRegistry(
+                packageDirectory,
+                configuration: config,
+                extraArgs: [
+                    "publish",
+                    "test.wrong-name",
+                    version,
+                    "--url=\(registryURL)",
+                    "--scratch-directory=\(workingDirectory.pathString)",
+                    "--dry-run",
+                ],
+                buildSystem: buildSystem,
+            )
+
+            #expect(
+                (stdout + stderr).contains(mismatchMarker),
+                "expected a name-mismatch warning, got stdout: '\(stdout)', stderr: '\(stderr)'"
+            )
+        }
+
+        // The name component of the package identity matches the manifest name
+        // (case-insensitively): no warning is emitted.
+        _ = try withTemporaryDirectory { temporaryDirectory in
+            let packageDirectory = temporaryDirectory.appending("MyPackage")
+            try localFileSystem.createDirectory(packageDirectory)
+
+            let initPackage = try InitPackage(
+                name: "MyPackage",
+                packageType: .executable,
+                destinationPath: packageDirectory,
+                fileSystem: localFileSystem
+            )
+            try initPackage.writePackageStructure()
+            expectFileExists(at: packageDirectory.appending("Package.swift"))
+
+            let workingDirectory = temporaryDirectory.appending(component: UUID().uuidString)
+            try localFileSystem.createDirectory(workingDirectory)
+
+            let (stdout, stderr) = try await executeSwiftPackageRegistry(
+                packageDirectory,
+                configuration: config,
+                extraArgs: [
+                    "publish",
+                    "test.mypackage",
+                    version,
+                    "--url=\(registryURL)",
+                    "--scratch-directory=\(workingDirectory.pathString)",
+                    "--dry-run",
+                ],
+                buildSystem: buildSystem,
+            )
+
+            #expect(
+                !(stdout + stderr).contains(mismatchMarker),
+                "expected no name-mismatch warning, got stdout: '\(stdout)', stderr: '\(stderr)'"
+            )
+        }
+    }
+
+    @Test(
+        .requiresWorkingDirectorySupport,
         .requiresSwiftConcurrencySupport,
         .tags(
             .TestSize.large,


### PR DESCRIPTION
### Motivation:

`swift package-registry publish <scope>.<name>` never checked the <name> component against the `name` declared in the package manifest, so a typoed or mismatched identity would publish silently. After validating the identity, load the root manifest and compare its displayName against the identity's name component, case-insensitively.

### Modifications:

On mismatch, emit a warning naming the manifest actually resolved. When attached to a TTY, prompt "Publish anyway? (yes/no):" and abort with "Publishing cancelled." unless the user answers yes/y; non-interactively. In environments without a TTY, warn and proceed.
