### PR TITLE
[6.4.x] Ensure trait-derived settings assignments are deterministic

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1334,7 +1334,7 @@ public final class PackageBuilder {
         }
 
         // For each trait we are now generating an additional define
-        for trait in self.enabledTraits {
+        for trait in self.enabledTraits.sorted() {
             var assignment = BuildSettings.Assignment()
             assignment.values = ["\(trait)"]
             assignment.conditions = []

--- a/Tests/PackageGraphTests/ModulesGraphTests+Traits.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests+Traits.swift
@@ -1050,4 +1050,66 @@ extension ModulesGraphTests {
         }
     }
 
+    @Test
+    func traitsProduceDeterministicCompilationConditions() throws {
+        let fs = InMemoryFileSystem(
+            emptyFiles: "/MainPkg/Sources/MainLib/source.swift", "/DepPkg/Sources/DepLib/source.swift"
+        )
+
+        let manifests = try [
+            Manifest.createRootManifest(
+                displayName: "MainPkg",
+                path: "/MainPkg",
+                toolsVersion: .v6_1,
+                dependencies: [
+                    .localSourceControl(
+                        path: "/DepPkg",
+                        requirement: .upToNextMajor(from: "1.0.0"),
+                        traits: ["FeatureA", "FeatureB"]
+                    ),
+                ],
+                targets: [
+                    TargetDescription(
+                        name: "MainLib",
+                        dependencies: [
+                            .product(name: "DepLib", package: "DepPkg"),
+                        ]
+                    ),
+                ]
+            ),
+            Manifest.createFileSystemManifest(
+                displayName: "DepPkg",
+                path: "/DepPkg",
+                toolsVersion: .v6_1,
+                products: [
+                    .init(name: "DepLib", type: .library(.automatic), targets: ["DepLib"]),
+                ],
+                targets: [
+                    TargetDescription(name: "DepLib"),
+                ],
+                traits: [
+                    "FeatureA",
+                    "FeatureB",
+                ]
+            ),
+        ]
+
+        for _ in 0..<5 {
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: manifests,
+                observabilityScope: observability.topScope,
+                enabledTraitsMap: [
+                    "DepPkg": EnabledTraits(["FeatureA", "FeatureB"], setBy: .package("mainpkg")),
+                ]
+            )
+            #expect(observability.diagnostics.count == 0)
+
+            let depLib = try #require(graph.allModules.first { $0.name == "DepLib" })
+            let assignments = depLib.underlying.buildSettings
+                .assignments[.SWIFT_ACTIVE_COMPILATION_CONDITIONS] ?? []
+            #expect(assignments.map(\.values) == [["FeatureA"], ["FeatureB"]])
+        }
+    }
 }


### PR DESCRIPTION
* Explanation: Previously, settings assignments for trait macros were pushed in a nondeterministic order, which could cause excessive recompilation in incremental builds. Ensure they're always in sorted order.
* Scope: Builds of packages which enable >1 trait
* Issues: rdar://183168076
* Risk:
Low, all this change does is sort the existing list of macros
* Testing: New unit test