### PR TITLE
Fix crash when close() frees the SQLite connection while a query is still running

### DIFF
--- a/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
+++ b/Sources/PackageCollections/Storage/SQLitePackageCollectionsStorage.swift
@@ -788,16 +788,10 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     let queryV1 = "SELECT collection_id_blob_base64, package_id, package_repository_url, name FROM \(Self.targetsFTSNameV1);"
                     try self.executeStatement(queryV1) { statement in
                         while let row = try statement.step() {
-                            #if os(Linux)
-                            // lock not required since executeStatement locks
+                            // lock not required since executeStatement (via withDB) holds the state lock
                             guard case .connected = self.state else {
                                 return
                             }
-                            #else
-                            guard case .connected = (try self.withStateLock { self.state }) else {
-                                return
-                            }
-                            #endif
 
                             let targetName = row.string(at: 3)
 
@@ -817,16 +811,10 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                     let queryV0 = "SELECT collection_id_blob_base64, package_repository_url, name FROM \(Self.targetsFTSNameV0);"
                     try self.executeStatement(queryV0) { statement in
                         while let row = try statement.step() {
-                            #if os(Linux)
-                            // lock not required since executeStatement locks
+                            // lock not required since executeStatement (via withDB) holds the state lock
                             guard case .connected = self.state else {
                                 return
                             }
-                            #else
-                            guard case .connected = (try self.withStateLock { self.state }) else {
-                                return
-                            }
-                            #endif
 
                             let targetName = row.string(at: 2)
 
@@ -884,7 +872,7 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
             return db
         }
 
-        let db = try self.withStateLock { () -> SQLite in
+        return try self.withStateLock {
             let db: SQLite
             switch (self.location, self.state) {
             case (_, .disconnecting), (_, .disconnected):
@@ -908,17 +896,9 @@ final class SQLitePackageCollectionsStorage: PackageCollectionsStorage, Closable
                 db = try createDB()
             }
             self.state = .connected(db)
-            return db
-        }
 
-        // FIXME: workaround linux sqlite concurrency issues causing CI failures
-        #if os(Linux)
-        return try self.withStateLock {
-            try body(db)
+            return try body(db)
         }
-        #else
-        return try body(db)
-        #endif
     }
 
     private func createSchemaIfNecessary(db: SQLite) throws {

--- a/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
+++ b/Tests/PackageCollectionsTests/PackageCollectionsStorageTests.swift
@@ -249,6 +249,41 @@ class PackageCollectionsStorageTests: XCTestCase {
             }
         }
     }
+
+    func testCloseWhileQueryingDoesNotCrash() async throws {
+        try await testWithTemporaryDirectory { tmpPath in
+            let path = tmpPath.appending("test.db")
+
+            let seed = SQLitePackageCollectionsStorage(path: path)
+            let mockCollections = makeMockCollections(count: 50)
+            for collection in mockCollections {
+                _ = try await seed.put(collection: collection)
+            }
+            try seed.close()
+
+            for _ in 0..<50 {
+                let storage = SQLitePackageCollectionsStorage(path: path)
+                let identifiers = mockCollections.map { $0.identifier }
+
+                await withTaskGroup(of: Void.self) { group in
+                    for _ in 0..<8 {
+                        group.addTask {
+                            for _ in 0..<100 {
+                                _ = try? await storage.list(identifiers: identifiers)
+                            }
+                        }
+                    }
+
+                    // Close the connection down while the queries are in flight
+                    group.addTask {
+                        try? storage.close()
+                    }
+                }
+
+                try? storage.close()
+            }
+        }
+    }
 }
 
 extension SQLitePackageCollectionsStorage {


### PR DESCRIPTION
### Motivation:

Fix crash when close() frees the SQLite connection while a query is still running

### Modifications:

Hold the stateLock for the entire query so close() can no longer free the SQLite connection out from under an active query.

This aligns Apple's behaviour with Linux's, so the #if os(Linux) special cases in withDB and populateTargetTrie were removed.

### Result:

The test case reliably crashed for me before the modifications.