### PR TITLE
Set "Tool" eyebrow on PackageManagerDocs, PackageDescription, PackagePlugin

### DIFF
--- a/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
@@ -1,7 +1,8 @@
 # ``PackageManagerDocs``
 
 @Metadata {
-    @DisplayName("Swift Package Manager")
+    @DisplayName("Package Manager (SwiftPM)")
+    @TitleHeading("Tool")
 }
 
 Organize, manage, and edit Swift packages.

--- a/Sources/Runtimes/PackageDescription/PackageDescription.docc/PackageDescription.md
+++ b/Sources/Runtimes/PackageDescription/PackageDescription.docc/PackageDescription.md
@@ -1,5 +1,9 @@
 # ``PackageDescription``
 
+@Metadata {
+    @TitleHeading("Tool")
+}
+
 Create reusable code, organize it in a lightweight way, and share it across your projects and with other developers.
 
 Swift packages are reusable components of Swift, Objective-C, Objective-C++, C, or C++ code that developers can use in their projects. They bundle source files, binaries, and resources in a way that’s easy to use in your app’s project. 

--- a/Sources/Runtimes/PackagePlugin/Documentation.docc/Documentation.md
+++ b/Sources/Runtimes/PackagePlugin/Documentation.docc/Documentation.md
@@ -1,5 +1,9 @@
 # ``PackagePlugin``
 
+@Metadata {
+    @TitleHeading("Tool")
+}
+
 Create plugins that extend the Swift Package Manager.
 
 <!-- swift package --disable-sandbox preview-documentation --target PackagePlugin -->


### PR DESCRIPTION
## Summary
- Adds `@TitleHeading("Tool")` to the root pages of `PackageManagerDocs`, `PackageDescription`, and `PackagePlugin`, so each shows a "Tool" eyebrow above its title.
- Updates `PackageManagerDocs`'s `@DisplayName` from "Swift Package Manager" to "Package Manager (SwiftPM)" to match the label already used for this catalog in the combined Swift.org documentation's "Tools" navigation group.
- `PackageDescription` and `PackagePlugin` DisplayNames are left unchanged.