### PR TITLE
fix(package-loading): improve executable target diagnostics

### DIFF
--- a/Sources/PackageLoading/Diagnostics.swift
+++ b/Sources/PackageLoading/Diagnostics.swift
@@ -73,18 +73,36 @@ extension Basics.Diagnostic {
         .error("\(type.description) product '\(product)' should not contain plugin targets (it has \(pluginTargets.map{ "'\($0)'" }.joined(separator: ", ")))")
     }
 
-    static func executableProductTargetNotExecutable(product: String, target: String) -> Self {
-        .error("""
-            executable product '\(product)' expects target '\(target)' to be executable; an executable target requires \
-            a 'main.swift' file
-            """)
+    static func executableProductTargetNotExecutable(
+        product: String,
+        target: String,
+        toolsVersion: ToolsVersion
+    ) -> Self {
+        if toolsVersion >= .v5_4 {
+            .error("""
+                executable product '\(product)' expects target '\(target)' to be executable; use \
+                'executableTarget()' to declare the target as executable
+                """)
+        } else {
+            .error("""
+                executable product '\(product)' expects target '\(target)' to be executable; \
+                an executable target requires a 'main.swift' file
+                """)
+        }
     }
 
-    static func executableProductWithoutExecutableTarget(product: String) -> Self {
-        .error("""
-            executable product '\(product)' should have one executable target; an executable target requires a \
-            'main.swift' file
-            """)
+    static func executableProductWithoutExecutableTarget(product: String, toolsVersion: ToolsVersion) -> Self {
+        if toolsVersion >= .v5_4 {
+            .error("""
+                executable product '\(product)' should have one executable target; use \
+                'executableTarget()' to declare a target as executable
+                """)
+        } else {
+            .error("""
+                executable product '\(product)' should have one executable target; an executable target requires a \
+                'main.swift' file
+                """)
+        }
     }
 
     static func executableProductWithMoreThanOneExecutableTarget(product: String) -> Self {

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1717,9 +1717,16 @@ public final class PackageBuilder {
             if executableTargetCount == 0 {
                 if let target = targets.spm_only {
                     self.observabilityScope
-                        .emit(.executableProductTargetNotExecutable(product: product.name, target: target.name))
+                        .emit(.executableProductTargetNotExecutable(
+                            product: product.name,
+                            target: target.name,
+                            toolsVersion: self.manifest.toolsVersion
+                        ))
                 } else {
-                    self.observabilityScope.emit(.executableProductWithoutExecutableTarget(product: product.name))
+                    self.observabilityScope.emit(.executableProductWithoutExecutableTarget(
+                        product: product.name,
+                        toolsVersion: self.manifest.toolsVersion
+                    ))
                 }
             } else {
                 self.observabilityScope.emit(.executableProductWithMoreThanOneExecutableTarget(product: product.name))

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -2454,6 +2454,45 @@ struct PackageBuilderTests {
     }
 
     @Test
+    func testBadExecutableProductDeclWithExecutableTargetSupport() throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/Application/application.swift",
+            "/Sources/Support/support.swift"
+        )
+
+        let manifest = Manifest.createRootManifest(
+            displayName: "MyPackage",
+            toolsVersion: .v5_4,
+            products: [
+                try ProductDescription(name: "single", type: .executable, targets: ["Application"]),
+                try ProductDescription(name: "multiple", type: .executable, targets: ["Application", "Support"]),
+            ],
+            targets: [
+                try TargetDescription(name: "Application"),
+                try TargetDescription(name: "Support"),
+            ]
+        )
+        try PackageBuilderTester(manifest, in: fs) { package, diagnostics in
+            try package.checkModule("Application") { _ in }
+            try package.checkModule("Support") { _ in }
+            diagnostics.check(
+                diagnostic: """
+                    executable product 'single' expects target 'Application' to be executable; use \
+                    'executableTarget()' to declare the target as executable
+                    """,
+                severity: .error
+            )
+            diagnostics.check(
+                diagnostic: """
+                    executable product 'multiple' should have one executable target; use \
+                    'executableTarget()' to declare a target as executable
+                    """,
+                severity: .error
+            )
+        }
+    }
+
+    @Test
     func testLibraryProductDiagnostics() throws {
         let fs = InMemoryFileSystem(emptyFiles:
             "/Sources/MyLibrary/library.swift",


### PR DESCRIPTION
Fixes #8342

## Summary

Improve the diagnostic emitted when an executable product contains no executable targets.

The existing error says that an executable target requires a `main.swift` file. Since tools version 5.4, targets can instead be declared with `executableTarget()`, allowing entry points such as `@main` without a file named `main.swift`.

## Changes

- Make missing executable-target diagnostics aware of the manifest tools version.
- Suggest `executableTarget()` for tools version 5.4 and newer.
- Preserve the existing `main.swift` guidance for older manifests.
- Add regression coverage for executable products containing one or multiple non-executable targets.
- Retain coverage for the legacy diagnostic behavior.

## Alternatives considered

Replacing the guidance unconditionally was rejected because manifests using tools versions before 5.4 cannot use `executableTarget()`.

Reporting only that the product contains no executable targets was also considered. Providing tools-version-appropriate remediation makes the diagnostic more actionable.

## Notes

Executable-product validation behavior is unchanged. This only updates the remediation presented when validation fails.

Source-based executable inference and binary executable products continue to behave as before.

## Testing

- `swift test --filter 'PackageBuilderTests.testBadExecutableProductDecl'`
- `swift test --skip-build --filter 'PackageBuilderTests'` — 75 tests passed