### PR TITLE
Do not include com.apple.application-identifier entitlement when using swiftbuild backend

### DIFF
--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -166,38 +166,11 @@ package final class SwiftBuildSystemPlanningOperationDelegate: SWBPlanningOperat
         }
 
         if identity == "-" {
-            let getTaskAllowEntitlementKey: String
-            let applicationIdentifierEntitlementKey: String
-
-            if provisioningSourceData.sdkRoot.contains("macos") || provisioningSourceData.sdkRoot
-                .contains("simulator")
-            {
-                getTaskAllowEntitlementKey = "com.apple.security.get-task-allow"
-                applicationIdentifierEntitlementKey = "com.apple.application-identifier"
-            } else {
-                getTaskAllowEntitlementKey = "get-task-allow"
-                applicationIdentifierEntitlementKey = "application-identifier"
-            }
-
-            let signedEntitlements = provisioningSourceData
-                .entitlementsDestination == "Signature" ? provisioningSourceData.productTypeEntitlements.merging(
-                    [applicationIdentifierEntitlementKey: .plString(provisioningSourceData.bundleIdentifier)],
-                    uniquingKeysWith: { _, new in new }
-                ).merging(provisioningSourceData.projectEntitlements ?? [:], uniquingKeysWith: { _, new in new })
-                : [:]
-
-            let simulatedEntitlements = provisioningSourceData.entitlementsDestination == "__entitlements"
-                ? provisioningSourceData.productTypeEntitlements.merging(
-                    ["application-identifier": .plString(provisioningSourceData.bundleIdentifier)],
-                    uniquingKeysWith: { _, new in new }
-                ).merging(provisioningSourceData.projectEntitlements ?? [:], uniquingKeysWith: { _, new in new })
-                : [:]
-
-            var additionalEntitlements: [String: SWBPropertyListItem] = [:]
-
-            if shouldEnableDebuggingEntitlement {
-                additionalEntitlements[getTaskAllowEntitlementKey] = .plBool(true)
-            }
+            let (signedEntitlements, simulatedEntitlements) = Self.adHocSignedEntitlements(
+                sdkRoot: provisioningSourceData.sdkRoot,
+                entitlementsDestination: provisioningSourceData.entitlementsDestination,
+                shouldEnableDebuggingEntitlement: self.shouldEnableDebuggingEntitlement
+            )
 
             return SWBProvisioningTaskInputs(
                 identityHash: "-",
@@ -206,10 +179,7 @@ package final class SwiftBuildSystemPlanningOperationDelegate: SWBPlanningOperat
                 profileUUID: nil,
                 profilePath: nil,
                 designatedRequirements: nil,
-                signedEntitlements: signedEntitlements.merging(
-                    additionalEntitlements,
-                    uniquingKeysWith: { _, new in new }
-                ),
+                signedEntitlements: signedEntitlements,
                 simulatedEntitlements: simulatedEntitlements,
                 appIdentifierPrefix: nil,
                 teamIdentifierPrefix: nil,
@@ -230,6 +200,27 @@ package final class SwiftBuildSystemPlanningOperationDelegate: SWBPlanningOperat
                 ]
             )
         }
+    }
+
+    package static func adHocSignedEntitlements(
+        sdkRoot: String,
+        entitlementsDestination: String,
+        shouldEnableDebuggingEntitlement: Bool
+    ) -> (signed: [String: SWBPropertyListItem], simulated: [String: SWBPropertyListItem]) {
+        let getTaskAllowEntitlementKey = if sdkRoot.contains("macos") || sdkRoot.contains("simulator") {
+            "com.apple.security.get-task-allow"
+        } else {
+            "get-task-allow"
+        }
+
+        var entitlements: [String: SWBPropertyListItem] = [:]
+        if shouldEnableDebuggingEntitlement {
+            entitlements[getTaskAllowEntitlementKey] = .plBool(true)
+        }
+
+        let signed = entitlementsDestination == "Signature" ? entitlements : [:]
+        let simulated = entitlementsDestination == "__entitlements" ? entitlements : [:]
+        return (signed, simulated)
     }
 
     public func executeExternalTool(

--- a/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
+++ b/Tests/SwiftBuildSupportTests/SwiftBuildSystemTests.swift
@@ -872,4 +872,66 @@ struct SwiftBuildSystemTests {
             #expect(runDestination.sdk == sdkRoot.pathString)
         }
     }
+
+    @Suite
+    struct AdHocEntitlementsTests {
+        private static let getTaskAllowKey = "com.apple.security.get-task-allow"
+        private static let applicationIdentifierKeys = [
+            "com.apple.application-identifier",
+            "application-identifier",
+        ]
+
+        @Test
+        func macOSSignatureAppliesOnlyGetTaskAllow() throws {
+            let (signed, simulated) = SwiftBuildSystemPlanningOperationDelegate.adHocSignedEntitlements(
+                sdkRoot: "macosx.sdk",
+                entitlementsDestination: "Signature",
+                shouldEnableDebuggingEntitlement: true
+            )
+
+            #expect(signed == [Self.getTaskAllowKey: .plBool(true)])
+            #expect(simulated.isEmpty)
+            for key in Self.applicationIdentifierKeys {
+                #expect(signed[key] == nil, "ad-hoc signature must not inject \(key)")
+            }
+        }
+
+        @Test
+        func macOSWithoutDebuggingEntitlementSignsNothing() throws {
+            let (signed, simulated) = SwiftBuildSystemPlanningOperationDelegate.adHocSignedEntitlements(
+                sdkRoot: "macosx.sdk",
+                entitlementsDestination: "Signature",
+                shouldEnableDebuggingEntitlement: false
+            )
+
+            #expect(signed.isEmpty)
+            #expect(simulated.isEmpty)
+        }
+
+        @Test
+        func simulatorAppliesGetTaskAllowToSimulatedEntitlements() throws {
+            let (signed, simulated) = SwiftBuildSystemPlanningOperationDelegate.adHocSignedEntitlements(
+                sdkRoot: "iphonesimulator.sdk",
+                entitlementsDestination: "__entitlements",
+                shouldEnableDebuggingEntitlement: true
+            )
+
+            #expect(signed.isEmpty)
+            #expect(simulated == [Self.getTaskAllowKey: .plBool(true)])
+            for key in Self.applicationIdentifierKeys {
+                #expect(simulated[key] == nil, "ad-hoc simulated entitlements must not inject \(key)")
+            }
+        }
+
+        @Test
+        func nonDarwinUsesUnprefixedGetTaskAllowKey() throws {
+            let (signed, _) = SwiftBuildSystemPlanningOperationDelegate.adHocSignedEntitlements(
+                sdkRoot: "linux",
+                entitlementsDestination: "Signature",
+                shouldEnableDebuggingEntitlement: true
+            )
+
+            #expect(signed == ["get-task-allow": .plBool(true)])
+        }
+    }
 }


### PR DESCRIPTION
Do not include com.apple.application-identifier entitlement when using swiftbuild backend

### Motivation:

Both the native and swiftbuild backends inject get-task-allow, however swiftbuild also added a malformed com.apple.application-identifier causing a regression security validation to fail for ad-hoc signatures.

### Modifications:

Remove the com.apple.application-identifier entitlement from swiftbuild, align with native behaviour.

