### PR TITLE
Resolve relative prebuilt paths from package scratch path

### DIFF
--- a/Sources/CoreCommands/Options.swift
+++ b/Sources/CoreCommands/Options.swift
@@ -230,6 +230,28 @@ public struct CachingOptions: ParsableArguments {
         help: .hidden
     )
     public var prebuiltsRootCertPath: String?
+
+    func resolvedPrebuiltsDownloadURL(relativeTo scratchDirectory: AbsolutePath) throws -> String? {
+        guard let prebuiltsDownloadURL,
+              let url = URL(string: prebuiltsDownloadURL),
+              url.isFileURL
+        else {
+            return prebuiltsDownloadURL
+        }
+
+        if (try? AbsolutePath(validating: url.path)) != nil {
+            return prebuiltsDownloadURL
+        }
+
+        let path = try AbsolutePath(validating: url.path, relativeTo: scratchDirectory)
+        return URL(fileURLWithPath: path.pathString).absoluteString
+    }
+
+    func resolvedPrebuiltsRootCertPath(relativeTo scratchDirectory: AbsolutePath) throws -> String? {
+        try prebuiltsRootCertPath.map {
+            try AbsolutePath(validating: $0, relativeTo: scratchDirectory).pathString
+        }
+    }
 }
 
 public struct LoggingOptions: ParsableArguments {

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -633,8 +633,8 @@ public final class SwiftCommandState {
                 },
                 manifestImportRestrictions: .none,
                 usePrebuilts: self.options.caching.usePrebuilts,
-                prebuiltsDownloadURL: options.caching.prebuiltsDownloadURL,
-                prebuiltsRootCertPath: options.caching.prebuiltsRootCertPath,
+                prebuiltsDownloadURL: try options.caching.resolvedPrebuiltsDownloadURL(relativeTo: self.scratchDirectory),
+                prebuiltsRootCertPath: try options.caching.resolvedPrebuiltsRootCertPath(relativeTo: self.scratchDirectory),
                 pruneDependencies: self.options.resolver.pruneDependencies,
                 traitConfiguration: self.traitConfiguration
             ),

--- a/Tests/CommandsTests/SwiftCommandStateTests.swift
+++ b/Tests/CommandsTests/SwiftCommandStateTests.swift
@@ -30,6 +30,7 @@ import enum TSCBasic.SystemError
 import var TSCBasic.stderrStream
 
 import Testing
+import struct Foundation.URL
 
 @Suite()
 struct SwiftCommandStateTestSuites {
@@ -93,6 +94,34 @@ struct SwiftCommandStateTestSuites {
             contents == "\(buildData.buildSystem)",
             "Actual is not as expected",
         )
+    }
+
+    @Test
+    func resolvesPrebuiltLocationsRelativeToScratchDirectory() throws {
+        let scratchDirectory = AbsolutePath.root.appending(components: "package", ".build")
+        var options = CachingOptions()
+
+        options.prebuiltsDownloadURL = "file:swift-syntax-prebuilt/feed"
+        options.prebuiltsRootCertPath = "swift-syntax-prebuilt/root.cer"
+
+        let expectedDownloadPath = scratchDirectory.appending(components: "swift-syntax-prebuilt", "feed")
+        #expect(
+            try options.resolvedPrebuiltsDownloadURL(relativeTo: scratchDirectory)
+                == URL(fileURLWithPath: expectedDownloadPath.pathString).absoluteString
+        )
+        #expect(
+            try options.resolvedPrebuiltsRootCertPath(relativeTo: scratchDirectory)
+                == scratchDirectory.appending(components: "swift-syntax-prebuilt", "root.cer").pathString
+        )
+
+        let absoluteDownloadURL = URL(fileURLWithPath: expectedDownloadPath.pathString).absoluteString
+        options.prebuiltsDownloadURL = absoluteDownloadURL
+        options.prebuiltsRootCertPath = expectedDownloadPath.pathString
+        #expect(try options.resolvedPrebuiltsDownloadURL(relativeTo: scratchDirectory) == absoluteDownloadURL)
+        #expect(try options.resolvedPrebuiltsRootCertPath(relativeTo: scratchDirectory) == expectedDownloadPath.pathString)
+
+        options.prebuiltsDownloadURL = "https://example.com/prebuilts"
+        #expect(try options.resolvedPrebuiltsDownloadURL(relativeTo: scratchDirectory) == options.prebuiltsDownloadURL)
     }
 }
 


### PR DESCRIPTION
The experimental prebuilt download URL and root certificate options currently require absolute local paths. This makes repository-local prebuilt feeds non-portable, especially when build-server clients launch SwiftPM with `--package-path` from another working directory.

This PR resolves relative `file:` download URLs and relative root certificate paths against the active package scratch path before constructing the workspace and preserves absolute file URLs and non-file URLs.
