### PR TITLE
fix(http-client): preserve error bodies for downloads 

### DIFF
--- a/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/URLSessionHTTPClient.swift
@@ -307,20 +307,19 @@ private final class DownloadTaskManager: NSObject, URLSessionDownloadDelegate {
         do {
             let path = try AbsolutePath(validating: location.path)
 
-            // Only proceed to move the file if status code is within 200-299 range.
+            // `URLSession` removes `location` after this callback returns, so consume it synchronously.
             if let response = downloadTask.response as? HTTPURLResponse,
-               response.statusCode < 200 || response.statusCode >= 300 {
-                throw HTTPClientError.badResponseStatusCode(response.statusCode)
+               response.statusCode < 200 || response.statusCode >= 300
+            {
+                // Preserve an unsuccessful response for the caller without moving it to the download destination.
+                task.responseBody = try Data(contentsOf: location)
+            } else {
+                try task.fileSystem.move(from: path, to: task.destination)
             }
-
-            // Always using synchronous `localFileSystem` here since `URLSession` requires temporary `location`
-            // to be moved from synchronously. Otherwise the file will be immediately cleaned up after returning
-            // from this delegate method.
-            try task.fileSystem.move(from: path, to: task.destination)
         } catch {
-            task.moveFileError = error
-            self.tasks[downloadTask.taskIdentifier] = task
+            task.fileOperationError = error
         }
+        self.tasks[downloadTask.taskIdentifier] = task
     }
 
     public func urlSession(
@@ -335,10 +334,10 @@ private final class DownloadTaskManager: NSObject, URLSessionDownloadDelegate {
         do {
             if let error {
                 throw HTTPClientError.downloadError(error.interpolationDescription)
-            } else if let error = task.moveFileError {
+            } else if let error = task.fileOperationError {
                 throw error
             } else if let response = downloadTask.response as? HTTPURLResponse {
-                task.completionHandler(.success(response.response(body: nil)))
+                task.completionHandler(.success(response.response(body: task.responseBody)))
             } else {
                 throw HTTPClientError.invalidResponse
             }
@@ -377,7 +376,8 @@ private final class DownloadTaskManager: NSObject, URLSessionDownloadDelegate {
         let completionHandler: LegacyHTTPClient.CompletionHandler
         let authorizationProvider: LegacyHTTPClientConfiguration.AuthorizationProvider?
 
-        var moveFileError: Error?
+        var responseBody: Data?
+        var fileOperationError: Error?
 
         init(
             task: URLSessionDownloadTask,

--- a/Tests/BasicsTests/URLSessionHTTPClientTests.swift
+++ b/Tests/BasicsTests/URLSessionHTTPClientTests.swift
@@ -1048,11 +1048,8 @@ final class URLSessionHTTPClientTest: XCTestCase {
         try await testWithTemporaryDirectory { temporaryDirectory in
             let url = URL("https://async-downloader-tests.com/testServerErrorWithBody.zip")
             let destination = temporaryDirectory.appending("download")
-            var options = HTTPClientRequest.Options()
-            options.validResponseCodes = [200]
             let request = HTTPClient.Request.download(
                 url: url,
-                options: options,
                 fileSystem: localFileSystem,
                 destination: destination
             )
@@ -1068,27 +1065,30 @@ final class URLSessionHTTPClientTest: XCTestCase {
             """.utf8)
 
             MockURLProtocol.onRequest(request) { request in
-                MockURLProtocol.sendResponse(statusCode: 500, headers: ["Content-Type": "application/json", "Content-Length": "\(errorJson.count)"], for: request)
-                // Send error response body - this should be downloaded to temp file but then deleted
+                MockURLProtocol.sendResponse(
+                    statusCode: 500,
+                    headers: ["Content-Type": "application/json", "Content-Length": "\(errorJson.count)"],
+                    for: request
+                )
+                // Send an error response body, which should be preserved without being moved to the destination.
                 MockURLProtocol.sendData(errorJson, for: request)
                 MockURLProtocol.sendCompletion(for: request)
             }
 
-            do {
-                _ = try await httpClient.execute(
-                    request,
-                    progress: { _, _ in
-                        // Progress may be called as data is downloaded, even for error responses
-                        // This is expected behavior
-                    }
-                )
-                XCTFail("unexpected success")
-            } catch {
-                XCTAssertEqual(error as? HTTPClientError, HTTPClientError.badResponseStatusCode(500))
-                // Verify that no file was created at the destination for bad response codes
-                // even though a response body was sent
-                XCTAssertFalse(localFileSystem.exists(destination), "Destination file should not exist for bad response codes, even when response body is present")
-            }
+            let response = try await httpClient.execute(
+                request,
+                progress: { _, _ in
+                    // Progress may be called as data is downloaded, even for error responses.
+                    // This is expected behavior.
+                }
+            )
+
+            XCTAssertEqual(response.statusCode, 500)
+            XCTAssertEqual(response.body, errorJson)
+            XCTAssertFalse(
+                localFileSystem.exists(destination),
+                "Destination file should not exist for bad response codes, even when response body is present"
+            )
         }
     }
 }


### PR DESCRIPTION
Fixes #10216

## Summary

Preserve non-2xx response bodies produced by URLSession download tasks so callers such as `RegistryClient` can inspect server error details.

Previously, `DownloadTaskManager` converted a non-2xx response into a file-move error before the temporary response body could reach the caller.

## Changes

- Read non-2xx download response bodies from URLSession’s temporary file before it is removed.
- Return the HTTP status, headers, and body to the higher-level HTTP client.
- Continue moving successful 2xx downloads to their requested destination.
- Keep non-2xx payloads out of the requested archive destination.
- Add regression coverage for preserving the response body and leaving the destination untouched.
- Preserve higher-level `validResponseCodes` enforcement and its `badResponseStatusCode` behavior.

## Alternatives considered

Handling this only inside `RegistryClient` was considered. However, the URLSession transport layer discarded the temporary response body before it reached the registry client.

Moving non-2xx payloads to the requested destination was also rejected because it could save an error document as a source archive, reversing the safety behavior introduced by #9474.

## Notes

This allows `RegistryClient.unexpectedStatusError` to parse existing RFC 9457 problem details without changing the registry-specific implementation.

## Testing

- `swift test --filter URLSessionHTTPClientTest`
- `swift test --filter PackageRegistryTests.DownloadSourceArchive`
- Verified that a non-2xx response body is preserved.
- Verified that no file is written to the download destination.
- Verified that `validResponseCodes = [200]` still produces `badResponseStatusCode`.
- Existing successful download coverage remains passing.