### PR TITLE
[6.4] Use the SBOM's real timestamp for the SPDX agent CreationInfo

### DIFF
--- a/Sources/SBOMModel/Converter/SPDXConverter.swift
+++ b/Sources/SBOMModel/Converter/SPDXConverter.swift
@@ -51,7 +51,9 @@ internal struct SPDXConverter {
         else {
             return []
         }
-                
+
+        let created = metadata.timestamp ?? Date().ISO8601Format()
+
         var agents: [any SPDXObject] = []
         for creator in creators {
             let creatorID = self.generateSPDXID(creator.id.value)
@@ -61,7 +63,7 @@ internal struct SPDXConverter {
                 type: .CreationInfo,
                 specVersion: creator.version,
                 createdBy: [creatorID],
-                created: "1970-01-01T00:00:00Z"
+                created: created
             )
             let tool = SPDXAgent(
                 id: creatorID,

--- a/Tests/SBOMModelTests/SPDXConverterTests.swift
+++ b/Tests/SBOMModelTests/SPDXConverterTests.swift
@@ -86,7 +86,7 @@ struct SPDXConverterTests {
         #expect(creationInfoUnwrapped.type == .CreationInfo)
         #expect(creationInfoUnwrapped.specVersion == "3.0.1")
         #expect(creationInfoUnwrapped.createdBy == ["urn:spdx:tool-1"])
-        #expect(creationInfoUnwrapped.created == "1970-01-01T00:00:00Z")
+        #expect(creationInfoUnwrapped.created == "2025-01-01T00:00:00Z")
 
         let agent = result[3] as? SPDXAgent
         let agentUnwrapped = try #require(agent)
@@ -139,6 +139,7 @@ struct SPDXConverterTests {
         let creationInfo1Unwrapped = try #require(creationInfo1)
         #expect(creationInfo1Unwrapped.id == "urn:spdx:tool-1:creationInfo")
         #expect(creationInfo1Unwrapped.createdBy == ["urn:spdx:tool-1"])
+        #expect(creationInfo1Unwrapped.created == "2025-01-01T00:00:00Z")
 
         let agent1 = result[3] as? SPDXAgent
         let agent1Unwrapped = try #require(agent1)
@@ -162,6 +163,7 @@ struct SPDXConverterTests {
         let creationInfo2Unwrapped = try #require(creationInfo2)
         #expect(creationInfo2Unwrapped.id == "urn:spdx:tool-2:creationInfo")
         #expect(creationInfo2Unwrapped.createdBy == ["urn:spdx:tool-2"])
+        #expect(creationInfo2Unwrapped.created == "2025-01-01T00:00:00Z")
 
         let agent2 = result[7] as? SPDXAgent
         let agent2Unwrapped = try #require(agent2)
@@ -1088,6 +1090,7 @@ struct SPDXConverterTests {
 
         let creationInfos = result.graph.compactMap { $0.getValue() as SPDXCreationInfo? }
         #expect(creationInfos.count == 2) // 1 from agent + 1 from document
+        #expect(creationInfos.allSatisfy { $0.created == "2025-01-01T00:00:00Z" })
 
         let packages = result.graph.compactMap { $0.getValue() as SPDXPackage? }
         #expect(packages.count == 1)


### PR DESCRIPTION
The CreationInfo describing the tool that generated the SBOM hardcoded `created` to "1970-01-01T00:00:00Z", so every SPDX document reported the epoch as its creation time. The document-level CreationInfo was correct, but agents are emitted first in `@graph`, so consumers scanning for `created` hit the bogus value.

Issue: #10354
