### PR TITLE
Make generated Swift sources read-only between builds

### DIFF
--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -438,6 +438,24 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
             return result
         }
 
+        let generatedSourceFileProtection = self.pluginConfiguration.map {
+            GeneratedSourceFileProtection(
+                fileSystem: self.fileSystem,
+                pluginWorkDirectory: $0.workDirectory
+            )
+        }
+        try generatedSourceFileProtection?.prepareForBuild()
+        defer {
+            do {
+                try generatedSourceFileProtection?.protectGeneratedSources()
+            } catch {
+                self.observabilityScope.emit(
+                    warning: "unable to make generated source files read-only",
+                    underlyingError: error
+                )
+            }
+        }
+
         if let stripProduct = self.config.destinationBuildParameters.stripProducts {
             self.observabilityScope.emit(
                 Basics.Diagnostic.unsupportedStripProductsConfigurationFlag(

--- a/Sources/SPMBuildCore/Plugins/GeneratedSourceFileProtection.swift
+++ b/Sources/SPMBuildCore/Plugins/GeneratedSourceFileProtection.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import enum TSCBasic.FileMode
+
+/// Keeps generated Swift sources read-only between builds while allowing build
+/// tool plugins to replace them when they run again.
+package struct GeneratedSourceFileProtection {
+    private let fileSystem: any FileSystem
+    private let outputDirectory: AbsolutePath
+
+    package init(fileSystem: any FileSystem, pluginWorkDirectory: AbsolutePath) {
+        self.fileSystem = fileSystem
+        self.outputDirectory = pluginWorkDirectory.appending("outputs")
+    }
+
+    /// Restores write access before prebuild and build commands may regenerate
+    /// their declared outputs.
+    package func prepareForBuild() throws {
+        try self.setGeneratedSourcesFileMode(.userWritable)
+    }
+
+    /// Removes write access from generated Swift sources after the build has
+    /// completed, including builds that fail while compiling generated code.
+    package func protectGeneratedSources() throws {
+        try self.setGeneratedSourcesFileMode(.userUnWritable)
+    }
+
+    private func setGeneratedSourcesFileMode(_ mode: FileMode) throws {
+        guard self.fileSystem.exists(self.outputDirectory) else {
+            return
+        }
+
+        for path in try walk(self.outputDirectory, fileSystem: self.fileSystem) {
+            guard
+                path.extension == "swift",
+                self.fileSystem.isFile(path),
+                !self.fileSystem.isSymlink(path)
+            else {
+                continue
+            }
+            try self.fileSystem.chmod(mode, path: path)
+        }
+    }
+}

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -459,6 +459,22 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
             return result
         }
 
+        let generatedSourceFileProtection = GeneratedSourceFileProtection(
+            fileSystem: self.fileSystem,
+            pluginWorkDirectory: self.pluginConfiguration.workDirectory
+        )
+        try generatedSourceFileProtection.prepareForBuild()
+        defer {
+            do {
+                try generatedSourceFileProtection.protectGeneratedSources()
+            } catch {
+                self.observabilityScope.emit(
+                    warning: "unable to make generated source files read-only",
+                    underlyingError: error
+                )
+            }
+        }
+
         if let stripProdduct = self.buildParameters.stripProducts, self.buildParameters.configuration != .release {
             self.observabilityScope.emit(
                 Basics.Diagnostic.unsupportedStripProductsConfigurationFlag(

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -924,10 +924,14 @@ extension Workspace {
         // Remove all but protected paths.
         let contentsToRemove = Set(contents).subtracting(protectedAssets)
         for name in contentsToRemove {
-            try? self.fileSystem.removeFileTree(AbsolutePath(
+            guard let path = try? AbsolutePath(
                 validating: name,
                 relativeTo: self.location.scratchDirectory
-            ))
+            ) else {
+                continue
+            }
+            try? self.fileSystem.chmod(.userWritable, path: path, options: [.recursive, .onlyFiles])
+            try? self.fileSystem.removeFileTree(path)
         }
     }
 

--- a/Tests/FunctionalTests/PluginTests.swift
+++ b/Tests/FunctionalTests/PluginTests.swift
@@ -66,6 +66,73 @@ struct PluginTests {
     }
 
     @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10288", relationship: .verifies),
+        .requiresSwiftConcurrencySupport,
+        .tags(
+            .Feature.Command.Build,
+            .Feature.CommandLineArguments.BuildSystem,
+            .Feature.Plugin,
+            .Feature.SourceGeneration,
+            .FunctionalArea.Workspace,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func testGeneratedSourcesAreReadOnly(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/Plugins/MySourceGenPlugin") { fixturePath in
+            let targetDirectory = fixturePath.appending(components: "Sources", "MyLocalTool")
+            let invalidInput = targetDirectory.appending("syntax-error.dat")
+            try localFileSystem.writeFileContents(invalidInput, string: "invalid")
+
+            await #expect(throws: SwiftPMError.self) {
+                try await executeSwiftBuild(
+                    fixturePath,
+                    extraArgs: ["--product", "MyLocalTool"],
+                    buildSystem: buildSystem,
+                )
+            }
+
+            let pluginOutputDirectory = fixturePath.appending(
+                components: ".build", "plugins", "outputs", "mysourcegenplugin", "MyLocalTool", "destination",
+                "MySourceGenBuildToolPlugin"
+            )
+            let invalidGeneratedSource = pluginOutputDirectory.appending("syntax-error.swift")
+            #expect(localFileSystem.exists(invalidGeneratedSource))
+            #expect(!localFileSystem.isWritable(invalidGeneratedSource))
+
+            _ = try await executeSwiftPackage(
+                fixturePath,
+                extraArgs: ["clean"],
+                buildSystem: buildSystem,
+            )
+            #expect(!localFileSystem.exists(invalidGeneratedSource))
+
+            try localFileSystem.removeFileTree(invalidInput)
+            _ = try await executeSwiftBuild(
+                fixturePath,
+                extraArgs: ["--product", "MyLocalTool"],
+                buildSystem: buildSystem,
+            )
+
+            let input = targetDirectory.appending("foo.dat")
+            let generatedSource = pluginOutputDirectory.appending("foo.swift")
+            #expect(!localFileSystem.isWritable(generatedSource))
+
+            try localFileSystem.writeFileContents(input, string: "regenerated")
+            _ = try await executeSwiftBuild(
+                fixturePath,
+                extraArgs: ["--product", "MyLocalTool"],
+                buildSystem: buildSystem,
+            )
+
+            let generatedSourceContents: String = try localFileSystem.readFileContents(generatedSource)
+            #expect(generatedSourceContents.contains("726567656e657261746564"))
+            #expect(!localFileSystem.isWritable(generatedSource))
+        }
+    }
+
+    @Test(
         .IssueWindowsRelativePathAssert,
         .requiresSwiftConcurrencySupport,
         .disabled(if: CiEnvironment.runningInSelfHostedPipeline && ProcessInfo.hostOperatingSystem == .windows),

--- a/Tests/SPMBuildCoreTests/GeneratedSourceFileProtectionTests.swift
+++ b/Tests/SPMBuildCoreTests/GeneratedSourceFileProtectionTests.swift
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+@testable import SPMBuildCore
+import Testing
+
+@Suite(.tags(.TestSize.small))
+struct GeneratedSourceFileProtectionTests {
+    @Test(.issue("https://github.com/swiftlang/swift-package-manager/issues/10288", relationship: .verifies))
+    func generatedSwiftSourcesAreReadOnlyBetweenBuilds() throws {
+        try withTemporaryDirectory { temporaryDirectory in
+            let pluginWorkDirectory = temporaryDirectory.appending("plugins")
+            let outputDirectory = pluginWorkDirectory.appending(components: "outputs", "package", "target")
+            let generatedSource = outputDirectory.appending("generated.swift")
+            let generatedResource = outputDirectory.appending("resource.txt")
+            #if !os(Windows)
+            let sourceOutsideOutputDirectory = temporaryDirectory.appending("source.swift")
+            let generatedSourceSymlink = outputDirectory.appending("source-link.swift")
+            #endif
+            try localFileSystem.createDirectory(outputDirectory, recursive: true)
+            try localFileSystem.writeFileContents(generatedSource, string: "let value = 1")
+            try localFileSystem.writeFileContents(generatedResource, string: "resource")
+            #if !os(Windows)
+            try localFileSystem.writeFileContents(sourceOutsideOutputDirectory, string: "let value = 2")
+            try localFileSystem.createSymbolicLink(
+                generatedSourceSymlink,
+                pointingAt: sourceOutsideOutputDirectory,
+                relative: false
+            )
+            #endif
+
+            let protection = GeneratedSourceFileProtection(
+                fileSystem: localFileSystem,
+                pluginWorkDirectory: pluginWorkDirectory
+            )
+            try protection.protectGeneratedSources()
+
+            #expect(!localFileSystem.isWritable(generatedSource))
+            #expect(localFileSystem.isWritable(generatedResource))
+            #if !os(Windows)
+            #expect(localFileSystem.isWritable(sourceOutsideOutputDirectory))
+            #endif
+
+            try protection.prepareForBuild()
+
+            #expect(localFileSystem.isWritable(generatedSource))
+            #expect(localFileSystem.isWritable(generatedResource))
+            #if !os(Windows)
+            #expect(localFileSystem.isWritable(sourceOutsideOutputDirectory))
+            #endif
+        }
+    }
+}


### PR DESCRIPTION
Make build-tool plugin generated Swift sources read-only between builds without preventing regeneration or cleanup.

### Motivation:

When a build-tool plugin generates invalid Swift code, compiler diagnostics point developers directly at the generated file. SwiftPM currently leaves that file writable, so it is easy to accidentally edit an artifact that will later be regenerated.

The root cause is that plugin output permissions are never changed after generation. Making the output read-only without coordinating the build lifecycle is insufficient because subsequent plugin runs need to replace the file, and cleanup must also be able to remove it.

### Modifications:

- Add a shared helper that restores write access to generated `.swift` files before a build and removes it afterward, while ignoring symbolic links and generated resources.
- Apply the lifecycle to both the native and SwiftBuild backends, including failed builds through deferred cleanup.
- Restore file write permissions before `swift package clean` removes build artifacts.
- Add unit coverage for permission transitions, resource preservation, and symbolic-link safety.
- Add functional coverage for failed builds, cleanup, and regeneration with both native and SwiftBuild backends.

### Result:

Generated Swift files reached through compiler diagnostics are read-only between builds. SwiftPM can still clean them and regenerate them after their inputs change.

### Validation:

- `swift test --disable-sandbox ... --filter GeneratedSourceFileProtectionTests` — 1 test passed.
- `swift test --disable-sandbox ... --filter PluginTests.testGeneratedSourcesAreReadOnly` — native and SwiftBuild cases passed.
- `git diff --cached --check` passed before commit.
- SwiftFormat 0.62.1 reports no formatting issues in the two new files.

### Limitations:

- The permission behavior was not run locally on Windows; CI should validate the Windows filesystem semantics. The symbolic-link safety assertion is conditionally excluded on Windows.
- Running SwiftFormat 0.62.1 across the four existing changed files reports many pre-existing or formatter-version drift issues outside this patch. To avoid unrelated full-file churn, only the two new files were fully formatted and linted.

Fixes #10288
