### PR TITLE
Package Registry Example: Rely on cross platform swift-crypto when CryptoKit isn't available

### DIFF
--- a/Examples/package-registry/Package.swift
+++ b/Examples/package-registry/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.121.0"),
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.19"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0" ..< "5.0.0"),
     ],
     targets: [
         .target(
@@ -26,6 +27,11 @@ let package = Package(
             dependencies: [
                 .product(name: "Vapor", package: "vapor"),
                 .product(name: "ZIPFoundation", package: "ZIPFoundation"),
+                .product(
+                    name: "Crypto",
+                    package: "swift-crypto",
+                    condition: .when(platforms: [.linux, .android, .windows, .wasi, .openbsd])
+                ),
             ],
             swiftSettings: [
                 .enableUpcomingFeature("ApproachableConcurrency"),

--- a/Examples/package-registry/Sources/RegistryExample/Publishing/ReleasePublisher.swift
+++ b/Examples/package-registry/Sources/RegistryExample/Publishing/ReleasePublisher.swift
@@ -11,7 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 import NIOCore
 
 /// Errors that ``ReleasePublisher/publish(identifier:version:body:contentType:signatureFormat:)``

--- a/Examples/package-registry/Sources/RegistryExample/Routes/MetadataRoutes.swift
+++ b/Examples/package-registry/Sources/RegistryExample/Routes/MetadataRoutes.swift
@@ -326,7 +326,11 @@ public struct MetadataRoutes: Sendable {
     }
 }
 
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 
 enum CryptoDigest {
     static func sha256(_ data: Data) -> [UInt8] {


### PR DESCRIPTION
### Motivation:

Allow the package registry example to be compiled cross-platform.

Fixes #10310
