### PR TITLE
SwiftBuild: Build host-only tool modules for the host, not the target platform

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -904,37 +904,16 @@ private func markHostOnlyModules(packageBuilders: [ResolvedPackageBuilder]) {
     // Pass 1: pin every macro/plugin and its whole dependency closure to `.host`. Nothing
     // is `.all` yet, so this also pins modules a shipped target depends on; pass 2 fixes them.
     for moduleBuilder in allModules where moduleBuilder.isHostOnly {
-        func markHost(_ depModule: ResolvedModuleBuilder) -> Bool {
-            switch depModule.platformConstraint {
-            case .all:
-                return false
-            case .host:
-                return true
-            case .none:
-                break
+        func markHost(_ depModule: ResolvedModuleBuilder) {
+            guard depModule.platformConstraint != .host else {
+                return
             }
-
             for dep in depModule.allModuleDependencies {
-                if !markHost(dep) {
-                    // Depends on something already pinned to the target; unwind so a single
-                    // chain doesn't mix host and target.
-                    func markExternal(_ depModule: ResolvedModuleBuilder) {
-                        guard depModule.platformConstraint == .host else {
-                            return
-                        }
-                        depModule.platformConstraint = .all
-                        for dep in depModule.allModuleDependencies {
-                            markExternal(dep)
-                        }
-                    }
-                    markExternal(depModule)
-                    return false
-                }
+                markHost(dep)
             }
             depModule.platformConstraint = .host
-            return true
         }
-        _ = markHost(moduleBuilder)
+        markHost(moduleBuilder)
     }
 
     // Pass 2: seed from every genuine target root (a non-test module pass 1 didn't pin to

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -887,90 +887,96 @@ private func createResolvedPackages(
         }
     }
 
+    markHostOnlyModules(packageBuilders: packageBuilders)
+
     // Adjust the package graph for any prebuilts, removing any that are no longer needed.
-    handlePrebuilts(packageBuilders: packageBuilders, root: root)
+    handlePrebuilts(packageBuilders: packageBuilders)
 
     return try IdentifiableSet(packageBuilders.map { try $0.construct() })
 }
 
+/// Mark modules that must only ever build for the host: macros, plugins, and anything
+/// reachable "only" through them (a plugin's build-time tool and its private dependencies
+/// but not in the case if the same module is also used by a shipped target).
+private func markHostOnlyModules(packageBuilders: [ResolvedPackageBuilder]) {
+    let allModules = packageBuilders.flatMap(\.modules)
+
+    // Pass 1: pin every macro/plugin and its whole dependency closure to `.host`. Nothing
+    // is `.all` yet, so this also pins modules a shipped target depends on; pass 2 fixes them.
+    for moduleBuilder in allModules where moduleBuilder.isHostOnly {
+        func markHost(_ depModule: ResolvedModuleBuilder) -> Bool {
+            switch depModule.platformConstraint {
+            case .all:
+                return false
+            case .host:
+                return true
+            case .none:
+                break
+            }
+
+            for dep in depModule.allModuleDependencies {
+                if !markHost(dep) {
+                    // Depends on something already pinned to the target; unwind so a single
+                    // chain doesn't mix host and target.
+                    func markExternal(_ depModule: ResolvedModuleBuilder) {
+                        guard depModule.platformConstraint == .host else {
+                            return
+                        }
+                        depModule.platformConstraint = .all
+                        for dep in depModule.allModuleDependencies {
+                            markExternal(dep)
+                        }
+                    }
+                    markExternal(depModule)
+                    return false
+                }
+            }
+            depModule.platformConstraint = .host
+            return true
+        }
+        _ = markHost(moduleBuilder)
+    }
+
+    // Pass 2: seed from every genuine target root (a non-test module pass 1 didn't pin to
+    // host) and walk its dependencies, flipping any dual-use module back to `.all` so it
+    // can build for both.
+    for moduleBuilder in allModules
+    where !moduleBuilder.isHostOnly && moduleBuilder.platformConstraint != .host {
+        func markExternal(_ depModule: ResolvedModuleBuilder) {
+            guard depModule.platformConstraint != .all else {
+                return
+            }
+            guard !depModule.isHostOnly else {
+                // Never pull a macro or plugin itself onto the target.
+                return
+            }
+            depModule.platformConstraint = .all
+            for dep in depModule.allModuleDependencies {
+                markExternal(dep)
+            }
+        }
+        markExternal(moduleBuilder)
+    }
+}
+
 // Adjust the graph to integrate prebuilts
-private func handlePrebuilts(packageBuilders: [ResolvedPackageBuilder], root: PackageGraphRoot) {
-    // Skip this if there are no prebuilts. Modules are unconstrained by default.
+private func handlePrebuilts(packageBuilders: [ResolvedPackageBuilder]) {
+    // Skip this if there are no prebuilts.
     guard packageBuilders.contains(where: { $0.prebuilts != nil }) else {
         return
     }
 
-    // First decorate the platform constraints from products in the root packages
-    for packageBuilder in packageBuilders where root.isExporting(packageBuilder.package.identity) {
-        for productBuilder in packageBuilder.products {
-            for moduleBuilder in productBuilder.moduleBuilders {
-                func markExternal(_ depModule: ResolvedModuleBuilder) {
-                    guard depModule.platformConstraint != .all else {
-                        return
-                    }
-                    guard !depModule.isHostOnly else {
-                        // Macros, macro tests, and plugins are host only
-                        return
-                    }
-                    depModule.platformConstraint = .all
-                    for dep in depModule.allModuleDependencies {
-                        markExternal(dep)
-                    }
-                }
-                markExternal(moduleBuilder)
-            }
+    // Prebuilts are host-only binaries. If a `.host` module depends on a `.all` module, that
+    // dependency is dual-use, and a host-only prebuilt can't stand in for it without mixing a
+    // prebuilt host build with a from-source target build of the same library. Rather than
+    // mix, drop the marking and build everything from source, as before.
+    let hasHostTargetMixing = packageBuilders.contains { packageBuilder in
+        packageBuilder.modules.contains { moduleBuilder in
+            moduleBuilder.platformConstraint == .host
+                && moduleBuilder.allModuleDependencies.contains { $0.platformConstraint == .all }
         }
     }
-
-    // Find those not marked that are references from macro and plugins.
-    // For now we can't have host modules depending on .all modules so only
-    // mark as .host if all the deps are .host
-    for packageBuilder in packageBuilders {
-        for moduleBuilder in packageBuilder.modules where moduleBuilder.isHostOnly {
-            func markHost(_ depModule: ResolvedModuleBuilder) -> Bool {
-                switch depModule.platformConstraint {
-                case .all:
-                    return false
-                case .host:
-                    return true
-                case .none:
-                    break
-                }
-
-                for dep in depModule.allModuleDependencies {
-                    if !markHost(dep) {
-                        // Depending on .all, revisit all deps and mark .all so we don't mix
-                        func markExternal(_ depModule: ResolvedModuleBuilder) {
-                            guard depModule.platformConstraint == .host else {
-                                return
-                            }
-                            depModule.platformConstraint = .all
-                            for dep in depModule.allModuleDependencies {
-                                markExternal(dep)
-                            }
-                        }
-                        markExternal(depModule)
-                        return false
-                    }
-                }
-                depModule.platformConstraint = .host
-                return true
-            }
-            _ = markHost(moduleBuilder)
-        }
-    }
-
-    // Also for now, to ensure we're not mixing prebuilts and not prebuilts in the build graph,
-    // Only use prebuilts if we can use them for all host only modules
-    guard packageBuilders.allSatisfy({
-        $0.modules.allSatisfy { moduleBuilder in
-            guard moduleBuilder.isHostOnly else {
-                return true
-            }
-            return moduleBuilder.platformConstraint == .host
-        }
-    }) else {
-        // Remove the platform constraints
+    guard !hasHostTargetMixing else {
         for packageBuilder in packageBuilders {
             for moduleBuilder in packageBuilder.modules {
                 moduleBuilder.platformConstraint = nil
@@ -1472,7 +1478,7 @@ private final class ResolvedModuleBuilder: ResolvedBuilder<ResolvedModule> {
     var isTestSupportModule: Bool = false
 
     var isHostOnly: Bool {
-        module.type == .macro || (module.type == .test && dependencies.contains(where: {
+        module.type == .macro || module.type == .plugin || (module.type == .test && dependencies.contains(where: {
                 switch $0 {
                 case .product(let productDependency, _):
                     productDependency.product.type == .macro

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -916,25 +916,44 @@ private func markHostOnlyModules(packageBuilders: [ResolvedPackageBuilder]) {
         markHost(moduleBuilder)
     }
 
-    // Pass 2: seed from every genuine target root (a non-test module pass 1 didn't pin to
-    // host) and walk its dependencies, flipping any dual-use module back to `.all` so it
-    // can build for both.
+    // Pass 2: flip every dual-use module back to `.all` so it builds for both. A module is
+    // dual-use when it is reachable both through a build tool (pass 1 pinned it `.host`) and
+    // from something that ships to the target.
+    func markExternal(_ depModule: ResolvedModuleBuilder) {
+        guard depModule.platformConstraint != .all else {
+            return
+        }
+        guard !depModule.isHostOnly else {
+            // Never pull a macro or plugin itself onto the target.
+            return
+        }
+        depModule.platformConstraint = .all
+        for dep in depModule.allModuleDependencies {
+            markExternal(dep)
+        }
+    }
+
+    // Seed from every genuine target root a non-test module pass 1 did not pin to host (this
+    // covers shipped executables and product-less library targets), then walk its
+    // dependencies.
     for moduleBuilder in allModules
     where !moduleBuilder.isHostOnly && moduleBuilder.platformConstraint != .host {
-        func markExternal(_ depModule: ResolvedModuleBuilder) {
-            guard depModule.platformConstraint != .all else {
-                return
+        markExternal(moduleBuilder)
+    }
+
+    // Also seed from the modules of a root package's library products. A library product
+    // ships for the target, so it must build for the target even when a plugin's build-time
+    // tool also depends on it. Pass 1 would otherwise leave such a library pinned `.host`
+    // with nothing above to flip it back.
+    for packageBuilder in packageBuilders where packageBuilder.package.manifest.packageKind.isRoot {
+        for productBuilder in packageBuilder.products {
+            guard case .library = productBuilder.product.type else {
+                continue
             }
-            guard !depModule.isHostOnly else {
-                // Never pull a macro or plugin itself onto the target.
-                return
-            }
-            depModule.platformConstraint = .all
-            for dep in depModule.allModuleDependencies {
-                markExternal(dep)
+            for moduleBuilder in productBuilder.moduleBuilders {
+                markExternal(moduleBuilder)
             }
         }
-        markExternal(moduleBuilder)
     }
 }
 

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -837,11 +837,22 @@ fileprivate func buildAggregatePIFProject(
                     continue
                 }
 
+                // Host-only build tools must not be specialized for the destination as top-level
+                // targets. They still build for the host via the edge that pulls them in. This
+                // covers both the module target and the dedicated "-product" target of a host-only
+                // executable, such as a plugin's build-time tool exposed as an explicit product.
                 if let resolvedModule = modulesGraph.module(for: target.name) {
                     guard modulesGraph.isInRootPackages(resolvedModule, satisfying: buildParameters.buildEnvironment) else {
                         // Disconnected target, possibly due to platform when condition that isn't satisfied
                         continue
                     }
+                    if resolvedModule.platformConstraint == .host {
+                        continue
+                    }
+                } else if let productName = PackagePIFBuilder.productName(forTargetName: target.name),
+                          let resolvedProduct = modulesGraph.product(for: productName),
+                          resolvedProduct.platformConstraint == .host {
+                    continue
                 }
 
                 aggregateProject[keyPath: allIncludingTestsTargetKeyPath].common.addDependency(

--- a/Sources/_InternalTestSupport/MockPackageGraphs.swift
+++ b/Sources/_InternalTestSupport/MockPackageGraphs.swift
@@ -294,6 +294,95 @@ package func macrosTestsPackageGraph() throws -> MockPackageGraph {
     return (graph, fs, observability.topScope)
 }
 
+/// A package with a build-tool plugin whose executable tool has a private
+/// local dependency. Both are reachable only through the plugin, so
+/// both must build for the host only, never the cross-compilation target.
+package func pluginToolPackageGraph() throws -> MockPackageGraph {
+    let fs = InMemoryFileSystem(emptyFiles:
+        "/swift-js/Sources/ForTarget/source.swift",
+        "/swift-js/Plugins/MyBuildPlugin/source.swift",
+        "/swift-js/Sources/MyBuildTool/source.swift",
+        "/swift-js/Sources/MyBuildToolCore/source.swift",
+        "/swift-syntax/Sources/SwiftSyntax/source.swift"
+    )
+
+    let observability = ObservabilitySystem.makeForTesting()
+    let graph = try loadModulesGraph(
+        fileSystem: fs,
+        manifests: [
+            Manifest.createRootManifest(
+                displayName: "swift-js",
+                path: "/swift-js",
+                dependencies: [
+                    .localSourceControl(
+                        path: "/swift-syntax",
+                        requirement: .upToNextMajor(from: "1.0.0")
+                    )
+                ],
+                products: [
+                    ProductDescription(
+                        name: "ForTarget",
+                        type: .library(.automatic),
+                        targets: ["ForTarget"]
+                    ),
+                    ProductDescription(
+                        name: "MyBuildPlugin",
+                        type: .plugin,
+                        targets: ["MyBuildPlugin"]
+                    ),
+                ],
+                targets: [
+                    TargetDescription(
+                        name: "ForTarget",
+                        dependencies: []
+                    ),
+                    TargetDescription(
+                        name: "MyBuildPlugin",
+                        dependencies: ["MyBuildTool"],
+                        type: .plugin,
+                        pluginCapability: .buildTool
+                    ),
+                    TargetDescription(
+                        name: "MyBuildTool",
+                        dependencies: [
+                            .target(name: "MyBuildToolCore"),
+                            .product(name: "SwiftSyntax", package: "swift-syntax"),
+                        ],
+                        type: .executable
+                    ),
+                    TargetDescription(
+                        name: "MyBuildToolCore",
+                        dependencies: []
+                    ),
+                ],
+                traits: []
+            ),
+            Manifest.createFileSystemManifest(
+                displayName: "swift-syntax",
+                path: "/swift-syntax",
+                products: [
+                    ProductDescription(
+                        name: "SwiftSyntax",
+                        type: .library(.automatic),
+                        targets: ["SwiftSyntax"]
+                    )
+                ],
+                targets: [
+                    TargetDescription(name: "SwiftSyntax", dependencies: []),
+                ],
+                traits: []
+            ),
+        ],
+        observabilityScope: observability.topScope,
+        traitConfiguration: .default,
+        enabledTraitsMap: .init()
+    )
+
+    XCTAssertNoDiagnostics(observability.diagnostics)
+
+    return (graph, fs, observability.topScope)
+}
+
 package func trivialPackageGraph() throws -> MockPackageGraph {
     let fs = InMemoryFileSystem(
         emptyFiles:

--- a/Tests/BuildTests/BuildPlanTraversalTests.swift
+++ b/Tests/BuildTests/BuildPlanTraversalTests.swift
@@ -167,6 +167,56 @@ struct BuildPlanTraversalTests {
     }
 
     @Test
+    func pluginToolBuildsForHostOnly() async throws {
+        // A build-tool plugin's executable tool, and anything reachable only through it,
+        // must be planned for the host only, even under a whole-package cross-compilation
+        // build that seeds every module for the target. Regression test for host-only tool
+        // modules being built for the target platform.
+        let destinationTriple = Triple.arm64Linux
+        let toolsTriple = Triple.x86_64MacOS
+
+        let (graph, fs, scope) = try pluginToolPackageGraph()
+        let plan = try await BuildPlan(
+            destinationBuildParameters: mockBuildParameters(
+                destination: .target,
+                buildSystemKind: .native,
+                triple: destinationTriple
+            ),
+            toolsBuildParameters: mockBuildParameters(
+                destination: .host,
+                buildSystemKind: .native,
+                triple: toolsTriple
+            ),
+            graph: graph,
+            fileSystem: fs,
+            observabilityScope: scope
+        )
+
+        let tool = try #require(graph.module(for: "MyBuildTool"))
+        let toolCore = try #require(graph.module(for: "MyBuildToolCore"))
+        let jsKit = try #require(graph.module(for: "ForTarget"))
+
+        // The tool and its private dependency are planned for the host...
+        #expect(plan.description(for: tool, context: .host) != nil)
+        #expect(plan.description(for: toolCore, context: .host) != nil)
+
+        // ...and never for the cross-compilation target.
+        #expect(plan.description(for: tool, context: .target) == nil)
+        #expect(plan.description(for: toolCore, context: .target) == nil)
+
+        // A regular library still builds for the target.
+        #expect(plan.description(for: jsKit, context: .target) != nil)
+
+        // Cross-check via the full traversal: neither host-only tool module appears at .target.
+        var results: [Result] = []
+        plan.traverseModules {
+            results.append(Result(parent: $1, module: $0))
+        }
+        #expect(self.getResults(for: "MyBuildTool", with: .target, in: results).isEmpty)
+        #expect(self.getResults(for: "MyBuildToolCore", with: .target, in: results).isEmpty)
+    }
+
+    @Test
     func recursiveDependencyTraversal() async throws {
         let destinationTriple = Triple.arm64Linux
         let toolsTriple = Triple.x86_64MacOS

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -246,11 +246,11 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
         )
         let result = try BuildPlanResult(plan: plan)
         result.checkProductsCount(3)
-        result.checkTargetsCount(10)
+        result.checkTargetsCount(9)
 
         XCTAssertTrue(try result.allTargets(named: "SwiftSyntax")
             .map { try $0.swift() }
-            .contains { $0.destination == .host })
+            .allSatisfy { $0.destination == .host })
         try result.check(destination: .host, triple: toolsTriple, for: "MMIOMacros")
         try result.check(destination: .target, triple: destinationTriple, for: "MMIO")
         try result.check(destination: .target, triple: destinationTriple, for: "Core")
@@ -309,7 +309,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
 
         let result = try BuildPlanResult(plan: plan)
         result.checkProductsCount(3)
-        result.checkTargetsCount(20)
+        result.checkTargetsCount(16)
 
         XCTAssertTrue(try result.allTargets(named: "SwiftSyntax")
             .map { try $0.swift() }
@@ -366,12 +366,12 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
                 observabilityScope: scope
             )
             let result = try BuildPlanResult(plan: plan)
-            result.checkProductsCount(4)
-            result.checkTargetsCount(6)
+            result.checkProductsCount(3)
+            result.checkTargetsCount(5)
 
             XCTAssertTrue(try result.allTargets(named: "SwiftSyntax")
                 .map { try $0.swift() }
-                .contains { $0.destination == .host })
+                .allSatisfy { $0.destination == .host })
 
             try result.check(destination: .host, triple: toolsTriple, for: "swift-mmioPackageTests")
             try result.check(destination: .host, triple: toolsTriple, for: "swift-mmioPackageDiscoveredTests")
@@ -384,7 +384,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
             XCTAssertEqual(macroProduct.buildParameters.triple, toolsTriple)
 
             let swiftSyntaxProducts = result.allProducts(named: "SwiftSyntax")
-            XCTAssertEqual(swiftSyntaxProducts.count, 2)
+            XCTAssertEqual(swiftSyntaxProducts.count, 1)
             let swiftSyntaxToolsProduct = try XCTUnwrap(swiftSyntaxProducts.first { $0.destination == .host })
             let archiveArguments = try swiftSyntaxToolsProduct.archiveArguments()
 

--- a/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
+++ b/Tests/BuildTests/CrossCompilationBuildPlanTests.swift
@@ -309,7 +309,7 @@ final class CrossCompilationBuildPlanTests: XCTestCase {
 
         let result = try BuildPlanResult(plan: plan)
         result.checkProductsCount(3)
-        result.checkTargetsCount(16)
+        result.checkTargetsCount(20)
 
         XCTAssertTrue(try result.allTargets(named: "SwiftSyntax")
             .map { try $0.swift() }

--- a/Tests/BuildTests/PluginInvocationTests.swift
+++ b/Tests/BuildTests/PluginInvocationTests.swift
@@ -106,7 +106,8 @@ final class PluginInvocationTests: XCTestCase {
             }
         }
 
-        // "FooTool{Lib}" duplicated as it's present for both build host and end target.
+        // FooTool and FooToolLib are only reachable through FooPlugin's tool dependency, so
+        // they build for the host alone, never for the end target.
         do {
             let buildPlanResult = try await BuildPlanResult(plan: mockBuildPlan(
                 graph: graph,
@@ -116,16 +117,13 @@ final class PluginInvocationTests: XCTestCase {
                 fileSystem: fileSystem,
                 observabilityScope: observability.topScope
             ))
-            buildPlanResult.checkProductsCount(3)
-            buildPlanResult.checkTargetsCount(5) // Note: plugins are not included here.
+            buildPlanResult.checkProductsCount(2)
+            buildPlanResult.checkTargetsCount(3) // Note: plugins are not included here.
 
             buildPlanResult.check(destination: .target, for: "Foo")
 
             buildPlanResult.check(destination: .host, for: "FooTool")
-            buildPlanResult.check(destination: .target, for: "FooTool")
-
             buildPlanResult.check(destination: .host, for: "FooToolLib")
-            buildPlanResult.check(destination: .target, for: "FooToolLib")
         }
 
         // A fake PluginScriptRunner that just checks the input conditions and returns canned output.

--- a/Tests/BuildTests/PrebuiltsBuildPlanTests.swift
+++ b/Tests/BuildTests/PrebuiltsBuildPlanTests.swift
@@ -654,4 +654,106 @@ class PrebuiltsBuildPlanTests: XCTestCase {
             XCTAssert(target.module.dependencies.contains(where: { $0.product?.packageIdentity == .plain("swift-syntax") }))
         }
     }
+
+    // Non-mixing case: a build-tool plugin's tool transitively depends on a prebuilt that
+    // NOTHING else in the graph uses (the BridgeJSTool -> swift-syntax shape). Here the
+    // prebuilt stays host-only, so `handlePrebuilts` does NOT wipe and it IS substituted into
+    // the host-only tool. Cross-compiling, the shipped wasm executable that merely *uses* the
+    // plugin must not pick up the host prebuilt.
+    func testPluginOnlyPrebuiltNoLeakCrossCompile() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/MyPackage/Sources/Base/Base.swift",
+            "/MyPackage/Sources/Generator/Generator.swift",
+            "/MyPackage/Plugins/Plugin/Plugin.swift",
+            "/MyRoot/Sources/MyApp/MyApp.swift",
+            "/swift-syntax/Sources/SwiftSyntaxMacros/SwiftSyntaxMacros.swift",
+        ])
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "MyRoot",
+                    path: "/MyRoot",
+                    dependencies: [
+                        .remoteSourceControl(url: "https://github.com/swiftlang/swift-syntax", requirement: .exact("600.0.1")),
+                        .fileSystem(path: "/MyPackage"),
+                    ],
+                    products: [
+                        ProductDescription(name: "MyApp", type: .executable, targets: ["MyApp"]),
+                    ],
+                    targets: [
+                        TargetDescription(
+                            name: "MyApp",
+                            dependencies: [],
+                            type: .executable,
+                            pluginUsages: [.plugin(name: "Plugin", package: "MyPackage")]
+                        ),
+                    ]
+                ),
+                Manifest.createFileSystemManifest(
+                    displayName: "MyPackage",
+                    path: "/MyPackage",
+                    dependencies: [
+                        .remoteSourceControl(url: "https://github.com/swiftlang/swift-syntax", requirement: .exact("600.0.1")),
+                    ],
+                    products: [
+                        ProductDescription(name: "Plugin", type: .plugin, targets: ["Plugin"]),
+                    ],
+                    targets: [
+                        TargetDescription(
+                            name: "Base",
+                            dependencies: [.product(name: "SwiftSyntaxMacros", package: "swift-syntax")]
+                        ),
+                        TargetDescription(name: "Generator", dependencies: ["Base"], type: .executable),
+                        TargetDescription(
+                            name: "Plugin",
+                            dependencies: ["Generator"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                    ]
+                ),
+                Manifest.createRemoteSourceControlManifest(
+                    displayName: "swift-syntax",
+                    url: "https://github.com/swiftlang/swift-syntax",
+                    path: "/swift-syntax",
+                    products: [
+                        ProductDescription(name: "SwiftSyntaxMacros", type: .library(.automatic), targets: ["SwiftSyntaxMacros"]),
+                    ],
+                    targets: [TargetDescription(name: "SwiftSyntaxMacros")]
+                ),
+            ],
+            prebuilts: [prebuiltLibrary.identity: prebuiltLibrary.products.reduce(into: [:]) {
+                $0[$1] = prebuiltLibrary
+            }],
+            observabilityScope: observability.topScope
+        )
+
+        let result = try await BuildPlanResult(
+            plan: mockBuildPlan(
+                triple: .wasi,
+                graph: graph,
+                fileSystem: fs,
+                observabilityScope: observability.topScope
+            )
+        )
+
+        let modulesDir = prebuiltLibrary.path.appending(component: "Modules").pathString
+        let libDir = prebuiltLibrary.path.appending(component: "lib").pathString
+        let lib = "-l\(prebuiltLibrary.libraryName)"
+
+        // Confirm this is the substitution path, not a `hasHostTargetMixing` wipe: the
+        // host-only tool actually uses the (host) prebuilt, so the case is exercised.
+        let anyUsesPrebuilt = result.targetMap.contains {
+            ((try? $0.swift().compileArguments().contains(modulesDir)) ?? false)
+        }
+        XCTAssert(anyUsesPrebuilt, "expected the host-only tool to use the prebuilt (substitution, not a wipe)")
+
+        // The shipped wasm executable must not reference the host prebuilt.
+        let myApp = try XCTUnwrap(result.productMap.first { $0.product.name == "MyApp" })
+        let myAppLink = try myApp.linkArguments()
+        XCTAssert(!myAppLink.contains(libDir), "MyApp leaked prebuilt libDir")
+        XCTAssert(!myAppLink.contains(lib), "MyApp leaked prebuilt lib")
+    }
 }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1407,7 +1407,7 @@ struct PIFBuilderTests {
                 let id = target.common.id.value
                 let config = try target.buildConfig(named: .debug)
                 let platforms = config.settings[.SUPPORTED_PLATFORMS]
-                if id == "PACKAGE-TARGET:MacroImpl" {
+                if id.hasPrefix("PACKAGE-TARGET:MacroImpl") {
                     #expect(platforms == ["$(HOST_PLATFORM)"], "target \(id) did not have the expected supported platform setting")
                 } else {
                     #expect(platforms == nil, "target \(id) has supported platforms set, unexpectedly")
@@ -1713,6 +1713,81 @@ struct PIFBuilderTests {
             pluginTarget.common.dependencies.contains { $0.targetId == pluginToolProductTarget.common.id },
             "Expected MyPlugin to depend on plugin-tool-product (the explicit product). Actual dependencies: \(pluginTarget.common.dependencies.map(\.targetId.value))"
         )
+    }
+
+    /// A build-tool plugin and its executable tool live in the *root* package. The tool is
+    /// host-only, so neither its module target nor its `-product` target may appear in the
+    /// top-level aggregates; otherwise a whole-package `swift build` specializes the tool for
+    /// the destination platform and fails on host-only imports.
+    @Test func hostOnlyBuildToolExcludedFromAggregates() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/RootLib/RootLib.swift",
+            "/Root/Sources/PluginTool/main.swift",
+            "/Root/Plugins/MyPlugin/plugin.swift",
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    products: [
+                        // Product name differs from the target name, so the tool's PIF target is
+                        // "plugin-tool-product", which also exercises the product-name resolution.
+                        ProductDescription(name: "plugin-tool", type: .executable, targets: ["PluginTool"]),
+                    ],
+                    targets: [
+                        TargetDescription(
+                            name: "RootLib",
+                            pluginUsages: [.plugin(name: "MyPlugin", package: nil)]
+                        ),
+                        TargetDescription(name: "PluginTool", type: .executable),
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: ["PluginTool"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let rootProject = try pif.workspace.project(named: "Root")
+        let rootLibID = try rootProject.target(named: "RootLib").common.id.value
+        let toolModuleID = try rootProject.target(named: "PluginTool").common.id.value
+        let toolProductID = try rootProject.target(named: "plugin-tool-product").common.id.value
+
+        let aggregate = try pif.workspace.project(named: "Aggregate")
+        for aggregateName in [PIFBuilder.allExcludingTestsTargetName, PIFBuilder.allIncludingTestsTargetName] {
+            let deps = Set(try aggregate.target(named: aggregateName).common.dependencies.map(\.targetId.value))
+            // The shipped library is a genuine top-level target and stays in the aggregate.
+            #expect(deps.contains(rootLibID), "\(aggregateName) should build the shipped library RootLib")
+            // The host-only tool must not be a top-level destination build, as either target.
+            #expect(!deps.contains(toolModuleID), "\(aggregateName) must not build the host-only tool module")
+            #expect(!deps.contains(toolProductID), "\(aggregateName) must not build the host-only tool product")
+        }
     }
 
     /// Tests the cross-package case: the build tool plugin lives in one package and its


### PR DESCRIPTION
Build host-only build-tool modules for the host during cross-compilation

### Motivation:

`platformConstraint` drives each module's destination, and both the build plan and the SwiftBuild PIF build for the target unless a module is pinned to .host. That pin was only computed inside `handlePrebuilts`, and only when a prebuilts fetch had populated the package. With no prebuilts nothing was pinned, so a whole-package cross build compiled these build-tool modules for the target. `handlePrebuilts` also only handled macros, never plugins.

This is blocking us from migrating JavaScriptKit to use SwiftBuild backend

### Modifications:

Compute the marking unconditionally, in its own pass, and also treat plugins like macros.

### Result:

Host-only build-tool (transitive) modules are compiled only for the host during cross-compilation.