### PR TITLE
Use each package's own file system when building its modules

### DIFF
--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -150,6 +150,10 @@ extension ModulesGraph {
             //
             // FIXME: Lift this out of the manifest.
             let packagePath = manifest.path.parentDirectory
+            // Use the file system associated with this package, if there is one. A package provided by a
+            // custom container may be backed by its own file system, and its sources can only be
+            // discovered through it rather than through the one backing the rest of the graph.
+            let packageFileSystem = manifestMap[node.identity]?.fs ?? fileSystem
             nodeObservabilityScope.trap {
                 // Create a package from the manifest and sources.
 
@@ -170,7 +174,7 @@ extension ModulesGraph {
                     shouldCreateMultipleTestProducts: shouldCreateMultipleTestProducts,
                     testEntryPointPath: testEntryPointPath,
                     createREPLProduct: manifest.packageKind.isRoot ? createREPLProduct : false,
-                    fileSystem: fileSystem,
+                    fileSystem: packageFileSystem,
                     observabilityScope: nodeObservabilityScope,
                     enabledTraits: enabledTraits
                 )

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -15936,6 +15936,104 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testCustomPackageContainerProviderWithMultipleTargets() async throws {
+        let sandbox = AbsolutePath("/tmp/ws/")
+        let fs = InMemoryFileSystem()
+
+        // The contents of a package provided by a custom container live in the file system vended by that
+        // container, and not in the one backing the rest of the workspace.
+        let customFS = InMemoryFileSystem()
+        // write a manifest
+        try customFS.writeFileContents(.root.appending(component: Manifest.filename), bytes: "")
+        try ToolsVersionSpecificationWriter.rewriteSpecification(
+            manifestDirectory: .root,
+            toolsVersion: .current,
+            fileSystem: customFS
+        )
+        // Write the sources of more than one target. A package with a single target may claim the whole
+        // predefined sources directory, so several targets are needed in order for each of them to have
+        // to be located individually.
+        let sourcesDir = AbsolutePath("/Sources")
+        for target in ["Baz", "Qux"] {
+            let targetDir = sourcesDir.appending(target)
+            try customFS.createDirectory(targetDir, recursive: true)
+            try customFS.writeFileContents(targetDir.appending("file.swift"), bytes: "")
+        }
+
+        let bazURL = SourceControlURL("https://example.com/baz")
+        let bazPackageReference = PackageReference(
+            identity: PackageIdentity(url: bazURL),
+            kind: .remoteSourceControl(bazURL)
+        )
+        let bazContainer = MockPackageContainer(
+            package: bazPackageReference,
+            dependencies: ["1.0.0": []],
+            fileSystem: customFS,
+            customRetrievalPath: .root
+        )
+
+        let fooPath = sandbox.appending("Foo")
+        let fooPackageReference = PackageReference(identity: PackageIdentity(path: fooPath), kind: .root(fooPath))
+        let fooContainer = MockPackageContainer(package: fooPackageReference)
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [
+                        MockTarget(name: "Foo", dependencies: [.product(name: "Baz", package: "baz")]),
+                    ],
+                    products: [
+                        MockProduct(name: "Foo", modules: ["Foo"]),
+                    ],
+                    dependencies: [
+                        .sourceControl(url: bazURL, requirement: .upToNextMajor(from: "1.0.0")),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Baz",
+                    url: bazURL.absoluteString,
+                    targets: [
+                        MockTarget(name: "Baz", dependencies: ["Qux"]),
+                        MockTarget(name: "Qux"),
+                    ],
+                    products: [
+                        MockProduct(name: "Baz", modules: ["Baz"]),
+                    ],
+                    versions: ["1.0.0"]
+                ),
+            ],
+            customPackageContainerProvider: MockPackageContainerProvider(containers: [fooContainer, bazContainer])
+        )
+
+        // Remove the sources from the workspace's own file system, so that they are only reachable
+        // through the file system vended by the custom container. The mock workspace materializes the
+        // contents of every package it is given, but a package provided by a custom container is not
+        // expected to be present on the file system backing the workspace.
+        try fs.removeFileTree(sourcesDir)
+
+        let deps: [MockDependency] = [
+            .sourceControl(url: bazURL, requirement: .exact("1.0.0")),
+        ]
+        try await workspace.checkPackageGraph(roots: ["Foo"], deps: deps) { graph, diagnostics in
+            PackageGraphTesterXCTest(graph) { result in
+                result.check(roots: "Foo")
+                result.check(packages: "Baz", "Foo")
+                result.check(modules: "Baz", "Foo", "Qux")
+                result.checkTarget("Foo") { result in result.check(dependencies: "Baz") }
+                result.checkTarget("Baz") { result in result.check(dependencies: "Qux") }
+            }
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "baz", at: .custom(Version(1, 0, 0), .root))
+        }
+    }
+
     func testRegistryMissingConfigurationErrors() async throws {
         let sandbox = AbsolutePath("/tmp/ws/")
         let fs = InMemoryFileSystem()


### PR DESCRIPTION
### Motivation

`ModulesGraph.load` is given a file system alongside every external manifest, because a package provided by a custom package container may be backed by its own file system rather than the one backing the rest of the graph.

That file system was used to load such a package's manifest, but not to construct its modules — `PackageBuilder` was always handed the graph-wide file system. As a result the sources of a package vended by a custom container could not be found, and loading the graph failed with:

```
Source files for target <name> should be located under 'Sources/<name>', or a custom sources path can be set with the 'path' property in Package.swift
```

### Modifications

Pass the file system associated with each manifest to `PackageBuilder` instead of the graph-wide one:

```swift
let packageFileSystem = manifestMap[node.identity]?.fs ?? fileSystem
```

Root packages, and packages that do not provide a file system of their own, are unaffected — they are mapped to the graph-wide file system, so they resolve to exactly the same object as before. Only packages vended by a custom container change behavior.

### Result

The modules of a package provided by a custom package container are built against the file system that container vends, so its sources are found.

### Tests

Added `testCustomPackageContainerProviderWithMultipleTargets`, modeled on the existing `testCustomPackageContainerProvider`. Without the fix it fails with the error above; with the fix it passes, as does the pre-existing test.

The existing coverage could not catch this: a package with a single target may claim the whole predefined sources directory, so that target is resolved without ever having to be located. The new test therefore uses two targets, which forces each to be located individually, and keeps the package's sources solely in the file system vended by the container.
