### PR TITLE
docs(package-plugin): clarify tool lookup behavior

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingBuildToolPlugin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingBuildToolPlugin.md
@@ -100,6 +100,19 @@ Note that this does not necessarily mean that _SomeTool_ will have been built wh
 Executable dependencies are built for the host platform as part of the build, while binary dependencies are references to `artifactbundle` archives that contains prebuilt binaries (see [SE-305](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md)).
 Binary targets are often used when the tool is built using a different build system than package manager, or when building it on demand is prohibitively expensive or requires a special build environment.
 
+Pass an executable target's name, an executable product's name, or an executable
+artifact's name to `PluginContext.tool(named:)`, as appropriate for the declared
+dependency. Binary artifact bundles must contain a variant that supports the
+host platform, because build tools run on the host even when the package is
+being cross-compiled.
+
+Declaring a dependency is the portable way to make a tool available to a build
+tool plugin. SwiftPM also searches the directory containing the selected Swift
+compiler, which makes tools in the active toolchain available, but it doesn't
+search the user's `PATH` for build tool plugins. IDEs and other hosts may provide
+different search directories. Don't require users to install a build tool on
+`PATH`; provide it through an executable or binary dependency instead.
+
 ### Implementing the build tool plugin script
 
 By default, Swift Package Manager looks for the implementation of a declared plugin in a subdirectory of the `Plugins` directory named with the same name as the plugin target.

--- a/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingBuildToolPlugin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingBuildToolPlugin.md
@@ -107,11 +107,12 @@ host platform, because build tools run on the host even when the package is
 being cross-compiled.
 
 Declaring a dependency is the portable way to make a tool available to a build
-tool plugin. SwiftPM also searches the directory containing the selected Swift
-compiler, which makes tools in the active toolchain available, but it doesn't
-search the user's `PATH` for build tool plugins. IDEs and other hosts may provide
-different search directories. Don't require users to install a build tool on
-`PATH`; provide it through an executable or binary dependency instead.
+tool plugin. Swift Package Manager also searches the directory containing the
+selected Swift compiler, which makes tools in the active toolchain available,
+but it doesn't search the user's `PATH` for build tool plugins. IDEs and other
+hosts may provide different search directories. Don't require users to install
+a build tool on `PATH`; provide it through an executable or binary dependency
+instead.
 
 ### Implementing the build tool plugin script
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingCommandPlugin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingCommandPlugin.md
@@ -72,6 +72,23 @@ In the above example, the plugin declares its purpose is source code formatting,
 The package manager runs plugins in a sandbox that prevents network access and most file system access.
 Package manager allows additional permissions to allow network access or file system acess when you declare them after it receives approval from the user.
 
+### Command plugin tool dependencies
+
+Declare command-line tools as direct dependencies of the plugin target when the
+plugin needs to work in SwiftPM, IDEs, and other hosts. Pass an executable
+target's name, an executable product's name, or an executable artifact's name to
+`PluginContext.tool(named:)`, as appropriate for the declared dependency.
+Executable dependencies are built for the host platform, and binary artifact
+bundles must provide a variant that supports the host platform.
+
+When SwiftPM invokes a command plugin from the command line and no declared
+dependency matches, it searches the directory containing the selected Swift
+compiler followed by the directories in the invoking process's `PATH`. This
+fallback is specific to the SwiftPM command-line interface; IDEs and other hosts
+may provide different search directories. If a command plugin intentionally
+requires a user-installed tool, document that requirement and report a clear
+diagnostic when `PluginContext.tool(named:)` can't find it.
+
 ### Implementing the command plugin script
 
 The source that implements command plugins should be located under the `Plugins` subdirectory in the package.

--- a/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingCommandPlugin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingCommandPlugin.md
@@ -72,22 +72,22 @@ In the above example, the plugin declares its purpose is source code formatting,
 The package manager runs plugins in a sandbox that prevents network access and most file system access.
 Package manager allows additional permissions to allow network access or file system acess when you declare them after it receives approval from the user.
 
-### Command plugin tool dependencies
+### Define plugin tool dependencies
 
 Declare command-line tools as direct dependencies of the plugin target when the
-plugin needs to work in SwiftPM, IDEs, and other hosts. Pass an executable
-target's name, an executable product's name, or an executable artifact's name to
-`PluginContext.tool(named:)`, as appropriate for the declared dependency.
-Executable dependencies are built for the host platform, and binary artifact
-bundles must provide a variant that supports the host platform.
+plugin needs to work in Swift Package Manager, IDEs, and other hosts. Pass an
+executable target's name, an executable product's name, or an executable
+artifact's name to `PluginContext.tool(named:)`, as appropriate for the declared
+dependency. Executable dependencies are built for the host platform, and binary
+artifact bundles must provide a variant that supports the host platform.
 
-When SwiftPM invokes a command plugin from the command line and no declared
-dependency matches, it searches the directory containing the selected Swift
-compiler followed by the directories in the invoking process's `PATH`. This
-fallback is specific to the SwiftPM command-line interface; IDEs and other hosts
-may provide different search directories. If a command plugin intentionally
-requires a user-installed tool, document that requirement and report a clear
-diagnostic when `PluginContext.tool(named:)` can't find it.
+When Package Manager invokes a command plugin from the command line and no
+declared dependency matches, it searches the directory containing the selected
+Swift compiler followed by the directories in the invoking process's `PATH`.
+This fallback is specific to the Package Manager command-line interface; IDEs
+and other hosts may provide different search directories. If a command plugin
+intentionally requires a user-installed tool, document that requirement and
+report a clear diagnostic when `PluginContext.tool(named:)` can't find it.
 
 ### Implementing the command plugin script
 

--- a/Sources/Runtimes/PackagePlugin/Context.swift
+++ b/Sources/Runtimes/PackagePlugin/Context.swift
@@ -52,12 +52,27 @@ public struct PluginContext {
     @available(_PackageDescription, introduced: 6.0)
     public let pluginWorkDirectoryURL: URL
 
-    /// Looks up and returns the path of a named command line executable.
-    /// 
-    /// The executable must be provided by an executable target or binary
-    /// target on which the package plugin target depends. This function throws
-    /// an error if the tool cannot be found. The lookup is case sensitive.
+    /// Finds a command-line executable available to the plugin.
+    ///
+    /// The plugin host first looks for a matching tool provided by a direct
+    /// dependency of the plugin target. Use the target name for an executable
+    /// target dependency, the product name for an executable product dependency,
+    /// or the executable artifact name from the artifact bundle metadata for a
+    /// binary target dependency.
+    ///
+    /// If no declared dependency provides a matching tool, the plugin host may
+    /// search additional directories. The directories and their order are
+    /// specific to the host. Declare every required tool as a plugin dependency
+    /// to make the plugin portable between SwiftPM, IDEs, and other hosts.
+    ///
+    /// Tool names are case sensitive.
+    ///
     /// - Parameter name: The name of the executable to find.
+    /// - Returns: Information about the matching host executable.
+    /// - Throws: ``PluginContextError/toolNotSupportedOnTargetPlatform(name:)``
+    ///   if a declared binary tool has no variant for the host platform, or
+    ///   ``PluginContextError/toolNotFound(name:)`` if no matching tool is
+    ///   available.
     public func tool(named name: String) throws -> Tool {
         if let tool = self.accessibleTools[name] {
             // For PluginAccessibleTool.builtTool, the triples value is not saved, thus
@@ -86,18 +101,18 @@ public struct PluginContext {
         throw PluginContextError.toolNotFound(name: name)
     }
 
-    /// A map from tool names to their paths and triples.
+    /// A map of the tools provided by the plugin target's direct dependencies.
     ///
-    /// This is not directly available to the plugin, but is used by  ``tool(named:)``.
+    /// This is not directly available to the plugin, but is used by ``tool(named:)``.
     let accessibleTools: [String: (path: URL, triples: [String]?)]
 
-    /// The paths of directories in which to search for tools that aren't in
-    /// the `toolNamesToPaths` map.
+    /// Host-provided paths in which to search for tools that aren't in
+    /// `accessibleTools`.
     @available(_PackageDescription, deprecated: 6.0, renamed: "toolSearchDirectoryURLs")
     let toolSearchDirectories: [Path]
 
-    /// The paths of directories in which to search for tools that aren't in
-    /// the `toolNamesToPaths` map.
+    /// Host-provided URLs in which to search for tools that aren't in
+    /// `accessibleTools`.
     @available(_PackageDescription, introduced: 6.0)
     let toolSearchDirectoryURLs: [URL]
 

--- a/Sources/Runtimes/PackagePlugin/Context.swift
+++ b/Sources/Runtimes/PackagePlugin/Context.swift
@@ -60,26 +60,27 @@ public struct PluginContext {
     /// or the executable artifact name from the artifact bundle metadata for a
     /// binary target dependency.
     ///
-    /// If no declared dependency provides a matching tool, the plugin host may
-    /// search additional directories. The directories and their order are
-    /// specific to the host. Declare every required tool as a plugin dependency
-    /// to make the plugin portable between SwiftPM, IDEs, and other hosts.
+    /// If no declared dependency provides a matching tool, ``tool(named:)``
+    /// searches additional directories supplied by the plugin host, in the order
+    /// provided. The host determines which directories, if any, it supplies.
+    /// Declare every required tool as a plugin dependency to make the plugin
+    /// portable between Swift Package Manager, IDEs, and other hosts.
     ///
     /// Tool names are case sensitive.
     ///
     /// - Parameter name: The name of the executable to find.
     /// - Returns: Information about the matching host executable.
     /// - Throws: ``PluginContextError/toolNotSupportedOnTargetPlatform(name:)``
-    ///   if a declared binary tool has no variant for the host platform, or
-    ///   ``PluginContextError/toolNotFound(name:)`` if no matching tool is
-    ///   available.
+    ///   if a declared binary tool has no variant for the platform on which the
+    ///   plugin runs, or ``PluginContextError/toolNotFound(name:)`` if no
+    ///   matching tool is available.
     public func tool(named name: String) throws -> Tool {
         if let tool = self.accessibleTools[name] {
             // For PluginAccessibleTool.builtTool, the triples value is not saved, thus
             // the value is always nil; this is intentional since if we are able to
-            // build the tool, it is by definition supporting the target platform.
+            // build the tool, it is by definition supporting the host platform.
             // For PluginAccessibleTool.vendedTool, only supported triples are saved,
-            // so empty triples means the tool is not supported on the target platform.
+            // so empty triples means the tool is not supported on the host platform.
             if let triples = tool.triples, triples.isEmpty {
                 throw PluginContextError.toolNotSupportedOnTargetPlatform(name: name)
             }

--- a/Sources/Runtimes/PackagePlugin/Documentation.docc/Curation/PluginContext.md
+++ b/Sources/Runtimes/PackagePlugin/Documentation.docc/Curation/PluginContext.md
@@ -1,5 +1,39 @@
 # ``PackagePlugin/PluginContext``
 
+Use a plugin context to inspect the package and locate the command-line tools
+that a plugin needs.
+
+## Locating Command-Line Tools
+
+Call ``tool(named:)`` with a tool's logical name to obtain the URL of an
+executable that runs on the host platform. SwiftPM builds executable dependencies
+for the host platform and selects host-compatible variants from binary artifact
+bundles.
+
+The lookup name depends on how the plugin declares the tool:
+
+| Dependency | Lookup name |
+| --- | --- |
+| Executable target in the same package | Target name |
+| Executable product from another package | Product name |
+| Executable in a binary target | Artifact name in the artifact bundle metadata |
+
+Only direct dependencies of the plugin target provide tools. A declared tool
+takes precedence over any executable with the same name in a host-provided
+search directory. If a binary target declares the requested artifact but has no
+variant for the host platform, lookup reports
+``PluginContextError/toolNotSupportedOnTargetPlatform(name:)`` instead of
+searching for another executable with that name.
+
+If no declared dependency matches, ``tool(named:)`` checks each host-provided
+search directory in order and returns the first executable file with the
+requested name. On Windows, it appends the `.exe` suffix when searching these
+directories. The directories are an implementation detail of the host and can
+differ between SwiftPM, an IDE, and other package-manager integrations. Declare
+every required executable as a plugin dependency when the plugin needs to work
+across hosts. A plugin that intentionally uses a tool installed on the user's
+system should document the supported host and configuration requirements.
+
 ## Topics
 
 ### Inspecting the Context

--- a/Sources/Runtimes/PackagePlugin/Documentation.docc/Curation/PluginContext.md
+++ b/Sources/Runtimes/PackagePlugin/Documentation.docc/Curation/PluginContext.md
@@ -3,12 +3,12 @@
 Use a plugin context to inspect the package and locate the command-line tools
 that a plugin needs.
 
-## Locating Command-Line Tools
+## Locating command-line tools
 
 Call ``tool(named:)`` with a tool's logical name to obtain the URL of an
-executable that runs on the host platform. SwiftPM builds executable dependencies
-for the host platform and selects host-compatible variants from binary artifact
-bundles.
+executable that runs on the host platform. Swift Package Manager builds
+executable dependencies for the host platform and selects host-compatible
+variants from binary artifact bundles.
 
 The lookup name depends on how the plugin declares the tool:
 
@@ -29,10 +29,11 @@ If no declared dependency matches, ``tool(named:)`` checks each host-provided
 search directory in order and returns the first executable file with the
 requested name. On Windows, it appends the `.exe` suffix when searching these
 directories. The directories are an implementation detail of the host and can
-differ between SwiftPM, an IDE, and other package-manager integrations. Declare
-every required executable as a plugin dependency when the plugin needs to work
-across hosts. A plugin that intentionally uses a tool installed on the user's
-system should document the supported host and configuration requirements.
+differ between Swift Package Manager, an IDE, and other package-manager
+integrations. Declare every required executable as a plugin dependency when the
+plugin needs to work across hosts. A plugin that intentionally uses a tool
+installed on the user's system should document the supported host and
+configuration requirements.
 
 ## Topics
 

--- a/Sources/Runtimes/PackagePlugin/Errors.swift
+++ b/Sources/Runtimes/PackagePlugin/Errors.swift
@@ -14,11 +14,11 @@
 public enum PluginContextError: Error {
     /// Could not find a tool with the given name.
     ///
-    /// This could be either because
-    /// it doesn't exist, or because the plugin doesn't have a dependency on it.
+    /// No plugin dependency or host-provided search directory contains an
+    /// executable with the given name.
     case toolNotFound(name: String)
 
-    /// The tool is not supported on the target platform
+    /// A declared binary tool has no variant that supports the host platform.
     case toolNotSupportedOnTargetPlatform(name: String)
 
     /// Could not find a target with the given name.

--- a/Sources/Runtimes/PackagePlugin/Errors.swift
+++ b/Sources/Runtimes/PackagePlugin/Errors.swift
@@ -18,7 +18,8 @@ public enum PluginContextError: Error {
     /// executable with the given name.
     case toolNotFound(name: String)
 
-    /// A declared binary tool has no variant that supports the host platform.
+    /// A declared binary tool has no variant that supports the platform on which
+    /// the plugin runs.
     case toolNotSupportedOnTargetPlatform(name: String)
 
     /// Could not find a target with the given name.


### PR DESCRIPTION
Fixes #6919

## Summary

Clarify how package plugins resolve tools through `PluginContext.tool(named:)`, including supported names, lookup precedence, host compatibility, and host-provided search directories.

The existing documentation does not clearly distinguish portable tools declared as package dependencies from tools supplied by a particular plugin host.

## Changes

- Document the names used to resolve executable targets, executable products, and executables in binary artifact bundles.
- Explain that directly declared tools take precedence over host-provided tools.
- Document the error behavior when a binary tool has no variant compatible with the host platform.
- Explain how host-provided tool search directories are evaluated, including Windows executable-name handling.
- Clarify that declaring a tool as a direct dependency is the portable way to make it available to a plugin.
- Document the tool search behavior used by SwiftPM for build-tool and command plugins.
- Clarify that build-tool plugins do not search the user’s `PATH`.
- Note that command-plugin search paths can vary between SwiftPM and other plugin hosts such as IDEs.

## Alternatives considered

Documenting only the current SwiftPM implementation was considered. However, `PluginContext` is also used by other plugin hosts, so the API documentation now distinguishes the portable package-plugin contract from host-specific search behavior.

Changing the lookup implementation was also considered unnecessary because the reported issue concerns undocumented existing behavior rather than incorrect resolution behavior.

## Notes

This is a documentation-only change. Tool lookup order and runtime behavior remain unchanged.

## Testing

- `swift test --filter PackagePluginAPITests` — 6 tests passed.
- Generated the `PackagePlugin` documentation with DocC successfully. One unrelated pre-existing warning remains in `PackageManager_SymbolGraphOptions.md`.
- Generated the `PackageManagerDocs` documentation with DocC successfully without warnings.