### PR TITLE
Registry Example: Remove ZIPFoundation dependency, use platform tools

### DIFF
--- a/.github/scripts/prebuild.ps1
+++ b/.github/scripts/prebuild.ps1
@@ -12,26 +12,11 @@
 
 param (
     [switch]$SkipAndroid,
-    [switch]$InstallCMake,
-    [switch]$InstallVcpkg,
-    [switch]$InstallZlib
+    [switch]$InstallCMake
 )
 
 # winget isn't easily made available in containers, so use chocolatey
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-
-if ($InstallVcpkg -or $InstallZlib) {
-    Write-Output "Installing vcpkg ..."
-    git clone --depth 1 https://github.com/microsoft/vcpkg.git
-    .\vcpkg\bootstrap-vcpkg.bat
-    # $PWD is a PathInfo object; use .Path to get the string
-    $currentDir = $PWD.Path
-    $env:VCPKG_ROOT = "${currentDir}\vcpkg"
-    $env:PATH = "$env:VCPKG_ROOT;$env:PATH"
-
-    Write-Output "VCPKG_ROOT: $env:VCPKG_ROOT"
-    Write-Output "PATH: $env:PATH"
-}
 
 if ($InstallCMake) {
     choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies
@@ -52,9 +37,4 @@ if (-not $SkipAndroid) {
 
     # Work around a bug in the package causing the env var to be set incorrectly
     $env:ANDROID_NDK_ROOT = $env:ANDROID_NDK_ROOT.replace('-windows.zip','')
-}
-
-if ($InstallZlib) {
-    Write-Output "Installing zlib ..."
-    vcpkg install zlib
 }

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,10 +48,9 @@ jobs:
       enable_linux_checks: true
       linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       linux_build_command: 'set -x; cd Examples/package-registry && swift test --parallel; set +x'
-      enable_windows_checks: false  # https://github.com/swiftlang/swift-package-manager/issues/10326
+      enable_windows_checks: true
       windows_swift_versions: '["nightly-main"]'
       # windows_swift_versions: '["nightly-main", "nightly-6.4.x"]'
-      windows_pre_build_command: 'Invoke-Program .\.github\scripts\prebuild.ps1 -InstallZlib -SkipAndroid'
       windows_build_timeout: 180
       windows_build_command: 'cd Examples\package-registry; Invoke-program swift test --parallel'
       enable_macos_checks: true

--- a/Examples/package-registry/Package.swift
+++ b/Examples/package-registry/Package.swift
@@ -18,7 +18,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.121.0"),
-        .package(url: "https://github.com/weichsel/ZIPFoundation.git", from: "0.9.19"),
         .package(url: "https://github.com/apple/swift-crypto.git", "3.0.0" ..< "5.0.0"),
     ],
     targets: [
@@ -26,7 +25,6 @@ let package = Package(
             name: "RegistryExample",
             dependencies: [
                 .product(name: "Vapor", package: "vapor"),
-                .product(name: "ZIPFoundation", package: "ZIPFoundation"),
                 .product(
                     name: "Crypto",
                     package: "swift-crypto",

--- a/Examples/package-registry/Sources/RegistryExample/Publishing/ManifestExtractor.swift
+++ b/Examples/package-registry/Sources/RegistryExample/Publishing/ManifestExtractor.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import ZIPFoundation
 
 /// Errors that can be thrown while extracting manifests from a published
 /// source archive.
@@ -54,9 +53,13 @@ public enum ManifestExtractorError: Error, Equatable, Sendable {
 public enum ManifestExtractor {
     /// Extracts the package manifests from a source archive.
     ///
-    /// - Parameter archiveData: The raw bytes of the source archive
-    ///   (typically the `source-archive` multipart part of a publish
-    ///   request).
+    /// - Parameters:
+    ///   - archiveData: The raw bytes of the source archive (typically the
+    ///     `source-archive` multipart part of a publish request).
+    ///   - maxManifestBytes: The maximum decompressed size of a single
+    ///     manifest. Entries that inflate beyond this cap throw
+    ///     ``ManifestExtractorError/manifestTooLarge`` instead of being
+    ///     buffered in full.
     /// - Returns: A dictionary mapping manifest keys to file contents. The
     ///   default `Package.swift` manifest is stored under the empty-string
     ///   key `""`; version-qualified manifests are stored under their
@@ -66,35 +69,38 @@ public enum ManifestExtractor {
     ///     not a readable zip archive.
     ///   - ``ManifestExtractorError/manifestMissing`` if no `Package.swift`
     ///     is found at depth 1 or 2 within the archive.
-    ///   - Any error thrown by ZIPFoundation while reading entry
-    ///     contents.
+    ///   - ``ManifestExtractorError/manifestTooLarge`` if a manifest's
+    ///     decompressed size exceeds `maxManifestBytes`.
     public static func extract(
         from archiveData: Data,
         maxManifestBytes: Int = 1_048_576
     ) throws -> [String: String] {
-        let archive: Archive
-        do {
-            archive = try Archive(data: archiveData, accessMode: .read)
-        } catch {
-            throw ManifestExtractorError.invalidArchive
-        }
+        let workingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("registry-manifest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workingDirectory) }
 
-        var candidates: [(depth: Int, key: String, path: String, entry: Entry)] = []
-        for entry in archive where entry.type == .file {
-            let path = entry.path
+        let archiveURL = workingDirectory.appendingPathComponent("source.zip", isDirectory: false)
+        try archiveData.write(to: archiveURL)
+
+        var candidates: [(depth: Int, key: String, path: String)] = []
+        for path in try listEntries(in: archiveURL) {
             let components = path.split(separator: "/")
             guard let filename = components.last.map(String.init) else { continue }
             let depth = components.count
             guard depth <= 2 else { continue }
             guard let key = manifestKey(from: filename) else { continue }
-            candidates.append((depth, key, path, entry))
+            candidates.append((depth, key, path))
         }
         candidates.sort { $0.depth < $1.depth || ($0.depth == $1.depth && $0.path < $1.path) }
 
         var manifests: [String: String] = [:]
         for candidate in candidates where manifests[candidate.key] == nil {
-            let contents = try readEntry(candidate.entry, from: archive, maxBytes: maxManifestBytes)
-            manifests[candidate.key] = contents
+            manifests[candidate.key] = try readEntry(
+                candidate.path,
+                from: archiveURL,
+                maxBytes: maxManifestBytes
+            )
         }
 
         guard manifests[""] != nil else {
@@ -121,21 +127,135 @@ public enum ManifestExtractor {
         return parts.allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
     }
 
-    private static func readEntry(_ entry: Entry, from archive: Archive, maxBytes: Int) throws -> String {
-        var buffer = Data()
-        var overflow = false
-        _ = try archive.extract(entry) { chunk in
-            if overflow { return }
-            let room = maxBytes - buffer.count
-            if chunk.count <= room {
-                buffer.append(chunk)
-            } else {
-                overflow = true
-            }
+    /// Lists every entry path stored in the archive by shelling out to the
+    /// platform's zip tooling.
+    ///
+    /// A non-zero exit status means the tool could not read the file as a
+    /// zip archive, which is surfaced as ``ManifestExtractorError/invalidArchive``.
+    private static func listEntries(in archiveURL: URL) throws -> [String] {
+        let result = try run(listArguments(for: archiveURL))
+        guard result.exitCode == 0 else {
+            throw ManifestExtractorError.invalidArchive
         }
-        if overflow {
+        return String(decoding: result.standardOutput, as: UTF8.self)
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+    }
+
+    /// Extracts a single archive entry to standard output, capping the
+    /// number of bytes read so a maliciously inflating manifest cannot be
+    /// buffered without bound.
+    private static func readEntry(_ path: String, from archiveURL: URL, maxBytes: Int) throws -> String {
+        let result = try run(extractArguments(for: archiveURL, entry: path), byteLimit: maxBytes)
+        if result.overflowed {
             throw ManifestExtractorError.manifestTooLarge
         }
-        return String(decoding: buffer, as: UTF8.self)
+        guard result.exitCode == 0 else {
+            throw ManifestExtractorError.invalidArchive
+        }
+        return String(decoding: result.standardOutput, as: UTF8.self)
+    }
+
+    #if os(Windows)
+    /// The libarchive-based `tar` bundled with Windows, which can read zip
+    /// archives. Resolved out of `System32` to avoid picking up an
+    /// incompatible `tar` earlier on `PATH` (e.g. from MSYS/Git for Windows).
+    private static let archiveTool: String = {
+        let command = "tar.exe"
+        guard let systemRoot = ProcessInfo.processInfo.environment["SystemRoot"] else {
+            return command
+        }
+        return systemRoot + "\\System32\\" + command
+    }()
+
+    private static func listArguments(for archiveURL: URL) -> [String] {
+        [archiveTool, "-tf", archiveURL.path]
+    }
+
+    private static func extractArguments(for archiveURL: URL, entry: String) -> [String] {
+        [archiveTool, "-xOf", archiveURL.path, entry]
+    }
+    #else
+    private static func listArguments(for archiveURL: URL) -> [String] {
+        ["unzip", "-Z1", archiveURL.path]
+    }
+
+    private static func extractArguments(for archiveURL: URL, entry: String) -> [String] {
+        ["unzip", "-p", archiveURL.path, entry]
+    }
+    #endif
+
+    private struct CommandResult {
+        let exitCode: Int32
+        let standardOutput: Data
+        /// `true` when reading was stopped because standard output exceeded
+        /// the configured byte limit.
+        let overflowed: Bool
+    }
+
+    /// Runs a command and captures its standard output.
+    ///
+    /// - Parameters:
+    ///   - arguments: The command to run, where the first element is the
+    ///     executable. On Unix a bare executable name is resolved via
+    ///     `/usr/bin/env`, matching how `unzip` is expected to be on `PATH`.
+    ///   - byteLimit: When set, reading stops once standard output would
+    ///     exceed this many bytes and the process is terminated. The result's
+    ///     `overflowed` flag is then `true`.
+    private static func run(_ arguments: [String], byteLimit: Int? = nil) throws -> CommandResult {
+        let process = Process()
+        let executable = arguments[0]
+        #if os(Windows)
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = Array(arguments.dropFirst())
+        #else
+        if executable.contains("/") {
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = Array(arguments.dropFirst())
+        } else {
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = arguments
+        }
+        #endif
+
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+
+        do {
+            try process.run()
+        } catch {
+            throw ManifestExtractorError.invalidArchive
+        }
+
+        let outputHandle = standardOutput.fileHandleForReading
+        var collected = Data()
+        var overflowed = false
+        while true {
+            let chunk = outputHandle.availableData
+            if chunk.isEmpty { break }
+            guard let byteLimit else {
+                collected.append(chunk)
+                continue
+            }
+            let room = byteLimit - collected.count
+            if chunk.count <= room {
+                collected.append(chunk)
+            } else {
+                overflowed = true
+                process.terminate()
+                break
+            }
+        }
+
+        _ = try? standardError.fileHandleForReading.readToEnd()
+        process.waitUntilExit()
+
+        return CommandResult(
+            exitCode: process.terminationStatus,
+            standardOutput: collected,
+            overflowed: overflowed
+        )
     }
 }

--- a/Examples/package-registry/Tests/RegistryExampleTests/ManifestExtractorTests.swift
+++ b/Examples/package-registry/Tests/RegistryExampleTests/ManifestExtractorTests.swift
@@ -12,7 +12,6 @@
 
 import Testing
 import Foundation
-import ZIPFoundation
 @testable import RegistryExample
 
 @Suite("ManifestExtractor")
@@ -82,20 +81,35 @@ struct ManifestExtractorTests {
     }
 }
 
+/// Builds a zip archive from in-memory entries using the system `zip`
+/// tool, so tests exercise the same command-line tooling that
+/// ``ManifestExtractor`` reads with (rather than a third-party zip
+/// library that does not build on Windows).
 func makeZip(entries: [String: String]) throws -> Data {
-    let archive = try Archive(accessMode: .create)
+    let fileManager = FileManager.default
+    let stagingDirectory = fileManager.temporaryDirectory
+        .appendingPathComponent("registry-makezip-\(UUID().uuidString)", isDirectory: true)
+    try fileManager.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: stagingDirectory) }
+
     for (path, contents) in entries {
-        let data = Data(contents.utf8)
-        try archive.addEntry(
-            with: path,
-            type: .file,
-            uncompressedSize: Int64(data.count),
-            compressionMethod: .deflate
-        ) { position, size in
-            let start = Int(position)
-            let end = min(start + size, data.count)
-            return data.subdata(in: start..<end)
-        }
+        let fileURL = stagingDirectory.appendingPathComponent(path, isDirectory: false)
+        try fileManager.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(contents.utf8).write(to: fileURL)
     }
-    return archive.data ?? Data()
+
+    let archiveURL = stagingDirectory.appendingPathComponent("archive.zip", isDirectory: false)
+    let topLevelEntries = Set(entries.keys.compactMap { $0.split(separator: "/").first.map(String.init) })
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.currentDirectoryURL = stagingDirectory
+    process.arguments = ["zip", "-qr", archiveURL.path] + topLevelEntries.sorted()
+    try process.run()
+    process.waitUntilExit()
+
+    return try Data(contentsOf: archiveURL)
 }

--- a/Examples/package-registry/Tests/RegistryExampleTests/MetadataRouteTests.swift
+++ b/Examples/package-registry/Tests/RegistryExampleTests/MetadataRouteTests.swift
@@ -14,7 +14,6 @@ import Testing
 import Foundation
 import Vapor
 import VaporTesting
-import ZIPFoundation
 @testable import RegistryExample
 
 @Suite("Metadata endpoints")

--- a/Examples/package-registry/Tests/RegistryExampleTests/PublishRouteTests.swift
+++ b/Examples/package-registry/Tests/RegistryExampleTests/PublishRouteTests.swift
@@ -14,7 +14,6 @@ import Testing
 import Foundation
 import Vapor
 import VaporTesting
-import ZIPFoundation
 @testable import RegistryExample
 
 @Suite("Publish endpoint")


### PR DESCRIPTION
We can't use ZIPFoundation on Windows. Replace it with the platform's zip tooling, mirroring how SwiftPM's Basics/ZipArchiver works.

Issue: #10326