### PR TITLE
Show plugin compiler errors at normal verbosity

### DIFF
--- a/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
+++ b/Sources/SPMBuildCore/Plugins/DefaultPluginScriptRunner.swift
@@ -373,10 +373,16 @@ public struct DefaultPluginScriptRunner: PluginScriptRunner, Cancellable {
             // We are now on our caller's requested callback queue, so we just call the completion handler directly.
             dispatchPrecondition(condition: .onQueue(callbackQueue))
             completion($0.tryMap { process in
-                // Emit the compiler output as observable info.
+                // Always show compiler output on failure, but only show successful
+                // compiler output at verbose log levels.
                 let compilerOutput = ((try? process.utf8Output()) ?? "") + ((try? process.utf8stderrOutput()) ?? "")
                 if !compilerOutput.isEmpty {
-                    observabilityScope.emit(info: compilerOutput)
+                    observabilityScope.print(
+                        compilerOutput,
+                        condition: process.exitStatus == .terminated(code: 0)
+                            ? .onlyWhenVerbose
+                            : .always
+                    )
                 }
 
                 // Save the persisted compilation state for possible reuse next time.

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -4943,6 +4943,52 @@ struct PackageCommandTests {
                 }
             }
         }
+
+        @Test(
+            .tags(
+              .Feature.Command.Build,
+              .Feature.PackageType.BuildToolPlugin
+            ),
+            .requiresSwiftConcurrencySupport,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildToolPluginCompilerErrorIsVisible(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            let config = BuildConfiguration.debug
+            try await fixture(name: "Miscellaneous/Plugins/BuildToolPluginCompilationError") { packageDir in
+                try localFileSystem.writeFileContents(
+                    packageDir.appending(components: "Plugins", "MyPlugin", "plugin.swift"),
+                    string: """
+                    import PackagePlugin
+
+                    @main
+                    struct MyBuildToolPlugin: BuildToolPlugin {
+                        func createBuildCommands(
+                            context: PluginContext,
+                            target: Target
+                        ) throws -> [Command] {
+                            let _ = intentionalCompilerError
+                            return []
+                        }
+                    }
+                    """
+                )
+
+                await expectThrowsCommandExecutionError(
+                    try await executeSwiftBuild(
+                        packageDir,
+                        configuration: config,
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.consoleOutput.contains("intentionalCompilerError"),
+                        "Plugin compiler diagnostic was not shown: \(error.consoleOutput)"
+                    )
+                }
+            }
+        }
     }
 
     @Suite(


### PR DESCRIPTION
Show actionable compiler diagnostics when build-tool plugin compilation fails.

### Motivation:

When a build-tool plugin contains a compiler error, SwiftPM exits without showing the compiler diagnostic at normal verbosity. The diagnostic is only visible with `-v`, mixed into verbose command output.

The compiler output is captured correctly, but it is emitted as info-level output and therefore hidden during normal builds.

Fixes #10313.

### Modifications:

- Always print raw plugin compiler output when compilation fails.
- Preserve verbose-only output for successful plugin compilation.
- Add command-level regression coverage for both the native and SwiftBuild backends.

### Result:

Plugin compiler errors are now visible without passing `-v`. Successful plugin compiler output retains its existing verbosity behavior.

### Testing:

- `swift test --filter buildToolPluginCompilerErrorIsVisible`
   - Passed for native and SwiftBuild.
- `swift test --filter buildToolPluginFailure`
   - Passed for native and SwiftBuild.
- Manually verified normal diagnostic output with both backends.
- Manually verified that verbose SwiftBuild output does not duplicate the compiler diagnostic.
