### PR TITLE
Emit xUnit output for XCTest in non-parallel test runs

### DIFF
--- a/Sources/Commands/SwiftTestCommand.swift
+++ b/Sources/Commands/SwiftTestCommand.swift
@@ -363,6 +363,7 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                     results += testProducts.lazy
                         .map { TestProductResult(productName: $0.productName, library: .xctest, result: .noMatchingTests) }
                 } else {
+                    let start = DispatchTime.now()
                     let productResults = try await runTestProducts(
                         testProducts,
                         additionalArguments: xctestArgs,
@@ -371,7 +372,19 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
                         library: .xctest,
                         buildSystem: buildSystem
                     )
+                    let duration = start.distance(to: .now())
                     results.append(contentsOf: productResults)
+
+                    // `ParallelTestRunner` isn't used in serial mode, so there's no per-test
+                    // breakdown to hand to `generateXUnitOutputIfRequested` above. Build one
+                    // from the enumerated tests so the XCTest xUnit XML is still emitted.
+                    try await generateXUnitOutputForSerialXCTestRunIfRequested(
+                        testProducts: testProducts,
+                        productResults: productResults,
+                        duration: duration,
+                        swiftCommandState: swiftCommandState,
+                        buildSystem: buildSystem
+                    )
                 }
             } else {
                 let testSuites = try await TestingSupport.getTestSuites(
@@ -520,6 +533,59 @@ public struct SwiftTestCommand: AsyncSwiftCommand {
             at: xUnitOutput,
             detailedFailureMessage: self.options.shouldShowDetailedFailureMessage
         )
+    }
+
+    /// Generate the xUnit file for a serial (non-parallel) XCTest run, if requested.
+    ///
+    /// `ParallelTestRunner` isn't used in this mode, so there are no per-test results to hand to
+    /// `generateXUnitOutputIfRequested` above; `productResults` only tracks pass/fail per test
+    /// product. Enumerate the tests that were run and attribute each one the result of its
+    /// containing product so the requested xUnit XML is still emitted.
+    private func generateXUnitOutputForSerialXCTestRunIfRequested(
+        testProducts: [BuiltTestProduct],
+        productResults: [TestProductResult],
+        duration: DispatchTimeInterval,
+        swiftCommandState: SwiftCommandState,
+        buildSystem: any BuildSystem
+    ) async throws {
+        guard options.xUnitOutput != nil else {
+            return
+        }
+
+        let testSuites = try await TestingSupport.getTestSuites(
+            in: testProducts,
+            swiftCommandState: swiftCommandState,
+            enableCodeCoverage: options.enableCodeCoverage,
+            shouldSkipBuilding: options.sharedOptions.shouldSkipBuilding,
+            experimentalTestOutput: options.enableExperimentalTestOutput,
+            sanitizers: globalOptions.build.sanitizers,
+            buildSystem: buildSystem
+        )
+        let tests = try testSuites
+            .filteredTests(specifier: options.testCaseSpecifier)
+            .skippedTests(specifier: options.skippedTests(fileSystem: swiftCommandState.fileSystem))
+
+        guard !tests.isEmpty else {
+            return
+        }
+
+        // Spread the overall run duration evenly across tests so the generated file's total
+        // matches the real elapsed time.
+        let perTestDuration = DispatchTimeInterval.nanoseconds(
+            Int((duration.timeInterval() ?? 0) / Double(tests.count) * 1_000_000_000)
+        )
+
+        let failedProducts = Set(productResults.filter { $0.result == .failure }.map(\.productName))
+        let testResults = tests.map {
+            ParallelTestRunner.TestResult(
+                unitTest: $0,
+                output: "",
+                success: !failedProducts.contains($0.testProduct.productName),
+                duration: perTestDuration
+            )
+        }
+
+        try generateXUnitOutputIfRequested(for: testResults, swiftCommandState: swiftCommandState)
     }
 
     // MARK: - Common implementation

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -788,6 +788,56 @@ struct TestCommandTests {
         }
     }
 
+    /// Regression test for the default (serial / non-parallel) mode: `--xunit-output` was only
+    /// ever written by `ParallelTestRunner`, so a plain `swift test --xunit-output <path>` run
+    /// produced only an empty `-swift-testing` companion file and never the XCTest xUnit XML.
+    @Test(
+        .tags(
+            .Feature.CommandLineArguments.TestOutputXunit,
+            .Feature.CommandLineArguments.TestEnableXCTest,
+            .Feature.CommandLineArguments.TestDisableSwiftTesting,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/9961", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func swiftTestXunitOutputWrittenInSerialMode(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let configuration = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/TestDebuggingMultiProduct") { fixturePath in
+            let xUnitOutput = fixturePath.appending("result.xml")
+
+            // Deliberately omit `--parallel` so this exercises the serial XCTest path.
+            _ = try await execute(
+                [
+                    "--enable-xctest",
+                    "--disable-swift-testing",
+                    "--xunit-output",
+                    xUnitOutput.pathString,
+                ],
+                packagePath: fixturePath,
+                configuration: configuration,
+                buildSystem: buildSystem,
+            )
+
+            try requireFileExists(at: xUnitOutput, "\(xUnitOutput) does not exist")
+
+            let contents: String = try localFileSystem.readFileContents(xUnitOutput)
+            #expect(
+                contents.contains(#"classname="LibATests.LibAXCTests""#),
+                "XCTest case from LibATests product must appear in xUnit file when running serially; got:\n\(contents)",
+            )
+            #expect(
+                contents.contains(#"classname="LibBTests.LibBXCTests""#),
+                "XCTest case from LibBTests product must appear in xUnit file when running serially; got:\n\(contents)",
+            )
+            #expect(
+                contents.contains("tests=\"2\""),
+                "Expected 2 XCTest cases counted in xUnit file; got:\n\(contents)",
+            )
+        }
+    }
+
     enum TestRunner {
         case XCTest
         case SwiftTesting


### PR DESCRIPTION
Fixes #9961.

`swift test --xunit-output` only wrote the XCTest results file under `--parallel`; the default serial path produced only an empty testing file. This makes the serial path emit the requested xUnit XML in both modes, with a regression test.