### PR TITLE
Support checksums for artifact bundle indexes

### DIFF
--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -579,10 +579,20 @@ extension Workspace {
             fileSystem: any FileSystem
         ) throws -> String {
             let archiver = archiver ?? UniversalArchiver(fileSystem)
+            let isArtifactBundleIndex =
+                path.extension?.lowercased() == "artifactbundleindex"
+
             // Validate the path has a supported extension.
-            guard let lastPathComponent = path.components.last, archiver.isFileSupported(lastPathComponent) else {
-                let supportedExtensionList = archiver.supportedExtensions.joined(separator: ", ")
-                throw StringError("unexpected file type; supported extensions are: \(supportedExtensionList)")
+            guard let lastPathComponent = path.components.last,
+                  archiver.isFileSupported(lastPathComponent) || isArtifactBundleIndex
+            else {
+                let supportedExtensionList =
+                    (archiver.supportedExtensions + ["artifactbundleindex"])
+                    .joined(separator: ", ")
+
+                throw StringError(
+                    "unexpected file type; supported extensions are: \(supportedExtensionList)"
+                )
             }
 
             // Ensure that the path with the accepted extension is a file.

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -8500,6 +8500,29 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(checksum, "ccbbaa")
         }
 
+        // Checks an artifact bundle index.
+        do {
+            let indexPath = sandbox.appending("binary.artifactbundleindex")
+            try fs.writeFileContents(
+                indexPath,
+                bytes: ByteString([0x11, 0x22, 0x33])
+            )
+
+            let checksum = try binaryArtifactsManager.checksum(
+                forBinaryArtifactAt: indexPath
+            )
+
+            XCTAssertEqual(
+                checksumAlgorithm.hashes.map(\.contents),
+                [
+                    [0xAA, 0xBB, 0xCC],
+                    [0x11, 0x22, 0x33],
+                ]
+            )
+
+            XCTAssertEqual(checksum, "332211")
+        }
+
         // Checks an unsupported extension.
         do {
             let unknownPath = sandbox.appending("unknown")


### PR DESCRIPTION
Allow `swift package compute-checksum` to accept `.artifactbundleindex` files.

### Motivation:

SE-0305 specifies that a binary target referencing an `.artifactbundleindex` uses the checksum of the index file itself.

However, `swift package compute-checksum` currently rejects `.artifactbundleindex` files because validation only accepts extensions supported by the archive handler.

Fixes #9219.

### Modifications:

- Allow `.artifactbundleindex` files through checksum file-type validation.
- Continue using the existing raw-file hashing implementation.
- Add regression coverage to `WorkspaceTests.testArtifactChecksum`.

### Result:

`swift package compute-checksum path/to/file.artifactbundleindex` now computes and prints the checksum instead of rejecting the file extension.

Tested with:

`swift test --filter WorkspaceTests.testArtifactChecksum`