### PR TITLE
fix(checksum): support artifact bundle index files

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageComputeChecksum.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageComputeChecksum.md
@@ -6,6 +6,9 @@
 
 Compute the checksum for a binary artifact.
 
+The command accepts archive formats supported by SwiftPM and artifact bundle index files with the
+`.artifactbundleindex` extension. It computes the checksum over the exact contents of the file.
+
 ```
 package compute-checksum [--package-path=<package-path>]
   [--cache-path=<cache-path>] [--config-path=<config-path>]
@@ -294,4 +297,3 @@ By default, color diagnostics are enabled when connected to a TTY and disabled o
 - term **--help**:
 
 *Show help information.*
-

--- a/Sources/Workspace/Workspace+BinaryArtifacts.swift
+++ b/Sources/Workspace/Workspace+BinaryArtifacts.swift
@@ -44,6 +44,8 @@ extension Workspace {
     public struct BinaryArtifactsManager: Cancellable {
         public typealias Delegate = BinaryArtifactsManagerDelegate
 
+        private static let checksumOnlyFileExtensions: Set<String> = ["artifactbundleindex"]
+
         private let fileSystem: FileSystem
         private let authorizationProvider: AuthorizationProvider?
         private let hostToolchain: UserToolchain
@@ -579,9 +581,15 @@ extension Workspace {
             fileSystem: any FileSystem
         ) throws -> String {
             let archiver = archiver ?? UniversalArchiver(fileSystem)
-            // Validate the path has a supported extension.
-            guard let lastPathComponent = path.components.last, archiver.isFileSupported(lastPathComponent) else {
-                let supportedExtensionList = archiver.supportedExtensions.joined(separator: ", ")
+            // Validate that the path is either an archive or another supported binary artifact file.
+            guard let lastPathComponent = path.components.last,
+                  archiver.isFileSupported(lastPathComponent)
+                  || path.extension.map(Self.checksumOnlyFileExtensions.contains) == true
+            else {
+                let supportedExtensionList = archiver.supportedExtensions
+                    .union(Self.checksumOnlyFileExtensions)
+                    .sorted()
+                    .joined(separator: ", ")
                 throw StringError("unexpected file type; supported extensions are: \(supportedExtensionList)")
             }
 

--- a/Tests/IntegrationTests/SwiftPMTests.swift
+++ b/Tests/IntegrationTests/SwiftPMTests.swift
@@ -79,6 +79,24 @@ private struct SwiftPMTests {
         }
     }
 
+    @Test
+    func packageComputeChecksumArtifactBundleIndex() async throws {
+        try await withTemporaryDirectory { temporaryDirectory in
+            let indexPath = temporaryDirectory.appending(component: "test.artifactbundleindex")
+            try localFileSystem.writeFileContents(indexPath, string: "{}")
+
+            let output = try await executeSwiftPackage(
+                temporaryDirectory,
+                extraArgs: ["compute-checksum", indexPath.pathString],
+                buildSystem: .native
+            )
+            #expect(
+                output.stdout.spm_chomp()
+                    == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+            )
+        }
+    }
+
     @Test(
         .tags(
             Tag.Feature.Command.Package.Init,

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -8500,6 +8500,19 @@ final class WorkspaceTests: XCTestCase {
             XCTAssertEqual(checksum, "ccbbaa")
         }
 
+        // Checks an artifact bundle index.
+        do {
+            let indexPath = sandbox.appending("binary.artifactbundleindex")
+            try fs.writeFileContents(indexPath, bytes: ByteString([0x11, 0x22, 0x33]))
+
+            let checksum = try binaryArtifactsManager.checksum(forBinaryArtifactAt: indexPath)
+            XCTAssertEqual(
+                checksumAlgorithm.hashes.map(\.contents),
+                [[0xAA, 0xBB, 0xCC], [0x11, 0x22, 0x33]]
+            )
+            XCTAssertEqual(checksum, "332211")
+        }
+
         // Checks an unsupported extension.
         do {
             let unknownPath = sandbox.appending("unknown")
@@ -8513,6 +8526,7 @@ final class WorkspaceTests: XCTestCase {
                 }
                 // What the file types are is platform specific
                 XCTAssert(stringError.description.hasPrefix("unexpected file type"))
+                XCTAssert(stringError.description.contains("artifactbundleindex"))
             }
         }
 


### PR DESCRIPTION
Fixes: #9219

## Summary

Allow `swift package compute-checksum` to compute checksums for `.artifactbundleindex` files.

SwiftPM already accepts artifact bundle index URLs for remote binary targets and validates downloaded indices using the checksum of their exact bytes. However, the command used to produce that checksum only accepted extractable archive formats.

## Changes

- Recognize `.artifactbundleindex` as a checksum-only binary artifact format.
- Keep artifact bundle indices separate from archive extraction support.
- Include `.artifactbundleindex` in unsupported-file-type diagnostics.
- Sort the supported-extension list for deterministic diagnostics.
- Add unit coverage verifying that the exact index bytes are hashed.
- Add command-level regression coverage for `swift package compute-checksum`.
- Document supported index files and exact-byte checksum semantics.

## Alternatives considered

Adding `.artifactbundleindex` to `UniversalArchiver` was rejected because artifact bundle indices are JSON files and cannot be extracted.

Special-casing the extension directly in the command was also considered. Keeping the behavior in the shared binary-artifact checksum helper avoids duplicating checksum logic and keeps the helper aligned with all supported binary artifact files.

## Notes

The index contents are hashed exactly as written. SwiftPM does not parse, normalize, or re-encode the JSON before computing the checksum.

Archive validation and extraction behavior remain unchanged.

## Testing

- `swift test --skip-build --filter 'WorkspaceTests.testArtifactChecksum|SwiftPMTests.packageComputeChecksumArtifactBundleIndex'`
- SwiftFormat lint on all changed Swift ranges
- Generated the `PackageManagerDocs` documentation successfully with DocC
- `git diff --check`