### PR TITLE
[6.4.x] Ensure test target settings are correctly applied to test runner executables

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -543,7 +543,7 @@ extension PackagePIFProjectBuilder {
         self.builtModulesAndProducts.append(moduleOrProduct)
 
         if moduleOrProductType == .unitTest {
-            try makeTestRunnerProduct(for: moduleOrProduct)
+            try makeTestRunnerProduct(for: moduleOrProduct, unitTestModule: mainModule)
         }
     }
 
@@ -1052,7 +1052,7 @@ extension PackagePIFProjectBuilder {
     }
 
     // MARK: - Test Runners
-    mutating func makeTestRunnerProduct(for unitTestProduct: PackagePIFBuilder.ModuleOrProduct) throws {
+    mutating func makeTestRunnerProduct(for unitTestProduct: PackagePIFBuilder.ModuleOrProduct, unitTestModule: ResolvedModule) throws {
         // Only generate a test runner for root packages with tests.
         guard pifBuilder.delegate.isRootPackage else {
             return
@@ -1085,7 +1085,6 @@ extension PackagePIFProjectBuilder {
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = "\(self.package.identity).\(name)"
             .spm_mangledToBundleIdentifier()
         settings[.SKIP_INSTALL] = "NO"
-        settings[.SWIFT_VERSION] = "5.0"
         // This should eventually be set universally for all package targets/products.
         settings[.LINKER_DRIVER] = "swiftc"
 
@@ -1123,11 +1122,22 @@ extension PackagePIFProjectBuilder {
             linkProduct: true
         )
 
+        // Apply user-specified settings on the test target to the test runner. This is especially important
+        // of e.g. linker settings specify a linked library external to the package.
+        var debugSettings: ProjectModel.BuildSettings = settings
+        var releaseSettings: ProjectModel.BuildSettings = settings
+        let allBuildSettings = unitTestModule.computeAllBuildSettings(observabilityScope: pifBuilder.observabilityScope, forRemotePackage: pifBuilder.delegate.isRemote)
+        allBuildSettings.apply(to: &debugSettings, for: .debug)
+        allBuildSettings.apply(to: &releaseSettings, for: .release)
+
+        debugSettings[.SWIFT_VERSION] = "5.0"
+        releaseSettings[.SWIFT_VERSION] = "5.0"
+
         self.project[keyPath: testRunnerTargetKeyPath].common.addBuildConfig { id in
             BuildConfig(
                 id: id,
                 name: "Debug",
-                settings: settings,
+                settings: debugSettings,
                 impartedBuildSettings: impartedSettings
             )
         }
@@ -1135,7 +1145,7 @@ extension PackagePIFProjectBuilder {
             BuildConfig(
                 id: id,
                 name: "Release",
-                settings: settings,
+                settings: releaseSettings,
                 impartedBuildSettings: impartedSettings
             )
         }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -913,6 +913,71 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10225", relationship: .verifies),
+        arguments: BuildConfiguration.allCases
+    )
+    func testRunnerInheritsUnitTestLinkerFlags(configuration: BuildConfiguration) async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/Lib/Lib.swift",
+            "/Root/Tests/LibTests/LibTests.swift",
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                .createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v6_2,
+                    targets: [
+                        TargetDescription(name: "Lib"),
+                        TargetDescription(
+                            name: "LibTests",
+                            dependencies: ["Lib"],
+                            type: .test,
+                            settings: [
+                                .init(tool: .linker, kind: .unsafeFlags(["-L", "/Vendor"])),
+                                .init(tool: .linker, kind: .linkedLibrary("helper")),
+                            ]
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        let project = try pif.workspace.project(named: "Root")
+
+        let runnerTarget = try #require(
+            project.underlying.targets.first {
+                guard case .target(let target) = $0 else { return false }
+                return target.productType == .swiftpmTestRunner
+            }
+        )
+
+        let ldFlags = try #require(try runnerTarget.buildConfig(named: configuration).settings[.OTHER_LDFLAGS])
+        #expect(ldFlags.contains("-lhelper"))
+        #expect(ldFlags.contains("-L") && ldFlags.contains("/Vendor"))
+    }
+
     @Test func impartedModuleMaps() async throws {
         try await withGeneratedPIF(fromFixture: "CFamilyTargets/ModuleMapGenerationCases") { pif, observabilitySystem, fixturePath in
             #expect(observabilitySystem.diagnostics.filter {


### PR DESCRIPTION
On non-darwin platforms, the test runner is modeled using a PIF target distinct from the one which represents the test target itself. Ensure the test runner builds using any settings the user specified for the test target in the manifest. This ensures that e.g. any load bearing linker settings are correctly applied to the runner.

Closes https://github.com/swiftlang/swift-package-manager/issues/10225