### PR TITLE
Filter additional warning control flags from remote dependencies to avoid conflicting flag errors during build

### DIFF
--- a/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/downstream/Package.swift
+++ b/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/downstream/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "downstream",
+    dependencies: [
+        .package(url: "../upstream", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "Downstream",
+            dependencies: [
+                .product(name: "CUpstream", package: "upstream"),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/downstream/Sources/Downstream/Downstream.swift
+++ b/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/downstream/Sources/Downstream/Downstream.swift
@@ -1,0 +1,5 @@
+import CUpstream
+
+public func value() -> Int32 {
+    cUpstreamValue()
+}

--- a/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/upstream/Package.swift
+++ b/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/upstream/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "upstream",
+    products: [
+        .library(name: "CUpstream", targets: ["CUpstream"]),
+    ],
+    targets: [
+        .target(
+            name: "CUpstream",
+            // Declare the SE-0480 warning-control settings for the C compiler in the
+            // manifest. `treatAllWarnings` lowers to `-Werror` and `treatWarning`
+            // lowers to `-Werror=<name>` in OTHER_CFLAGS.
+            cSettings: [
+                .treatAllWarnings(as: .error),
+                .treatWarning("return-type", as: .error),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/upstream/Sources/CUpstream/CUpstream.c
+++ b/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/upstream/Sources/CUpstream/CUpstream.c
@@ -1,0 +1,9 @@
+#include "CUpstream.h"
+
+int cUpstreamValue(void) {
+    // Intentionally omit the `return` statement. This emits -Wreturn-type
+    // ("control reaches end of non-void function"), which is enabled by default.
+    // The manifest promotes it to an error via treatAllWarnings/treatWarning when
+    // this package is the root, but the setting is stripped (and warnings
+    // suppressed) when the package is consumed as a remote dependency.
+}

--- a/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/upstream/Sources/CUpstream/include/CUpstream.h
+++ b/Fixtures/Miscellaneous/CWarningControlFlagsInManifest/upstream/Sources/CUpstream/include/CUpstream.h
@@ -1,0 +1,6 @@
+#ifndef CUPSTREAM_H
+#define CUPSTREAM_H
+
+int cUpstreamValue(void);
+
+#endif

--- a/Fixtures/Miscellaneous/WarningControlFlagsInManifest/downstream/Package.swift
+++ b/Fixtures/Miscellaneous/WarningControlFlagsInManifest/downstream/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "downstream",
+    dependencies: [
+        .package(url: "../upstream", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "Downstream",
+            dependencies: [
+                .product(name: "Upstream", package: "upstream"),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/WarningControlFlagsInManifest/downstream/Sources/Downstream/Downstream.swift
+++ b/Fixtures/Miscellaneous/WarningControlFlagsInManifest/downstream/Sources/Downstream/Downstream.swift
@@ -1,0 +1,5 @@
+import Upstream
+
+public func greet() -> String {
+    Upstream.NewAPI()
+}

--- a/Fixtures/Miscellaneous/WarningControlFlagsInManifest/upstream/Package.swift
+++ b/Fixtures/Miscellaneous/WarningControlFlagsInManifest/upstream/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "upstream",
+    products: [
+        .library(name: "Upstream", targets: ["Upstream"]),
+    ],
+    targets: [
+        .target(
+            name: "Upstream",
+            // Declare the SE-0480 warning-control settings in the manifest rather than
+            // passing them on the command line. `treatAllWarnings` lowers to
+            // `-warnings-as-errors` and `treatWarning` lowers to the two-token
+            // `-Werror <group>` form in OTHER_SWIFT_FLAGS.
+            swiftSettings: [
+                .treatAllWarnings(as: .error),
+                .treatWarning("DeprecatedDeclaration", as: .error),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/WarningControlFlagsInManifest/upstream/Sources/Upstream/Upstream.swift
+++ b/Fixtures/Miscellaneous/WarningControlFlagsInManifest/upstream/Sources/Upstream/Upstream.swift
@@ -1,0 +1,12 @@
+@available(*, deprecated, renamed: "NewAPI")
+public func deprecatedFunction() -> String {
+    "hello from upstream"
+}
+
+public func NewAPI() -> String {
+    // Calling the deprecated function emits a DeprecatedDeclaration warning within
+    // upstream itself. When upstream is built as the root package its manifest
+    // promotes that warning to an error; when it is consumed as a remote
+    // dependency the warning-control settings are stripped and warnings suppressed.
+    deprecatedFunction()
+}

--- a/Sources/SPMBuildCore/WarningControlFlags.swift
+++ b/Sources/SPMBuildCore/WarningControlFlags.swift
@@ -16,25 +16,18 @@ package enum WarningControlFlags {
     }
 
     package static func filterSwiftWarningControlFlags(_ args: [String]) -> [String] {
-        var filtered: [String] = []
-        var skipNextArg = false
+        self.filterSwiftWarningControlFlags(args, value: { $0 })
+    }
 
-        for arg in args {
-            if skipNextArg {
-                skipNextArg = false
-                continue
-            }
+    package static func filterSwiftWarningControlFlags<Element>(
+        _ args: [Element],
+        value: (Element) -> String
+    ) -> [Element] {
+        self.splitSwiftWarningControlFlags(args, value: value).other
+    }
 
-            switch arg {
-            case "-warnings-as-errors", "-no-warnings-as-errors":
-                break
-            case "-Wwarning", "-Werror":
-                skipNextArg = true
-            default:
-                filtered.append(arg)
-            }
-        }
-        return filtered
+    package static func extractSwiftWarningControlFlags(_ args: [String]) -> [String] {
+        self.splitSwiftWarningControlFlags(args, value: { $0 }).warningControl
     }
 
     package static func filterClangWarningControlFlags(_ args: [String]) -> [String] {
@@ -48,5 +41,33 @@ package enum WarningControlFlags {
             // -Wno-error=xxxx
             arg.count <= 2 || !arg.starts(with: "-W")
         }
+    }
+
+    package static func splitSwiftWarningControlFlags<Element>(
+        _ args: [Element],
+        value: (Element) -> String
+    ) -> (warningControl: [Element], other: [Element]) {
+        var warningControl: [Element] = []
+        var other: [Element] = []
+        var captureNextArg = false
+
+        for arg in args {
+            if captureNextArg {
+                captureNextArg = false
+                warningControl.append(arg)
+                continue
+            }
+
+            switch value(arg) {
+            case "-warnings-as-errors", "-no-warnings-as-errors":
+                warningControl.append(arg)
+            case "-Wwarning", "-Werror":
+                warningControl.append(arg)
+                captureNextArg = true
+            default:
+                other.append(arg)
+            }
+        }
+        return (warningControl, other)
     }
 }

--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -250,7 +250,10 @@ public final class PIFBuilder {
     ) async throws -> [(ResolvedPackage, PackagePIFBuilder, any PackagePIFBuilder.BuildDelegate)] {
         let pluginScriptRunner = self.parameters.pluginScriptRunner
         let outputDir = self.parameters.pluginWorkingDirectory.appending("outputs")
-        let treatWarningsAsErrors = WarningControlFlags.containsWarningsAsErrors(buildParameters.flags.swiftCompilerFlags.map(\.value))
+        let warningControlFlags = WarningControlFlags.extractSwiftWarningControlFlags(
+            buildParameters.flags.swiftCompilerFlags.map(\.value)
+        )
+        let treatWarningsAsErrors = WarningControlFlags.containsWarningsAsErrors(warningControlFlags)
 
         let pluginsPerModule = graph.pluginsPerModule(
             satisfying: buildParameters.buildEnvironment // .buildEnvironment(for: .host)
@@ -474,7 +477,7 @@ public final class PIFBuilder {
                 addLocalRpaths: self.parameters.addLocalRpaths,
                 packageDisplayVersion: package.manifest.displayName,
                 pkgConfigDirectories: self.parameters.pkgConfigDirectories,
-                treatWarningsAsErrors: treatWarningsAsErrors,
+                warningControlFlags: warningControlFlags,
                 fileSystem: self.fileSystem,
                 observabilityScope: self.observabilityScope,
             )

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder.swift
@@ -207,8 +207,8 @@ public final class PackagePIFBuilder {
 
     let pkgConfigDirectories: [AbsolutePath]
 
-    /// True if the user passed -warnings-as-errors on the command line, false otherwise.
-    let treatWarningsAsErrors: Bool
+    /// The warning-control flags the user passed on the command line.
+    let warningControlFlags: [String]
 
     /// The file system to read from.
     let fileSystem: FileSystem
@@ -239,7 +239,7 @@ public final class PackagePIFBuilder {
         addLocalRpaths: AddLocalRpaths = .always,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
-        treatWarningsAsErrors: Bool = false,
+        warningControlFlags: [String] = [],
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
     ) {
@@ -256,7 +256,7 @@ public final class PackagePIFBuilder {
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
         self.addLocalRpaths = addLocalRpaths
-        self.treatWarningsAsErrors = treatWarningsAsErrors
+        self.warningControlFlags = warningControlFlags
     }
 
     public init(
@@ -271,7 +271,7 @@ public final class PackagePIFBuilder {
         addLocalRpaths: AddLocalRpaths = .always,
         packageDisplayVersion: String?,
         pkgConfigDirectories: [AbsolutePath],
-        treatWarningsAsErrors: Bool = false,
+        warningControlFlags: [String] = [],
         fileSystem: FileSystem,
         observabilityScope: ObservabilityScope,
     ) {
@@ -286,7 +286,7 @@ public final class PackagePIFBuilder {
         self.addLocalRpaths = addLocalRpaths
         self.packageDisplayVersion = packageDisplayVersion
         self.pkgConfigDirectories = pkgConfigDirectories
-        self.treatWarningsAsErrors = treatWarningsAsErrors
+        self.warningControlFlags = warningControlFlags
         self.fileSystem = fileSystem
         self.observabilityScope = observabilityScope
     }
@@ -629,8 +629,10 @@ public final class PackagePIFBuilder {
             if self.skipStaticAnalyzerForPackageDependencies {
                 settings[.SKIP_CLANG_STATIC_ANALYZER] = "YES"
             }
-        } else if self.treatWarningsAsErrors {
-            settings[.SWIFT_TREAT_WARNINGS_AS_ERRORS] = "YES"
+        } else if !self.warningControlFlags.isEmpty {
+            settings[.OTHER_SWIFT_FLAGS].lazilyInitializeAndMutate(initialValue: ["$(inherited)"]) {
+                $0.append(contentsOf: self.warningControlFlags)
+            }
         }
 
         settings[.SWIFT_ACTIVE_COMPILATION_CONDITIONS]

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1181,9 +1181,11 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         swiftCompilerFlags += buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
         // User arguments (from -Xcc) should follow generated arguments to allow user overrides
         swiftCompilerFlags += buildParameters.flags.cCompilerFlags.asSwiftcCCompilerFlags()
-        // We strip warning control flags (-warnings-as-errors) from the user supplied swift compiler flags.
-        // Per-package toggling of this flag is handled with  SWIFT_TREAT_WARNINGS_AS_ERRORS in the PIF.
-        swiftCompilerFlags = swiftCompilerFlags.filter { !WarningControlFlags.containsWarningsAsErrors([$0.value]) }
+        // We filter out the warning control flags from the user supplied swift compiler flags. If we don't, these global
+        // flags would be inherited by dependent targets, which are compiled with -suppress-warnings, and the
+        // driver rejects that combination (errors with "conflicting options '-Wwarning' and '-suppress-warnings'").
+        // Applying these flags to local targets is handled for individual packages in the PIF.
+        swiftCompilerFlags = WarningControlFlags.filterSwiftWarningControlFlags(swiftCompilerFlags, value: \.value)
         // TODO: Pass -Xcxx flags to swiftc (#6491)
         // Uncomment when downstream support arrives.
         // swiftCompilerFlags += buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()

--- a/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
+++ b/Sources/SwiftBuildSupport/SwiftBuildSystem.swift
@@ -1177,7 +1177,7 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
 
     private static func constructExtraToolFlagsSettingsOverrides(from buildParameters: BuildParameters, verbosityFlags: [String]) -> [String: String] {
         var settings: [String: String] = [:]
-        var swiftCompilerFlags = buildParameters.toolchain.extraFlags.swiftCompilerFlags + buildParameters.flags.swiftCompilerFlags
+        var swiftCompilerFlags = WarningControlFlags.filterSwiftWarningControlFlags(buildParameters.toolchain.extraFlags.swiftCompilerFlags + buildParameters.flags.swiftCompilerFlags, value: \.value)
         swiftCompilerFlags += buildParameters.toolchain.extraFlags.cCompilerFlags.asSwiftcCCompilerFlags()
         // User arguments (from -Xcc) should follow generated arguments to allow user overrides
         swiftCompilerFlags += buildParameters.flags.cCompilerFlags.asSwiftcCCompilerFlags()
@@ -1185,7 +1185,6 @@ public final class SwiftBuildSystem: SPMBuildCore.BuildSystem {
         // flags would be inherited by dependent targets, which are compiled with -suppress-warnings, and the
         // driver rejects that combination (errors with "conflicting options '-Wwarning' and '-suppress-warnings'").
         // Applying these flags to local targets is handled for individual packages in the PIF.
-        swiftCompilerFlags = WarningControlFlags.filterSwiftWarningControlFlags(swiftCompilerFlags, value: \.value)
         // TODO: Pass -Xcxx flags to swiftc (#6491)
         // Uncomment when downstream support arrives.
         // swiftCompilerFlags += buildParameters.toolchain.extraFlags.cxxCompilerFlags.rawFlags.asSwiftcCXXCompilerFlags()

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1530,6 +1530,34 @@ struct MiscellaneousTestCase {
         .tags(
             .Feature.Command.Build,
         ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10192", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func clangWarningControlFlagsPassedViaXccDoNotCorruptSwiftFlags(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/Simple") { path in
+            let (stdout, stderr) = try await executeSwiftBuild(
+                path,
+                Xcc: ["-Werror"],
+                buildSystem: buildSystem,
+            )
+            let buildOutput = try await getBinPath(
+                path,
+                Xcc: ["-Werror"],
+                buildSystem: buildSystem,
+            )
+            expectDirectoryExists(at: buildOutput)
+            let combined = stdout + stderr
+            #expect(!combined.contains("unknown argument"))
+            #expect(!combined.contains("-plugin-path"))
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
     func rootPackageWithConditionals(

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1332,16 +1332,14 @@ struct MiscellaneousTestCase {
             let downstreamPath = path.appending("downstream")
             let (stdout, stderr) = try await executeSwiftBuild(
                 downstreamPath,
-                Xswiftc: ["-warnings-as-errors"],
-                buildSystem: .swiftbuild,
+                Xswiftc: ["-warnings-as-errors", "-Wwarning", "DeprecatedDeclaration"],
+                buildSystem: buildSystem,
             )
             let combined = stdout + stderr
             print(combined)
             #expect(!combined.contains("conflicting options"))
             #expect(!combined.contains("'deprecatedFunction' is deprecated"))
         }
-    }
-
     }
 
     @Test(
@@ -1368,6 +1366,33 @@ struct MiscellaneousTestCase {
             ) { error in
                 #expect((error.stdout + error.stderr).contains("'greet()' is deprecated:"))
             }
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10192", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func warningGroupFlagsStillApplyToLocalPackage(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/WarningsAsErrorsInLocalPackage") { path in
+            let upstreamPath = path.appending("upstream")
+            initGitRepo(upstreamPath, tag: "1.0.0")
+
+            let downstreamPath = path.appending("downstream")
+            let (stdout, stderr) = try await executeSwiftBuild(
+                downstreamPath,
+                Xswiftc: ["-warnings-as-errors", "-Wwarning", "DeprecatedDeclaration"],
+                buildSystem: buildSystem,
+            )
+            let combined = stdout + stderr
+            print(combined)
+            #expect(!combined.contains("error: 'greet()' is deprecated:"))
+            #expect(combined.contains("'greet()' is deprecated:"))
         }
     }
 
@@ -1426,6 +1451,7 @@ struct MiscellaneousTestCase {
             ProcessInfo.isHostAmazonLinux2() // libFuzzer link issues occur on AL2
         }
     }
+}
 
 @Suite
 struct MiscellaneousSwiftTestingTests {

--- a/Tests/FunctionalTests/MiscellaneousTests.swift
+++ b/Tests/FunctionalTests/MiscellaneousTests.swift
@@ -1332,13 +1332,44 @@ struct MiscellaneousTestCase {
             let downstreamPath = path.appending("downstream")
             let (stdout, stderr) = try await executeSwiftBuild(
                 downstreamPath,
-                Xswiftc: ["-warnings-as-errors", "-Wwarning", "DeprecatedDeclaration"],
+                Xswiftc: ["-warnings-as-errors"],
                 buildSystem: buildSystem,
             )
             let combined = stdout + stderr
-            print(combined)
             #expect(!combined.contains("conflicting options"))
             #expect(!combined.contains("'deprecatedFunction' is deprecated"))
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10192", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func warningGroupFlagsDoNotReachRemoteDependencies(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/WarningsAsErrorsWithRemoteDep") { path in
+            let upstreamPath = path.appending("upstream")
+            initGitRepo(upstreamPath, tag: "1.0.0")
+
+            let downstreamPath = path.appending("downstream")
+            let (stdout, stderr) = try await executeSwiftBuild(
+                downstreamPath,
+                Xswiftc: ["-Werror", "DeprecatedDeclaration"],
+                buildSystem: buildSystem,
+            )
+            let buildOutput = try await getBinPath(
+                downstreamPath,
+                Xswiftc: ["-Werror", "DeprecatedDeclaration"],
+                buildSystem: buildSystem,
+            )
+            expectDirectoryExists(at: buildOutput)
+            let combined = stdout + stderr
+            #expect(!combined.contains("conflicting options"))
+            #expect(!combined.contains("'deprecatedFunction()' is deprecated"))
         }
     }
 
@@ -1393,6 +1424,105 @@ struct MiscellaneousTestCase {
             print(combined)
             #expect(!combined.contains("error: 'greet()' is deprecated:"))
             #expect(combined.contains("'greet()' is deprecated:"))
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10192", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func manifestWarningControlFlagsDoNotReachRemoteDependencies(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/WarningControlFlagsInManifest") { path in
+            let upstreamPath = path.appending("upstream")
+            initGitRepo(upstreamPath, tag: "1.0.0")
+
+            let downstreamPath = path.appending("downstream")
+            let (stdout, stderr) = try await executeSwiftBuild(
+                downstreamPath,
+                buildSystem: buildSystem,
+            )
+            let combined = stdout + stderr
+            #expect(!combined.contains("conflicting options"))
+            #expect(!combined.contains("'deprecatedFunction()' is deprecated"))
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10192", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func manifestWarningControlFlagsStillApplyToLocalPackage(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/WarningControlFlagsInManifest") { path in
+            let upstreamPath = path.appending("upstream")
+            await expectThrowsCommandExecutionError(
+                try await executeSwiftBuild(
+                    upstreamPath,
+                    buildSystem: buildSystem,
+                )
+            ) { error in
+                #expect((error.stdout + error.stderr).contains("'deprecatedFunction()' is deprecated:"))
+            }
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10192", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func manifestClangWarningControlFlagsDoNotReachRemoteDependencies(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/CWarningControlFlagsInManifest") { path in
+            let upstreamPath = path.appending("upstream")
+            initGitRepo(upstreamPath, tag: "1.0.0")
+
+            let downstreamPath = path.appending("downstream")
+            let (stdout, stderr) = try await executeSwiftBuild(
+                downstreamPath,
+                buildSystem: buildSystem,
+            )
+            let buildOutput = try await getBinPath(
+                downstreamPath,
+                buildSystem: buildSystem,
+            )
+            expectDirectoryExists(at: buildOutput)
+            #expect(!(stdout + stderr).contains("non-void function"))
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Build,
+        ),
+        .issue("https://github.com/swiftlang/swift-package-manager/issues/10192", relationship: .verifies),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func manifestClangWarningControlFlagsStillApplyToLocalPackage(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Miscellaneous/CWarningControlFlagsInManifest") { path in
+            let upstreamPath = path.appending("upstream")
+            await expectThrowsCommandExecutionError(
+                try await executeSwiftBuild(
+                    upstreamPath,
+                    buildSystem: buildSystem,
+                )
+            ) { error in
+                #expect((error.stdout + error.stderr).contains("non-void function"))
+            }
         }
     }
 


### PR DESCRIPTION
Filter additional warning control flags from remote dependencies to avoid conflicting flag errors during build

### Motivation:

Additional warning control flags were identified in the following issue:
https://github.com/swiftlang/swift-package-manager/issues/10192

### Modifications:

Filters additional warning control flags

