### PR TITLE
Inline explicitNameForModuleDependencyResolutionOnly at call sites

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -497,9 +497,16 @@ private func createResolvedPackages(
                     // 9/2021 this is currently emitting a warning only to support
                     // backwards compatibility with older versions of SwiftPM that had too weak of a validation
                     // we will upgrade this to an error in a few versions to tighten up the validation
-                    if dependency.explicitNameForModuleDependencyResolutionOnly == .none ||
-                        resolvedPackage.package.manifest.displayName == dependency
-                        .explicitNameForModuleDependencyResolutionOnly
+                    let explicitName: String? = switch dependency {
+                    case .fileSystem(let settings):
+                        settings.nameForTargetDependencyResolutionOnly
+                    case .sourceControl(let settings):
+                        settings.nameForTargetDependencyResolutionOnly
+                    case .registry:
+                        nil
+                    }
+                    if explicitName == .none ||
+                        resolvedPackage.package.manifest.displayName == explicitName
                     {
                         packageObservabilityScope
                             .emit(
@@ -522,7 +529,15 @@ private func createResolvedPackages(
 
                 // checks if two dependencies have the same explicit name which can cause module based dependency
                 // package lookup issue
-                if let explicitDependencyName = dependency.explicitNameForModuleDependencyResolutionOnly {
+                let explicitDependencyNameForModuleDependencyResolution: String? = switch dependency {
+                case .fileSystem(let settings):
+                    settings.nameForTargetDependencyResolutionOnly
+                case .sourceControl(let settings):
+                    settings.nameForTargetDependencyResolutionOnly
+                case .registry:
+                    nil
+                }
+                if let explicitDependencyName = explicitDependencyNameForModuleDependencyResolution {
                     if let previouslyResolvedPackage =
                         dependenciesByNameForModuleDependencyResolution[explicitDependencyName]
                     {

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -248,19 +248,6 @@ public enum PackageDependency: Equatable, Hashable, Sendable {
         }
     }
 
-    // FIXME: we should simplify target based dependencies such that this is no longer required
-    // A name to be used *only* for target dependencies resolution
-    public var explicitNameForModuleDependencyResolutionOnly: String? {
-        switch self {
-        case .fileSystem(let settings):
-            return settings.nameForTargetDependencyResolutionOnly
-        case .sourceControl(let settings):
-            return settings.nameForTargetDependencyResolutionOnly
-        case .registry:
-            return nil
-        }
-    }
-
     public var productFilter: ProductFilter {
         switch self {
         case .fileSystem(let settings):

--- a/Sources/PackageModel/ManifestSourceGeneration.swift
+++ b/Sources/PackageModel/ManifestSourceGeneration.swift
@@ -163,7 +163,15 @@ fileprivate extension SourceCodeFragment {
     /// Instantiates a SourceCodeFragment to represent a single package dependency.
     init(from dependency: PackageDependency, pathAnchor: AbsolutePath) {
         var params: [SourceCodeFragment] = []
-        if let explicitName = dependency.explicitNameForModuleDependencyResolutionOnly {
+        let explicitName: String? = switch dependency {
+        case .fileSystem(let settings):
+            settings.nameForTargetDependencyResolutionOnly
+        case .sourceControl(let settings):
+            settings.nameForTargetDependencyResolutionOnly
+        case .registry:
+            nil
+        }
+        if let explicitName {
             params.append(SourceCodeFragment(key: "name", string: explicitName))
         }
         switch dependency {


### PR DESCRIPTION
### Motivation

Partial investigation of #10108, which asks whether `nameForModuleDependencyResolutionOnly`, `explicitNameForModuleDependencyResolutionOnly`, and related properties can be reduced/removed.

`explicitNameForModuleDependencyResolutionOnly` is a pure pass-through wrapper around the stored `nameForTargetDependencyResolutionOnly` value (`.fileSystem`/`.sourceControl` return the stored value, `.registry` returns `nil`) with no computation of its own. It had only 4 call sites across 2 files and no direct test coverage, making it a mechanically safe candidate to inline and remove.

`nameForModuleDependencyResolutionOnly` (the sibling mentioned in the issue) is left untouched — it performs real default-name computation (falling back to `PackageIdentityParser.computeDefaultName`) and is load-bearing across dependency-name resolution, validation, and diagnostics, so it's out of scope for this change.

### Changes

- Inlined the equivalent switch at the 4 call sites in `ModulesGraph+Loading.swift` and `ManifestSourceGeneration.swift`.
- Removed the now-unused `explicitNameForModuleDependencyResolutionOnly` computed property and its FIXME comment from `PackageDependencyDescription.swift`.

No behavior change intended — this is a pure refactor.

### Testing

- `swift build`: clean
- `swift test --filter PackageGraphTests`: 74 passed
- `swift test --filter PackageLoadingTests`: 83 passed
- `swift test --filter WorkspaceTests.ManifestSourceGenerationTests`: 23 passed (4 skipped, pre-existing/unrelated — `ENABLE_APPLE_PRODUCT_TYPES` not set in this environment)

Relates to #10108