### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ The SwiftPM devcontainer is based on the `swiftlang/swift:nightly-main` Docker i
 
 ### Building and Testing in the Container
 
-Once you've opened the project in VS Code, choose `> Dev Containers: Build and Reopen in Container` from the command pallete. Once the container finishes building it will open and you can develop as if you are on Linux using VS Code.
+Once you've opened the project in VS Code, choose `> Dev Containers: Build and Reopen in Container` from the command palette. Once the container finishes building it will open and you can develop as if you are on Linux using VS Code.
 
 All the commands described in the "Local Development" section below will work in the container environment.
 

--- a/Sources/Basics/Errors.swift
+++ b/Sources/Basics/Errors.swift
@@ -32,7 +32,7 @@ public struct InternalError: Error {
 
 /// Wraps another error and provides additional context when printed.
 /// This is useful for user facing errors that need to provide a user friendly message
-/// explaning why an error might have occured, while still showing the detailed underlying error.
+/// explaining why an error might have occurred, while still showing the detailed underlying error.
 public struct ErrorWithContext<E: Error>: Error {
     public let error: E
     public let context: String

--- a/Sources/Basics/HTTPClient/HTTPClient.swift
+++ b/Sources/Basics/HTTPClient/HTTPClient.swift
@@ -120,7 +120,7 @@ public actor HTTPClient {
         return try await self.executeWithStrategies(request: request, requestNumber: 0, observabilityScope, progress)
     }
 
-    /// Cancel all in flight network reqeusts.
+    /// Cancel all in flight network requests.
     public func cancel(deadline: DispatchTime) async {
         for task in activeTasks {
             task.cancel()

--- a/Sources/Build/BuildDescription/ProductBuildDescription.swift
+++ b/Sources/Build/BuildDescription/ProductBuildDescription.swift
@@ -196,7 +196,7 @@ public final class ProductBuildDescription: SPMBuildCore.ProductBuildDescription
         var isLinkingStaticStdlib = false
         let triple = self.buildParameters.triple
 
-        // radar://112671586 supress unnecessary warnings
+        // radar://112671586 suppress unnecessary warnings
         if triple.isMacOSX {
             args += ["-Xlinker", "-no_warn_duplicate_libraries"]
         }

--- a/Sources/Build/BuildOperation.swift
+++ b/Sources/Build/BuildOperation.swift
@@ -895,7 +895,7 @@ public final class BuildOperation: PackageStructureDelegate, SPMBuildCore.BuildS
 
         // If progress has been printed this will add a newline to separate it from what could be
         // the output of the command. For instance `swift test --skip-build` may print progress for
-        // the Planning Build stage, followed immediately by a list of tests. Without this finialize()
+        // the Planning Build stage, followed immediately by a list of tests. Without this finalize()
         // call the first entry in the list appear on the same line as the Planning Build progress.
         tracker.finalize(success: true)
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -54,7 +54,7 @@ add_subdirectory(tsan_utils)
 if(SwiftPM_ENABLE_RUNTIME)
   add_subdirectory(Runtimes)
   # NOTE: maintain the custom output directory for the ManifestAPI modules to
-  # allow the boostrap scripts to continue functioning as they have historically.
+  # allow the bootstrap scripts to continue functioning as they have historically.
   # This is unnecessary with the split runtime build, but is left here to
   # minimize disruption.
   set_target_properties(CompilerPluginSupport PROPERTIES

--- a/Sources/Commands/PackageCommands/APIDiff.swift
+++ b/Sources/Commands/PackageCommands/APIDiff.swift
@@ -200,7 +200,7 @@ struct APIDiff: AsyncSwiftCommand {
         // Build the baseline revision to generate baseline files.
         let modulesWithBaselines = try await generateAPIBaselineUsingIntegratedAPIDigesterSupport(swiftCommandState, baselineRevision: baselineRevision, baselineDir: baselineDir, modulesNeedingBaselines: modulesToDiff)
 
-        // Build the package and run a comparison agains the baselines.
+        // Build the package and run a comparison against the baselines.
         var productsBuildParameters = try swiftCommandState.productsBuildParameters
         productsBuildParameters.apiDigesterMode = .compareToBaselines(
             baselinesDirectory: baselineDir,

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -98,7 +98,7 @@ public protocol _SwiftCommand {
     var workspaceLoaderProvider: WorkspaceLoaderProvider { get }
     func buildSystemProvider(_ swiftCommandState: SwiftCommandState) throws -> BuildSystemProvider
 
-    // If a packagePath is specificed, this indicates that the command allows
+    // If a packagePath is specified, this indicates that the command allows
     // creating the directory if it doesn't exist.
     var createPackagePath: Bool { get }
 }

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -289,7 +289,7 @@ private func checkAllDependenciesAreUsed(
 
             // Skip this check if traits are enabled since it is valid to add a dependency just
             // to enable traits on it. This is useful if there is a transitive dependency in the graph
-            // that can be configured by enabling traits e.g. the depdency has a trait for its logging
+            // that can be configured by enabling traits e.g. the dependency has a trait for its logging
             // behaviour. This allows the root package to configure traits of transitive dependencies
             // without emitting an unused dependency warning.
             if dependency.manifest.supportsTraits {
@@ -1012,7 +1012,7 @@ private func handlePrebuilts(packageBuilders: [ResolvedPackageBuilder], root: Pa
 
             // Add build settings to hook up the prebuilts
             // TODO: prebuilts should really be modules e.g system libraries
-            // TODO: so we don't have to alter the underyling modules build settings
+            // TODO: so we don't have to alter the underlying modules build settings
             let prebuiltLibraries = prebuiltDeps.reduce(into: [String: PrebuiltLibrary]()) {
                 guard let prebuilt = $1.packageBuilder.prebuilts?[$1.product.name] else {
                     return

--- a/Sources/PackageManagerDocs/Documentation.docc/Dependencies/AddingDependencies.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Dependencies/AddingDependencies.md
@@ -84,7 +84,7 @@ dependencies: [
 
 Swift package manager determines the traits to enable using the entire graph of dependencies in a project.
 The traits enabled for a dependency is the union of all of the traits that for packages that depend upon it.
-For example, if you opt out of all traits, but a dependency you use uses the same package with some trait enabled, the package will use the depdendency with the requested traits enabled.
+For example, if you opt out of all traits, but a dependency you use uses the same package with some trait enabled, the package will use the dependency with the requested traits enabled.
 
 > Note: By disabling any default traits, you may be removing available APIs from the dependency you use. 
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Dependencies/ResolvingDependencyFailures.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Dependencies/ResolvingDependencyFailures.md
@@ -10,7 +10,7 @@ Prior to running a build or test, or when you run <doc:PackageResolve>, the pack
 It then attempts to choose a version of each dependency that fits within the constraints of your package, and any constraints provided by your dependencies.
 
 If all the dependencies are available and resolved, the versions are recorded locally in the file `Package.resolved`.
-You can view these dependencies using the command <doc:PackageShowDependencies>, which provides a succint list of the entire set of dependencies.
+You can view these dependencies using the command <doc:PackageShowDependencies>, which provides a succinct list of the entire set of dependencies.
 
 If the dependencies can't be resolved, for example when the packages your package depends on have conflicting constraints, the package manager returns an error, describing the conflicting constraint: 
 ```

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDiagnoseAPIBreakingChange.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageDiagnoseAPIBreakingChange.md
@@ -313,7 +313,7 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 
 - term **--traits=\<traits\>**:
 
-*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
+*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explicitly enabled as well by passing `defaults` to this command.*
 
 
 - term **--enable-all-traits**:

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageGenerateSBOM.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageGenerateSBOM.md
@@ -340,7 +340,7 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 
 - term **--traits=\<traits\>**:
 
-*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list, for example, `--traits Trait1,Trait2`. When enabling specific traits the default traits also need to be explictily enabled as well by passing `defaults` to this command.*
+*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list, for example, `--traits Trait1,Trait2`. When enabling specific traits the default traits also need to be explicitly enabled as well by passing `defaults` to this command.*
 
 
 - term **--enable-all-traits**:

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageResolve.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageResolve.md
@@ -306,7 +306,7 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 
 - term **--traits=\<traits\>**:
 
-*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
+*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explicitly enabled as well by passing `defaults` to this command.*
 
 
 - term **--enable-all-traits**:

--- a/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingCommandPlugin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Plugins/WritingCommandPlugin.md
@@ -70,7 +70,7 @@ let package = Package(
 
 In the above example, the plugin declares its purpose is source code formatting, and that it needs permission to modify files in the package directory.
 The package manager runs plugins in a sandbox that prevents network access and most file system access.
-Package manager allows additional permissions to allow network access or file system acess when you declare them after it receives approval from the user.
+Package manager allows additional permissions to allow network access or file system access when you declare them after it receives approval from the user.
 
 ### Implementing the command plugin script
 

--- a/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes/6.4.md
@@ -83,7 +83,7 @@ Running `swift test --debugger` will launch tests in an LLDB debugging session o
 ### Mirrors deterministic order
 
 When adding or removing a mirror configuration using `swift package config <command>`, the produced `mirrors.json` file
-was being completely rewritting with a non-deterministic order.  A change to SwiftPM renders the `mirror.json` file in a
+was being completely rewriting with a non-deterministic order.  A change to SwiftPM renders the `mirror.json` file in a
 deterministic order.
 
 ## Reporting issues

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftBuild.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftBuild.md
@@ -340,7 +340,7 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 
 - term **--traits=\<traits\>**:
 
-*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
+*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explicitly enabled as well by passing `defaults` to this command.*
 
 
 - term **--enable-all-traits**:

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftRun.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftRun.md
@@ -317,7 +317,7 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 
 - term **--traits=\<traits\>**:
 
-*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
+*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explicitly enabled as well by passing `defaults` to this command.*
 
 
 - term **--enable-all-traits**:

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftTest.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftTest.md
@@ -370,7 +370,7 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 
 - term **--traits=\<traits\>**:
 
-*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
+*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explicitly enabled as well by passing `defaults` to this command.*
 
 
 - term **--enable-all-traits**:
@@ -655,7 +655,7 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 
 - term **--traits=\<traits\>**:
 
-*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explictily enabled as well by passing `defaults` to this command.*
+*Enables the passed traits of the package. Multiple traits can be specified by providing a comma separated list e.g. `--traits Trait1,Trait2`. When enabling specific traits the defaults traits need to explicitly enabled as well by passing `defaults` to this command.*
 
 
 - term **--enable-all-traits**:

--- a/Sources/PackageManagerDocs/README.md
+++ b/Sources/PackageManagerDocs/README.md
@@ -1,7 +1,7 @@
 Manually generated the docc content stubs using the swift argument parser tool `generate-docc-reference-tool`:
 
 The `generate-docc-reference` doesn't work for automatically creating all these because of a quirk in swift-package-manager, which is a driver
-executable and expects to be called with different names. The heurstics in swift-argument-parser's generation tool don't accomodate this use case.
+executable and expects to be called with different names. The heuristics in swift-argument-parser's generation tool don't accommodate this use case.
 
 ```bash
 swift build -c release

--- a/Sources/PackageModel/Manifest/Manifest+Traits.swift
+++ b/Sources/PackageModel/Manifest/Manifest+Traits.swift
@@ -87,7 +87,7 @@ extension Manifest {
         }
     }
 
-    /// Validates a set of traits that is intended to be enabled for the manifest; if there are any discrepencies in the
+    /// Validates a set of traits that is intended to be enabled for the manifest; if there are any discrepancies in the
     /// set of enabled traits and whether the manifest defines these traits (or if it defines any traits at all), then an
     /// error indicating the issue will be thrown.
     public func validateEnabledTraits(_ explicitlyEnabledTraits: EnabledTraits) throws {
@@ -417,7 +417,7 @@ extension Manifest {
         }
     }
 
-    /// Given a set of enabled traits, determine whether a package dependecy of this manifest is
+    /// Given a set of enabled traits, determine whether a package dependency of this manifest is
     /// guarded by traits.
     private func isPackageDependencyTraitGuarded(_ dependency: PackageDependency, enabledTraits: EnabledTraits) throws -> Bool {
         let targetDependenciesForPackageDependency = self.targets.flatMap({ $0.dependencies })

--- a/Sources/Runtimes/PackagePlugin/Protocols.swift
+++ b/Sources/Runtimes/PackagePlugin/Protocols.swift
@@ -15,7 +15,7 @@
 // Any proposal that adds such a facility should also add initializers
 // to set those values as plugin properties.
 
-/// A protocol that defines functionality common to all package manger plugins.
+/// A protocol that defines functionality common to all package manager plugins.
 ///
 /// For example, the way to instantiate and run a plugin.
 public protocol Plugin {

--- a/Sources/SPMBuildCore/XcodeProjectRepresentation.swift
+++ b/Sources/SPMBuildCore/XcodeProjectRepresentation.swift
@@ -12,7 +12,7 @@
 
 import Basics
 
-/// Represents a simplifed view of an Xcode project to a plugin.
+/// Represents a simplified view of an Xcode project to a plugin.
 public struct XcodeProjectRepresentation: Equatable, Hashable {
     public var displayName: String
     public var directoryPath: AbsolutePath

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -779,7 +779,7 @@ extension PackageGraph.ResolvedModule {
                     }
 
                     // Handle imparted settings for OTHER_LDFLAGS and prebuilts include paths (always multiple values)
-                    // TODO: Do we realy need to impart OTHER_LDFLAGS?
+                    // TODO: Do we really need to impart OTHER_LDFLAGS?
                     // TODO: Doing that for the PREBUILT_LIBRARIES was causing duplicate library warnings.
                     if let multipleValueSetting = multipleValueSetting,
                         declaration != .PREBUILT_LIBRARIES,
@@ -947,7 +947,7 @@ extension PackageGraph.ResolvedProduct {
         }
     }
 
-    /// Shoud we link this product dependency?
+    /// Should we link this product dependency?
     var isLinkable: Bool {
         switch self.type {
         case .library, .executable, .snippet, .test, .macro:

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -117,7 +117,7 @@ extension PackagePIFProjectBuilder {
         settings[.TARGET_TEMP_DIR_SUFFIX] = "-p"
         settings[.PACKAGE_RESOURCE_TARGET_KIND] = "regular"
         settings[.PRODUCT_NAME] = "$(TARGET_NAME)"
-        // We must use the main module name here instead of the product name, because they're not guranteed to be the same, and the users may have authored e.g. tests which rely on an executable's module name.
+        // We must use the main module name here instead of the product name, because they're not guaranteed to be the same, and the users may have authored e.g. tests which rely on an executable's module name.
         settings[.PRODUCT_MODULE_NAME] = mainModule.c99name
 
         if let aliases = mainModule.moduleAliases {

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -792,7 +792,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                                 case .dynamicLibrary:
                                     .dynamicLibrary
                                 case .framework:
-                                    // We treat frameworks as dylibs here, but the plugin API should grow to accomodate more product types
+                                    // We treat frameworks as dylibs here, but the plugin API should grow to accommodate more product types
                                     .dynamicLibrary
                                 }
                                 var name = target.name

--- a/Sources/Workspace/Workspace+State.swift
+++ b/Sources/Workspace/Workspace+State.swift
@@ -455,7 +455,7 @@ extension WorkspaceStateStorage {
                     case .xcframework:
                         return .xcframework
                     case .artifactsArchive:
-                        // For backwards compatiblity reasons we assume an empty types array which in the worst case
+                        // For backwards compatibility reasons we assume an empty types array which in the worst case
                         // results in a need for a clean build but we won't fail decoding the JSON.
                         return .artifactsArchive(types: [])
                     case .typedArtifactsArchive(let types):

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -45,7 +45,7 @@ struct PIFBuilderParameters {
     /// The toolchain's SDK root path.
     let sdkRootPath: AbsolutePath?
 
-    /// The Swift language versions supported by the XCBuild being used for the buid.
+    /// The Swift language versions supported by the XCBuild being used for the build.
     let supportedSwiftVersions: [SwiftLanguageVersion]
 }
 
@@ -725,7 +725,7 @@ final class PackagePIFProjectBuilder: PIFProjectBuilder {
             impartedSettings[.OTHER_LDFLAGS, default: ["$(inherited)"]].append("-lc++")
         }
 
-        // radar://112671586 supress unnecessary warnings
+        // radar://112671586 suppress unnecessary warnings
         impartedSettings[.OTHER_LDFLAGS, default: ["$(inherited)"]].append("-Wl,-no_warn_duplicate_libraries")
 
         self.addSources(target.sources, to: pifTarget)

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -93,7 +93,7 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
-    /// Enabled if toolsupm suported SDK Dependent Tests
+    /// Enabled if toolsupm supported SDK Dependent Tests
     public static var requiresSDKDependentTestsSupport: Self {
         enabled("skipping because test environment doesn't support this test") {
             (try? UserToolchain.default)!.supportsSDKDependentTests()

--- a/Utilities/README.md
+++ b/Utilities/README.md
@@ -32,7 +32,7 @@ Here are some steps the worked running on Windows.
     ```
     $ParentPID = 1234  # Replace with your actual PID
     ```
-1. Define a funtion that will get transitive process ID
+1. Define a function that will get transitive process ID
     ```
     function Get-TransitiveChildren ($pidList) {
         if ($pidList.Count -eq 0) { return }

--- a/Utilities/helpers.py
+++ b/Utilities/helpers.py
@@ -31,7 +31,7 @@ def change_directory(directory: pathlib.Path) -> t.Iterator[pathlib.Path]:
     try:
         yield directory
     finally:
-        logging.debug("Chaning directory back to %s", current_directory)
+        logging.debug("Changing directory back to %s", current_directory)
         os.chdir(current_directory)
 
 


### PR DESCRIPTION
Fix typos in comments and documentation.

### Motivation:

While reading through the codebase I noticed a number of misspellings in code comments, doc comments, and the DocC documentation (e.g. explictily, guranteed, accomodate, package manger in the PackagePlugin API docs).

### Modifications:

Comment- and documentation-only spelling fixes across 31 files, found with codespell and hand-reviewed. No identifiers, string literals, or code were changed.

### Result:

 Documentation and comments read correctly; no functional change.
