### PR TITLE
swift package experimental-build-server should tolerate dependency resolution errors

### DIFF
--- a/Sources/Commands/PackageCommands/BuildServer.swift
+++ b/Sources/Commands/PackageCommands/BuildServer.swift
@@ -51,7 +51,12 @@ struct BuildServer: AsyncSwiftCommand {
             sendMirrorFile: nil
         )
 
-        let buildSystem = try await swiftCommandState.createBuildSystem(explicitBuildSystem: .swiftbuild)
+        let buildSystem = try await swiftCommandState.createBuildSystem(
+            explicitBuildSystem: .swiftbuild,
+            // Tolerate errors while loading the package graph, so we can still report things like sources
+            // for the root package.
+            packageGraphLoader: { try await swiftCommandState.loadPackageGraph(exitOnError: false) }
+        )
         guard let swiftBuildSystem = buildSystem as? SwiftBuildSystem else {
             throw ArgumentParser.ValidationError("Failed to initialize the '--build-system swiftbuild' backend; expected a 'SwiftBuildSystem' but got '\(buildSystem)'")
         }

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -863,11 +863,13 @@ public final class SwiftCommandState {
     /// - Parameters:
     ///   - explicitProduct: The product specified on the command line to a “swift run” or “swift build” command. This
     /// allows executables from dependencies to be run directly without having to hook them up to any particular target.
+    ///   - exitOnError: Whether loading errors should cause this method to throw a failure exit code. Defaults to `true`.
     @discardableResult
     package func loadPackageGraph(
         explicitProduct: String? = nil,
         enableAllTraits: Bool = false,
-        testEntryPointPath: AbsolutePath? = nil
+        testEntryPointPath: AbsolutePath? = nil,
+        exitOnError: Bool = true
     ) async throws -> ModulesGraph {
         do {
             let workspace = try getActiveWorkspace(enableAllTraits: enableAllTraits)
@@ -889,7 +891,7 @@ public final class SwiftCommandState {
 
             // Throw if there were errors when loading the graph.
             // The actual errors will be printed before exiting.
-            guard !packageGraphObservabilityScope.errorsReported else {
+            guard !exitOnError || !packageGraphObservabilityScope.errorsReported else {
                 throw ExitCode.failure
             }
             return graph

--- a/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
+++ b/Tests/SwiftPMBuildServerTests/BuildServerTests.swift
@@ -139,6 +139,52 @@ struct SwiftPMBuildServerTests {
     }
 
     @Test
+    func sourcesItemsWithUnresolvedDependency() async throws {
+        try await testWithTemporaryDirectory { tmpDir in
+            let packagePath = tmpDir.appending("MyPackage")
+            try localFileSystem.createDirectory(packagePath.appending(components: "Sources", "MyLib"), recursive: true)
+            try localFileSystem.writeFileContents(
+                packagePath.appending("Package.swift"),
+                string: """
+                    // swift-tools-version: 6.0
+                    import PackageDescription
+                    let package = Package(
+                        name: "MyPackage",
+                        dependencies: [
+                            .package(url: "https://github.com/swiftlang/swift-testing.git", branch: "main"),
+                        ],
+                        targets: [
+                            .target(
+                                name: "MyLib",
+                                dependencies: [.product(name: "Testing", package: "swift-testing")]
+                            ),
+                        ]
+                    )
+                    """
+            )
+            try localFileSystem.writeFileContents(
+                packagePath.appending(components: "Sources", "MyLib", "MyLib.swift"),
+                string: "public func foo() {}\n"
+            )
+
+            try await withSwiftPMBSP(packagePath: packagePath, extraBSPArgs: ["--force-resolved-versions"]) {
+                connection,
+                _ in
+                let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())
+                guard let myLib = targetResponse.targets.first(where: { $0.displayName == "MyLib" }) else {
+                    return
+                }
+                // Even though the dependencies failed to resolve, we should still be able to list sources.
+                let sourcesResponse = try await connection.send(BuildTargetSourcesRequest(targets: [myLib.id]))
+                #expect(sourcesResponse.items.flatMap(\.sources).compactMap { $0.uri.fileURL?.lastPathComponent } == ["MyLib.swift"])
+            }
+
+            // Ensure we actually skipped dependency resolution.
+            #expect(!localFileSystem.exists(packagePath.appending("Package.resolved")))
+        }
+    }
+
+    @Test
     func compilerArgsBasics() async throws {
         try await withSwiftPMBSP(fixtureName: "Miscellaneous/Simple") { connection, _, _ in
             let targetResponse = try await connection.send(WorkspaceBuildTargetsRequest())


### PR DESCRIPTION
Where reasonably possible, the build server should recover from errors and provide as much semantic functionality as possible. Ignore package graph loading failures when constructing a build system so we can continue to list targets, sources, etc. in the root package