### PR TITLE
[6.4.x] Only link the testable variant of a macro target if it is the direct dependency of a test target

### DIFF
--- a/Fixtures/Macros/MacroWithDirectTestDependency/Package.swift
+++ b/Fixtures/Macros/MacroWithDirectTestDependency/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.0
+import PackageDescription
+import CompilerPluginSupport
+
+let package = Package(
+    name: "MacroWithDirectTestDependency",
+    platforms: [
+        .macOS(.v13),
+    ],
+    targets: [
+        .target(name: "MacroImplHelpers"),
+        .macro(name: "MacroImpl", dependencies: ["MacroImplHelpers"]),
+        .target(name: "MacroDef", dependencies: ["MacroImpl"]),
+        .testTarget(name: "MacroImplTests", dependencies: ["MacroImpl", "MacroDef"]),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/Fixtures/Macros/MacroWithDirectTestDependency/Sources/MacroDef/MacroDef.swift
+++ b/Fixtures/Macros/MacroWithDirectTestDependency/Sources/MacroDef/MacroDef.swift
@@ -1,0 +1,2 @@
+@freestanding(expression)
+public macro stringify<T>(_ value: T) -> String = #externalMacro(module: "MacroImpl", type: "StringifyMacro")

--- a/Fixtures/Macros/MacroWithDirectTestDependency/Sources/MacroImpl/StringifyMacro.swift
+++ b/Fixtures/Macros/MacroWithDirectTestDependency/Sources/MacroImpl/StringifyMacro.swift
@@ -1,0 +1,75 @@
+import Foundation
+import MacroImplHelpers
+
+@main
+struct MacroPlugin {
+    static func main() throws {
+        while true {
+            guard let headerData = try read(count: 8),
+                  headerData.count == 8 else {
+                break
+            }
+            let length = headerData.withUnsafeBytes { buffer in
+                buffer.load(as: UInt64.self)
+            }
+            let payloadLength = UInt64(littleEndian: length)
+
+            if payloadLength == 0 {
+                break
+            }
+
+            guard let payloadData = try read(count: Int(payloadLength)),
+                  payloadData.count == Int(payloadLength) else {
+                break
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any] else {
+                continue
+            }
+
+            if json.keys.contains("getCapability") {
+                let response: [String: Any] = [
+                    "getCapabilityResult": [
+                        "capability": [
+                            "protocolVersion": 2
+                        ]
+                    ]
+                ]
+                if let responseData = try? JSONSerialization.data(withJSONObject: response) {
+                    try writeMessage(responseData, to: FileHandle.standardOutput)
+                }
+            } else if json.keys.contains("expandFreestandingMacro") {
+                let response: [String: Any] = [
+                    "expandMacroResult": [
+                        "expandedSource": "\"\(macroImplHelper())\"",
+                        "diagnostics": []
+                    ]
+                ]
+                if let responseData = try? JSONSerialization.data(withJSONObject: response) {
+                    try writeMessage(responseData, to: FileHandle.standardOutput)
+                }
+            }
+        }
+    }
+}
+
+private func read(count: Int) throws -> Data? {
+    var accumulated = Data()
+    while accumulated.count < count {
+        let remaining = count - accumulated.count
+        guard let chunk = try FileHandle.standardInput.read(upToCount: remaining), !chunk.isEmpty else {
+            return accumulated.isEmpty ? nil : accumulated
+        }
+        accumulated.append(chunk)
+    }
+    return accumulated
+}
+
+private func writeMessage(_ data: Data, to handle: FileHandle) throws {
+    var length = UInt64(data.count).littleEndian
+    let headerData = withUnsafeBytes(of: &length) { buffer in
+        Data(buffer)
+    }
+    try handle.write(contentsOf: headerData)
+    try handle.write(contentsOf: data)
+}

--- a/Fixtures/Macros/MacroWithDirectTestDependency/Sources/MacroImplHelpers/MacroImplHelpers.swift
+++ b/Fixtures/Macros/MacroWithDirectTestDependency/Sources/MacroImplHelpers/MacroImplHelpers.swift
@@ -1,0 +1,3 @@
+public func macroImplHelper() -> String {
+    "expanded"
+}

--- a/Fixtures/Macros/MacroWithDirectTestDependency/Tests/MacroImplTests/MacroImplTests.swift
+++ b/Fixtures/Macros/MacroWithDirectTestDependency/Tests/MacroImplTests/MacroImplTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+import MacroDef
+@testable import MacroImpl
+
+final class MacroImplTests: XCTestCase {
+    func testMacroPluginType() {
+        _ = MacroPlugin.self
+    }
+
+    func testStringify() {
+        let result = #stringify(42)
+        XCTAssertEqual(result, "expanded")
+    }
+}

--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/MacroImplHelpers/Package.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/MacroImplHelpers/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MacroImplHelpers",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .library(name: "MacroImplHelpers", targets: ["MacroImplHelpers"]),
+    ],
+    targets: [
+        .target(name: "MacroImplHelpers"),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/MacroImplHelpers/Sources/MacroImplHelpers/MacroImplHelpers.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/MacroImplHelpers/Sources/MacroImplHelpers/MacroImplHelpers.swift
@@ -1,0 +1,7 @@
+#if os(WASI)
+#error("MacroImplHelpers must not be compiled for WebAssembly.")
+#endif
+
+public func macroImplHelper() -> String {
+    "expanded"
+}

--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Package.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+import PackageDescription
+import CompilerPluginSupport
+
+let package = Package(
+    name: "MinimalWebAssemblyMacroPackage",
+    platforms: [
+        .macOS(.v13),
+    ],
+    dependencies: [
+        .package(path: "MacroImplHelpers"),
+    ],
+    targets: [
+        .macro(name: "MacroImpl", dependencies: [
+            .product(name: "MacroImplHelpers", package: "MacroImplHelpers"),
+        ]),
+        .target(name: "MacroDef", dependencies: ["MacroImpl"]),
+        .executableTarget(name: "MacroClient", dependencies: ["MacroDef"]),
+        .testTarget(name: "MinimalWebAssemblyMacroPackageTests", dependencies: ["MacroDef"]),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroClient/main.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroClient/main.swift
@@ -1,0 +1,4 @@
+import MacroDef
+
+let result = #stringify(42)
+print("Macro result: \(result)")

--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroDef/MacroDef.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroDef/MacroDef.swift
@@ -1,0 +1,2 @@
+@freestanding(expression)
+public macro stringify<T>(_ value: T) -> String = #externalMacro(module: "MacroImpl", type: "StringifyMacro")

--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroImpl/StringifyMacro.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroImpl/StringifyMacro.swift
@@ -1,0 +1,79 @@
+import Foundation
+import MacroImplHelpers
+
+#if os(WASI)
+#error("MacroImpl must not be compiled for WebAssembly.")
+#endif
+
+@main
+struct MacroPlugin {
+    static func main() throws {
+        while true {
+            guard let headerData = try read(count: 8),
+                  headerData.count == 8 else {
+                break
+            }
+            let length = headerData.withUnsafeBytes { buffer in
+                buffer.load(as: UInt64.self)
+            }
+            let payloadLength = UInt64(littleEndian: length)
+
+            if payloadLength == 0 {
+                break
+            }
+
+            guard let payloadData = try read(count: Int(payloadLength)),
+                  payloadData.count == Int(payloadLength) else {
+                break
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any] else {
+                continue
+            }
+
+            if json.keys.contains("getCapability") {
+                let response: [String: Any] = [
+                    "getCapabilityResult": [
+                        "capability": [
+                            "protocolVersion": 2
+                        ]
+                    ]
+                ]
+                if let responseData = try? JSONSerialization.data(withJSONObject: response) {
+                    try writeMessage(responseData, to: FileHandle.standardOutput)
+                }
+            } else if json.keys.contains("expandFreestandingMacro") {
+                let response: [String: Any] = [
+                    "expandMacroResult": [
+                        "expandedSource": "\"\(macroImplHelper())\"",
+                        "diagnostics": []
+                    ]
+                ]
+                if let responseData = try? JSONSerialization.data(withJSONObject: response) {
+                    try writeMessage(responseData, to: FileHandle.standardOutput)
+                }
+            }
+        }
+    }
+}
+
+private func read(count: Int) throws -> Data? {
+    var accumulated = Data()
+    while accumulated.count < count {
+        let remaining = count - accumulated.count
+        guard let chunk = try FileHandle.standardInput.read(upToCount: remaining), !chunk.isEmpty else {
+            return accumulated.isEmpty ? nil : accumulated
+        }
+        accumulated.append(chunk)
+    }
+    return accumulated
+}
+
+private func writeMessage(_ data: Data, to handle: FileHandle) throws {
+    var length = UInt64(data.count).littleEndian
+    let headerData = withUnsafeBytes(of: &length) { buffer in
+        Data(buffer)
+    }
+    try handle.write(contentsOf: headerData)
+    try handle.write(contentsOf: data)
+}

--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Tests/MinimalWebAssemblyMacroPackageTests/MinimalWebAssemblyMacroPackageTests.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Tests/MinimalWebAssemblyMacroPackageTests/MinimalWebAssemblyMacroPackageTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+
+import MacroDef
+
+final class MinimalWebAssemblyMacroPackageTests: XCTestCase {
+    func testStringify() {
+        let result = #stringify(42)
+        XCTAssertEqual(result, "expanded")
+    }
+}

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -824,10 +824,7 @@ fileprivate func buildAggregatePIFProject(
         for target in packageProject.targets {
             switch target {
             case .target(let target):
-                guard !target.id.hasSuffix(.dynamic) else {
-                    // Otherwise we hit a bunch of "Unknown multiple commands produce: ..." errors,
-                    // as the build artifacts from "PACKAGE-TARGET:Foo"
-                    // conflicts with those from "PACKAGE-TARGET:Foo-dynamic".
+                guard !target.id.hasSuffix(.dynamic) && !target.id.hasSuffix(.testable) else {
                     continue
                 }
 

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -970,8 +970,8 @@ extension PackageGraph.ResolvedProduct {
 }
 
 extension PackageGraph.ResolvedModule {
-    func recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: Bool, with block: (ResolvedModule.Dependency) -> Void) {
-        [self].recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: includeMacroDependencies, with: block)
+    func recursivelyTraverseTransitiveLinkageDependencies(includeDependenciesOfMacros: Set<ResolvedModule.ID>, with block: (ResolvedModule.Dependency) -> Void) {
+        [self].recursivelyTraverseTransitiveLinkageDependencies(includeDependenciesOfMacros: includeDependenciesOfMacros, with: block)
     }
 
     func addParseAsLibrarySettings(to settings: inout BuildSettings, toolsVersion: ToolsVersion, fileSystem: FileSystem) {
@@ -999,7 +999,7 @@ extension PackageGraph.ResolvedModule {
 extension Collection<PackageGraph.ResolvedModule> {
     /// Recursively applies a block to each of the linkage dependencies of the given module, in topological sort order.
     /// Each module or product dependency is visited only once.
-    func recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: Bool, with block: (ResolvedModule.Dependency) -> Void) {
+    func recursivelyTraverseTransitiveLinkageDependencies(includeDependenciesOfMacros: Set<ResolvedModule.ID>, with block: (ResolvedModule.Dependency) -> Void) {
         var moduleIDsSeen: Set<ResolvedModule.ID> = []
         var productIDsSeen: Set<ResolvedProduct.ID> = []
 
@@ -1015,7 +1015,7 @@ extension Collection<PackageGraph.ResolvedModule> {
                 let stopTraversal: Bool
                 switch moduleDependency.type {
                 case .macro:
-                    stopTraversal = !includeMacroDependencies
+                    stopTraversal = !includeDependenciesOfMacros.contains(moduleDependency.id)
                 case .plugin:
                     stopTraversal = true
                 default:

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -63,7 +63,7 @@ extension PackagePIFProjectBuilder {
         // Add the dependencies.
         var pluginTarget = self.project[keyPath: pluginTargetKeyPath]
         let mainModuleProducts = self.package.products.filter(\.isMainModuleProduct)
-        pluginModule.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: false) { dependency in
+        pluginModule.recursivelyTraverseTransitiveLinkageDependencies(includeDependenciesOfMacros: []) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
                 // This assertion is temporarily disabled since we may see targets from
@@ -736,7 +736,7 @@ extension PackagePIFProjectBuilder {
         let shouldLinkProduct = (desiredModuleType == .dynamicLibrary) || (desiredModuleType == .macro)
         var moduleTarget = self.project[keyPath: sourceModuleTargetKeyPath]
         let moduleMainProducts = self.package.products.filter(\.isMainModuleProduct)
-        sourceModule.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: false) { dependency in
+        sourceModule.recursivelyTraverseTransitiveLinkageDependencies(includeDependenciesOfMacros: []) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
                 // This assertion is temporarily disabled since we may see targets from

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -377,8 +377,25 @@ extension PackagePIFProjectBuilder {
 
         // Handle the main target's dependencies (and link against them).
         var mainModuleTarget = self.project[keyPath: mainModuleTargetKeyPath]
-        // If this is a test target, include dependencies of macros, as we will be linking their testable variant.
-        mainModule.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: product.type == .test) { dependency in
+
+        // A test target links the testable variant of any macro that is a direct dependency, so that the macro's
+        // implementation can be unit tested. For such macros we also need to traverse into (and link) the macro's own
+        // dependencies. Macros which are transitive dependencies do not link the testable variant.
+        let directMacroDependencyIDs: Set<ResolvedModule.ID>
+        if product.type == .test {
+            directMacroDependencyIDs = Set(mainModule.dependencies.compactMap { dependency in
+                // Macros are always represented by a target in the manifest, so a product dependency can never
+                // be a direct dependency on a macro implementation.
+                guard case .module(let moduleDependency, _) = dependency, moduleDependency.type == .macro else {
+                    return nil
+                }
+                return moduleDependency.id
+            })
+        } else {
+            directMacroDependencyIDs = []
+        }
+
+        mainModule.recursivelyTraverseTransitiveLinkageDependencies(includeDependenciesOfMacros: directMacroDependencyIDs) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
                 // This assertion is temporarily disabled since we may see targets from
@@ -426,8 +443,7 @@ extension PackagePIFProjectBuilder {
                     )
                     log(.debug, indent: 1, "Added dependency on product '\(dependencyId)'")
 
-                    // Link with a testable version of the macro if appropriate.
-                    if product.type == .test {
+                    if directMacroDependencyIDs.contains(moduleDependency.id) {
                         mainModuleTarget.common.addDependency(
                             on: moduleDependency.pifTargetGUID(suffix: .testable),
                             platformFilters: packageConditions
@@ -776,7 +792,7 @@ extension PackagePIFProjectBuilder {
         // against them).
         var libraryUmbrellaTarget = self.project[keyPath: libraryUmbrellaTargetKeyPath]
         let mainModuleProducts = package.products.filter(\.isMainModuleProduct)
-        product.modules.recursivelyTraverseTransitiveLinkageDependencies(includeMacroDependencies: false) { dependency in
+        product.modules.recursivelyTraverseTransitiveLinkageDependencies(includeDependenciesOfMacros: []) { dependency in
             switch dependency {
             case .module(let moduleDependency, let packageConditions):
                 // This assertion is temporarily disabled since we may see targets from

--- a/Tests/FunctionalTests/MacroTests.swift
+++ b/Tests/FunctionalTests/MacroTests.swift
@@ -67,4 +67,23 @@ struct MacroTests {
             #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
         }
     }
+
+    @Test(
+        .tags(
+            Tag.Feature.Command.Build
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func minimalExecutableTestableMacroImplementation(
+        buildSystem: BuildSystemProvider.Kind
+    ) async throws {
+        try await fixture(name: "Macros/MacroWithDirectTestDependency") { fixturePath in
+            let (stdout, _) = try await executeSwiftBuild(
+                fixturePath,
+                extraArgs: ["--build-tests"],
+                buildSystem: buildSystem
+            )
+            #expect(stdout.contains("Build complete!"), "stdout:\n\(stdout)")
+        }
+    }
 }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1415,7 +1415,7 @@ struct PIFBuilderTests {
         }
     }
 
-    @Test func macroPackageTestDependencies() async throws {
+    @Test func testTargetWithTransitiveMacroImplementationDependency() async throws {
         try await withGeneratedPIF(fromFixture: "Macros/MinimalMacroPackage") { pif, observabilitySystem, _ in
             #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
 
@@ -1430,15 +1430,34 @@ struct PIFBuilderTests {
 
             let depIDs = testTarget.common.dependencies.map(\.targetId.value)
 
-            // The test bundle should link both the testable variant of the macro target, and its transitive dependency.
-            #expect(
-                depIDs.contains { $0.hasPrefix("PACKAGE-TARGET:MacroImpl-") && $0.hasSuffix("-testable") },
-                "Expected test bundle to link testable variant of MacroImpl, found dependencies: \(depIDs)"
-            )
-            #expect(
-                depIDs.contains("PACKAGE-TARGET:MacroImplHelpers"),
-                "Expected test bundle to link MacroImplHelpers, found dependencies: \(depIDs)"
-            )
+            // The macro implementation is a transitive dependency of the tests. The PIF should represent this
+            // dependency, but it should not be a linkage dependency, and the macro helpers also should not be
+            // linked.
+            #expect(depIDs.contains("PACKAGE-TARGET:MacroImpl"))
+            #expect(!depIDs.contains { $0.hasPrefix("PACKAGE-TARGET:MacroImpl-") && $0.hasSuffix("-testable") })
+            #expect(!depIDs.contains("PACKAGE-TARGET:MacroImplHelpers"))
+        }
+    }
+
+    @Test func testTargetWithDirectMacroImplementationDependency() async throws {
+        try await withGeneratedPIF(fromFixture: "Macros/MacroWithDirectTestDependency") { pif, observabilitySystem, _ in
+            #expect(observabilitySystem.diagnostics.filter { $0.severity == .error }.isEmpty)
+
+            let project = try pif.workspace.project(named: "MacroWithDirectTestDependency")
+
+            let testProduct = try project.target(named: "MacroImplTests-product")
+            guard case .target(let testTarget) = testProduct else {
+                Issue.record("Expected MacroImplTests-product to be a regular target")
+                return
+            }
+            #expect(testTarget.productType == .unitTest)
+
+            let depIDs = testTarget.common.dependencies.map(\.targetId.value)
+
+            // The macro implementation is a direct dependency of the test target. Ensure the testable variant and
+            // the helpers are linkage dependencies.
+            #expect(depIDs.contains { $0.hasPrefix("PACKAGE-TARGET:MacroImpl-") && $0.hasSuffix("-testable") })
+            #expect(depIDs.contains("PACKAGE-TARGET:MacroImplHelpers"))
         }
     }
 

--- a/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -99,6 +99,33 @@ private struct WebAssemblyIntegrationTests {
     @Test(
         .requiresWebAssemblySwiftSDK,
         .tags(
+            .Feature.Command.Build,
+        ),
+    )
+    func macroPackageIncludingTests() async throws {
+        try await fixture(name: "WebAssembly/MinimalWebAssemblyMacroPackage") { fixturePath in
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndSDKIDForTesting(for: .webassembly))
+
+            var env = Environment()
+            env["SWIFT_EXEC"] = compilerPath.pathString
+
+            // Build the tests for WebAssembly. The macro implementation and its helper
+            // target will fail to compile if built for WebAssembly instead of the host platform.
+            let buildOutput = try await executeSwiftBuild(
+                fixturePath,
+                extraArgs: ["--swift-sdk", sdkID, "--build-tests", "-v"],
+                env: env,
+                buildSystem: .swiftbuild,
+            )
+            #expect(buildOutput.stdout.contains("Build complete"))
+
+            _ = try await executeSwiftTest(fixturePath, extraArgs: [], env: env, buildSystem: .swiftbuild)
+        }
+    }
+
+    @Test(
+        .requiresWebAssemblySwiftSDK,
+        .tags(
             .Feature.Command.Run,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,

--- a/Tests/WorkspaceTests/InitTests.swift
+++ b/Tests/WorkspaceTests/InitTests.swift
@@ -119,6 +119,7 @@ struct InitTests {
                 try await executeSwiftBuild(
                     path,
                     configuration: configuration,
+                    extraArgs: ["--build-tests"],
                     buildSystem: buildSystem,
                 )
                 let binPath = try await getBinPath(


### PR DESCRIPTION
Closes https://github.com/swiftlang/swift-package-manager/issues/10224

The implementation of a macro should only build a testable variant for the target platform if it's being tested. Update PIF generation to remove the linkage dependency for macros which are depended on only transitively. Also, exclude testable variants of all targets from the top-level aggregate targets so they are not specialized as top level targets.