### PR TITLE
[6.4] Fix REPL imports for generated C module maps

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -412,6 +412,10 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
                 "FRAMEWORK_SEARCH_PATHS",
             ]
         )
+        let moduleMapPaths = try await getUniqueBuildSettingsIncludingDependencies(
+            of: request.configuredTargets,
+            buildSettings: ["MODULEMAP_PATH"]
+        )
 
         let graph = try await self.getPackageGraph()
         // Link the special REPL product that contains all of the library targets.
@@ -420,9 +424,9 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         // The graph should have the REPL product.
         assert(graph.product(for: replProductName) != nil)
 
-        let arguments = ["repl", "-l\(replProductName)"] + includePaths.map {
-            "-I\($0)"
-        }
+        let arguments = ["repl", "-l\(replProductName)"]
+            + includePaths.map { "-I\($0)" }
+            + moduleMapPaths.filter { !$0.isEmpty }.flatMap { ["-Xcc", "-fmodule-map-file=\($0)"] }
 
         self.outputStream.send("Done.\n")
         return arguments

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -425,7 +425,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         assert(graph.product(for: replProductName) != nil)
 
         let arguments = ["repl", "-l\(replProductName)"]
-            + includePaths.map { "-I\($0)" }
+            + includePaths.filter { !$0.isEmpty }.map { "-I\($0)" }
             + moduleMapPaths.filter { !$0.isEmpty }.flatMap { ["-Xcc", "-fmodule-map-file=\($0)"] }
 
         self.outputStream.send("Done.\n")

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -30,6 +30,7 @@ import _InternalTestSupport
 func withInstantiatedSwiftBuildSystem(
     fromFixture fixtureName: String,
     buildParameters: BuildParameters? = nil,
+    createREPLProduct: Bool = false,
     logLevel: Basics.Diagnostic.Severity = .warning,
     do doIt: @escaping (SwiftBuildSupport.SwiftBuildSystem, SWBBuildService, SWBBuildServiceSession, TestingObservability, BuildParameters,) async throws -> (),
 ) async throws {
@@ -41,12 +42,20 @@ func withInstantiatedSwiftBuildSystem(
             let buildParameters = if let buildParameters {
                 buildParameters
             } else {
-                mockBuildParameters(destination: .host, toolchain: toolchain, buildSystemKind: .swiftbuild)
+                mockBuildParameters(
+                    destination: .host,
+                    buildPath: tmpDir.appending("build"),
+                    toolchain: toolchain,
+                    buildSystemKind: .swiftbuild,
+                )
             }
             let observabilitySystem: TestingObservability = ObservabilitySystem.makeForTesting()
+            var workspaceConfiguration = WorkspaceConfiguration.default
+            workspaceConfiguration.createREPLProduct = createREPLProduct
             let workspace = try Workspace(
                 fileSystem: fileSystem,
                 forRootPackage: fixturePath,
+                configuration: workspaceConfiguration,
                 customManifestLoader: ManifestLoader(toolchain: toolchain),
             )
             let rootInput = PackageGraphRootInput(packages: [fixturePath], dependencies: [])
@@ -141,6 +150,26 @@ extension PackageModel.Sanitizer {
     .requireCompiledWith6_3OrLater(because: "https://github.com/swiftlang/swift-corelibs-foundation/pull/5269")
 )
 struct SwiftBuildSystemTests {
+
+    @Test
+    func replIncludesGeneratedModuleMaps() async throws {
+        try await withInstantiatedSwiftBuildSystem(
+            fromFixture: "CFamilyTargets/ModuleMapGenerationCases",
+            createREPLProduct: true,
+        ) { swiftBuild, _, _, _, _ in
+            let result = try await swiftBuild.build(
+                subset: .allExcludingTests,
+                buildOutputs: [.replArguments],
+            )
+            let replArguments = try #require(result.replArguments)
+
+            #expect(replArguments.contains("-Xcc"))
+            #expect(!replArguments.contains("-fmodule-map-file="))
+            #expect(replArguments.contains {
+                $0.hasSuffix("/FlatInclude.modulemap") && $0.hasPrefix("-fmodule-map-file=")
+            })
+        }
+    }
 
     @Suite(
         .tags(


### PR DESCRIPTION
## Summary

Fixes #10307 by forwarding generated C-family module maps to `swift run --repl`.

Swift Build exposes each map through `MODULEMAP_PATH`, but REPL argument generation previously only forwarded include directories. The REPL now passes every non-empty map as `-Xcc -fmodule-map-file=<path>`.

## Validation

- `swift test --skip-build --filter 'SwiftBuildSupportTests.SwiftBuildSystemTests/replIncludesGeneratedModuleMaps()'`
- Built `swift-run --repl` against `CFamilyTargets/ModuleMapGenerationCases` and successfully imported `FlatInclude`.

## Test coverage

Adds a Swift Build regression test that builds C targets with generated module maps and verifies the REPL arguments include the generated `FlatInclude.modulemap` without forwarding an empty module-map path.

---
clean cherry-pick of #10323 