### PR TITLE
[6.4] Ensure PIF metadata matches module name in build settings for main module products

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -545,7 +545,7 @@ extension PackagePIFProjectBuilder {
         let moduleOrProduct = PackagePIFBuilder.ModuleOrProduct(
             type: moduleOrProductType,
             name: product.name,
-            moduleName: product.c99name,
+            moduleName: mainModule.c99name,
             pifTarget: .target(self.project[keyPath: mainModuleTargetKeyPath]),
             indexableFileURLs: indexableFileURLs,
             headerFiles: headerFiles,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -840,6 +840,53 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test
+    func mainModuleProductMetadataUsesMainModuleName() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let fs = InMemoryFileSystem(
+            emptyFiles: [
+                "/MyPkg/Sources/MyAppModule/main.swift",
+            ]
+        )
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                .createRootManifest(
+                    displayName: "MyPkg",
+                    path: "/MyPkg",
+                    toolsVersion: .v6_2,
+                    products: [
+                        .init(name: "my-exec", type: .executable, targets: ["exec"]),
+                    ],
+                    targets: [
+                        .init(name: "exec", type: .executable),
+                    ]
+                )
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root,
+                addLocalRpaths: .always
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let (_, metadata) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        let product = try #require(metadata.first { $0.name == "my-exec" })
+        #expect(product.moduleName == "exec")
+    }
+
     @Test(
         arguments: BuildConfiguration.allCases,
     )


### PR DESCRIPTION
* Explanation: When an executable product name did not match the main module name, the ancillary PIF metadata could report the wrong module name to library clients.
* Scope: Clients of libSwiftPM
* Issues: rdar://183459384
* Risk:
      Low, this only affects PIF metadata and doesn't impact the build itself
* Testing: Added unit test
