### PR TITLE
Always explicitly specify -fmodule-name for test targets

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -141,6 +141,16 @@ extension PackagePIFProjectBuilder {
         if mainModule.type == .test {
             settings[.BUILD_SERVER_PROTOCOL_TARGET_TAGS, default: ["$(inherited)"]].append("test")
 
+            // A C-language test target does not necessarily define a clang module. However, BSP clients
+            // may infer a module name based on -fmodule-name to disambiguate tests, so always pass the
+            // flag.
+            settings[.OTHER_CFLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                $0.append("-fmodule-name=$(PRODUCT_MODULE_NAME)")
+            }
+            settings[.OTHER_CPLUSPLUSFLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                $0.append("-fmodule-name=$(PRODUCT_MODULE_NAME)")
+            }
+
             // FIXME: we shouldn't always include both the deep and shallow bundle paths here, but for that we'll need rdar://31867023
             if pifBuilder.addLocalRpaths != .never {
                 settings[.LD_RUNPATH_SEARCH_PATHS] = [

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -1026,6 +1026,56 @@ struct PIFBuilderTests {
         #expect(ldFlags.contains("-L") && ldFlags.contains("/Vendor"))
     }
 
+    @Test(.skipHostOS(.linux, "linux does not support C-family test targets"), arguments: BuildConfiguration.allCases)
+    func testProductsPassModuleNameToClang(configuration: BuildConfiguration) async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Tests/CLibTests/CLibTests.c",
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                .createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v6_2,
+                    targets: [
+                        TargetDescription(name: "CLibTests", dependencies: [], type: .test, settings: [.init(tool: .c, kind: .unsafeFlags(["-DFOO=1"]))]),
+                    ]
+                ),
+            ],
+            shouldCreateMultipleTestProducts: true,
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        let project = try pif.workspace.project(named: "Root")
+
+        let settings = try project.target(named: "CLibTests-product")
+            .buildConfig(named: configuration)
+            .settings
+
+        #expect(settings[.OTHER_CFLAGS]?.contains("-fmodule-name=$(PRODUCT_MODULE_NAME)") == true)
+        #expect(settings[.OTHER_CFLAGS]?.contains("-DFOO=1") == true)
+        #expect(settings[.OTHER_CPLUSPLUSFLAGS]?.contains("-fmodule-name=$(PRODUCT_MODULE_NAME)") == true)
+    }
+
     @Test(arguments: BuildConfiguration.allCases)
     func productTargetsReportProductNameAsBSPDisplayName(configuration: BuildConfiguration) async throws {
         let observability = ObservabilitySystem.makeForTesting()


### PR DESCRIPTION
C-family test targets have not historically defined a module when they don't have a consumer (although mixed source targets would change this in some cases). However, tools like SourceKit-LSP currently rely on -fmodule-name to construct test identifiers internally. Always pass the flag explicitly so compiler args vended by the BSP expose this information.