### PR TITLE
Report the path of a file whose contents cannot be decoded

### DIFF
--- a/Sources/Basics/JSON+Extensions.swift
+++ b/Sources/Basics/JSON+Extensions.swift
@@ -64,7 +64,31 @@ extension JSONEncoder {
 extension JSONDecoder {
     public func decode<T: Decodable>(path: AbsolutePath, fileSystem: FileSystem, as kind: T.Type) throws -> T {
         let data: Data = try fileSystem.readFileContents(path)
-        return try self.decode(kind, from: data)
+        do {
+            return try self.decode(kind, from: data)
+        } catch {
+            // The underlying error describes what is wrong with the contents, but not where those
+            // contents came from, which is usually the more useful half of the diagnosis.
+            throw FileDecodingError(path: path, underlyingError: error)
+        }
+    }
+}
+
+/// An error describing why the contents of a file could not be decoded.
+public struct FileDecodingError: Error, CustomStringConvertible {
+    /// The path of the file whose contents could not be decoded.
+    public let path: AbsolutePath
+
+    /// The error encountered while decoding the contents of the file.
+    public let underlyingError: Error
+
+    public init(path: AbsolutePath, underlyingError: Error) {
+        self.path = path
+        self.underlyingError = underlyingError
+    }
+
+    public var description: String {
+        "could not decode contents of '\(self.path)': \(self.underlyingError.interpolationDescription)"
     }
 }
 

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -209,6 +209,7 @@ extension ModulesGraph {
             platformRegistry: customPlatformsRegistry ?? .default,
             platformVersionProvider: platformVersionProvider,
             fileSystem: fileSystem,
+            packageFileSystems: manifestMap.reduce(into: [:]) { $0[$1.key] = $1.value.fs },
             observabilityScope: observabilityScope,
             productsFilter: productsFilter,
             modulesFilter: modulesFilter
@@ -387,6 +388,8 @@ private func createResolvedPackages(
     platformRegistry: PlatformRegistry,
     platformVersionProvider: PlatformVersionProvider,
     fileSystem: FileSystem,
+    /// The file systems of the packages that provide one of their own, keyed by package identity.
+    packageFileSystems: [PackageIdentity: FileSystem],
     observabilityScope: ObservabilityScope,
     productsFilter: ((Product) -> Bool)?,
     modulesFilter: ((Module) -> Bool)?
@@ -637,10 +640,15 @@ private func createResolvedPackages(
         }
 
         // add registry metadata if available
-        if fileSystem.exists(package.path.appending(component: RegistryReleaseMetadataStorage.fileName)) {
+        //
+        // A package's own file system is the one that has to be consulted here: asking the graph-wide
+        // file system about a path belonging to a package that provides its own would describe some
+        // unrelated file, or none at all.
+        let packageFileSystem = packageFileSystems[package.identity] ?? fileSystem
+        if packageFileSystem.exists(package.path.appending(component: RegistryReleaseMetadataStorage.fileName)) {
             packageBuilder.registryMetadata = try RegistryReleaseMetadataStorage.load(
                 from: package.path.appending(component: RegistryReleaseMetadataStorage.fileName),
-                fileSystem: fileSystem
+                fileSystem: packageFileSystem
             )
         }
     }

--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -921,7 +921,16 @@ extension SwiftSDK {
                 decoder: decoder,
                 observabilityScope: observabilityScope
             )
-        } catch DecodingError.keyNotFound {
+        } catch let error as FileDecodingError {
+            // A missing key means the description predates the schema version it was looked up by, and
+            // so has to be decoded as a legacy one. Any other reason for not being able to decode it
+            // is a genuine failure to report.
+            guard let decodingError = error.underlyingError as? DecodingError,
+                  case .keyNotFound = decodingError
+            else {
+                throw error
+            }
+
             let version = try decoder.decode(path: path, fileSystem: fileSystem, as: VersionInfo.self)
             return try [SwiftSDK(legacy: version, fromFile: path, fileSystem: fileSystem, decoder: decoder)]
         }


### PR DESCRIPTION
### Motivation

A failure to decode the contents of a file described what was wrong with those contents, but not which file they came from — usually the more useful half of the diagnosis. An empty file, for instance, produced only:

```
dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 "Unexpected end of file")))
```

Loading a package graph reads a number of JSON files (the resolved packages store, workspace state, registry release metadata, and whatever a custom package container provides), so there was no way to tell which of them was meant.

While tracking such a failure down, I also found that the registry release metadata of a package is looked up in the graph-wide file system rather than in the package's own. For a package that provides its own file system, that describes some unrelated file, or none at all — the same mistake that #10367 fixed for the package's modules. With an empty file at that path, it surfaced as precisely the unhelpful decoding failure above.

### Modifications

- `JSONDecoder.decode(path:fileSystem:as:)` wraps decoding failures in a new `FileDecodingError`, which reports the path alongside the underlying error. Nothing catches the underlying `DecodingError`, so this only changes what is reported.
- `createResolvedPackages` takes the packages' file systems and consults a package's own file system when looking for its registry release metadata.

### Result

Decoding failures now name the file, e.g.:

```
could not decode contents of '/path/to/some.json': The given data was not valid JSON. ...
```

and a package's registry release metadata is looked for in the file system that actually holds that package.

### Tests

No behavioral change to cover: the first part only enriches an error that is already reported, and the second corrects which file system is consulted for a file that is absent in the cases exercised by the existing tests. Verified that the package builds and that the custom package container tests (`testCustomPackageContainerProvider`, `testCustomPackageContainerProviderWithMultipleTargets`) still pass.
