### PR TITLE
[6.4]Swift Build: Don't include host-only build tool dependencies in the top level aggregate target

### DIFF
--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Package.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Package.swift
@@ -11,7 +11,9 @@ let package = Package(
         .package(path: "MacroImplHelpers"),
     ],
     targets: [
+        .target(name: "MacroImplSupport"),
         .macro(name: "MacroImpl", dependencies: [
+            "MacroImplSupport",
             .product(name: "MacroImplHelpers", package: "MacroImplHelpers"),
         ]),
         .target(name: "MacroDef", dependencies: ["MacroImpl"]),

--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroImpl/StringifyMacro.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroImpl/StringifyMacro.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MacroImplHelpers
+import MacroImplSupport
 
 #if os(WASI)
 #error("MacroImpl must not be compiled for WebAssembly.")
@@ -45,7 +46,7 @@ struct MacroPlugin {
             } else if json.keys.contains("expandFreestandingMacro") {
                 let response: [String: Any] = [
                     "expandMacroResult": [
-                        "expandedSource": "\"\(macroImplHelper())\"",
+                        "expandedSource": quoted(macroImplHelper()),
                         "diagnostics": []
                     ]
                 ]

--- a/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroImplSupport/MacroImplSupport.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyMacroPackage/Sources/MacroImplSupport/MacroImplSupport.swift
@@ -1,0 +1,7 @@
+#if os(WASI)
+#error("MacroImplSupport must not be compiled for WebAssembly.")
+#endif
+
+public func quoted(_ value: String) -> String {
+    "\"\(value)\""
+}

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Package.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MinimalWebAssemblyPluginPackage",
+    platforms: [
+        .macOS(.v13),
+    ],
+    dependencies: [
+        .package(path: "PluginToolHelpers"),
+    ],
+    targets: [
+        .target(name: "PluginToolSupport"),
+        .executableTarget(name: "GenerateTool", dependencies: [
+            "PluginToolSupport",
+            .product(name: "PluginToolHelpers", package: "PluginToolHelpers"),
+        ]),
+        .plugin(
+            name: "GenerateSourcePlugin",
+            capability: .buildTool(),
+            dependencies: ["GenerateTool"]
+        ),
+        .target(name: "PluginConsumer", plugins: ["GenerateSourcePlugin"]),
+        .executableTarget(name: "PluginClient", dependencies: ["PluginConsumer"]),
+        .testTarget(name: "MinimalWebAssemblyPluginPackageTests", dependencies: ["PluginConsumer"]),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/PluginToolHelpers/Package.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/PluginToolHelpers/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "PluginToolHelpers",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .library(name: "PluginToolHelpers", targets: ["PluginToolHelpers"]),
+    ],
+    targets: [
+        .target(name: "PluginToolHelpers"),
+    ],
+    swiftLanguageModes: [.v5]
+)

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/PluginToolHelpers/Sources/PluginToolHelpers/PluginToolHelpers.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/PluginToolHelpers/Sources/PluginToolHelpers/PluginToolHelpers.swift
@@ -1,0 +1,7 @@
+#if os(WASI)
+#error("PluginToolHelpers must not be compiled for WebAssembly.")
+#endif
+
+public func pluginToolHelper() -> String {
+    "generated"
+}

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Plugins/GenerateSourcePlugin/plugin.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Plugins/GenerateSourcePlugin/plugin.swift
@@ -1,0 +1,20 @@
+import PackagePlugin
+
+@main
+struct GenerateSourcePlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        guard let target = target as? SourceModuleTarget else { return [] }
+        return try target.sourceFiles.compactMap { file -> Command? in
+            guard file.url.pathExtension == "dat" else { return nil }
+            let outputName = file.url.deletingPathExtension().appendingPathExtension("swift").lastPathComponent
+            let outputPath = context.pluginWorkDirectoryURL.appendingPathComponent(outputName)
+            return .buildCommand(
+                displayName: "Generating \(outputName) from \(file.url.lastPathComponent)",
+                executable: try context.tool(named: "GenerateTool").url,
+                arguments: [outputPath.path],
+                inputFiles: [file.url],
+                outputFiles: [outputPath]
+            )
+        }
+    }
+}

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/GenerateTool/main.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/GenerateTool/main.swift
@@ -1,0 +1,11 @@
+import Foundation
+import PluginToolHelpers
+import PluginToolSupport
+
+#if os(WASI)
+#error("GenerateTool must not be compiled for WebAssembly.")
+#endif
+
+let outputFile = ProcessInfo.processInfo.arguments[1]
+try generatedSource(returning: pluginToolHelper())
+    .write(toFile: outputFile, atomically: true, encoding: .utf8)

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/PluginClient/main.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/PluginClient/main.swift
@@ -1,0 +1,3 @@
+import PluginConsumer
+
+print("Plugin result: \(pluginConsumerValue())")

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/PluginConsumer/Generated.dat
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/PluginConsumer/Generated.dat
@@ -1,0 +1,1 @@
+generate

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/PluginConsumer/PluginConsumer.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/PluginConsumer/PluginConsumer.swift
@@ -1,0 +1,3 @@
+public func pluginConsumerValue() -> String {
+    generatedFunction()
+}

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/PluginToolSupport/PluginToolSupport.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Sources/PluginToolSupport/PluginToolSupport.swift
@@ -1,0 +1,11 @@
+#if os(WASI)
+#error("PluginToolSupport must not be compiled for WebAssembly.")
+#endif
+
+public func generatedSource(returning value: String) -> String {
+    """
+    public func generatedFunction() -> String {
+        "\(value)"
+    }
+    """
+}

--- a/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Tests/MinimalWebAssemblyPluginPackageTests/MinimalWebAssemblyPluginPackageTests.swift
+++ b/Fixtures/WebAssembly/MinimalWebAssemblyPluginPackage/Tests/MinimalWebAssemblyPluginPackageTests/MinimalWebAssemblyPluginPackageTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+import PluginConsumer
+
+final class MinimalWebAssemblyPluginPackageTests: XCTestCase {
+    func testGeneratedSource() {
+        XCTAssertEqual(pluginConsumerValue(), "generated")
+    }
+}

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -21,6 +21,8 @@ import TSCUtility
 import SPMBuildCore
 
 import func TSCBasic.topologicalSort
+import func TSCBasic.transitiveClosure
+import struct TSCBasic.OrderedSet
 import var TSCBasic.stdoutStream
 
 import enum SwiftBuild.ProjectModel
@@ -765,6 +767,97 @@ fileprivate final class PackagePIFBuilderDelegate: PackagePIFBuilder.BuildDelega
     }
 }
 
+/// Determine the list of modules in the modules graph which should not be added to the top level aggregate for the root package (which would cause them to always build for the destination platform).
+fileprivate func computeHostOnlyModuleIDsInRootPackages(in modulesGraph: ModulesGraph) -> Set<ResolvedModule.ID> {
+    // Macros and plugins always build only for the host platform. Dependencies of macros and plugins might build for
+    // only the host platform, or both the host and destination platform.
+    func hasHostOnlyModuleKind(_ module: ResolvedModule) -> Bool {
+        switch module.type {
+        case .macro, .plugin:
+            true
+        default:
+            false
+        }
+    }
+
+    // Collect modules from root packages. We only consider root packages here because only targets from root packages
+    // are ever added to the top level build request. Targets from dependencies are only ever added via dependency edges
+    // from a root package, so we don't need to worry about unnecessary specializations for the destination platform.
+    var rootPackageModulesByID: [ResolvedModule.ID: ResolvedModule] = [:]
+    var hostOnlyModulesInRootPackageIDs: Set<ResolvedModule.ID> = []
+    for package in modulesGraph.rootPackages {
+        for module in package.modules {
+            rootPackageModulesByID[module.id] = module
+            if hasHostOnlyModuleKind(module) {
+                hostOnlyModulesInRootPackageIDs.insert(module.id)
+            }
+        }
+    }
+
+    // Find the transitive closure covered by host-only targets. These are modules which should be excluded from
+    // the top level build request unless they specifically need to build for the destination. Again, we only consider
+    // root packages.
+    let modulesInRootPackagesReachableFromHostOnlyModuleIDs = transitiveClosure(Array(hostOnlyModulesInRootPackageIDs), successors: { moduleID in
+        guard let module = rootPackageModulesByID[moduleID] else {
+            return []
+        }
+        return module.dependencies.flatMap { dependency in
+            switch dependency {
+            case .module(let moduleDependency, _):
+                return [moduleDependency.id]
+            case .product(let productDependency, _):
+                return Array(productDependency.modules.map(\.id))
+            }
+        }.filter {
+            rootPackageModulesByID.keys.contains($0)
+        }
+    }).union(hostOnlyModulesInRootPackageIDs)
+
+    // Determine the list of targets in the root package which can be reached without traversing an edge to a macro or plugin.
+    // These are targets which must build for the destination, and cannot be excluded from the top level build request. The roots
+    // of the traversal are:
+    // 1. Any target which is part of an explicit executable/library product in the manifest
+    // 2. Any target which is not reachable from any macro/plugin
+    var modulesReachableFromTopLevelWithoutTraversingHostOnlyEdgeIDs: Set<ResolvedModule.ID> = []
+    // If a module is in the root package and not in the closure of a host only module, it's considered top-level
+    modulesReachableFromTopLevelWithoutTraversingHostOnlyEdgeIDs.formUnion(Set(rootPackageModulesByID.keys).subtracting(modulesInRootPackagesReachableFromHostOnlyModuleIDs))
+    // If a module is included in a non-implicit product, it's considered top-level
+    for package in modulesGraph.rootPackages {
+        for product in package.products where !product.underlying.isImplicit {
+            for module in product.modules {
+                if !hasHostOnlyModuleKind(module) {
+                    modulesReachableFromTopLevelWithoutTraversingHostOnlyEdgeIDs.insert(module.id)
+                }
+            }
+        }
+    }
+    // If a module in the root package is reachable from one of the ones we've discovered so far, without traversing an edge to a host-only module, it's considered top-level.
+    modulesReachableFromTopLevelWithoutTraversingHostOnlyEdgeIDs.formUnion(transitiveClosure(Array(modulesReachableFromTopLevelWithoutTraversingHostOnlyEdgeIDs), successors: { moduleID in
+        guard let module = rootPackageModulesByID[moduleID] else {
+            return []
+        }
+        // A test target which depends on an otherwise host-only target should not cause that dependency to be
+        // included in the top-level build request. It should only be specialized for the destination when building
+        // the tests.
+        guard module.type != .test else {
+            return []
+        }
+        return module.dependencies.flatMap { dependency in
+            switch dependency {
+            case .module(let moduleDependency, _):
+                return [moduleDependency]
+            case .product(let productDependency, _):
+                return Array(productDependency.modules)
+            }
+        }.filter {
+            rootPackageModulesByID.keys.contains($0.id) && !hasHostOnlyModuleKind($0)
+        }.map(\.id)
+    }))
+
+
+    return Set(rootPackageModulesByID.keys).subtracting(modulesReachableFromTopLevelWithoutTraversingHostOnlyEdgeIDs)
+}
+
 fileprivate func buildAggregatePIFProject(
     packagesAndProjects: [(package: ResolvedPackage, project: ProjectModel.Project)],
     observabilityScope: ObservabilityScope,
@@ -820,6 +913,8 @@ fileprivate func buildAggregatePIFProject(
     addEmptyBuildConfig(to: allExcludingTestsTargetKeyPath, name: "Debug")
     addEmptyBuildConfig(to: allExcludingTestsTargetKeyPath, name: "Release")
 
+    let hostOnlyModuleIDs = computeHostOnlyModuleIDsInRootPackages(in: modulesGraph)
+
     for (package, packageProject) in packagesAndProjects where package.manifest.packageKind.isRoot {
         for target in packageProject.targets {
             switch target {
@@ -833,6 +928,14 @@ fileprivate func buildAggregatePIFProject(
                         // Disconnected target, possibly due to platform when condition that isn't satisfied
                         continue
                     }
+                    if hostOnlyModuleIDs.contains(resolvedModule.id) {
+                        continue
+                    }
+                } else if let productName = PackagePIFBuilder.productName(forTargetName: target.name),
+                          let resolvedProduct = modulesGraph.product(for: productName),
+                          !resolvedProduct.modules.isEmpty,
+                          resolvedProduct.modules.allSatisfy({ hostOnlyModuleIDs.contains($0.id) }) {
+                    continue
                 }
 
                 aggregateProject[keyPath: allIncludingTestsTargetKeyPath].common.addDependency(

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1798,6 +1798,427 @@ struct PIFBuilderTests {
         )
     }
 
+    @Test func hostBuildToolExcludedFromAggregates() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/RootLib/RootLib.swift",
+            "/Root/Sources/PluginTool/main.swift",
+            "/Root/Plugins/MyPlugin/plugin.swift",
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    targets: [
+                        TargetDescription(
+                            name: "RootLib",
+                            pluginUsages: [.plugin(name: "MyPlugin", package: nil)]
+                        ),
+                        TargetDescription(name: "PluginTool", type: .executable),
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: ["PluginTool"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let rootProject = try pif.workspace.project(named: "Root")
+        let rootLibID = try rootProject.target(named: "RootLib").common.id.value
+        let toolModuleID = try rootProject.target(named: "PluginTool").common.id.value
+        let toolProductID = try rootProject.target(named: "PluginTool-product").common.id.value
+
+        let aggregate = try pif.workspace.project(named: "Aggregate")
+        for aggregateName in [PIFBuilder.allExcludingTestsTargetName, PIFBuilder.allIncludingTestsTargetName] {
+            let deps = Set(try aggregate.target(named: aggregateName).common.dependencies.map(\.targetId.value))
+            #expect(deps.contains(rootLibID))
+            #expect(!deps.contains(toolModuleID))
+            #expect(!deps.contains(toolProductID))
+        }
+    }
+
+    @Test func hostBuildToolDependencyExcludedFromAggregates() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/RootLib/RootLib.swift",
+            "/Root/Sources/PluginTool/main.swift",
+            "/Root/Plugins/MyPlugin/plugin.swift",
+            "/Root/Sources/Dep/dep.swift"
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    targets: [
+                        TargetDescription(
+                            name: "RootLib",
+                            pluginUsages: [.plugin(name: "MyPlugin", package: nil)]
+                        ),
+                        TargetDescription(name: "PluginTool", dependencies: ["Dep"], type: .executable),
+                        TargetDescription(name: "Dep"),
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: ["PluginTool"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let rootProject = try pif.workspace.project(named: "Root")
+        let rootLibID = try rootProject.target(named: "RootLib").common.id.value
+        let toolModuleID = try rootProject.target(named: "PluginTool").common.id.value
+        let depModuleID = try rootProject.target(named: "Dep").common.id.value
+        let toolProductID = try rootProject.target(named: "PluginTool-product").common.id.value
+
+        let aggregate = try pif.workspace.project(named: "Aggregate")
+        for aggregateName in [PIFBuilder.allExcludingTestsTargetName, PIFBuilder.allIncludingTestsTargetName] {
+            let deps = Set(try aggregate.target(named: aggregateName).common.dependencies.map(\.targetId.value))
+            #expect(deps.contains(rootLibID))
+            #expect(!deps.contains(toolModuleID))
+            #expect(!deps.contains(toolProductID))
+            // Dep is only a dependency of a host tool, so it should not be included in the aggregate
+            #expect(!deps.contains(depModuleID))
+        }
+    }
+
+    @Test func standaloneTargetIncludedInAggregates() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/RootLib/RootLib.swift",
+            "/Root/Sources/OtherLib/OtherLib.swift",
+            "/Root/Sources/PluginTool/main.swift",
+            "/Root/Plugins/MyPlugin/plugin.swift",
+            "/Root/Sources/Dep/dep.swift"
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    targets: [
+                        TargetDescription(
+                            name: "RootLib",
+                            pluginUsages: [.plugin(name: "MyPlugin", package: nil)]
+                        ),
+                        TargetDescription(name: "OtherLib"),
+                        TargetDescription(name: "PluginTool", dependencies: ["Dep"], type: .executable),
+                        TargetDescription(name: "Dep"),
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: ["PluginTool"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let rootProject = try pif.workspace.project(named: "Root")
+        let rootLibID = try rootProject.target(named: "RootLib").common.id.value
+        let otherLibID = try rootProject.target(named: "OtherLib").common.id.value
+        let toolModuleID = try rootProject.target(named: "PluginTool").common.id.value
+        let depModuleID = try rootProject.target(named: "Dep").common.id.value
+        let toolProductID = try rootProject.target(named: "PluginTool-product").common.id.value
+
+        let aggregate = try pif.workspace.project(named: "Aggregate")
+        for aggregateName in [PIFBuilder.allExcludingTestsTargetName, PIFBuilder.allIncludingTestsTargetName] {
+            let deps = Set(try aggregate.target(named: aggregateName).common.dependencies.map(\.targetId.value))
+            #expect(deps.contains(rootLibID))
+            #expect(deps.contains(otherLibID))
+            #expect(!deps.contains(toolModuleID))
+            #expect(!deps.contains(toolProductID))
+            #expect(!deps.contains(depModuleID))
+        }
+    }
+
+    @Test func sharedHostBuildToolAndDestinationDependencyIncludedInAggregates() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/RootLib/RootLib.swift",
+            "/Root/Sources/PluginTool/main.swift",
+            "/Root/Plugins/MyPlugin/plugin.swift",
+            "/Root/Sources/Dep/dep.swift"
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    targets: [
+                        TargetDescription(
+                            name: "RootLib",
+                            dependencies: ["Dep"],
+                            pluginUsages: [.plugin(name: "MyPlugin", package: nil)]
+                        ),
+                        TargetDescription(name: "PluginTool", dependencies: ["Dep"], type: .executable),
+                        TargetDescription(name: "Dep"),
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: ["PluginTool"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let rootProject = try pif.workspace.project(named: "Root")
+        let rootLibID = try rootProject.target(named: "RootLib").common.id.value
+        let toolModuleID = try rootProject.target(named: "PluginTool").common.id.value
+        let depModuleID = try rootProject.target(named: "Dep").common.id.value
+        let toolProductID = try rootProject.target(named: "PluginTool-product").common.id.value
+
+        let aggregate = try pif.workspace.project(named: "Aggregate")
+        for aggregateName in [PIFBuilder.allExcludingTestsTargetName, PIFBuilder.allIncludingTestsTargetName] {
+            let deps = Set(try aggregate.target(named: aggregateName).common.dependencies.map(\.targetId.value))
+            #expect(deps.contains(rootLibID))
+            #expect(!deps.contains(toolModuleID))
+            #expect(!deps.contains(toolProductID))
+            // Dep is depended upon by host and non-host targets, so it should be included in the aggregate.
+            #expect(deps.contains(depModuleID))
+        }
+    }
+
+    @Test func hostBuildToolDependencyIncludedInProductIncludedInAggregates() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/RootLib/RootLib.swift",
+            "/Root/Sources/PluginTool/main.swift",
+            "/Root/Plugins/MyPlugin/plugin.swift",
+            "/Root/Sources/Dep/dep.swift"
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    products: [
+                        ProductDescription(name: "MyProduct", type: .library(.automatic), targets: ["Dep"])
+                    ],
+                    targets: [
+                        TargetDescription(
+                            name: "RootLib",
+                            pluginUsages: [.plugin(name: "MyPlugin", package: nil)]
+                        ),
+                        TargetDescription(name: "PluginTool", dependencies: ["Dep"], type: .executable),
+                        TargetDescription(name: "Dep"),
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: ["PluginTool"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let rootProject = try pif.workspace.project(named: "Root")
+        let rootLibID = try rootProject.target(named: "RootLib").common.id.value
+        let toolModuleID = try rootProject.target(named: "PluginTool").common.id.value
+        let depModuleID = try rootProject.target(named: "Dep").common.id.value
+        let toolProductID = try rootProject.target(named: "PluginTool-product").common.id.value
+
+        let aggregate = try pif.workspace.project(named: "Aggregate")
+        for aggregateName in [PIFBuilder.allExcludingTestsTargetName, PIFBuilder.allIncludingTestsTargetName] {
+            let deps = Set(try aggregate.target(named: aggregateName).common.dependencies.map(\.targetId.value))
+            #expect(deps.contains(rootLibID))
+            #expect(!deps.contains(toolModuleID))
+            #expect(!deps.contains(toolProductID))
+            // Dep is part of a product, so it should be included in the aggregate.
+            #expect(deps.contains(depModuleID))
+        }
+    }
+
+    @Test func hostBuildToolDependencyUsedByTestTargetIncludedInAggregates() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/RootLib/RootLib.swift",
+            "/Root/Sources/PluginTool/main.swift",
+            "/Root/Plugins/MyPlugin/plugin.swift",
+            "/Root/Sources/Dep/dep.swift",
+            "/Root/Tests/DepTests/DepTests.swift"
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    targets: [
+                        TargetDescription(
+                            name: "RootLib",
+                            pluginUsages: [.plugin(name: "MyPlugin", package: nil)]
+                        ),
+                        TargetDescription(name: "PluginTool", dependencies: ["Dep"], type: .executable),
+                        TargetDescription(name: "Dep"),
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: ["PluginTool"],
+                            type: .plugin,
+                            pluginCapability: .buildTool
+                        ),
+                        TargetDescription(name: "DepTests", dependencies: ["Dep"], type: .test),
+                    ]
+                ),
+            ],
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let rootProject = try pif.workspace.project(named: "Root")
+        let rootLibID = try rootProject.target(named: "RootLib").common.id.value
+        let toolModuleID = try rootProject.target(named: "PluginTool").common.id.value
+        let depModuleID = try rootProject.target(named: "Dep").common.id.value
+        let toolProductID = try rootProject.target(named: "PluginTool-product").common.id.value
+
+        let aggregate = try pif.workspace.project(named: "Aggregate")
+        for aggregateName in [PIFBuilder.allExcludingTestsTargetName, PIFBuilder.allIncludingTestsTargetName] {
+            let deps = Set(try aggregate.target(named: aggregateName).common.dependencies.map(\.targetId.value))
+            #expect(deps.contains(rootLibID))
+            #expect(!deps.contains(toolModuleID))
+            #expect(!deps.contains(toolProductID))
+            // Dep is a dependency of a host tool, and the tests, so it should not be included in the aggregate.
+            // It will still be specialized for the destination when building tests because the test target is
+            // part of the tests aggregate.
+            #expect(!deps.contains(depModuleID))
+        }
+    }
+
     /// Tests the cross-package case: the build tool plugin lives in one package and its
     /// executable tool lives in a separate package. The plugin declares the dependency via
     /// `.product(name:package:)`, which routes through a different code path than the

--- a/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
+++ b/Tests/SwiftPMWebAssemblyIntegrationTests/WebAssemblyIntegrationTests.swift
@@ -110,7 +110,36 @@ private struct WebAssemblyIntegrationTests {
             env["SWIFT_EXEC"] = compilerPath.pathString
 
             // Build the tests for WebAssembly. The macro implementation and its helper
-            // target will fail to compile if built for WebAssembly instead of the host platform.
+            // targets, both in-package and from a dependency package, will fail to compile
+            // if built for WebAssembly instead of the host platform.
+            let buildOutput = try await executeSwiftBuild(
+                fixturePath,
+                extraArgs: ["--swift-sdk", sdkID, "--build-tests", "-v"],
+                env: env,
+                buildSystem: .swiftbuild,
+            )
+            #expect(buildOutput.stdout.contains("Build complete"))
+
+            _ = try await executeSwiftTest(fixturePath, extraArgs: [], env: env, buildSystem: .swiftbuild)
+        }
+    }
+
+    @Test(
+        .requiresWebAssemblySwiftSDK,
+        .tags(
+            .Feature.Command.Build,
+        ),
+    )
+    func buildToolPluginPackageIncludingTests() async throws {
+        try await fixture(name: "WebAssembly/MinimalWebAssemblyPluginPackage") { fixturePath in
+            let (compilerPath, sdkID) = try #require(try await findCompilerAndSDKIDForTesting(for: .webassembly))
+
+            var env = Environment()
+            env["SWIFT_EXEC"] = compilerPath.pathString
+
+            // Build the tests for WebAssembly. The executable used by the build tool plugin
+            // and its helper targets, both in-package and from a dependency package, will fail
+            // to compile if built for WebAssembly instead of the host platform.
             let buildOutput = try await executeSwiftBuild(
                 fixturePath,
                 extraArgs: ["--swift-sdk", sdkID, "--build-tests", "-v"],


### PR DESCRIPTION
Cherrypick of https://github.com/swiftlang/swift-package-manager/pull/10348

* Explanation: Previously, all targets in a root package would be included in the top level aggregate. This meant that they would all be specialized for the destination platform, even if they were solely macro/plugin dependencies and only supported compiling for the host. Update PIF construction to exclude these targets from the aggregate. They'll still be built via dependency edges from macro/plugin consumers, but they'll only be specialized for the host platform

* Scope: Cross compilation of packages with build tools dependencies not depended on by other products/targets
* Issues: https://github.com/swiftlang/swift-package-manager/issues/10224
* Risk:
      Low - moderate. This change affects how we generate the aggregate top-level PIF targets. However, it's designed to have minimal impact on other parts of SwiftPM, and should only impact packages with host tools.
* Testing: Added unit tests and integration tests
* Reviewers:
@dschaefer2