### PR TITLE
fix(package-plugin): support static Swift stdlib builds

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Plugins/diagnostics-stub/diagnostics_stub.swift
+++ b/Fixtures/Miscellaneous/Plugins/CommandPluginTestStub/Plugins/diagnostics-stub/diagnostics_stub.swift
@@ -9,9 +9,13 @@ struct diagnostics_stub: CommandPlugin {
         if arguments.contains("build") {
             // If echoLogs is true, SwiftPM will print build logs to stderr as they are produced.
             // SwiftPM does not add a prefix to these logs.
+            let logging: PackageManager.BuildLogVerbosity = arguments.contains("verbose") ? .verbose : .concise
             let result = try packageManager.build(
                 .product("placeholder"),
-                parameters: .init(echoLogs: arguments.contains("echologs"))
+                parameters: .init(
+                    logging: logging,
+                    echoLogs: arguments.contains("echologs")
+                )
             )
 
             // To verify that logs are also returned correctly to the plugin,

--- a/Sources/Commands/PackageCommands/PluginCommand.swift
+++ b/Sources/Commands/PackageCommands/PluginCommand.swift
@@ -127,6 +127,14 @@ struct PluginCommand: AsyncSwiftCommand {
             help: "Limit available plugins to a single package with the given identity."
         )
         var packageIdentity: String? = nil
+
+        /// Determines whether binaries built by the plugin should statically link the Swift standard library.
+        @Flag(
+            name: .customLong("static-swift-stdlib"),
+            inversion: .prefixedNo,
+            help: "Determines whether Swift stdlib links statically."
+        )
+        var shouldLinkStaticSwiftStdlib: Bool?
     }
 
     @OptionGroup()
@@ -364,7 +372,12 @@ struct PluginCommand: AsyncSwiftCommand {
         }
 
         // Set up a delegate to handle callbacks from the command plugin.
-        let pluginDelegate = PluginDelegate(swiftCommandState: swiftCommandState, buildSystem: buildSystemKind, plugin: pluginTarget)
+        let pluginDelegate = PluginDelegate(
+            swiftCommandState: swiftCommandState,
+            buildSystem: buildSystemKind,
+            plugin: pluginTarget,
+            shouldLinkStaticSwiftStdlib: options.shouldLinkStaticSwiftStdlib ?? false
+        )
         let delegateQueue = DispatchQueue(label: "plugin-invocation")
 
         // Run the command plugin.

--- a/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
+++ b/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
@@ -196,7 +196,7 @@ extension PluginCommand.PluginOptions {
     func merged(with other: Self) -> Self {
         // validate against developer mistake
         assert(
-            Mirror(reflecting: self).children.count == 4,
+            Mirror(reflecting: self).children.count == 5,
             "Property added to PluginOptions without updating merged(with:)!"
         )
         // actual merge
@@ -209,6 +209,9 @@ extension PluginCommand.PluginOptions {
         }
         if other.packageIdentity != nil {
             merged.packageIdentity = other.packageIdentity
+        }
+        if let shouldLinkStaticSwiftStdlib = other.shouldLinkStaticSwiftStdlib {
+            merged.shouldLinkStaticSwiftStdlib = shouldLinkStaticSwiftStdlib
         }
         return merged
     }

--- a/Sources/Commands/Utilities/PluginDelegate.swift
+++ b/Sources/Commands/Utilities/PluginDelegate.swift
@@ -27,12 +27,19 @@ final class PluginDelegate: PluginInvocationDelegate {
     let swiftCommandState: SwiftCommandState
     let buildSystem: BuildSystemProvider.Kind
     let plugin: PluginModule
+    let shouldLinkStaticSwiftStdlib: Bool
     var lineBufferedOutput: Data
 
-    init(swiftCommandState: SwiftCommandState, buildSystem: BuildSystemProvider.Kind, plugin: PluginModule) {
+    init(
+        swiftCommandState: SwiftCommandState,
+        buildSystem: BuildSystemProvider.Kind,
+        plugin: PluginModule,
+        shouldLinkStaticSwiftStdlib: Bool
+    ) {
         self.swiftCommandState = swiftCommandState
         self.buildSystem = buildSystem
         self.plugin = plugin
+        self.shouldLinkStaticSwiftStdlib = shouldLinkStaticSwiftStdlib
         self.lineBufferedOutput = Data()
     }
 
@@ -169,6 +176,7 @@ final class PluginDelegate: PluginInvocationDelegate {
             explicitBuildSystem: buildSystem,
             explicitProduct: explicitProduct,
             cacheBuildManifest: false,
+            shouldLinkStaticSwiftStdlib: self.shouldLinkStaticSwiftStdlib,
             productsBuildParameters: buildParameters,
             toolsBuildParameters: toolsBuildParameters,
             outputStream: outputStream,

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePlugin.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackagePlugin.md
@@ -52,7 +52,9 @@ package plugin [--package-path=<package-path>]
   [--allow-writing-to-package-directory]
   [--allow-writing-to-directory=<allow-writing-to-directory>...]
   [--allow-network-connections=<allow-network-connections>]
-  [--package=<package>] [<command>] [<arguments>...]
+  [--package=<package>]
+  [--static-swift-stdlib|no-static-swift-stdlib]
+  [<command>] [<arguments>...]
   [--version] [--help]
 ```
 
@@ -311,6 +313,11 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 *Limit available plugins to a single package with the given identity.*
 
 
+- term **--static-swift-stdlib|no-static-swift-stdlib**:
+
+*Determines whether Swift stdlib links statically.*
+
+
 - term **command**:
 
 *Verb of the command plugin to invoke.*
@@ -329,4 +336,3 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 - term **--help**:
 
 *Show help information.*
-

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -113,6 +113,21 @@ struct PackageCommandTests {
     }
 
     @Test(
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/8424", relationship: .verifies)
+    )
+    func staticSwiftStdlibOptionIsAcceptedForPluginInvocation() throws {
+        let command = try #require(
+            SwiftPackageCommand.parseAsRoot([
+                "--static-swift-stdlib",
+                "my-plugin",
+            ]) as? SwiftPackageCommand.DefaultCommand
+        )
+
+        #expect(command.pluginOptions.shouldLinkStaticSwiftStdlib == true)
+        #expect(command.remaining == ["my-plugin"])
+    }
+
+    @Test(
         .issue("rdar://131126477", relationship: .defect),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
@@ -6023,6 +6038,40 @@ struct PackageCommandTests {
                 }
                 expectFileDoesNotExist(at: fileShouldNotExist, "build-target build-inherit")
                 expectFileIsExecutable(at: fileShouldExist, "build-target build-inherit")
+            }
+        }
+
+        @Test(
+            .issue("https://github.com/swiftlang/swift-package-manager/issues/8424", relationship: .verifies),
+            .tags(
+                .Feature.Command.Build,
+                .Feature.Command.Package.CommandPlugin,
+                .Feature.PackageType.CommandPlugin
+            ),
+            .requiresStdlibSupport,
+            .requiresSwiftConcurrencySupport
+        )
+        func commandPluginBuildHonorsStaticSwiftStdlib() async throws {
+            let config = BuildConfiguration.debug
+
+            try await fixture(name: "Miscellaneous/Plugins/CommandPluginTestStub") { fixturePath in
+                let (stdout, _) = try await execute(
+                    [
+                        "--static-swift-stdlib",
+                        "print-diagnostics",
+                        "build",
+                        "printlogs",
+                        "verbose",
+                    ],
+                    packagePath: fixturePath,
+                    configuration: config,
+                    buildSystem: .native
+                )
+
+                #expect(
+                    stdout.contains("-static-stdlib"),
+                    "Expected plugin-requested build to link the static Swift stdlib. Output: \(stdout)"
+                )
             }
         }
 

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -67,6 +67,16 @@ struct TestCommandTests {
         #expect(stdout.contains("USAGE: swift test"), "got stdout:\n\(stdout)")
     }
 
+    @Test
+    func staticSwiftStdlibOptionRemainsUnavailable() {
+        do {
+            _ = try SwiftTestCommand.parseAsRoot(["--static-swift-stdlib"])
+            Issue.record("Expected swift test to reject --static-swift-stdlib")
+        } catch {
+            #expect(SwiftTestCommand.message(for: error).contains("Unknown option '--static-swift-stdlib'"))
+        }
+    }
+
     @Test(
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
@@ -2564,4 +2574,3 @@ struct TestCommandTests {
         }
     }
 }
-


### PR DESCRIPTION
Fixes: #8424

## Summary

Allow `swift package --static-swift-stdlib <plugin invocation>` to request static Swift standard-library linking for binaries built through `PackageManager.build`.

Previously, this option was scoped only to `swift build`, causing `swift package` to reject it before invoking a command plugin.

## Changes

- Add plugin-scoped `--static-swift-stdlib` and `--no-static-swift-stdlib` options.
- Preserve explicitly enabled or disabled values when parsing options before or after the plugin command.
- Forward the selected value to build operations requested through `PackageManager.build`.
- Keep the option unavailable to `swift test` and unrelated SwiftPM commands.
- Add parser coverage for package-plugin acceptance and continued `swift test` rejection.
- Add supported-platform integration coverage that verifies the linker receives `-static-stdlib`.
- Update the package-plugin command documentation.

## Alternatives considered

Moving the flag into the shared build options was rejected because it would expose it to every command using `GlobalOptions`, including `swift test`, where statically linking the Swift core libraries is unsupported.

Retaining the `-Xswiftc -static-stdlib` workaround was also rejected because the dedicated option should behave consistently between `swift build` and plugin-requested builds.

## Notes

The option is forwarded only to builds requested through `PackageManager.build`. Plugin-requested test and symbol-graph operations remain unchanged.

The end-to-end linker assertion is conditional on the active toolchain supporting static Swift standard-library linking.

## Testing

- `swift test --filter 'staticSwiftStdlibOptionIsAcceptedForPluginInvocation|staticSwiftStdlibOptionRemainsUnavailable|commandPluginBuildHonorsStaticSwiftStdlib'`
  - Package-plugin parser regression passed.
  - `swift test` isolation regression passed.
  - Static-link integration test was discovered but skipped on macOS because the toolchain does not support static Swift standard-library linking.
- Verified that `swift build` and `swift package plugin` expose the option.
- Verified that `swift test`, `swift run`, and unrelated package commands do not expose it.
- `swift package --disable-sandbox generate-documentation --target PackageManagerDocs`
- SwiftFormat lint on the changed lines.