### PR TITLE
GHA: Build and Test the reference pacakge registry

### DIFF
--- a/.github/scripts/prebuild.ps1
+++ b/.github/scripts/prebuild.ps1
@@ -12,11 +12,26 @@
 
 param (
     [switch]$SkipAndroid,
-    [switch]$InstallCMake
+    [switch]$InstallCMake,
+    [switch]$InstallVcpkg,
+    [switch]$InstallZlib
 )
 
 # winget isn't easily made available in containers, so use chocolatey
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+if ($InstallVcpkg -or $InstallZlib) {
+    Write-Output "Installing vcpkg ..."
+    git clone --depth 1 https://github.com/microsoft/vcpkg.git
+    .\vcpkg\bootstrap-vcpkg.bat
+    # $PWD is a PathInfo object; use .Path to get the string
+    $currentDir = $PWD.Path
+    $env:VCPKG_ROOT = "${currentDir}\vcpkg"
+    $env:PATH = "$env:VCPKG_ROOT;$env:PATH"
+
+    Write-Output "VCPKG_ROOT: $env:VCPKG_ROOT"
+    Write-Output "PATH: $env:PATH"
+}
 
 if ($InstallCMake) {
     choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies
@@ -37,4 +52,9 @@ if (-not $SkipAndroid) {
 
     # Work around a bug in the package causing the env var to be set incorrectly
     $env:ANDROID_NDK_ROOT = $env:ANDROID_NDK_ROOT.replace('-windows.zip','')
+}
+
+if ($InstallZlib) {
+    Write-Output "Installing zlib ..."
+    vcpkg install zlib
 }

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,6 +38,27 @@ jobs:
       enable_ios_checks: false
       # ios_build_command: 'swift run swift-build --build-tests  --sdk \"$(xcrun --sdk iphoneos --show-sdk-path)\" --triple arm64-apple-ios'
 
+  test-example-package-registry:
+    strategy:
+      fail-fast: false
+    name: Build and Test Example Package Registry
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.12
+    with:
+      enable_cross_pr_testing: false
+      enable_linux_checks: true
+      linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
+      linux_build_command: 'set -x; cd Examples/package-registry && swift test --parallel; set +x'
+      enable_windows_checks: false  # https://github.com/swiftlang/swift-package-manager/issues/10326
+      windows_swift_versions: '["nightly-main"]'
+      # windows_swift_versions: '["nightly-main", "nightly-6.4.x"]'
+      windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1 -InstallZlib -SkipAndroid'
+      windows_build_timeout: 180
+      windows_build_command: 'cd Examples\package-registry; Invoke-program swift test --parallel'
+      enable_macos_checks: true
+      macos_xcode_versions: "['27.b2']"
+      macos_build_command: 'set -x; cd Examples/package-registry && xcrun swift test --parallel; set +x'
+      enable_ios_checks: false
+
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.13
@@ -82,6 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - test-example-package-registry
       - soundness
       - integration-tests
     if: always()  # Runs even if previous jobs fail so it can evaluate them


### PR DESCRIPTION
A recent change introduced a reference package registry example code. Build and test the reference package registry to ensure we don't regress

Depends on #10312
Fixes #10327