### PR TITLE
[6.4.x] Fix nondeterministic build setting and resource ordering in PIF

### DIFF
--- a/Sources/PackageLoading/TargetSourcesBuilder.swift
+++ b/Sources/PackageLoading/TargetSourcesBuilder.swift
@@ -651,6 +651,10 @@ public struct GeneratedFiles {
         apiNotes.append(contentsOf: other.apiNotes)
         resources.merge(other.resources, uniquingKeysWith: { winner, _ in winner })
     }
+
+    public var sortedResourcePaths: [Basics.AbsolutePath] {
+        resources.keys.sorted()
+    }
 }
 
 /// Describes a rule for including a source or resource file in a target.

--- a/Sources/PackageModel/BuildSettings.swift
+++ b/Sources/PackageModel/BuildSettings.swift
@@ -13,7 +13,7 @@
 /// Namespace for build settings.
 public enum BuildSettings {
     /// Build settings declarations.
-    public struct Declaration: Hashable {
+    public struct Declaration: Hashable, Comparable {
         // Swift.
         public static let SWIFT_ACTIVE_COMPILATION_CONDITIONS: Declaration =
             .init("SWIFT_ACTIVE_COMPILATION_CONDITIONS")
@@ -41,6 +41,15 @@ public enum BuildSettings {
 
         private init(_ name: String) {
             self.name = name
+        }
+
+        /// Ordered by name so that consumers iterating an assignment table can produce
+        /// deterministic output. Several declarations map onto a single build setting
+        /// downstream (`LINK_LIBRARIES`, `LINK_FRAMEWORKS` and `OTHER_LDFLAGS`,
+        /// all become `OTHER_LDFLAGS` in the PIF); sorting on the name prevents the
+        /// order of the emitted flags from varying between builds of identical sources.
+        public static func < (lhs: Declaration, rhs: Declaration) -> Bool {
+            lhs.name < rhs.name
         }
     }
 

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -703,7 +703,7 @@ extension PackageGraph.ResolvedModule {
     func computeAllBuildSettings(observabilityScope: ObservabilityScope, forRemotePackage: Bool) -> AllBuildSettings {
         var allSettings = AllBuildSettings()
 
-        for (declaration, settingsAssigments) in self.underlying.buildSettings.assignments {
+        for (declaration, settingsAssigments) in self.underlying.buildSettings.assignments.sorted(by: { $0.key < $1.key }) {
             for settingAssignment in settingsAssigments {
                 // Create a build setting value; in some cases there
                 // isn't a direct mapping to Swift Build build settings.

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Modules.swift
@@ -339,7 +339,7 @@ extension PackagePIFProjectBuilder {
             let (result, resourceBundle) = try addResourceBundle(
                 for: sourceModule,
                 targetKeyPath: sourceModuleTargetKeyPath,
-                generatedResourceFiles: generatedFiles.resources.keys.map(\.pathString)
+                generatedResourceFiles: generatedFiles.sortedResourcePaths.map(\.pathString)
             )
             if let resourceBundle { self.builtModulesAndProducts.append(resourceBundle) }
 
@@ -377,7 +377,7 @@ extension PackagePIFProjectBuilder {
                 sourceModuleTargetKeyPath: sourceModuleTargetKeyPath,
                 resourceBundleTargetKeyPath: resourceBundleTargetKeyPath,
                 sourceFilePaths: generatedFiles.sources.map(\.self),
-                resourceFilePaths: generatedFiles.resources.keys.map(\.pathString)
+                resourceFilePaths: generatedFiles.sortedResourcePaths.map(\.pathString)
             )
         }
 

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -267,7 +267,7 @@ extension PackagePIFProjectBuilder {
 
         // Add any additional resource files emitted by synthesized build commands
         let generatedResourceFiles: [String] = {
-            var generatedResourceFiles = generatedFiles.resources.keys.map(\.pathString)
+            var generatedResourceFiles = generatedFiles.sortedResourcePaths.map(\.pathString)
             generatedResourceFiles.append(
                 contentsOf: addBuildToolCommands(
                     from: synthesizedResourceGeneratingPluginInvocationResults,
@@ -353,7 +353,7 @@ extension PackagePIFProjectBuilder {
                     sourceModuleTargetKeyPath: mainModuleTargetKeyPath,
                     resourceBundleTargetKeyPath: resourceBundleTargetKeyPath,
                     sourceFilePaths: generatedFiles.sources.map(\.self),
-                    resourceFilePaths: generatedFiles.resources.keys.map(\.pathString)
+                    resourceFilePaths: generatedFiles.sortedResourcePaths.map(\.pathString)
                 )
             } else {
                 // Generated resources always trigger the creation of a bundle accessor.
@@ -370,7 +370,7 @@ extension PackagePIFProjectBuilder {
                     sourceModuleTargetKeyPath: mainModuleTargetKeyPath,
                     resourceBundleTargetKeyPath: mainModuleTargetKeyPath,
                     sourceFilePaths: generatedFiles.sources.map(\.self),
-                    resourceFilePaths: generatedFiles.resources.keys.map(\.pathString)
+                    resourceFilePaths: generatedFiles.sortedResourcePaths.map(\.pathString)
                 )
             }
         }

--- a/Sources/XCBuildSupport/PIFBuilder.swift
+++ b/Sources/XCBuildSupport/PIFBuilder.swift
@@ -1637,7 +1637,7 @@ extension BuildSettings.AssignmentTable {
     fileprivate var pifAssignments: [PIF.BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] {
         var pifAssignments: [PIF.BuildSettings.MultipleValueSetting: [PIFBuildSettingAssignment]] = [:]
 
-        for (declaration, assignments) in self.assignments {
+        for (declaration, assignments) in self.assignments.sorted(by: { $0.key < $1.key }) {
             for assignment in assignments {
                 let setting: PIF.BuildSettings.MultipleValueSetting
                 let value: [String]

--- a/Tests/SwiftBuildSupportTests/PIFDeterminismTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFDeterminismTests.swift
@@ -92,3 +92,197 @@ struct PIFDeterminismTests {
         }
     }
 }
+
+// MARK: - Targeted determinism regressions
+//
+// The suite above is a broad net: it dumps the PIF for every fixture in the repo and
+// diffs repeated runs. It catches anything, but it is disabled by default because it
+// shells out and is far too slow for CI.
+//
+// The suite below complements it with fast, always-on assertions that name a specific
+// defect and pin the exact expected output. Everything it needs is declared here so the
+// two can evolve independently.
+
+import PackageLoading
+import SwiftBuild
+import SwiftBuildSupport
+
+@testable import SPMBuildCore
+
+@_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly) @testable import PackageGraph
+@_spi(SwiftPMInternal) @testable import PackageModel
+
+/// Regression tests for individual sources of non-deterministic PIF generation.
+///
+/// SwiftPM seeds its hash function per process, so iterating a `Set` or `Dictionary` and
+/// appending the results to an ordered structure yields a different order on every
+/// invocation. When that structure reaches the PIF, an unchanged package produces a
+/// different build description each time: swift-build reads the `signature` fields written
+/// by `PIF.sign(workspace:)` straight out of the JSON and folds them into the
+/// `BuildDescriptionSignature` it uses as its on-disk cache key.
+///
+/// PR #10344 fixed one instance of this in trait-derived settings, and #10345 fixed header
+/// ordering. See rdar://183168076.
+///
+/// Each test asserts an exact expected order rather than merely "stable across N runs".
+/// A stability-only assertion would pass by luck whenever a single process happened to
+/// produce a consistent order, and would not pin down *which* order is correct.
+@Suite(
+    .tags(
+        .TestSize.medium,
+        .FunctionalArea.PIF
+    )
+)
+struct PIFOrderingTests {
+    // MARK: - Linker flag ordering
+
+    /// The linker-setting declarations a manifest can express that all collapse into the
+    /// single PIF setting `OTHER_LDFLAGS`, paired with the flags each contributes.
+    ///
+    /// **Listed in the expected output order**, which is the contributing declarations
+    /// sorted by name: LINK_FRAMEWORKS, LINK_LIBRARIES, OTHER_LDFLAGS. Expectations below
+    /// are derived from this ordering rather than restated, so changing the intended sort
+    /// means editing one list.
+    private static let linkerContributions: [(declaration: String, setting: TargetBuildSettingDescription.Kind, flags: [String])] = [
+        (declaration: "LINK_FRAMEWORKS", setting: .linkedFramework("Foundation"), flags: ["-framework", "Foundation"]),
+        (declaration: "LINK_LIBRARIES", setting: .linkedLibrary("z"), flags: ["-lz"]),
+        (declaration: "OTHER_LDFLAGS", setting: .unsafeFlags(["-Wl,-U,_undefined"]), flags: ["-Wl,-U,_undefined"]),
+    ]
+
+    /// `LINK_LIBRARIES`, `LINK_FRAMEWORKS` and `OTHER_LDFLAGS` are three distinct SwiftPM
+    /// declarations that all map onto the single PIF setting `OTHER_LDFLAGS`.
+    /// `computeAllBuildSettings` iterates the `[Declaration: [Assignment]]` dictionary and
+    /// appends each group to a shared array, so the dictionary's iteration order becomes
+    /// the linker argument order.
+    ///
+    /// This is the only defect in this suite that changes build *semantics* rather than
+    /// only the cache key: linker argument order governs static archive resolution and
+    /// duplicate-symbol precedence, so a package can link differently between two builds
+    /// of identical sources.
+    @Test
+    func linkerFlagsFromDistinctDeclarationsAreOrderedDeterministically() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let (pif, expectations) = try await constructPIFForLinkerSettings(
+            observability: observability.topScope
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        for expectation in expectations {
+            let flags = try otherLDFlags(in: pif, forModuleNamed: expectation.moduleName)
+            let contributed = flags.filter { $0 != "$(inherited)" }
+            #expect(
+                contributed == expectation.flags,
+                "target \(expectation.moduleName) emitted linker flags out of order"
+            )
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// Builds a PIF containing one target per multi-element subset of `linkerContributions`.
+    ///
+    /// Several targets rather than one is deliberate. Swift fixes its hash seed per
+    /// *process*, so a single target samples exactly one dictionary iteration order per
+    /// run and passes by luck whenever that order happens to be the sorted one — measured
+    /// at 3 false passes in 12 runs against the unfixed code. Each subset presents a
+    /// differently shaped dictionary, so the targets sample several independent orderings
+    /// within one process and the test only passes if every one comes out sorted. That
+    /// drops the false-pass rate to roughly 1 in 20.
+    ///
+    /// The residual flakiness is one-directional and therefore safe: against the *fixed*
+    /// code this test passed 20 of 20 runs, so it will not fail spuriously in CI. It can
+    /// only ever under-report the bug, never invent one.
+    private func constructPIFForLinkerSettings(
+        observability: ObservabilityScope
+    ) async throws -> (pif: SwiftBuildSupport.PIF.TopLevelObject, expectations: [(moduleName: String, flags: [String])]) {
+        let subsets = Self.linkerContributions.indices
+            .reduce(into: [[Int]]()) { subsets, index in
+                subsets = subsets + subsets.map { $0 + [index] } + [[index]]
+            }
+            .filter { $0.count > 1 }
+
+        var targets: [TargetDescription] = []
+        var expectations: [(moduleName: String, flags: [String])] = []
+        var sourceFiles: [String] = []
+
+        for subset in subsets {
+            let moduleName = "Link\(subset.map(String.init).joined())"
+            sourceFiles.append("/MyPkg/Sources/\(moduleName)/lib.swift")
+            targets.append(
+                try TargetDescription(
+                    name: moduleName,
+                    settings: subset.map { .init(tool: .linker, kind: Self.linkerContributions[$0].setting) }
+                )
+            )
+            // The correct output order is the contributions sorted by declaration name,
+            // which is the order `linkerContributions` is written in.
+            expectations.append(
+                (moduleName, subset.sorted().flatMap { Self.linkerContributions[$0].flags })
+            )
+        }
+
+        let fs = InMemoryFileSystem(emptyFiles: sourceFiles)
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                .createRootManifest(
+                    displayName: "MyPkg",
+                    path: "/MyPkg",
+                    toolsVersion: .v5_9,
+                    products: try targets.map {
+                        try .init(name: $0.name, type: .library(.automatic), targets: [$0.name])
+                    },
+                    targets: targets
+                )
+            ],
+            observabilityScope: observability
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root,
+                addLocalRpaths: .always
+            ),
+            fileSystem: fs,
+            observabilityScope: observability
+        )
+
+        let pif = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        ).0
+
+        return (pif, expectations)
+    }
+
+    // MARK: - Helpers
+
+    /// Looks up a module target by name. A library product also yields a `-dynamic`
+    /// variant carrying the same name, so match on the canonical `PACKAGE-TARGET:<name>`
+    /// id rather than the name alone.
+    private func module(
+        named name: String,
+        in pif: SwiftBuildSupport.PIF.TopLevelObject
+    ) throws -> ProjectModel.BaseTarget {
+        let project = try #require(
+            pif.workspace.projects.filter { $0.underlying.name == "MyPkg" }.only,
+            "expected exactly one MyPkg project"
+        )
+        return try #require(
+            project.underlying.targets.filter { $0.common.id.value == "PACKAGE-TARGET:\(name)" }.only,
+            "expected exactly one target with id PACKAGE-TARGET:\(name)"
+        )
+    }
+
+    private func otherLDFlags(
+        in pif: SwiftBuildSupport.PIF.TopLevelObject,
+        forModuleNamed name: String
+    ) throws -> [String] {
+        let target = try module(named: name, in: pif)
+        let config = try #require(
+            target.common.buildConfigs.first { $0.name == "Debug" },
+            "expected a Debug build configuration"
+        )
+        return config.settings[.OTHER_LDFLAGS] ?? []
+    }
+}


### PR DESCRIPTION
A follow on to #10344 and #10345, which fixed this class of bug in trait-derived
settings and headers. An audit of the PIF builder turned up two more places where
we iterate  a Set or Dictionary and append the results to ordered output.

1. LINK_LIBRARIES, LINK_FRAMEWORKS and OTHER_LDFLAGS are distinct declarations
that all collapse into OTHER_LDFLAGS and append to a shared array, so the
declaration dictionary's iteration order became the linker argument order. This
one changes the build rather than just the cache key, since link order governs
archive resolution and duplicate-symbol precedence. Declaration now conforms to
Comparable and both PIF builders sort by it.

2. Plugin-generated resource paths were projected out of a path-keyed dictionary
with .keys at five call sites. Added GeneratedFiles.sortedResourcePaths.

After the fix those fixtures produce a single build description across six
identical builds. This should improve incremental build times.

Tests build on the fixture-sweeping suite from #10345.