### PR TITLE
SE-NNNN: Introduce `swift package audit`

### DIFF
--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer-transitive/Package.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer-transitive/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:999.0
+import PackageDescription
+
+let package = Package(
+    name: "consumer-transitive",
+    dependencies: [
+        .package(path: "../consumer"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyTransitiveApp",
+            dependencies: [
+                .product(name: "MyLib", package: "consumer"),
+            ],
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer-transitive/Sources/MyTransitiveApp/main.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer-transitive/Sources/MyTransitiveApp/main.swift
@@ -1,0 +1,8 @@
+import MyLib
+
+@main
+struct MyTransitiveApp {
+    static func main() {
+        print("MyTransitiveApp using MyLib \(myLibExperimentalName())")
+    }
+}

--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Package.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Package.swift
@@ -3,6 +3,15 @@ import PackageDescription
 
 let package = Package(
     name: "consumer",
+    products: [
+        // Expose MyLib as a product so downstream packages (e.g.
+        // `consumer-transitive`) can depend on it and thereby transitively
+        // reach `PaperExperimental` from the producer.
+        .library(
+            name: "MyLib",
+            targets: ["MyLib"],
+        ),
+    ],
     dependencies: [
         .package(path: "../producer"),
     ],

--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Package.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:999.0
+import PackageDescription
+
+let package = Package(
+    name: "consumer",
+    dependencies: [
+        .package(path: "../producer"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyApp",
+            dependencies: [
+                .product(name: "PaperLegacy", package: "producer"),
+            ],
+        ),
+        .target(
+            name: "MyLib",
+            dependencies: [
+                .product(name: "PaperExperimental", package: "producer"),
+            ],
+            swiftSettings: [
+                .treatAllWarnings(as: .error),
+            ],
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Sources/MyApp/main.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Sources/MyApp/main.swift
@@ -1,0 +1,8 @@
+import PaperLegacy
+
+@main
+struct MyApp {
+    static func main() {
+        print("MyApp using PaperLegacy \(paperLegacyVersion())")
+    }
+}

--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Sources/MyLib/MyLib.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Sources/MyLib/MyLib.swift
@@ -1,0 +1,5 @@
+import PaperExperimental
+
+public func myLibExperimentalName() -> String {
+    return paperExperimentalName()
+}

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Package.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version:999.0
+import PackageDescription
+
+let package = Package(
+    name: "producer",
+    products: [
+        .library(
+            name: "Paper",
+            targets: ["Paper"],
+        ),
+        .library(
+            name: "PaperLegacy",
+            targets: ["PaperLegacy"],
+            deprecated: .unsupported(
+                message: "PaperLegacy is superseded by Paper.",
+                replacement: .renamed("Paper"),
+            ),
+        ),
+        .library(
+            name: "PaperExperimental",
+            targets: ["PaperExperimental"],
+            deprecated: .unsupported(
+                message: "PaperExperimental is going away with no replacement.",
+            ),
+        ),
+        .executable(
+            name: "paper-tool-old",
+            targets: ["paper-tool-old"],
+            deprecated: .unsupported(
+                message: "Migrate to the standalone paper-tools package.",
+                replacement: .renamed("paper-tool", package: "paper-tools"),
+            ),
+        ),
+    ],
+    targets: [
+        .target(name: "Paper"),
+        .target(name: "PaperLegacy", dependencies: ["Paper"]),
+        .target(name: "PaperExperimental"),
+        .executableTarget(name: "paper-tool-old"),
+    ]
+)

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/Paper/Paper.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/Paper/Paper.swift
@@ -1,0 +1,1 @@
+public func paperVersion() -> String { "1.0" }

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/PaperExperimental/PaperExperimental.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/PaperExperimental/PaperExperimental.swift
@@ -1,0 +1,1 @@
+public func paperExperimentalName() -> String { "experimental" }

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/PaperLegacy/PaperLegacy.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/PaperLegacy/PaperLegacy.swift
@@ -1,0 +1,2 @@
+import Paper
+public func paperLegacyVersion() -> String { paperVersion() }

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/paper-tool-old/main.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/paper-tool-old/main.swift
@@ -1,0 +1,6 @@
+@main
+struct PaperToolOld {
+    static func main() {
+        print("paper-tool-old")
+    }
+}

--- a/Sources/Commands/PackageCommands/Audit.swift
+++ b/Sources/Commands/PackageCommands/Audit.swift
@@ -1,0 +1,471 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Basics
+import CoreCommands
+import Foundation
+import PackageGraph
+import PackageModel
+
+struct Audit: AsyncSwiftCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "audit",
+        abstract: "Report deprecated products in the current package graph.",
+        helpNames: [.short, .long, .customLong("help", withSingleDash: true)]
+    )
+
+    @OptionGroup(visibility: .hidden)
+    var globalOptions: GlobalOptions
+
+    @Option(help: "Set the output format ('text' or 'json').")
+    var format: AuditFormat = .text
+
+    @Option(
+        name: .customLong("include-transitive"),
+        defaultAsFlag: IncludeTransitive.reachable,
+        help: ArgumentHelp(
+            "Report deprecated products reached only transitively (via a non-deprecated product's own dependencies).",
+            discussion: "Bare '--include-transitive' selects 'reachable'. Explicit values: 'reachable', 'all', 'non-reachable'.",
+        ),
+    )
+    var includeTransitiveMode: IncludeTransitive? = nil
+
+    @Flag(
+        name: .customLong("allow-deprecations"),
+        help: "Exit with status 0 even when deprecated products are found.",
+    )
+    var allowDeprecations: Bool = false
+
+    func run(_ swiftCommandState: SwiftCommandState) async throws {
+        // Audit produces its own structured deprecation report — suppress the
+        // graph-load-time deprecation warnings/errors so they don't duplicate
+        // (or, when a consumer target has `.treatAllWarnings(.error)`, prevent
+        // the load from completing at all). `exitOnError: false` is likewise
+        // required so a per-target escalation of another consumer's warning
+        // does not halt the load before this command can print its report.
+        let graph = try await swiftCommandState.loadPackageGraph(
+            explicitProduct: nil,
+            enableAllTraits: false,
+            testEntryPointPath: nil,
+            exitOnError: false,
+            emitProductDeprecationDiagnostics: false,
+        )
+        let report = buildAuditReport(
+            graph: graph,
+            includeTransitive: self.includeTransitiveMode ?? .off,
+        )
+
+        switch self.format {
+        case .text:
+            print(renderAuditReportAsText(report))
+        case .json:
+            let encoder = JSONEncoder()
+            encoder.outputFormatting.insert(.sortedKeys)
+            encoder.outputFormatting.insert(.prettyPrinted)
+            let data = try encoder.encode(report)
+            print(String(decoding: data, as: UTF8.self))
+        }
+
+        if report.hasViolations && !self.allowDeprecations {
+            throw ExitCode(1)
+        }
+    }
+
+    // MARK: - Model
+
+    enum AuditFormat: String, RawRepresentable, CustomStringConvertible, ExpressibleByArgument, CaseIterable {
+        case text, json
+
+        init?(rawValue: String) {
+            switch rawValue.lowercased() {
+            case "text":
+                self = .text
+            case "json":
+                self = .json
+            default:
+                return nil
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .text: return "text"
+            case .json: return "json"
+            }
+        }
+    }
+}
+
+// MARK: - `--include-transitive` mode
+
+/// Filter applied to the audit report.
+///
+/// * `.off` (default when the flag is absent) — only direct violations.
+/// * `.reachable` (bare `--include-transitive` or `=reachable`) — direct
+///   plus transitively reachable violations.
+/// * `.all` (`=all`) — direct + reachable + unreachable.
+/// * `.nonReachable` (`=non-reachable`) — unreachable only.
+enum IncludeTransitive: String, CaseIterable, ExpressibleByArgument {
+    case off
+    case reachable
+    case all
+    case nonReachable = "non-reachable"
+
+    // `.off` is an internal-only sentinel — it can never come in from the CLI.
+    static var allValueStrings: [String] {
+        Self.allCases.compactMap { $0 == .off ? nil : $0.rawValue }
+    }
+
+    init?(argument: String) {
+        guard argument != IncludeTransitive.off.rawValue else { return nil }
+        self.init(rawValue: argument)
+    }
+}
+
+// MARK: - Report model (internal so unit tests can construct + assert)
+
+struct AuditReport: Codable, Equatable {
+    struct Deprecated: Codable, Equatable {
+        var products: [DeprecatedProduct]
+    }
+
+    var deprecated: Deprecated
+}
+
+struct DeprecatedProduct: Codable, Equatable {
+    /// Classification of how (or whether) the deprecated product is reached
+    /// from any root-package target. Serialized as a string; matches the JSON
+    /// schema in the proposal.
+    enum Transitive: String, Codable {
+        case direct
+        case transitiveReachable
+        case transitiveUnreachable
+    }
+
+    var message: String?
+    var package: String
+    var product: String
+    var replacement: ProductDeprecation.Replacement?
+    var type: String
+    var usedBy: [String]
+    var transitive: Transitive
+    /// Sequence(s) of hops from a root-package target down to the deprecated
+    /// product. `nil` (omitted from JSON) for `.transitiveUnreachable` entries.
+    var breadcrumb: [[BreadcrumbHop]]?
+}
+
+/// A single step in a breadcrumb path. The first hop of a path always names a
+/// root-package target (`target` populated, `product` nil); every subsequent
+/// hop names a product-boundary crossing (`product` populated, `target` nil).
+struct BreadcrumbHop: Codable, Equatable {
+    var package: String
+    var target: String?
+    var product: String?
+
+    init(package: String, target: String? = nil, product: String? = nil) {
+        self.package = package
+        self.target = target
+        self.product = product
+    }
+}
+
+struct ProductKey: Hashable {
+    let package: String
+    let product: String
+}
+
+// MARK: - Pure report-building logic (internal for testability)
+
+/// Walks the resolved graph and produces an audit report of deprecated products.
+///
+/// - Parameters:
+///   - graph: The resolved package graph to inspect.
+///   - includeTransitive: Filter mode. See `IncludeTransitive` for semantics.
+/// - Returns: An `AuditReport` with products sorted by `(package, product)`
+///   for deterministic output.
+func buildAuditReport(
+    graph: ModulesGraph,
+    includeTransitive: IncludeTransitive,
+) -> AuditReport {
+    // 1. Enumerate every deprecated product in the resolved graph. We match
+    //    them by (packageIdentity, productName) since the same product name
+    //    in two different packages is distinct.
+    var deprecatedProducts: [ProductKey: ResolvedProduct] = [:]
+    for product in graph.allProducts {
+        guard product.underlying.deprecation != nil else { continue }
+        guard auditProductTypeString(product.type) != nil else { continue }
+        let key = ProductKey(
+            package: product.packageIdentity.description,
+            product: product.name,
+        )
+        deprecatedProducts[key] = product
+    }
+
+    // 2. BFS on the target-dependency graph starting from each root-package
+    //    target. Every `.product(...)` edge we traverse contributes a hop to
+    //    the current breadcrumb. When we cross into a deprecated product we
+    //    record the path (and stop — we don't recurse into the deprecated
+    //    product's own dependencies).
+    var reachedPaths: [ProductKey: [[BreadcrumbHop]]] = [:]
+    var reachedRootTargets: [ProductKey: Set<String>] = [:]
+
+    for rootPackage in graph.rootPackages {
+        for rootTarget in rootPackage.modules {
+            let rootHop = BreadcrumbHop(
+                package: rootPackage.identity.description,
+                target: rootTarget.name,
+            )
+            walkFromRootTarget(
+                rootTarget: rootTarget,
+                rootHop: rootHop,
+                rootTargetName: rootTarget.name,
+                deprecatedProducts: deprecatedProducts,
+                reachedPaths: &reachedPaths,
+                reachedRootTargets: &reachedRootTargets,
+            )
+        }
+    }
+
+    // 3. Assemble entries. Classify each product by whether it was reached
+    //    directly (any path of length 2 = root-target-hop +
+    //    deprecated-product-hop) or only transitively (all paths longer than
+    //    2). Products that were never reached are `.transitiveUnreachable`.
+    var entries: [DeprecatedProduct] = []
+    for (key, product) in deprecatedProducts {
+        guard let typeString = auditProductTypeString(product.type) else { continue }
+
+        let deprecation = product.underlying.deprecation
+        let rawPaths = reachedPaths[key] ?? []
+        let paths = deduplicateAndSortBreadcrumbPaths(rawPaths)
+        let usedBy = (reachedRootTargets[key] ?? []).sorted()
+
+        let transitive: DeprecatedProduct.Transitive
+        let breadcrumb: [[BreadcrumbHop]]?
+        if paths.isEmpty {
+            transitive = .transitiveUnreachable
+            breadcrumb = nil
+        } else {
+            transitive = paths.contains(where: { $0.count == 2 }) ? .direct : .transitiveReachable
+            breadcrumb = paths
+        }
+
+        // Apply the filter mode.
+        switch (includeTransitive, transitive) {
+        case (.off, .direct):
+            break
+        case (.off, _):
+            continue
+        case (.reachable, .transitiveUnreachable):
+            continue
+        case (.reachable, _):
+            break
+        case (.nonReachable, .transitiveUnreachable):
+            break
+        case (.nonReachable, _):
+            continue
+        case (.all, _):
+            break
+        }
+
+        entries.append(
+            DeprecatedProduct(
+                message: deprecation?.message,
+                package: key.package,
+                product: key.product,
+                replacement: deprecation?.replacement,
+                type: typeString,
+                usedBy: usedBy,
+                transitive: transitive,
+                breadcrumb: breadcrumb,
+            )
+        )
+    }
+
+    entries.sort { lhs, rhs in
+        if lhs.package != rhs.package {
+            return lhs.package < rhs.package
+        }
+        return lhs.product < rhs.product
+    }
+
+    return AuditReport(deprecated: .init(products: entries))
+}
+
+/// BFS from a single root-package target. Visited-set is on `(target,
+/// breadcrumb-length)` so we don't loop forever, but distinct paths to the
+/// same deprecated product are recorded separately.
+private func walkFromRootTarget(
+    rootTarget: ResolvedModule,
+    rootHop: BreadcrumbHop,
+    rootTargetName: String,
+    deprecatedProducts: [ProductKey: ResolvedProduct],
+    reachedPaths: inout [ProductKey: [[BreadcrumbHop]]],
+    reachedRootTargets: inout [ProductKey: Set<String>],
+) {
+    struct Frame {
+        let module: ResolvedModule
+        let breadcrumb: [BreadcrumbHop]
+    }
+    var queue: [Frame] = [Frame(module: rootTarget, breadcrumb: [rootHop])]
+    // Guard against traversal cycles within the target-dependency graph. A
+    // module can legitimately appear on multiple *distinct* paths (that's
+    // what produces multi-path breadcrumbs), so the visited key is the
+    // (module, breadcrumb-of-product-hops) pair — not just the module.
+    var visited: Set<String> = []
+    while !queue.isEmpty {
+        let frame = queue.removeFirst()
+        let productHopsKey = frame.breadcrumb.dropFirst()
+            .map { "\($0.package)/\($0.product ?? "")" }
+            .joined(separator: "→")
+        let visitKey = "\(frame.module.packageIdentity)/\(frame.module.name)|\(productHopsKey)"
+        if visited.contains(visitKey) { continue }
+        visited.insert(visitKey)
+
+        for dependency in frame.module.dependencies {
+            switch dependency {
+            case .module(let dependee, _):
+                // Same-package target dep: no hop added, just keep walking.
+                queue.append(Frame(module: dependee, breadcrumb: frame.breadcrumb))
+            case .product(let dependeeProduct, _):
+                let key = ProductKey(
+                    package: dependeeProduct.packageIdentity.description,
+                    product: dependeeProduct.name,
+                )
+                let productHop = BreadcrumbHop(
+                    package: dependeeProduct.packageIdentity.description,
+                    product: dependeeProduct.name,
+                )
+                let extendedBreadcrumb = frame.breadcrumb + [productHop]
+
+                if deprecatedProducts[key] != nil {
+                    // Reached a deprecated product — record the path and stop
+                    // descending. (Consumers don't care about deps *of* a
+                    // deprecated product for audit purposes.)
+                    reachedPaths[key, default: []].append(extendedBreadcrumb)
+                    reachedRootTargets[key, default: []].insert(rootTargetName)
+                } else {
+                    // Non-deprecated intermediate — enter each of the
+                    // product's constituent modules with the extended
+                    // breadcrumb.
+                    for member in dependeeProduct.modules {
+                        queue.append(Frame(module: member, breadcrumb: extendedBreadcrumb))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Order breadcrumb paths deterministically: element-wise by (target-or-product
+/// name) so that a stable sort emerges regardless of graph-walk order.
+private func compareBreadcrumbPaths(_ lhs: [BreadcrumbHop], _ rhs: [BreadcrumbHop]) -> Bool {
+    for (l, r) in zip(lhs, rhs) {
+        let lName = l.target ?? l.product ?? ""
+        let rName = r.target ?? r.product ?? ""
+        if lName != rName { return lName < rName }
+        if l.package != r.package { return l.package < r.package }
+    }
+    return lhs.count < rhs.count
+}
+
+/// The same product can be reached from a single root target via multiple
+/// same-package `.target(...)` chains that collapse to identical product-hop
+/// sequences. Those are indistinguishable in the audit's product-oriented
+/// breadcrumb, so we deduplicate here rather than surface duplicates.
+private func deduplicateAndSortBreadcrumbPaths(_ paths: [[BreadcrumbHop]]) -> [[BreadcrumbHop]] {
+    var seen: Set<String> = []
+    var unique: [[BreadcrumbHop]] = []
+    for path in paths {
+        let key = path
+            .map { "\($0.package)/\($0.target ?? "")|\($0.product ?? "")" }
+            .joined(separator: "→")
+        if seen.insert(key).inserted {
+            unique.append(path)
+        }
+    }
+    return unique.sorted(by: compareBreadcrumbPaths)
+}
+
+/// Renders an `AuditReport` as human-readable text, grouped into three
+/// possible sections by the `transitive` classification. Sections with no
+/// entries are omitted. Returns a fixed "No deprecated products found." line
+/// when the report is empty.
+func renderAuditReportAsText(_ report: AuditReport) -> String {
+    guard !report.deprecated.products.isEmpty else {
+        return "No deprecated products found."
+    }
+
+    var sectionsOutput: [String] = []
+    let sections: [(header: String, kind: DeprecatedProduct.Transitive)] = [
+        ("Directly consumed deprecated products:", .direct),
+        ("Transitively reachable deprecated products:", .transitiveReachable),
+        ("Transitively unreachable deprecated products:", .transitiveUnreachable),
+    ]
+    for section in sections {
+        let entries = report.deprecated.products.filter { $0.transitive == section.kind }
+        guard !entries.isEmpty else { continue }
+        sectionsOutput.append(renderSection(header: section.header, entries: entries))
+    }
+    return sectionsOutput.joined(separator: "\n\n")
+}
+
+/// Formats a single audit section: header line followed by per-package
+/// groupings, each with one indented block per deprecated product.
+private func renderSection(header: String, entries: [DeprecatedProduct]) -> String {
+    var lines: [String] = [header]
+    var currentPackage: String? = nil
+    for entry in entries {
+        if entry.package != currentPackage {
+            lines.append("  package '\(entry.package)':")
+            currentPackage = entry.package
+        }
+        lines.append("    \(entry.type) '\(entry.product)' is unsupported")
+        if let message = entry.message, !message.isEmpty {
+            lines.append("      \(message)")
+        }
+        if let replacement = entry.replacement {
+            lines.append("      \(replacement.formattedInstruction)")
+        }
+        if !entry.usedBy.isEmpty {
+            lines.append("      Used by: \(entry.usedBy.joined(separator: ", "))")
+        }
+    }
+    return lines.joined(separator: "\n")
+}
+
+/// Maps a `ProductType` to the schema-legal string used in the audit JSON
+/// output. Returns `nil` for product kinds that cannot be declared as
+/// deprecated via the public API (test/snippet/macro), so those are silently
+/// filtered out of the report.
+func auditProductTypeString(_ type: ProductType) -> String? {
+    switch type {
+    case .executable:
+        return "executable"
+    case .library:
+        return "library"
+    case .plugin:
+        return "plugin"
+    case .snippet, .test, .macro:
+        return nil
+    }
+}
+
+// MARK: - Report-level helpers
+
+extension AuditReport {
+    /// `true` iff any product in the report should fail the audit (any
+    /// non-empty report has at least one violation).
+    var hasViolations: Bool {
+        !self.deprecated.products.isEmpty
+    }
+}

--- a/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
+++ b/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
@@ -34,6 +34,7 @@ public struct SwiftPackageCommand: AsyncParsableCommand {
             AddTarget.self,
             AddTargetDependency.self,
             AddSetting.self,
+            Audit.self,
             AuditBinaryArtifact.self,
             AddTargetPlugin.self,
             Clean.self,

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -856,12 +856,14 @@ public final class SwiftCommandState {
     @discardableResult
     public func loadPackageGraph(
         explicitProduct: String? = nil,
-        testEntryPointPath: AbsolutePath? = nil
+        testEntryPointPath: AbsolutePath? = nil,
+        emitProductDeprecationDiagnostics: Bool = true,
     ) async throws -> ModulesGraph {
         try await self.loadPackageGraph(
             explicitProduct: explicitProduct,
             enableAllTraits: false,
-            testEntryPointPath: testEntryPointPath
+            testEntryPointPath: testEntryPointPath,
+            emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
         )
     }
 
@@ -871,12 +873,18 @@ public final class SwiftCommandState {
     ///   - explicitProduct: The product specified on the command line to a “swift run” or “swift build” command. This
     /// allows executables from dependencies to be run directly without having to hook them up to any particular target.
     ///   - exitOnError: Whether loading errors should cause this method to throw a failure exit code. Defaults to `true`.
+    ///   - emitProductDeprecationDiagnostics: Whether the graph load should
+    ///     emit warnings/errors when a consumer target depends on a deprecated
+    ///     product. Commands that produce their own structured deprecation
+    ///     report (e.g. `swift package audit`) should pass `false` to suppress
+    ///     redundant graph-load-time diagnostics.
     @discardableResult
     package func loadPackageGraph(
         explicitProduct: String? = nil,
         enableAllTraits: Bool = false,
         testEntryPointPath: AbsolutePath? = nil,
-        exitOnError: Bool = true
+        exitOnError: Bool = true,
+        emitProductDeprecationDiagnostics: Bool = true,
     ) async throws -> ModulesGraph {
         do {
             let workspace = try getActiveWorkspace(enableAllTraits: enableAllTraits)
@@ -902,6 +910,7 @@ public final class SwiftCommandState {
                 testEntryPointPath: testEntryPointPath,
                 observabilityScope: packageGraphObservabilityScope,
                 treatWarningsAsErrors: treatWarningsAsErrors,
+                emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
             )
 
             // Throw if there were errors when loading the graph.

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -833,6 +833,14 @@ public final class SwiftCommandState {
             observabilityScope: self.observabilityScope
         )
 
+        // Also load the full module graph so graph-level diagnostics (e.g. product
+        // deprecation warnings) surface during a plain `swift package resolve`.
+        // `loadPackageGraph` will honor `-Xswiftc -warnings-as-errors` and escalate
+        // those diagnostics accordingly.
+        if !self.observabilityScope.errorsReported {
+            _ = try await self.loadPackageGraph(exitOnError: false)
+        }
+
         // Throw if there were errors when loading the graph.
         // The actual errors will be printed before exiting.
         guard !self.observabilityScope.errorsReported else {
@@ -879,13 +887,21 @@ public final class SwiftCommandState {
             // package graph load attempts to also fail due to sharing the same `errorsReported` bit.
             let packageGraphObservabilityScope = self.observabilityScope.makeChildScope(description: "Loading Package Graph")
 
+            // Detect `-warnings-as-errors` in the user-supplied swift compiler flags so
+            // SwiftPM's own graph-time diagnostics (e.g. product-deprecation warnings)
+            // are escalated to errors consistently with the compiler's own behavior.
+            let treatWarningsAsErrors = WarningControlFlags.containsWarningsAsErrors(
+                self.options.build.swiftCompilerFlags,
+            )
+
             // Fetch and load the package graph.
             let graph = try await workspace.loadPackageGraph(
                 rootInput: self.getWorkspaceRoot(),
                 explicitProduct: explicitProduct,
                 forceResolvedVersions: self.options.resolver.forceResolvedVersions,
                 testEntryPointPath: testEntryPointPath,
-                observabilityScope: packageGraphObservabilityScope
+                observabilityScope: packageGraphObservabilityScope,
+                treatWarningsAsErrors: treatWarningsAsErrors,
             )
 
             // Throw if there were errors when loading the graph.

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -40,7 +40,8 @@ extension ModulesGraph {
         observabilityScope: ObservabilityScope,
         productsFilter: ((Product) -> Bool)? = nil,
         modulesFilter: ((Module) -> Bool)? = nil,
-        enabledTraitsMap: EnabledTraitsMap
+        enabledTraitsMap: EnabledTraitsMap,
+        treatWarningsAsErrors: Bool = false,
     ) throws -> ModulesGraph {
         let observabilityScope = observabilityScope.makeChildScope(description: "Loading Package Graph")
 
@@ -211,7 +212,8 @@ extension ModulesGraph {
             fileSystem: fileSystem,
             observabilityScope: observabilityScope,
             productsFilter: productsFilter,
-            modulesFilter: modulesFilter
+            modulesFilter: modulesFilter,
+            treatWarningsAsErrors: treatWarningsAsErrors,
         )
 
         let rootPackages = resolvedPackages.filter { root.manifests.values.contains($0.manifest) }
@@ -389,7 +391,8 @@ private func createResolvedPackages(
     fileSystem: FileSystem,
     observabilityScope: ObservabilityScope,
     productsFilter: ((Product) -> Bool)?,
-    modulesFilter: ((Module) -> Bool)?
+    modulesFilter: ((Module) -> Bool)?,
+    treatWarningsAsErrors: Bool,
 ) throws -> IdentifiableSet<ResolvedPackage> {
     // Create package builder objects from the input manifests.
     var packageBuilders: [ResolvedPackageBuilder] = nodes.compactMap { node in
@@ -786,6 +789,22 @@ private func createResolvedPackages(
                 }
 
                 moduleBuilder.dependencies.append(.product(product, conditions: conditions))
+
+                // Emit a diagnostic if the consumed product is deprecated.
+                if let deprecation = product.product.deprecation {
+                    let severity: Diagnostic.Severity = shouldEscalateProductDeprecationToError(
+                        consumer: moduleBuilder.module,
+                        globalTreatWarningsAsErrors: treatWarningsAsErrors,
+                    ) ? .error : .warning
+                    let text = formatProductDeprecationDiagnostic(
+                        product: product.product,
+                        producingPackage: product.packageBuilder.package.identity,
+                        deprecation: deprecation,
+                    )
+                    packageObservabilityScope.emit(
+                        .init(severity: severity, message: text, metadata: nil),
+                    )
+                }
             }
         }
     }
@@ -1644,4 +1663,56 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
             platformVersionProvider: self.platformVersionProvider
         )
     }
+}
+
+// MARK: - Product deprecation diagnostics (SE-NNNN)
+
+/// Formats the diagnostic text for a deprecated product consumed by a target,
+/// matching the wording specified in the proposal:
+///
+/// `product 'X' from package 'Y' is unsupported[: <message> [Use 'N' instead.| Use 'N' from package 'P' instead.]]`
+internal func formatProductDeprecationDiagnostic(
+    product: Product,
+    producingPackage: PackageIdentity,
+    deprecation: ProductDeprecation,
+) -> String {
+    var text = "product '\(product.name)' from package '\(producingPackage.description)' is unsupported"
+    var trailing: [String] = []
+    if let message = deprecation.message, !message.isEmpty {
+        trailing.append(message)
+    }
+    if let replacement = deprecation.replacement {
+        trailing.append(replacement.formattedInstruction)
+    }
+    if !trailing.isEmpty {
+        text += ": " + trailing.joined(separator: " ")
+    }
+    return text
+}
+
+/// Decides whether SwiftPM's product-deprecation diagnostic should be emitted as
+/// an error rather than a warning, honoring:
+///
+/// 1. The build-invocation-level `treatWarningsAsErrors` flag (equivalent to
+///    `-Xswiftc -warnings-as-errors` at build time).
+/// 2. The consumer target's own Swift build settings — specifically
+///    `.treatAllWarnings(.error)` on the Swift tool.
+///
+/// Other warning-level controls (per-warning `treatWarning(name:as:)`, C/C++
+/// `treatAllWarnings`) do NOT affect the severity of this diagnostic — it is
+/// SwiftPM-emitted, not compiler-emitted.
+internal func shouldEscalateProductDeprecationToError(
+    consumer: Module,
+    globalTreatWarningsAsErrors: Bool,
+) -> Bool {
+    if globalTreatWarningsAsErrors {
+        return true
+    }
+    // `.treatAllWarnings(as: .error)` on the Swift tool is compiled into a
+    // `-warnings-as-errors` Swift-compiler flag stored under `OTHER_SWIFT_FLAGS`
+    // in the target's build-settings assignment table. Its presence in any
+    // assignment for this target means the consumer opted into escalation.
+    let swiftFlags = consumer.buildSettings.assignments[.OTHER_SWIFT_FLAGS]?
+        .flatMap(\.values) ?? []
+    return swiftFlags.contains("-warnings-as-errors")
 }

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -42,6 +42,7 @@ extension ModulesGraph {
         modulesFilter: ((Module) -> Bool)? = nil,
         enabledTraitsMap: EnabledTraitsMap,
         treatWarningsAsErrors: Bool = false,
+        emitProductDeprecationDiagnostics: Bool = true,
     ) throws -> ModulesGraph {
         let observabilityScope = observabilityScope.makeChildScope(description: "Loading Package Graph")
 
@@ -214,6 +215,7 @@ extension ModulesGraph {
             productsFilter: productsFilter,
             modulesFilter: modulesFilter,
             treatWarningsAsErrors: treatWarningsAsErrors,
+            emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
         )
 
         let rootPackages = resolvedPackages.filter { root.manifests.values.contains($0.manifest) }
@@ -393,6 +395,7 @@ private func createResolvedPackages(
     productsFilter: ((Product) -> Bool)?,
     modulesFilter: ((Module) -> Bool)?,
     treatWarningsAsErrors: Bool,
+    emitProductDeprecationDiagnostics: Bool,
 ) throws -> IdentifiableSet<ResolvedPackage> {
     // Create package builder objects from the input manifests.
     var packageBuilders: [ResolvedPackageBuilder] = nodes.compactMap { node in
@@ -791,7 +794,11 @@ private func createResolvedPackages(
                 moduleBuilder.dependencies.append(.product(product, conditions: conditions))
 
                 // Emit a diagnostic if the consumed product is deprecated.
-                if let deprecation = product.product.deprecation {
+                // Suppressed when the caller (e.g. `swift package audit`) is
+                // producing its own structured deprecation report and wants
+                // the graph load to remain quiet.
+                if emitProductDeprecationDiagnostics,
+                   let deprecation = product.product.deprecation {
                     let severity: Diagnostic.Severity = shouldEscalateProductDeprecationToError(
                         consumer: moduleBuilder.module,
                         globalTreatWarningsAsErrors: treatWarningsAsErrors,

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -467,7 +467,8 @@ public func loadModulesGraph(
     customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
     observabilityScope: ObservabilityScope,
     traitConfiguration: TraitConfiguration = .default,
-    enabledTraitsMap: EnabledTraitsMap = .init()
+    enabledTraitsMap: EnabledTraitsMap = .init(),
+    treatWarningsAsErrors: Bool = false,
 ) throws -> ModulesGraph {
     let rootManifests = manifests.filter(\.packageKind.isRoot).spm_createDictionary { ($0.path, $0) }
     let externalManifests = try manifests.filter { !$0.packageKind.isRoot }
@@ -504,6 +505,7 @@ public func loadModulesGraph(
         observabilityScope: observabilityScope,
         productsFilter: nil,
         modulesFilter: nil,
-        enabledTraitsMap: enabledTraitsMap
+        enabledTraitsMap: enabledTraitsMap,
+        treatWarningsAsErrors: treatWarningsAsErrors,
     )
 }

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -469,6 +469,7 @@ public func loadModulesGraph(
     traitConfiguration: TraitConfiguration = .default,
     enabledTraitsMap: EnabledTraitsMap = .init(),
     treatWarningsAsErrors: Bool = false,
+    emitProductDeprecationDiagnostics: Bool = true,
 ) throws -> ModulesGraph {
     let rootManifests = manifests.filter(\.packageKind.isRoot).spm_createDictionary { ($0.path, $0) }
     let externalManifests = try manifests.filter { !$0.packageKind.isRoot }
@@ -507,5 +508,6 @@ public func loadModulesGraph(
         modulesFilter: nil,
         enabledTraitsMap: enabledTraitsMap,
         treatWarningsAsErrors: treatWarningsAsErrors,
+        emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
     )
 }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -500,10 +500,35 @@ extension ProductDescription {
         case .library(let type):
             productType = .library(.init(type))
         }
+
+        let modelDeprecation: PackageModel.ProductDeprecation? = product.deprecation.map { wire in
+            let modelReplacement = wire.replacement.map { r -> PackageModel.ProductDeprecation.Replacement in
+                switch r {
+                case .renamed(let product, let package):
+                    return .renamed(product, package: package)
+                }
+            }
+            return PackageModel.ProductDeprecation(
+                message: wire.message,
+                replacement: modelReplacement,
+            )
+        }
+
         #if ENABLE_APPLE_PRODUCT_TYPES
-        try self.init(name: product.name, type: productType, targets: product.targets, settings: product.settings.map { .init($0) })
+        try self.init(
+            name: product.name,
+            type: productType,
+            targets: product.targets,
+            settings: product.settings.map { .init($0) },
+            deprecation: modelDeprecation,
+        )
         #else
-        try self.init(name: product.name, type: productType, targets: product.targets)
+        try self.init(
+            name: product.name,
+            type: productType,
+            targets: product.targets,
+            deprecation: modelDeprecation,
+        )
         #endif
     }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1595,7 +1595,15 @@ public final class PackageBuilder {
                 }
             }
 
-            try append(Product(package: self.identity, name: product.name, type: product.type, modules: modules))
+            try append(
+                Product(
+                    package: self.identity,
+                    name: product.name,
+                    type: product.type,
+                    modules: modules,
+                    deprecation: product.deprecation,
+                )
+            )
         }
 
         // Add implicit executables - for root packages and for dependency plugins.

--- a/Sources/PackageManagerDocs/Documentation.docc/Dependencies/AddingDependencies.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Dependencies/AddingDependencies.md
@@ -115,6 +115,7 @@ For more information on creating a binary target, see [Creating a multiplatform 
 
 - <doc:ResolvingPackageVersions>
 - <doc:PackageTraits>
+- <doc:DeprecatingProducts>
 - <doc:ResolvingDependencyFailures>
 - <doc:AddingSystemLibraryDependency>
 - <doc:ExampleSystemLibraryPkgConfig>

--- a/Sources/PackageManagerDocs/Documentation.docc/Dependencies/DeprecatingProducts.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Dependencies/DeprecatingProducts.md
@@ -1,0 +1,137 @@
+# Deprecating package products
+
+Signal to consumers that a product should no longer be used, optionally
+pointing them at a replacement.
+
+## Overview
+
+When you evolve a package, you sometimes need to steer consumers off of a
+product you can no longer support — because it's been superseded by a
+better-designed replacement, moved to a different package, or is being
+retired entirely. Swift Package Manager lets you record that intent
+directly in `Package.swift`, so consumers see a diagnostic at build time
+and can survey the state of their dependency graph on demand.
+
+Use the `deprecated:` parameter on `.library(...)`, `.executable(...)`, or
+`.plugin(...)` to mark a product as unsupported. The parameter accepts a
+value produced by `Product.Deprecation.unsupported(message:replacement:)`.
+Both `message:` and `replacement:` are optional — omit them both to signal
+a bare "unsupported" state with no additional guidance.
+
+```swift
+// swift-tools-version: 6.5
+import PackageDescription
+
+let package = Package(
+    name: "Paper",
+    products: [
+        .library(name: "Paper", targets: ["Paper"]),
+
+        // Replaced by another product in the same package.
+        .library(
+            name: "PaperLegacy",
+            targets: ["PaperLegacy"],
+            deprecated: .unsupported(
+                message: "PaperLegacy is superseded by Paper.",
+                replacement: .renamed("Paper")
+            )
+        ),
+
+        // Retired with no advertised replacement.
+        .library(
+            name: "PaperExperimental",
+            targets: ["PaperExperimental"],
+            deprecated: .unsupported(
+                message: "PaperExperimental is going away with no replacement."
+            )
+        ),
+
+        // Superseded by a product in another package.
+        .executable(
+            name: "paper-tool-old",
+            targets: ["paper-tool-old"],
+            deprecated: .unsupported(
+                message: "Migrate to the standalone paper-tools package.",
+                replacement: .renamed("paper-tool", package: "paper-tools")
+            )
+        ),
+    ],
+    targets: [
+        .target(name: "Paper"),
+        .target(name: "PaperLegacy", dependencies: ["Paper"]),
+        .target(name: "PaperExperimental"),
+        .executableTarget(name: "paper-tool-old"),
+    ]
+)
+```
+
+The `deprecated:` parameter is optional and defaults to `nil`. Existing
+packages are unaffected.
+
+### Describing the replacement
+
+`Product.Deprecation.Replacement` has a single factory,
+`.renamed(_ product:package:)`, that identifies the product a consumer
+should adopt in place of the unsupported product.
+
+- Omit `package:` when the replacement lives in the same package as the
+  deprecated product. Example: `.renamed("Paper")`.
+- Pass `package:` when the replacement lives in a different package that
+  consumers must already depend on. Example:
+  `.renamed("paper-tool", package: "paper-tools")`.
+
+Swift Package Manager does not verify that a replacement product actually
+exists in the referenced package — unresolved names are surfaced as-is in
+the diagnostic, mirroring how `@available(_, renamed:)` behaves in the
+Swift compiler.
+
+## Diagnostic behavior for consumers
+
+When a consumer package's target depends on a deprecated product, Swift
+Package Manager emits a warning through its diagnostic system during graph
+resolution. `swift build`, `swift test` and `swift package resolve` all
+surface the diagnostic. The warning text is derived from the `message:`
+(if any) and the `replacement:` locator:
+
+- Same-package replacement — appended sentence: `Use 'X' instead.`
+- Cross-package replacement — appended sentence:
+  `Use 'X' from package 'P' instead.`
+- No replacement — no additional sentence; the message alone is emitted.
+
+The warning is emitted once per consuming target that references the
+deprecated product. It is emitted by SwiftPM itself (not by the Swift
+compiler), so it applies uniformly to libraries, executables, and plugins.
+
+If the consuming target opts into `.treatAllWarnings(as: .error)` in its
+Swift build settings, or if the build invocation passes
+`-Xswiftc -warnings-as-errors`, the deprecation diagnostic is escalated
+from a warning to an error, matching how the compiler treats its own
+deprecation diagnostics.
+
+## Interaction with `dump-package`
+
+The output of <doc:PackageDumpPackage> gains an optional `deprecation`
+object on each deprecated product, with the following shape:
+
+```json
+{
+  "message": "PaperLegacy is superseded by Paper.",
+  "replacement": {
+    "kind": "renamed",
+    "product": "Paper"
+  }
+}
+```
+
+The `replacement` object always has `kind: "renamed"` and a `product`
+string. A `package` field is present only when the replacement lives in a
+different package. Products without a `deprecated:` argument have no
+`deprecation` key in the dumped JSON, so existing consumers of
+`dump-package` output are unaffected.
+
+## Tools-version requirement
+
+Manifests that declare `deprecated:` require a Swift tools-version of
+`6.5` or later. Older tools versions parse the manifest without
+recognizing the parameter, matching how other version-gated `Package.swift`
+API is handled.

--- a/Sources/PackageManagerDocs/Documentation.docc/Dependencies/DeprecatingProducts.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Dependencies/DeprecatingProducts.md
@@ -89,9 +89,9 @@ Swift compiler.
 
 When a consumer package's target depends on a deprecated product, Swift
 Package Manager emits a warning through its diagnostic system during graph
-resolution. `swift build`, `swift test` and `swift package resolve` all
-surface the diagnostic. The warning text is derived from the `message:`
-(if any) and the `replacement:` locator:
+resolution. `swift build`, `swift test`, `swift package resolve`, and
+`swift package audit` all surface the diagnostic. The warning text is
+derived from the `message:` (if any) and the `replacement:` locator:
 
 - Same-package replacement — appended sentence: `Use 'X' instead.`
 - Cross-package replacement — appended sentence:
@@ -107,6 +107,25 @@ Swift build settings, or if the build invocation passes
 `-Xswiftc -warnings-as-errors`, the deprecation diagnostic is escalated
 from a warning to an error, matching how the compiler treats its own
 deprecation diagnostics.
+
+## Surveying deprecated products on demand
+
+Build-time warnings only surface deprecations for products that a package
+currently consumes. To answer questions like "which of my transitive
+dependencies vend an unsupported product?" without triggering a build,
+use <doc:PackageAudit>:
+
+```
+swift package audit
+```
+
+By default the command reports only *directly consumed* deprecated
+products and exits with a non-zero status when it finds any. Use
+`--include-transitive` to also see products reached through intermediate
+non-deprecated products, or `--include-transitive=all` to also see
+deprecated products that exist in the resolved graph but no target
+currently reaches. See <doc:PackageAudit> for a full description of the
+output format, JSON schema, and exit-code semantics.
 
 ## Interaction with `dump-package`
 

--- a/Sources/PackageManagerDocs/Documentation.docc/Development.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Development.md
@@ -1,0 +1,6 @@
+# SwiftPM 999.0 Release Notes
+
+
+## SE-#### Allow deprecating package products
+
+read more <doc:DeprecatingProducts>

--- a/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
@@ -37,6 +37,7 @@ The Swift Package Manager lets you share your code as a package, depend on and u
 - <doc:AddingDependencies>
 - <doc:UsingSwiftPackageRegistry>
 - <doc:BundlingResources>
+- <doc:DeprecatingProducts>
 
 ### Targets
 - <doc:CreatingCLanguageTargets>

--- a/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAudit.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Package/PackageAudit.md
@@ -1,0 +1,207 @@
+# swift package audit
+
+@Metadata {
+    @PageImage(purpose: icon, source: command-icon)
+    @Available("Swift", introduced: "6.5")
+}
+
+Report deprecated products in the current package graph.
+
+```
+package audit [--package-path=<package-path>]
+  [--cache-path=<cache-path>] [--config-path=<config-path>]
+  [--security-path=<security-path>]
+  [--scratch-path=<scratch-path>]
+  [--swift-sdks-path=<swift-sdks-path>]
+  [--toolset=<toolset>...]
+  [--pkg-config-path=<pkg-config-path>...]
+  [--enable-dependency-cache] [--disable-dependency-cache]
+  [--enable-build-manifest-caching]
+  [--disable-build-manifest-caching]
+  [--manifest-cache=<manifest-cache>]
+  [--enable-experimental-prebuilts]
+  [--disable-experimental-prebuilts] [--verbose]
+  [--very-verbose|vv] [--quiet] [--color-diagnostics]
+  [--no-color-diagnostics] [--disable-sandbox] [--netrc]
+  [--enable-netrc] [--disable-netrc]
+  [--netrc-file=<netrc-file>] [--enable-keychain]
+  [--disable-keychain]
+  [--resolver-fingerprint-checking=<resolver-fingerprint-checking>]
+  [--resolver-signing-entity-checking=<resolver-signing-entity-checking>]
+  [--enable-signature-validation]
+  [--disable-signature-validation] [--enable-prefetching]
+  [--disable-prefetching]
+  [--force-resolved-versions|disable-automatic-resolution|only-use-versions-from-resolved-file]
+  [--skip-update] [--disable-scm-to-registry-transformation]
+  [--use-registry-identity-for-scm]
+  [--replace-scm-with-registry]
+  [--default-registry-url=<default-registry-url>]
+  [--configuration=<configuration>] [--=<Xcc>...]
+  [--=<Xswiftc>...] [--=<Xlinker>...] [--=<Xcxx>...]
+  [--triple=<triple>] [--sdk=<sdk>] [--toolchain=<toolchain>]
+  [--swift-sdk=<swift-sdk>] [--sanitize=<sanitize>...]
+  [--auto-index-store] [--enable-index-store]
+  [--disable-index-store]
+  [--enable-parseable-module-interfaces] [--jobs=<jobs>]
+  [--use-integrated-swift-driver]
+  [--explicit-target-dependency-import-check=<explicit-target-dependency-import-check>]
+  [--build-system=<build-system>] [--=<debug-info-format>]
+  [--enable-dead-strip] [--disable-dead-strip]
+  [--disable-local-rpath] [--format=<format>]
+  [--include-transitive[=<mode>]] [--allow-deprecations]
+  [--version] [--help]
+```
+
+## Overview
+
+`swift package audit` inspects the resolved package graph for products that
+their producing packages have marked as unsupported using the
+`deprecated:` parameter on `.library(...)`, `.executable(...)`, or
+`.plugin(...)`. For each such product it reports the producing package, the
+product type, an optional author-supplied message, an optional replacement,
+and the list of root-package targets whose dependency chain reaches the
+product.
+
+Every entry is classified into one of three categories via the `transitive`
+field:
+
+- `direct` — at least one root-package target has a
+  `.product(name:package:)` dependency on the deprecated product.
+- `transitiveReachable` — no root target names the deprecated product
+  directly, but a root target reaches it via another consumed product's
+  internal target chain (for example, `MyApp → MyLib → OldProduct`).
+- `transitiveUnreachable` — the deprecated product exists in the resolved
+  graph but no root-target dependency chain touches it.
+
+Direct violations are always reported. Whether transitive-reachable and
+transitive-unreachable entries appear is controlled by
+`--include-transitive` (see below).
+
+For each `direct` or `transitiveReachable` entry the report includes a
+`breadcrumb` field: one or more paths from a root-package target down to
+the deprecated product. Each hop identifies either a root-package target
+(`{package, target}`) or a product-boundary crossing (`{package, product}`).
+`transitiveUnreachable` entries carry no `breadcrumb` because no reaching
+path exists.
+
+By default the command exits with a non-zero status when any deprecated
+product is reported. Pass `--allow-deprecations` to always exit `0` on a
+successful audit (load failures still exit non-zero). This is intended for
+interactive human use; CI pipelines can rely on the default behavior to
+turn a finding into a failing job.
+
+To silence the graph-load-time deprecation warnings while running an audit,
+`swift package audit` suppresses them internally so its structured report
+is the sole surface for deprecation output. A consumer target's per-target
+`.treatAllWarnings(as: .error)` setting does not prevent the audit from
+completing.
+
+### Output formats
+
+`swift package audit --format text` (the default) groups results into up to
+three sections in fixed order — "Directly consumed deprecated products:",
+"Transitively reachable deprecated products:", "Transitively unreachable
+deprecated products:" — each present only when it has entries. Within a
+section, entries are grouped by producing package.
+
+`swift package audit --format json` emits a structured document with
+alphabetically-sorted keys at every level. Every entry has the fields
+`package`, `product`, `transitive`, `type`, and `usedBy`; optional fields
+`message`, `replacement`, and `breadcrumb` appear when present. The
+`replacement` object always has `kind: "renamed"` and a `product` string;
+a `package` field is included only for cross-package replacements.
+
+For an in-depth guide to declaring deprecations in your own package and
+migrating consumers of deprecated products, see <doc:DeprecatingProducts>.
+
+- term **--format=\<format\>**:
+
+*Set the output format ('text' or 'json'). Defaults to `text`.*
+
+
+- term **--include-transitive[=\<mode\>]**:
+
+*Include transitive violations in the report. When passed without a value,
+selects the `reachable` mode. Accepted explicit values:*
+
+*`reachable` — include direct + transitively-reachable violations (bare
+`--include-transitive` is equivalent to this).*
+
+*`all` — include direct + transitively-reachable + transitively-unreachable
+violations.*
+
+*`non-reachable` — include only transitively-unreachable violations,
+skipping reachable ones (useful for surveying deprecated products that
+are still in the graph but not yet consumed).*
+
+
+- term **--allow-deprecations**:
+
+*Exit with status 0 even when deprecated products are found. Load failures
+still exit non-zero.*
+
+
+- term **--package-path=\<package-path\>**:
+
+*Specify the package path to operate on (default current directory). This changes the working directory before any other operation.*
+
+
+- term **--cache-path=\<cache-path\>**:
+
+*Specify the shared cache directory path.*
+
+
+- term **--config-path=\<config-path\>**:
+
+*Specify the shared configuration directory path.*
+
+
+- term **--security-path=\<security-path\>**:
+
+*Specify the shared security directory path.*
+
+
+- term **--scratch-path=\<scratch-path\>**:
+
+*Specify a custom scratch directory path. (default .build)*
+
+
+- term **--swift-sdks-path=\<swift-sdks-path\>**:
+
+*Path to the directory containing installed Swift SDKs.*
+
+
+- term **--verbose**:
+
+*Increase verbosity to include informational output.*
+
+
+- term **--very-verbose|vv**:
+
+*Increase verbosity to include debug output.*
+
+
+- term **--quiet**:
+
+*Decrease verbosity to only include error output.*
+
+
+- term **--color-diagnostics|no-color-diagnostics**:
+
+*Enables or disables color diagnostics when printing to a TTY.
+By default, color diagnostics are enabled when connected to a TTY and disabled otherwise.*
+
+
+- term **--disable-sandbox**:
+
+*Disable using the sandbox when executing subprocesses.*
+
+
+- term **--version**:
+
+*Show the version.*
+
+
+- term **--help**:
+
+*Show help information.*

--- a/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes.md
@@ -11,3 +11,4 @@
 - <doc:5.5>
 - <doc:5.4>
 - <doc:5.3>
+- <doc:Development>

--- a/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/SwiftPackageCommands.md
@@ -38,6 +38,7 @@ Overview of package manager commands here...
 <!-- ref to swift-docc-plugin -->
 
 ### Inspecting packages
+- <doc:PackageAudit>
 - <doc:PackageDescribe>
 - <doc:PackageShowDependencies>
 - <doc:PackageShowExecutables>

--- a/Sources/PackageModel/Manifest/ProductDescription.swift
+++ b/Sources/PackageModel/Manifest/ProductDescription.swift
@@ -27,11 +27,15 @@ public struct ProductDescription: Hashable, Codable, Sendable {
     /// The product-specific settings declared for this product.
     public let settings: [ProductSetting]
 
+    /// The deprecation information declared for the product, if any.
+    public let deprecation: ProductDeprecation?
+
     public init(
         name: String,
         type: ProductType,
         targets: [String],
-        settings: [ProductSetting] = []
+        settings: [ProductSetting] = [],
+        deprecation: ProductDeprecation? = nil,
     ) throws {
         guard type != .test else {
             throw InternalError("Declaring test products isn't supported: \(name):\(targets)")
@@ -40,6 +44,81 @@ public struct ProductDescription: Hashable, Codable, Sendable {
         self.type = type
         self.targets = targets
         self.settings = settings
+        self.deprecation = deprecation
+    }
+}
+
+/// The deprecation state of a product declared in a package manifest.
+public struct ProductDeprecation: Hashable, Codable, Sendable {
+    /// The product a consumer should adopt in place of an unsupported product.
+    ///
+    /// This enum is non-frozen: additional cases may be introduced in future evolution.
+    public enum Replacement: Hashable, Sendable {
+        /// The replacement product. When `package` is nil the replacement lives
+        /// in the same package as the deprecated product; otherwise it lives in
+        /// the named package (which the consumer must already depend on).
+        case renamed(_ product: String, package: String? = nil)
+    }
+
+    /// An author-supplied human-readable explanation of the deprecation.
+    public let message: String?
+
+    /// The product a consumer should adopt in place of the unsupported product.
+    public let replacement: Replacement?
+
+    public init(
+        message: String?,
+        replacement: Replacement?,
+    ) {
+        self.message = message
+        self.replacement = replacement
+    }
+}
+
+extension ProductDeprecation.Replacement: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case product
+        case package
+    }
+
+    private enum Kind: String, Codable {
+        case renamed
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .renamed(let product, let package):
+            try container.encode(Kind.renamed, forKey: .kind)
+            try container.encode(product, forKey: .product)
+            try container.encodeIfPresent(package, forKey: .package)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .renamed:
+            self = .renamed(
+                try container.decode(String.self, forKey: .product),
+                package: try container.decodeIfPresent(String.self, forKey: .package),
+            )
+        }
+    }
+}
+
+extension ProductDeprecation.Replacement {
+    /// A human-readable sentence pointing the consumer at the replacement,
+    /// suitable for appending to a deprecation diagnostic.
+    public var formattedInstruction: String {
+        switch self {
+        case .renamed(let product, nil):
+            return "Use '\(product)' instead."
+        case .renamed(let product, let package?):
+            return "Use '\(product)' from package '\(package)' instead."
+        }
     }
 }
 

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -36,6 +36,9 @@ public class Product: Identifiable {
     /// Was this product implicitly created
     public let isImplicit: Bool
 
+    /// The deprecation information declared for this product, if any.
+    public let deprecation: ProductDeprecation?
+
     /// The suffix for REPL product name.
     public static let replProductSuffix: String = "__REPL"
 
@@ -45,7 +48,8 @@ public class Product: Identifiable {
         type: ProductType,
         modules: [Module],
         testEntryPointPath: AbsolutePath? = nil,
-        isImplicit: Bool = false
+        isImplicit: Bool = false,
+        deprecation: ProductDeprecation? = nil,
     ) throws {
         guard !modules.isEmpty else {
             throw InternalError("Targets cannot be empty")
@@ -67,6 +71,7 @@ public class Product: Identifiable {
         self.modules = modules
         self.testEntryPointPath = testEntryPointPath
         self.isImplicit = isImplicit
+        self.deprecation = deprecation
     }
 }
 

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -36,6 +36,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     public static let v6_2 = ToolsVersion(version: "6.2.0")
     public static let v6_3 = ToolsVersion(version: "6.3.0")
     public static let v6_4 = ToolsVersion(version: "6.4.0")
+    public static let v6_5 = ToolsVersion(version: "6.5.0")
     public static let vNext = ToolsVersion(version: "999.0.0")
 
     /// The current tools version in use.

--- a/Sources/Runtimes/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/Runtimes/PackageDescription/PackageDescriptionSerialization.swift
@@ -260,9 +260,51 @@ enum Serialization {
             case plugin
         }
 
+        struct Deprecation: Codable {
+            enum Replacement: Codable {
+                case renamed(_ product: String, package: String? = nil)
+
+                private enum CodingKeys: String, CodingKey {
+                    case kind
+                    case product
+                    case package
+                }
+
+                private enum Kind: String, Codable {
+                    case renamed
+                }
+
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self {
+                    case .renamed(let product, let package):
+                        try container.encode(Kind.renamed, forKey: .kind)
+                        try container.encode(product, forKey: .product)
+                        try container.encodeIfPresent(package, forKey: .package)
+                    }
+                }
+
+                init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    let kind = try container.decode(Kind.self, forKey: .kind)
+                    switch kind {
+                    case .renamed:
+                        self = .renamed(
+                            try container.decode(String.self, forKey: .product),
+                            package: try container.decodeIfPresent(String.self, forKey: .package),
+                        )
+                    }
+                }
+            }
+
+            let message: String?
+            let replacement: Replacement?
+        }
+
         let name: String
         let targets: [String]
         let productType: ProductType
+        let deprecation: Deprecation?
 
         #if ENABLE_APPLE_PRODUCT_TYPES
         let settings: [ProductSetting]

--- a/Sources/Runtimes/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/Runtimes/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -363,6 +363,7 @@ extension Serialization.Product {
         self.name = executable.name
         self.targets = executable.targets
         self.productType = .executable
+        self.deprecation = executable.deprecation.map(Serialization.Product.Deprecation.init)
         #if ENABLE_APPLE_PRODUCT_TYPES
         self.settings = executable.settings.map { .init($0) }
         #endif
@@ -373,6 +374,7 @@ extension Serialization.Product {
         self.targets = library.targets
         let libraryType = library.type.map { ProductType.LibraryType($0) } ?? .automatic
         self.productType = .library(type: libraryType)
+        self.deprecation = library.deprecation.map(Serialization.Product.Deprecation.init)
         #if ENABLE_APPLE_PRODUCT_TYPES
         self.settings = []
         #endif
@@ -382,9 +384,26 @@ extension Serialization.Product {
         self.name = plugin.name
         self.targets = plugin.targets
         self.productType = .plugin
+        self.deprecation = plugin.deprecation.map(Serialization.Product.Deprecation.init)
         #if ENABLE_APPLE_PRODUCT_TYPES
         self.settings = []
         #endif
+    }
+}
+
+extension Serialization.Product.Deprecation {
+    init(_ deprecation: PackageDescription.Product.Deprecation) {
+        self.message = deprecation.message
+        self.replacement = deprecation.replacement.map(Replacement.init)
+    }
+}
+
+extension Serialization.Product.Deprecation.Replacement {
+    init(_ replacement: PackageDescription.Product.Deprecation.Replacement) {
+        switch replacement.storage {
+        case .renamed(let product, let package):
+            self = .renamed(product, package: package)
+        }
     }
 }
 

--- a/Sources/Runtimes/PackageDescription/Product.swift
+++ b/Sources/Runtimes/PackageDescription/Product.swift
@@ -63,23 +63,38 @@ public class Product {
     /// The name of the package product.
     public let name: String
 
-    init(name: String) {
+    /// The deprecation declared for this product, if any.
+    let deprecation: Deprecation?
+
+    init(
+        name: String,
+        deprecation: Deprecation? = nil,
+    ) {
         self.name = name
+        self.deprecation = deprecation
     }
 
     /// The executable product of a Swift package.
     public final class Executable: Product, @unchecked Sendable {
         /// The names of the targets in this product.
         public let targets: [String]
-        
+
         /// Any specific product settings that apply to this product.
         @_spi(PackageProductSettings)
         public let settings: [ProductSetting]
 
-        init(name: String, targets: [String], settings: [ProductSetting]) {
+        init(
+            name: String,
+            targets: [String],
+            settings: [ProductSetting],
+            deprecation: Deprecation? = nil,
+        ) {
             self.targets = targets
             self.settings = settings
-            super.init(name: name)
+            super.init(
+                name: name,
+                deprecation: deprecation,
+            )
         }
     }
 
@@ -102,10 +117,18 @@ public class Product {
         /// based on the client's preference.
         public let type: LibraryType?
 
-        init(name: String, type: LibraryType? = nil, targets: [String]) {
+        init(
+            name: String,
+            type: LibraryType? = nil,
+            targets: [String],
+            deprecation: Deprecation? = nil,
+        ) {
             self.type = type
             self.targets = targets
-            super.init(name: name)
+            super.init(
+                name: name,
+                deprecation: deprecation,
+            )
         }
     }
 
@@ -114,9 +137,16 @@ public class Product {
         /// The name of the plug-in target to vend as a product.
         public let targets: [String]
 
-        init(name: String, targets: [String]) {
+        init(
+            name: String,
+            targets: [String],
+            deprecation: Deprecation? = nil,
+        ) {
             self.targets = targets
-            super.init(name: name)
+            super.init(
+                name: name,
+                deprecation: deprecation,
+            )
         }
     }
 
@@ -187,6 +217,130 @@ public class Product {
     ) -> Product {
         return Plugin(name: name, targets: targets)
     }
+
+    /// Creates a library product that a package consumer can adopt, with an optional
+    /// deprecation declaration.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the library product.
+    ///   - type: The optional type of the library.
+    ///   - targets: The targets that are bundled into the library product.
+    ///   - deprecated: An optional ``Product/Deprecation`` value describing the deprecation
+    ///     state of the product. When set, consumers of the product see a warning at
+    ///     build time.
+    ///
+    /// - Returns: A `Product` instance.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func library(
+        name: String,
+        type: Library.LibraryType? = nil,
+        targets: [String],
+        deprecated: Deprecation? = nil,
+    ) -> Product {
+        return Library(
+            name: name,
+            type: type,
+            targets: targets,
+            deprecation: deprecated,
+        )
+    }
+
+    /// Creates an executable package product with an optional deprecation declaration.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the executable product.
+    ///   - targets: The targets to bundle into an executable product.
+    ///   - deprecated: An optional ``Product/Deprecation`` value describing the deprecation
+    ///     state of the product.
+    /// - Returns: A `Product` instance.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func executable(
+        name: String,
+        targets: [String],
+        deprecated: Deprecation? = nil,
+    ) -> Product {
+        return Executable(
+            name: name,
+            targets: targets,
+            settings: [],
+            deprecation: deprecated,
+        )
+    }
+
+    /// Defines a plugin product with an optional deprecation declaration.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the plugin product.
+    ///   - targets: The plugin targets to vend as a product.
+    ///   - deprecated: An optional ``Product/Deprecation`` value describing the deprecation
+    ///     state of the product.
+    /// - Returns: A `Product` instance.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func plugin(
+        name: String,
+        targets: [String],
+        deprecated: Deprecation? = nil,
+    ) -> Product {
+        return Plugin(
+            name: name,
+            targets: targets,
+            deprecation: deprecated,
+        )
+    }
+}
+
+extension Product {
+    /// Describes the deprecation state of a package product.
+    ///
+    /// Values of this type are constructed exclusively through the static factory below.
+    /// The type intentionally exposes no public properties so future evolution can add
+    /// deprecation metadata without a source or ABI break.
+    public struct Deprecation: Sendable, Equatable {
+        // Storage is internal so PackageDescriptionSerializationConversion can read it.
+        internal let message: String?
+        internal let replacement: Replacement?
+
+        /// Marks a product as unsupported.
+        ///
+        /// - Parameters:
+        ///   - message: A human-readable explanation of the deprecation.
+        ///   - replacement: An optional locator identifying the product consumers should
+        ///     adopt instead. When `nil`, the product is retired with no advertised
+        ///     replacement.
+        public static func unsupported(
+            message: String? = nil,
+            replacement: Replacement? = nil,
+        ) -> Deprecation {
+            return Deprecation(
+                message: message,
+                replacement: replacement,
+            )
+        }
+
+        /// Identifies the product a consumer should adopt in place of an unsupported product.
+        ///
+        /// Values of this type are constructed exclusively through the static factories below.
+        public struct Replacement: Sendable, Equatable {
+            internal enum Storage: Sendable, Equatable {
+                case renamed(product: String, package: String?)
+            }
+            internal let storage: Storage
+
+            /// The replacement product a consumer should adopt.
+            ///
+            /// - Parameters:
+            ///   - product: The name of the replacement product.
+            ///   - package: The identity of the package that vends the replacement.
+            ///     Omit (or pass `nil`) when the replacement lives in the same
+            ///     package as the deprecated product.
+            public static func renamed(
+                _ product: String,
+                package: String? = nil,
+            ) -> Replacement {
+                return Replacement(storage: .renamed(product: product, package: package))
+            }
+        }
+    }
 }
 
 
@@ -237,18 +391,18 @@ public enum ProductSetting: Equatable {
             // Named asset in an asset catalog.
             case asset(String)
         }
-        
+
         /// Represents a family of device types that an application can support.
         public enum DeviceFamily: String, Equatable {
             case phone
             case pad
             case mac
         }
-        
+
         /// Represents a condition on a particular device family.
         public struct DeviceFamilyCondition: Equatable {
             public var deviceFamilies: [DeviceFamily]
-            
+
             public init(deviceFamilies: [DeviceFamily]) {
                 self.deviceFamilies = deviceFamilies
             }
@@ -256,7 +410,7 @@ public enum ProductSetting: Equatable {
                 return DeviceFamilyCondition(deviceFamilies: deviceFamilies)
             }
         }
-        
+
         /// Represents a supported device interface orientation.
         public enum InterfaceOrientation: Equatable {
             case portrait(_ condition: DeviceFamilyCondition? = nil)
@@ -269,7 +423,7 @@ public enum ProductSetting: Equatable {
             public static var landscapeRight: Self { landscapeRight(nil) }
             public static var landscapeLeft: Self { landscapeLeft(nil) }
         }
-        
+
         /// A capability required by the device.
         public enum Capability: Equatable {
             case appTransportSecurity(configuration: AppTransportSecurityConfiguration, _ condition: DeviceFamilyCondition? = nil)
@@ -294,7 +448,7 @@ public enum ProductSetting: Equatable {
             case speechRecognition(purposeString: String, _ condition: DeviceFamilyCondition? = nil)
             case userTracking(purposeString: String, _ condition: DeviceFamilyCondition? = nil)
         }
-        
+
         public struct AppTransportSecurityConfiguration: Equatable {
             public var allowsArbitraryLoadsInWebContent: Bool? = nil
             public var allowsArbitraryLoadsForMedia: Bool? = nil
@@ -326,13 +480,13 @@ public enum ProductSetting: Equatable {
                     self.requiresCertificateTransparency = requiresCertificateTransparency
                 }
             }
-            
+
             public struct PinnedDomain: Equatable {
                 public var domainName: String
                 public var includesSubdomains : Bool? = nil
                 public var pinnedCAIdentities : [[String: String]]? = nil
                 public var pinnedLeafIdentities : [[String: String]]? = nil
-                
+
                 public init(
                     domainName: String,
                     includesSubdomains: Bool? = nil,
@@ -345,7 +499,7 @@ public enum ProductSetting: Equatable {
                     self.pinnedLeafIdentities = pinnedLeafIdentities
                 }
             }
-            
+
             public init(
                 allowsArbitraryLoadsInWebContent: Bool? = nil,
                 allowsArbitraryLoadsForMedia: Bool? = nil,
@@ -395,7 +549,7 @@ public enum ProductSetting: Equatable {
                 }
             }
         }
-        
+
         public struct AppCategory: Equatable, ExpressibleByStringLiteral {
             public var rawValue: String
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1003,6 +1003,7 @@ extension Workspace {
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
         observabilityScope: ObservabilityScope,
         treatWarningsAsErrors: Bool = false,
+        emitProductDeprecationDiagnostics: Bool = true,
     ) async throws -> ModulesGraph {
         let start = DispatchTime.now()
         self.delegate?.willLoadGraph()
@@ -1065,6 +1066,7 @@ extension Workspace {
             observabilityScope: observabilityScope,
             enabledTraitsMap: self.enabledTraitsMap,
             treatWarningsAsErrors: treatWarningsAsErrors,
+            emitProductDeprecationDiagnostics: emitProductDeprecationDiagnostics,
         )
 
         try self.validateSignatures(

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1001,7 +1001,8 @@ extension Workspace {
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
         testEntryPointPath: AbsolutePath? = nil,
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
+        treatWarningsAsErrors: Bool = false,
     ) async throws -> ModulesGraph {
         let start = DispatchTime.now()
         self.delegate?.willLoadGraph()
@@ -1062,7 +1063,8 @@ extension Workspace {
             testEntryPointPath: testEntryPointPath,
             fileSystem: self.fileSystem,
             observabilityScope: observabilityScope,
-            enabledTraitsMap: self.enabledTraitsMap
+            enabledTraitsMap: self.enabledTraitsMap,
+            treatWarningsAsErrors: treatWarningsAsErrors,
         )
 
         try self.validateSignatures(

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -77,6 +77,7 @@ extension Tag.FunctionalArea {
     @Tag public static var Sanitizer: Tag
     @Tag public static var LibraryEvoluton: Tag
     @Tag public static var LinkSwiftStaticStdlib: Tag
+    @Tag public static var Manifest: Tag
     @Tag public static var Metal: Tag
     @Tag public static var ModuleMaps: Tag
     @Tag public static var Resources: Tag
@@ -96,6 +97,7 @@ extension Tag.Feature {
     @Tag public static var BuildCache: Tag
     @Tag public static var CodeCoverage: Tag
     @Tag public static var CTargets: Tag
+    @Tag public static var Deprecation: Tag
     @Tag public static var DependencyResolution: Tag
     @Tag public static var ModuleAliasing: Tag
     @Tag public static var Mirror: Tag

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -191,6 +191,7 @@ extension Tag.Feature.Command.Package {
     @Tag public static var AddTarget: Tag
     @Tag public static var AddTargetDependency: Tag
     @Tag public static var AddTargetPlugin: Tag
+    @Tag public static var Audit: Tag
     @Tag public static var BuildPlugin: Tag
     @Tag public static var Clean: Tag
     @Tag public static var CommandPlugin: Tag

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -268,4 +268,15 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    /// Skip test if compiler is older than 6.5.
+    public static var requireSwift6_5: Self {
+        enabled("This test requires Swift 6.5, or newer.") {
+            #if compiler(>=6.5)
+                true
+            #else
+                false
+            #endif
+        }
+    }
+
 }

--- a/Tests/CommandsTests/AuditReporTests.swift
+++ b/Tests/CommandsTests/AuditReporTests.swift
@@ -1,0 +1,1525 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Foundation
+import PackageModel
+import Testing
+import _InternalTestSupport
+
+@_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
+import PackageGraph
+
+@testable import Commands
+
+/// Pure-logic unit tests for the `swift package audit` report-building and
+/// text-rendering helpers. These tests construct in-memory package graphs via
+/// `loadModulesGraph` (no `executeSwiftPackage`, no fixture on disk, no swiftc
+/// invocation) and assert on `AuditReport` values directly. Complements the
+/// end-to-end tests in `PackageCommandTests+Audit.swift`.
+@Suite(
+    .tags(
+        .TestSize.small,
+        .Feature.Command.Package.Audit,
+        .Feature.Deprecation,
+    ),
+)
+struct AuditReportTests {
+
+    // MARK: - buildAuditReport
+    @Suite
+    struct AuditReportBuilderTests {
+
+        // MARK: Empty / no deprecations
+
+        @Test
+        func report_isEmpty_whenNoDeprecatedProducts() throws {
+            let graph = try loadSingleRootGraph(
+                withProducts: [
+                    try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"]),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            #expect(report.deprecated.products.isEmpty)
+        }
+
+        // MARK: --include-transitive off
+
+        @Test
+        func report_omitsUnconsumedDeprecatedProduct_whenIncludeTransitiveIsOff() throws {
+            // Root package vends a deprecated product but no target in the root
+            // package consumes it. With .off, the report is empty.
+            let graph = try loadSingleRootGraph(
+                withProducts: [
+                    try ProductDescription(
+                        name: "OldLib",
+                        type: .library(.automatic),
+                        targets: ["OldLib"],
+                        deprecation: ProductDeprecation(
+                            message: "gone",
+                            replacement: .renamed("NewLib"),
+                        ),
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            #expect(report.deprecated.products.isEmpty)
+        }
+
+        @Test
+        func report_omitsUnreachableDeprecatedProduct_whenIncludeTransitiveIsReachable() throws {
+            // Root package declares a deprecated product but no target
+            // consumes it. Since no root-target dependency chain reaches
+            // the product, it is transitively unreachable — and `.reachable`
+            // mode excludes unreachable entries. Use `.all` (or `.nonReachable`)
+            // to surface it.
+            let graph = try loadSingleRootGraph(
+                withProducts: [
+                    try ProductDescription(
+                        name: "OldLib",
+                        type: .library(.automatic),
+                        targets: ["OldLib"],
+                        deprecation: ProductDeprecation(
+                            message: "gone",
+                            replacement: .renamed("NewLib"),
+                        ),
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.isEmpty)
+        }
+
+        // MARK: Direct violations
+
+        @Test
+        func report_populatesUsedByAndBreadcrumb_forDirectlyConsumedProduct() throws {
+            let graph = try loadConsumerProducerGraph(
+                producerProducts: [
+                    try ProductDescription(
+                        name: "PaperLegacy",
+                        type: .library(.automatic),
+                        targets: ["PaperLegacy"],
+                        deprecation: ProductDeprecation(
+                            message: "Use Paper instead.",
+                            replacement: .renamed("Paper"),
+                        ),
+                    ),
+                ],
+                producerTargets: [
+                    TargetDescription(name: "PaperLegacy"),
+                ],
+                consumerTargets: [
+                    TargetDescription(
+                        name: "MyApp",
+                        dependencies: [
+                            .product(name: "PaperLegacy", package: "Producer"),
+                        ],
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            #expect(report.deprecated.products.count == 1)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.product == "PaperLegacy")
+            #expect(entry.package == "producer")
+            #expect(entry.usedBy == ["MyApp"])
+            #expect(entry.transitive == .direct)
+
+            // Breadcrumb: single path with two hops — [target, product].
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 1)
+            let path = try #require(breadcrumb.first)
+            #expect(path.count == 2)
+            #expect(path[0] == BreadcrumbHop(package: "consumer", target: "MyApp"))
+            #expect(path[1] == BreadcrumbHop(package: "producer", product: "PaperLegacy"))
+        }
+
+        @Test
+        func report_multipleConsumersOfSameProduct_areSortedInUsedBy() throws {
+            let graph = try loadConsumerProducerGraph(
+                producerProducts: [
+                    try ProductDescription(
+                        name: "Old",
+                        type: .library(.automatic),
+                        targets: ["Old"],
+                        deprecation: ProductDeprecation(
+                            message: "gone",
+                            replacement: nil,
+                        ),
+                    ),
+                ],
+                producerTargets: [
+                    TargetDescription(name: "Old"),
+                ],
+                consumerTargets: [
+                    TargetDescription(
+                        name: "ZTarget",
+                        dependencies: [.product(name: "Old", package: "Producer")],
+                    ),
+                    TargetDescription(
+                        name: "ATarget",
+                        dependencies: [.product(name: "Old", package: "Producer")],
+                    ),
+                    TargetDescription(
+                        name: "MTarget",
+                        dependencies: [.product(name: "Old", package: "Producer")],
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.usedBy == ["ATarget", "MTarget", "ZTarget"])
+            #expect(entry.transitive == .direct)
+            // A single deprecated product consumed by three targets: one path
+            // per consumer, sorted by consumer name.
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 3)
+            #expect(breadcrumb[0].first == BreadcrumbHop(package: "consumer", target: "ATarget"))
+            #expect(breadcrumb[1].first == BreadcrumbHop(package: "consumer", target: "MTarget"))
+            #expect(breadcrumb[2].first == BreadcrumbHop(package: "consumer", target: "ZTarget"))
+        }
+
+        @Test
+        func report_sortsEntriesByPackageThenProduct() throws {
+            let graph = try loadConsumerProducerGraph(
+                producerProducts: [
+                    try ProductDescription(
+                        name: "Zebra",
+                        type: .library(.automatic),
+                        targets: ["Zebra"],
+                        deprecation: ProductDeprecation(message: nil, replacement: nil),
+                    ),
+                    try ProductDescription(
+                        name: "Alpha",
+                        type: .library(.automatic),
+                        targets: ["Alpha"],
+                        deprecation: ProductDeprecation(message: nil, replacement: nil),
+                    ),
+                ],
+                producerTargets: [
+                    TargetDescription(name: "Zebra"),
+                    TargetDescription(name: "Alpha"),
+                ],
+                consumerTargets: [
+                    TargetDescription(
+                        name: "MyApp",
+                        dependencies: [
+                            .product(name: "Zebra", package: "Producer"),
+                            .product(name: "Alpha", package: "Producer"),
+                        ],
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            #expect(report.deprecated.products.count == 2)
+            #expect(report.deprecated.products.map(\.product) == ["Alpha", "Zebra"])
+            for entry in report.deprecated.products {
+                #expect(
+                    entry.transitive == .direct,
+                    "product \(entry.product) in package \(entry.package) transitive should be direct",
+                )
+            }
+        }
+
+        @Test
+        func report_capturesReplacementInPackageVariant() throws {
+            let graph = try loadConsumerProducerGraph(
+                producerProducts: [
+                    try ProductDescription(
+                        name: "old-tool",
+                        type: .executable,
+                        targets: ["old-tool"],
+                        deprecation: ProductDeprecation(
+                            message: "Migrate to new-tool.",
+                            replacement: .renamed("new-tool", package: "tools"),
+                        ),
+                    ),
+                ],
+                producerTargets: [
+                    TargetDescription(name: "old-tool", type: .executable),
+                ],
+                consumerTargets: [
+                    TargetDescription(
+                        name: "Consumer",
+                        dependencies: [.product(name: "old-tool", package: "Producer")],
+                    ),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .off)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.type == "executable")
+            #expect(entry.transitive == .direct)
+            #expect(entry.replacement == .renamed("new-tool", package: "tools"))
+        }
+
+        // MARK: --include-transitive reachable
+
+        @Test
+        func report_includesReachableDeprecatedProduct_viaNonDeprecatedIntermediate() throws {
+            // Root consumer has one target that depends on non-deprecated
+            // product 'MidLib' in package 'middle'. MidLib's target depends on
+            // deprecated 'Old' in package 'producer'. The deprecated product is
+            // transitively reachable — must appear with .transitiveReachable
+            // and a breadcrumb of length 3.
+            let graph = try loadThreePackageChain(
+                rootTarget: TargetDescription(
+                    name: "App",
+                    dependencies: [.product(name: "MidLib", package: "middle")],
+                ),
+                middlePackageIdentity: "middle",
+                middleProducts: [
+                    try ProductDescription(
+                        name: "MidLib",
+                        type: .library(.automatic),
+                        targets: ["MidLib"],
+                    ),
+                ],
+                middleTargets: [
+                    TargetDescription(
+                        name: "MidLib",
+                        dependencies: [.product(name: "Old", package: "producer")],
+                    ),
+                ],
+                leafPackageIdentity: "producer",
+                leafProducts: [
+                    try ProductDescription(
+                        name: "Old",
+                        type: .library(.automatic),
+                        targets: ["Old"],
+                        deprecation: ProductDeprecation(
+                            message: "gone",
+                            replacement: .renamed("New"),
+                        ),
+                    ),
+                ],
+                leafTargets: [TargetDescription(name: "Old")],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.count == 1)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.product == "Old")
+            #expect(entry.package == "producer")
+            #expect(entry.transitive == .transitiveReachable)
+            #expect(entry.usedBy == ["App"])
+
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 1)
+            let path = try #require(breadcrumb.first)
+            #expect(path.count == 3)
+            #expect(path[0] == BreadcrumbHop(package: "consumer", target: "App"))
+            #expect(path[1] == BreadcrumbHop(package: "middle", product: "MidLib"))
+            #expect(path[2] == BreadcrumbHop(package: "producer", product: "Old"))
+        }
+
+        @Test
+        func report_reachableMode_omitsUnreachableSiblings() throws {
+            // Producer declares two deprecated products: 'Old' (reachable
+            // through middle.MidLib) and 'Unrelated' (not on any chain from
+            // the root). In .reachable mode, 'Unrelated' must be omitted.
+            let graph = try loadThreePackageChain(
+                rootTarget: TargetDescription(
+                    name: "App",
+                    dependencies: [.product(name: "MidLib", package: "middle")],
+                ),
+                middlePackageIdentity: "middle",
+                middleProducts: [
+                    try ProductDescription(
+                        name: "MidLib",
+                        type: .library(.automatic),
+                        targets: ["MidLib"],
+                    ),
+                ],
+                middleTargets: [
+                    TargetDescription(
+                        name: "MidLib",
+                        dependencies: [.product(name: "Old", package: "producer")],
+                    ),
+                ],
+                leafPackageIdentity: "producer",
+                leafProducts: [
+                    try ProductDescription(
+                        name: "Old",
+                        type: .library(.automatic),
+                        targets: ["Old"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                    try ProductDescription(
+                        name: "Unrelated",
+                        type: .library(.automatic),
+                        targets: ["Unrelated"],
+                        deprecation: ProductDeprecation(message: "also gone", replacement: nil),
+                    ),
+                ],
+                leafTargets: [
+                    TargetDescription(name: "Old"),
+                    TargetDescription(name: "Unrelated"),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.map(\.product) == ["Old"])
+        }
+
+        @Test
+        func report_multiplePathsToSameProduct_areAllCapturedInBreadcrumb() throws {
+            // Two root-package targets (AppA and AppB) both depend on
+            // `middle.MidLib`, whose target depends on the deprecated
+            // `producer.Old`. The single deprecated product must be
+            // reported with a breadcrumb containing TWO paths — one per
+            // root consumer — sorted by root target name.
+            let fs = InMemoryFileSystem(emptyFiles: [
+                "/Consumer/Sources/AppA/source.swift",
+                "/Consumer/Sources/AppB/source.swift",
+                "/Middle/Sources/MidLib/source.swift",
+                "/Producer/Sources/Old/source.swift",
+            ])
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Middle",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "AppA",
+                                dependencies: [.product(name: "MidLib", package: "middle")],
+                            ),
+                            TargetDescription(
+                                name: "AppB",
+                                dependencies: [.product(name: "MidLib", package: "middle")],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Middle",
+                        path: "/Middle",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        products: [
+                            try ProductDescription(
+                                name: "MidLib",
+                                type: .library(.automatic),
+                                targets: ["MidLib"],
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "MidLib",
+                                dependencies: [.product(name: "Old", package: "producer")],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                            ),
+                        ],
+                        targets: [TargetDescription(name: "Old")],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.count == 1)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.transitive == .transitiveReachable)
+            #expect(entry.usedBy == ["AppA", "AppB"])
+
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 2)
+            // Paths sorted by root consumer target name.
+            #expect(breadcrumb[0] == [
+                BreadcrumbHop(package: "consumer", target: "AppA"),
+                BreadcrumbHop(package: "middle", product: "MidLib"),
+                BreadcrumbHop(package: "producer", product: "Old"),
+            ])
+            #expect(breadcrumb[1] == [
+                BreadcrumbHop(package: "consumer", target: "AppB"),
+                BreadcrumbHop(package: "middle", product: "MidLib"),
+                BreadcrumbHop(package: "producer", product: "Old"),
+            ])
+        }
+
+        @Test
+        func report_multipleDistinctChains_produceDistinctBreadcrumbPaths() throws {
+            // Single root target `App` depends on two non-deprecated
+            // intermediate products (`middle.LibA` and `middle.LibB`).
+            // Both intermediate targets depend on `producer.Old`
+            // (deprecated). The report must contain a single deprecated
+            // entry whose breadcrumb has TWO distinct paths differing
+            // in the intermediate product hop.
+            let fs = InMemoryFileSystem(emptyFiles: [
+                "/Consumer/Sources/App/source.swift",
+                "/Middle/Sources/LibA/source.swift",
+                "/Middle/Sources/LibB/source.swift",
+                "/Producer/Sources/Old/source.swift",
+            ])
+            let observability = ObservabilitySystem.makeForTesting()
+            let graph = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Middle",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "App",
+                                dependencies: [
+                                    .product(name: "LibA", package: "middle"),
+                                    .product(name: "LibB", package: "middle"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Middle",
+                        path: "/Middle",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        products: [
+                            try ProductDescription(
+                                name: "LibA",
+                                type: .library(.automatic),
+                                targets: ["LibA"],
+                            ),
+                            try ProductDescription(
+                                name: "LibB",
+                                type: .library(.automatic),
+                                targets: ["LibB"],
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "LibA",
+                                dependencies: [.product(name: "Old", package: "producer")],
+                            ),
+                            TargetDescription(
+                                name: "LibB",
+                                dependencies: [.product(name: "Old", package: "producer")],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                            ),
+                        ],
+                        targets: [TargetDescription(name: "Old")],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .reachable)
+            #expect(report.deprecated.products.count == 1)
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.transitive == .transitiveReachable)
+            // The consumer target `App` reaches `Old` via two intermediates,
+            // but `usedBy` deduplicates on the root-target name.
+            #expect(entry.usedBy == ["App"])
+
+            let breadcrumb = try #require(entry.breadcrumb)
+            #expect(breadcrumb.count == 2)
+            // Paths sorted by intermediate product name (LibA before LibB).
+            #expect(breadcrumb[0] == [
+                BreadcrumbHop(package: "consumer", target: "App"),
+                BreadcrumbHop(package: "middle", product: "LibA"),
+                BreadcrumbHop(package: "producer", product: "Old"),
+            ])
+            #expect(breadcrumb[1] == [
+                BreadcrumbHop(package: "consumer", target: "App"),
+                BreadcrumbHop(package: "middle", product: "LibB"),
+                BreadcrumbHop(package: "producer", product: "Old"),
+            ])
+        }
+
+        // MARK: --include-transitive all
+
+        @Test
+        func report_allMode_reportsDirectReachableAndUnreachable() throws {
+            // A direct violation (App → middle.Direct), a reachable
+            // transitive (App → middle.MidLib → producer.Reachable), and
+            // an unreachable deprecated product (producer.Unreachable, not
+            // on any chain from the root).
+            //
+            // Note: root can only reference products from `middle` directly
+            // (the only package it depends on); anything in `producer` must
+            // be reached via a middle product.
+            let graph = try loadThreePackageChain(
+                rootTarget: TargetDescription(
+                    name: "App",
+                    dependencies: [
+                        .product(name: "MidLib", package: "middle"),
+                        .product(name: "Direct", package: "middle"),
+                    ],
+                ),
+                middlePackageIdentity: "middle",
+                middleProducts: [
+                    try ProductDescription(
+                        name: "MidLib",
+                        type: .library(.automatic),
+                        targets: ["MidLib"],
+                    ),
+                    try ProductDescription(
+                        name: "Direct",
+                        type: .library(.automatic),
+                        targets: ["Direct"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                ],
+                middleTargets: [
+                    TargetDescription(
+                        name: "MidLib",
+                        dependencies: [.product(name: "Reachable", package: "producer")],
+                    ),
+                    TargetDescription(name: "Direct"),
+                ],
+                leafPackageIdentity: "producer",
+                leafProducts: [
+                    try ProductDescription(
+                        name: "Reachable",
+                        type: .library(.automatic),
+                        targets: ["Reachable"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                    try ProductDescription(
+                        name: "Unreachable",
+                        type: .library(.automatic),
+                        targets: ["Unreachable"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                ],
+                leafTargets: [
+                    TargetDescription(name: "Reachable"),
+                    TargetDescription(name: "Unreachable"),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .all)
+            let byName = Dictionary(uniqueKeysWithValues: report.deprecated.products.map { ($0.product, $0) })
+            #expect(byName.count == 3)
+
+            let direct = try #require(byName["Direct"])
+            #expect(direct.transitive == .direct)
+            let directCrumb = try #require(direct.breadcrumb?.first)
+            #expect(directCrumb == [
+                BreadcrumbHop(package: "consumer", target: "App"),
+                BreadcrumbHop(package: "middle", product: "Direct"),
+            ])
+
+            let reachable = try #require(byName["Reachable"])
+            #expect(reachable.transitive == .transitiveReachable)
+            let reachableCrumb = try #require(reachable.breadcrumb?.first)
+            #expect(reachableCrumb == [
+                BreadcrumbHop(package: "consumer", target: "App"),
+                BreadcrumbHop(package: "middle", product: "MidLib"),
+                BreadcrumbHop(package: "producer", product: "Reachable"),
+            ])
+
+            let unreachable = try #require(byName["Unreachable"])
+            #expect(unreachable.transitive == .transitiveUnreachable)
+            #expect(unreachable.usedBy == [])
+            // Unreachable entries carry no breadcrumb — no chain to record.
+            #expect(unreachable.breadcrumb == nil)
+        }
+
+        // MARK: --include-transitive nonReachable
+
+        @Test
+        func report_nonReachableMode_omitsDirectAndReachable() throws {
+            // Same graph as `report_allMode_...` above — root reaches a direct
+            // deprecated `middle.Direct` and a transitive-reachable
+            // `producer.Reachable`. `producer.Unreachable` is deprecated but
+            // not on any chain. In `.nonReachable` mode only Unreachable
+            // survives the filter.
+            let graph = try loadThreePackageChain(
+                rootTarget: TargetDescription(
+                    name: "App",
+                    dependencies: [
+                        .product(name: "MidLib", package: "middle"),
+                        .product(name: "Direct", package: "middle"),
+                    ],
+                ),
+                middlePackageIdentity: "middle",
+                middleProducts: [
+                    try ProductDescription(
+                        name: "MidLib",
+                        type: .library(.automatic),
+                        targets: ["MidLib"],
+                    ),
+                    try ProductDescription(
+                        name: "Direct",
+                        type: .library(.automatic),
+                        targets: ["Direct"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                ],
+                middleTargets: [
+                    TargetDescription(
+                        name: "MidLib",
+                        dependencies: [.product(name: "Reachable", package: "producer")],
+                    ),
+                    TargetDescription(name: "Direct"),
+                ],
+                leafPackageIdentity: "producer",
+                leafProducts: [
+                    try ProductDescription(
+                        name: "Reachable",
+                        type: .library(.automatic),
+                        targets: ["Reachable"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                    try ProductDescription(
+                        name: "Unreachable",
+                        type: .library(.automatic),
+                        targets: ["Unreachable"],
+                        deprecation: ProductDeprecation(message: "gone", replacement: nil),
+                    ),
+                ],
+                leafTargets: [
+                    TargetDescription(name: "Reachable"),
+                    TargetDescription(name: "Unreachable"),
+                ],
+            )
+            let report = buildAuditReport(graph: graph, includeTransitive: .nonReachable)
+            #expect(report.deprecated.products.map(\.product) == ["Unreachable"])
+            let entry = try #require(report.deprecated.products.first)
+            #expect(entry.transitive == .transitiveUnreachable)
+            #expect(entry.usedBy == [])
+            #expect(entry.breadcrumb == nil)
+        }
+
+        // MARK: - Helpers
+
+        /// Builds a graph containing a single root package with the given products
+        /// and a target for each product. No dependencies.
+        private func loadSingleRootGraph(
+            withProducts products: [ProductDescription],
+        ) throws -> ModulesGraph {
+            var files: [String] = []
+            var targets: [TargetDescription] = []
+            for product in products {
+                for target in product.targets {
+                    files.append("/Root/Sources/\(target)/source.swift")
+                    if !targets.contains(where: { $0.name == target }) {
+                        targets.append(try TargetDescription(name: target))
+                    }
+                }
+            }
+            let fs = InMemoryFileSystem(emptyFiles: files)
+            let observability = ObservabilitySystem.makeForTesting()
+            return try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Root",
+                        path: "/Root",
+                        products: products,
+                        targets: targets,
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+        }
+
+        /// Builds a two-package graph: a `Consumer` root package that depends on
+        /// a `Producer` file-system package. Callers supply the producer's products
+        /// and targets, and the consumer's targets (which can reference producer's
+        /// products via `.product(name:package:)` dependencies).
+        private func loadConsumerProducerGraph(
+            producerProducts: [ProductDescription],
+            producerTargets: [TargetDescription],
+            consumerTargets: [TargetDescription],
+        ) throws -> ModulesGraph {
+            var files: [String] = []
+            for target in producerTargets {
+                files.append("/Producer/Sources/\(target.name)/source.swift")
+            }
+            for target in consumerTargets {
+                files.append("/Consumer/Sources/\(target.name)/source.swift")
+            }
+            let fs = InMemoryFileSystem(emptyFiles: files)
+            let observability = ObservabilitySystem.makeForTesting()
+            return try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: consumerTargets,
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: producerProducts,
+                        targets: producerTargets,
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+        }
+
+        /// Builds a three-package graph:
+        ///   `Consumer` (root) → `middle` → `<leafPackageIdentity>`
+        ///
+        /// The root package depends ONLY on `middle`; the leaf package is
+        /// reachable only transitively via one of the middle's products.
+        /// Callers supply the middle package's products/targets and the leaf
+        /// package's products/targets — this permits scenarios where middle
+        /// has its own deprecated product (a `.direct` violation) alongside a
+        /// non-deprecated product that chains to a deprecated leaf product
+        /// (`.transitiveReachable`).
+        private func loadThreePackageChain(
+            rootTarget: TargetDescription,
+            middlePackageIdentity: String,
+            middleProducts: [ProductDescription],
+            middleTargets: [TargetDescription],
+            leafPackageIdentity: String,
+            leafProducts: [ProductDescription],
+            leafTargets: [TargetDescription],
+        ) throws -> ModulesGraph {
+            let middleDisplay = middlePackageIdentity.capitalized
+            let leafDisplay = leafPackageIdentity.capitalized
+
+            var files: [String] = ["/Consumer/Sources/\(rootTarget.name)/source.swift"]
+            for target in middleTargets {
+                files.append("/\(middleDisplay)/Sources/\(target.name)/source.swift")
+            }
+            for target in leafTargets {
+                files.append("/\(leafDisplay)/Sources/\(target.name)/source.swift")
+            }
+            let fs = InMemoryFileSystem(emptyFiles: files)
+            let observability = ObservabilitySystem.makeForTesting()
+            return try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: AbsolutePath("/\(middleDisplay)"),
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [rootTarget],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: middleDisplay,
+                        path: AbsolutePath("/\(middleDisplay)"),
+                        dependencies: [
+                            .localSourceControl(
+                                path: AbsolutePath("/\(leafDisplay)"),
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        products: middleProducts,
+                        targets: middleTargets,
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: leafDisplay,
+                        path: AbsolutePath("/\(leafDisplay)"),
+                        products: leafProducts,
+                        targets: leafTargets,
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+        }
+    }
+
+    @Suite
+    struct AuditReportProductTypeStringTests {
+
+        @Test
+        func productTypeString_mapsSupportedKinds() async throws {
+            #expect(auditProductTypeString(.executable) == "executable")
+            #expect(auditProductTypeString(.library(.automatic)) == "library")
+            #expect(auditProductTypeString(.library(.static)) == "library")
+            #expect(auditProductTypeString(.library(.dynamic)) == "library")
+            #expect(auditProductTypeString(.plugin) == "plugin")
+        }
+
+        @Test
+        func productTypeString_returnsNilForUnsupportedKinds() async throws {
+            #expect(auditProductTypeString(.test) == nil)
+            #expect(auditProductTypeString(.snippet) == nil)
+            #expect(auditProductTypeString(.macro) == nil)
+        }
+
+    }
+
+
+    @Suite
+    struct AuditReportTextRenderer {
+
+        @Test
+        func text_emptyReport_returnsExplicitMessage() async throws {
+            let empty = AuditReport(deprecated: .init(products: []))
+            #expect(renderAuditReportAsText(empty) == "No deprecated products found.")
+        }
+
+        @Test
+        func text_directOnly_emitsOnlyDirectSection() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "Use Paper.",
+                        package: "producer",
+                        product: "PaperLegacy",
+                        replacement: .renamed("Paper"),
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "MyApp"),
+                            BreadcrumbHop(package: "producer", product: "PaperLegacy"),
+                        ]],
+                    ),
+                ]),
+            )
+            let expected = """
+                Directly consumed deprecated products:
+                  package 'producer':
+                    library 'PaperLegacy' is unsupported
+                      Use Paper.
+                      Use 'Paper' instead.
+                      Used by: MyApp
+                """
+            #expect(renderAuditReportAsText(report) == expected)
+        }
+
+        @Test
+        func text_transitiveReachableOnly_emitsOnlyReachableSection() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "PaperExperimental",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["MyTransitiveApp"],
+                        transitive: .transitiveReachable,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer-transitive", target: "MyTransitiveApp"),
+                            BreadcrumbHop(package: "consumer", product: "MyLib"),
+                            BreadcrumbHop(package: "producer", product: "PaperExperimental"),
+                        ]],
+                    ),
+                ]),
+            )
+            let rendered = renderAuditReportAsText(report)
+            #expect(rendered.contains("Transitively reachable deprecated products:") == true)
+            #expect(rendered.contains("library 'PaperExperimental' is unsupported") == true)
+            #expect(rendered.contains("Used by: MyTransitiveApp") == true)
+            #expect(rendered.contains("Directly consumed deprecated products:") == false)
+            #expect(rendered.contains("Transitively unreachable") == false)
+        }
+
+        @Test
+        func text_transitiveUnreachableOnly_emitsOnlyUnreachableSection() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "Migrate to the standalone paper-tools package.",
+                        package: "producer",
+                        product: "paper-tool-old",
+                        replacement: .renamed("paper-tool", package: "paper-tools"),
+                        type: "executable",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let rendered = renderAuditReportAsText(report)
+            #expect(rendered.contains("Transitively unreachable deprecated products:") == true)
+            #expect(rendered.contains("executable 'paper-tool-old' is unsupported") == true)
+            #expect(rendered.contains("Migrate to the standalone paper-tools package.") == true)
+            #expect(rendered.contains("Use 'paper-tool' from package 'paper-tools' instead.") == true)
+            #expect(rendered.contains("Directly consumed deprecated products:") == false)
+            #expect(rendered.contains("Transitively reachable deprecated products:") == false)
+            // Unreachable entries have no 'Used by' line.
+            #expect(rendered.contains("Used by:") == false)
+        }
+
+        @Test
+        func text_allSections_areRenderedInFixedOrder() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Direct",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["App"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "App"),
+                            BreadcrumbHop(package: "producer", product: "Direct"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Reachable",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["MidLib"],
+                        transitive: .transitiveReachable,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "App"),
+                            BreadcrumbHop(package: "middle", product: "MidLib"),
+                            BreadcrumbHop(package: "producer", product: "Reachable"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Unreachable",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let rendered = renderAuditReportAsText(report)
+            let directIdx = try #require(rendered.range(of: "Directly consumed deprecated products:"))
+            let reachableIdx = try #require(rendered.range(of: "Transitively reachable deprecated products:"))
+            let unreachableIdx = try #require(rendered.range(of: "Transitively unreachable deprecated products:"))
+            #expect(directIdx != nil)
+            #expect(reachableIdx != nil)
+            #expect(unreachableIdx != nil)
+
+            #expect(directIdx.lowerBound < reachableIdx.lowerBound)
+            #expect(reachableIdx.lowerBound < unreachableIdx.lowerBound)
+        }
+
+        @Test
+        func text_emptyMessageStringIsSkipped() async throws {
+            // An empty (but non-nil) message string is treated the same as
+            // nil — no message line is emitted.
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "",
+                        package: "producer",
+                        product: "Old",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "Old"),
+                        ]],
+                    ),
+                ]),
+            )
+            let expected = """
+                Directly consumed deprecated products:
+                  package 'producer':
+                    library 'Old' is unsupported
+                      Used by: Consumer
+                """
+            let actual = renderAuditReportAsText(report)
+            #expect(actual == expected)
+        }
+
+        @Test
+        func text_executableAndPluginProductTypeLabelsAppear() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "old-tool",
+                        replacement: nil,
+                        type: "executable",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "old-tool"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "OldPlugin",
+                        replacement: nil,
+                        type: "plugin",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "OldPlugin"),
+                        ]],
+                    ),
+                ]),
+            )
+            let rendered = renderAuditReportAsText(report)
+            #expect(rendered.contains("executable 'old-tool' is unsupported") == true)
+            #expect(rendered.contains("plugin 'OldPlugin' is unsupported") == true)
+        }
+
+        @Test
+        func text_multipleEntriesGroupedByPackageWithinSection() async throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Alpha",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "Alpha"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Beta",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["Consumer"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "Consumer"),
+                            BreadcrumbHop(package: "producer", product: "Beta"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "third-party",
+                        product: "Gamma",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let expected = """
+                Directly consumed deprecated products:
+                  package 'producer':
+                    library 'Alpha' is unsupported
+                      Used by: Consumer
+                    library 'Beta' is unsupported
+                      Used by: Consumer
+
+                Transitively unreachable deprecated products:
+                  package 'third-party':
+                    library 'Gamma' is unsupported
+                """
+            let actual = renderAuditReportAsText(report)
+            #expect(actual == expected)
+        }
+    }
+
+    @Suite
+    struct AuditReportCodableTests {
+
+        @Test
+        func report_roundTripsThroughJSON() throws {
+            let original = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "Use New.",
+                        package: "producer",
+                        product: "Old",
+                        replacement: .renamed("New"),
+                        type: "library",
+                        usedBy: ["A", "B"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "A"),
+                            BreadcrumbHop(package: "producer", product: "Old"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: "The message",
+                        package: "thepackage",
+                        product: "deprecatedProductName",
+                        replacement: .renamed("New"),
+                        type: "executable",
+                        usedBy: ["A", "B", "C"],
+                        transitive: .transitiveReachable,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "A"),
+                            BreadcrumbHop(package: "intermediate", product: "Mid"),
+                            BreadcrumbHop(package: "thepackage", product: "deprecatedProductName"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "otherPackage",
+                        product: "otherProduct",
+                        replacement: nil,
+                        type: "plugin",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+
+                ]),
+            )
+            let encoded = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(AuditReport.self, from: encoded)
+            #expect(decoded == original)
+        }
+
+        @Test
+        func json_emptyReport_hasCanonicalShape() throws {
+            let empty = AuditReport(deprecated: .init(products: []))
+            let encoder = JSONEncoder()
+            encoder.outputFormatting.insert(.sortedKeys)
+            let data = try encoder.encode(empty)
+            let jsonString = String(decoding: data, as: UTF8.self)
+            // Sorted keys → the two keys serialize in stable alphabetical order.
+            #expect(jsonString == #"{"deprecated":{"products":[]}}"#)
+        }
+
+        @Test
+        func json_topLevelHasDeprecatedProductsKey() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "p",
+                        product: "q",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let deprecated = try #require(root["deprecated"] as? [String: Any])
+            let products = try #require(deprecated["products"] as? [[String: Any]])
+            #expect(products.count == 1)
+        }
+
+        @Test
+        func json_directEntryEmitsTransitiveDirectAndBreadcrumb() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "m",
+                        package: "producer",
+                        product: "Old",
+                        replacement: .renamed("New"),
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [
+                            [
+                                BreadcrumbHop(package: "consumer", target: "MyApp"),
+                                BreadcrumbHop(package: "producer", product: "Old"),
+                            ],
+                        ],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+
+            #expect(entry["message"] as? String == "m")
+            #expect(entry["package"] as? String == "producer")
+            #expect(entry["product"] as? String == "Old")
+            #expect(entry["type"] as? String == "library")
+            #expect(entry["usedBy"] as? [String] == ["MyApp"])
+            #expect(entry["transitive"] as? String == "direct")
+
+            let breadcrumb = try #require(entry["breadcrumb"] as? [[[String: Any]]])
+            #expect(breadcrumb.count == 1)
+            let path = try #require(breadcrumb.first)
+            #expect(path.count == 2)
+            #expect(path[0]["package"] as? String == "consumer")
+            #expect(path[0]["target"] as? String == "MyApp")
+            #expect(path[0]["product"] == nil)
+            #expect(path[1]["package"] as? String == "producer")
+            #expect(path[1]["product"] as? String == "Old")
+            #expect(path[1]["target"] == nil)
+
+            let replacement = try #require(entry["replacement"] as? [String: Any])
+            #expect(replacement["kind"] as? String == "renamed")
+            #expect(replacement["product"] as? String == "New")
+        }
+
+        @Test
+        func json_transitiveReachableEntry_hasReachableStringAndBreadcrumb() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "PaperExperimental",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["MyTransitiveApp"],
+                        transitive: .transitiveReachable,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer-transitive", target: "MyTransitiveApp"),
+                            BreadcrumbHop(package: "consumer", product: "MyLib"),
+                            BreadcrumbHop(package: "producer", product: "PaperExperimental"),
+                        ]],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            #expect(entry["transitive"] as? String == "transitiveReachable")
+            let breadcrumb = try #require(entry["breadcrumb"] as? [[[String: Any]]])
+            let path = try #require(breadcrumb.first)
+            #expect(path.count == 3)
+        }
+
+        @Test
+        func json_transitiveUnreachableEntry_omitsBreadcrumbKey() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "paper-tool-old",
+                        replacement: nil,
+                        type: "executable",
+                        usedBy: [],
+                        transitive: .transitiveUnreachable,
+                        breadcrumb: nil,
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            #expect(entry["transitive"] as? String == "transitiveUnreachable")
+            #expect(entry["breadcrumb"] == nil)
+            #expect(entry["usedBy"] as? [String] == [])
+        }
+
+        @Test
+        func json_crossPackageReplacementEmitsPackageAndProductFields() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "old-tool",
+                        replacement: .renamed("new-tool", package: "tools"),
+                        type: "executable",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "MyApp"),
+                            BreadcrumbHop(package: "producer", product: "old-tool"),
+                        ]],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            let replacement = try #require(entry["replacement"] as? [String: Any])
+            #expect(replacement["kind"] as? String == "renamed")
+            #expect(replacement["package"] as? String == "tools")
+            #expect(replacement["product"] as? String == "new-tool")
+        }
+
+        @Test
+        func json_nilReplacementOmitsReplacementKey() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "gone",
+                        package: "producer",
+                        product: "Old",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [
+                            [
+                                BreadcrumbHop(package: "consumer", target: "MyApp"),
+                                BreadcrumbHop(package: "producer", product: "Old"),
+                            ],
+                        ],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            #expect(entry["replacement"] == nil)
+        }
+
+        @Test
+        func json_nilMessageOmitsMessageKey() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "producer",
+                        product: "Old",
+                        replacement: .renamed("New"),
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "MyApp"),
+                            BreadcrumbHop(package: "producer", product: "Old"),
+                        ]],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let entry = try #require(products.first)
+            #expect(entry["message"] == nil)
+        }
+
+        @Test
+        func json_sortedKeysProducesByteStableOutput() throws {
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: "m",
+                        package: "producer",
+                        product: "Old",
+                        replacement: .renamed("New"),
+                        type: "library",
+                        usedBy: ["MyApp"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "MyApp"),
+                            BreadcrumbHop(package: "producer", product: "Old"),
+                        ]],
+                    ),
+                ]),
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting.insert(.sortedKeys)
+
+            // Two independent encodes with sortedKeys must produce identical bytes,
+            // regardless of dictionary iteration order.
+            let first = try encoder.encode(report)
+            let second = try encoder.encode(report)
+            #expect(first == second)
+
+            // Additionally verify the top-level object's keys are in alphabetical
+            // order (a schema requirement — audit-v1 says sorted keys at every
+            // nesting level).
+            let jsonString = String(decoding: first, as: UTF8.self)
+            let deprecatedIndex = try #require(jsonString.range(of: "\"deprecated\""))
+            #expect(jsonString[..<deprecatedIndex.lowerBound] == "{")
+        }
+
+        @Test
+        func json_multipleEntriesArraySortIsPreserved() throws {
+            // The encoder does not re-sort array elements; whatever order
+            // `buildAuditReport` places entries in is preserved on the wire.
+            let report = AuditReport(
+                deprecated: .init(products: [
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "aaa",
+                        product: "Alpha",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["C"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "C"),
+                            BreadcrumbHop(package: "aaa", product: "Alpha"),
+                        ]],
+                    ),
+                    DeprecatedProduct(
+                        message: nil,
+                        package: "bbb",
+                        product: "Beta",
+                        replacement: nil,
+                        type: "library",
+                        usedBy: ["C"],
+                        transitive: .direct,
+                        breadcrumb: [[
+                            BreadcrumbHop(package: "consumer", target: "C"),
+                            BreadcrumbHop(package: "bbb", product: "Beta"),
+                        ]],
+                    ),
+                ]),
+            )
+            let data = try JSONEncoder().encode(report)
+            let root = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let products = try #require((root["deprecated"] as? [String: Any])?["products"] as? [[String: Any]])
+            let names = products.compactMap { $0["product"] as? String }
+            #expect(names == ["Alpha", "Beta"])
+        }
+    }
+}

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -2036,6 +2036,126 @@ struct BuildCommandTestCases {
             #expect(hasOptRecord, "Should have .opt.yaml files in custom directory")
         }
     }
+
+    // MARK: - Product deprecation (SE-NNNN)
+
+    @Suite(
+        .tags(
+            .Feature.Deprecation,
+        ),
+    )
+    struct ProductDeprecation {
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildEmitsWarningForConsumerOfDeprecatedProduct(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    try await executeSwiftBuild(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperExperimental' from package 'producer' is unsupported: PaperExperimental is going away with no replacement.",
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                     #expect(
+                        error.stderr.contains(
+                            "warning: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+               }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildEscalatesToErrorForTargetWithTreatAllWarningsError(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    _ = try await executeSwiftBuild(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        extraArgs: ["--target", "MyLib"],
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperExperimental' from package 'producer' is unsupported: PaperExperimental is going away with no replacement.",
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                    #expect(
+                        error.stderr.contains(
+                            "warning: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildEscalatesToErrorViaXswiftcWarningsAsErrors(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    try await executeSwiftBuild(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        extraArgs: [
+                            "--target", "MyApp",
+                            "-Xswiftc", "-warnings-as-errors",
+                        ],
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildDoesNotWarnForNonConsumingPackage(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/producer") { fixturePath in
+                let (stdout, stderr) = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: .debug,
+                    buildSystem: buildSystem,
+                )
+                #expect(!stderr.contains("is unsupported"))
+                #expect(!stdout.contains("is unsupported"))
+            }
+        }
+    }
 }
 
 extension Triple {

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -2047,7 +2047,6 @@ struct BuildCommandTestCases {
     struct ProductDeprecation {
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func buildEmitsWarningForConsumerOfDeprecatedProduct(
@@ -2078,7 +2077,6 @@ struct BuildCommandTestCases {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func buildEscalatesToErrorForTargetWithTreatAllWarningsError(
@@ -2110,7 +2108,6 @@ struct BuildCommandTestCases {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func buildEscalatesToErrorViaXswiftcWarningsAsErrors(
@@ -2139,7 +2136,6 @@ struct BuildCommandTestCases {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func buildDoesNotWarnForNonConsumingPackage(
@@ -2151,8 +2147,42 @@ struct BuildCommandTestCases {
                     configuration: .debug,
                     buildSystem: buildSystem,
                 )
-                #expect(!stderr.contains("is unsupported"))
-                #expect(!stdout.contains("is unsupported"))
+                #expect(
+                    stderr.contains("is unsupported") == false,
+                    "stdout:\n\(stdout)",
+                )
+                #expect(
+                    stdout.contains("is unsupported") == false,
+                    "stderr:\n\(stderr)",
+                )
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildDoesNotWarnAboutProducersOwnProducts(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            // Building the producer package should NOT emit a deprecation
+            // diagnostic for any of its OWN products (PaperLegacy,
+            // PaperExperimental, paper-tool-old) because no producer target
+            // depends on them via `.product()`. A diagnostic about
+            // OldThirdParty (which the producer's `Paper` target does consume)
+            // is acceptable — that's the correct behavior for a producer that
+            // consumes a deprecated product from a third-party dependency.
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                let (_, stderr) = try await executeSwiftBuild(
+                    fixturePath.appending("producer"),
+                    configuration: .debug,
+                    buildSystem: buildSystem,
+                )
+                for productName in ["PaperLegacy", "PaperExperimental", "paper-tool-old"] {
+                    #expect(
+                        stderr.contains("product '\(productName)' from package 'producer' is unsupported") == false,
+                        "producer should not warn about its own product '\(productName)'\nstderr:\n\(stderr)",
+                    )
+                }
             }
         }
     }

--- a/Tests/CommandsTests/PackageCommandTests+Audit.swift
+++ b/Tests/CommandsTests/PackageCommandTests+Audit.swift
@@ -1,0 +1,658 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import _InternalTestSupport
+
+import struct SPMBuildCore.BuildSystemProvider
+
+extension PackageCommandTests.PackageAuditCommandTests {
+
+    @Suite(
+        .tags(
+            .Feature.Deprecation,
+        ),
+    )
+    struct ProductDeprecation {
+
+        // MARK: - Direct violations (transitive == "direct")
+
+        @Suite
+        struct DirectViolationsTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditReportsDirectDeprecatedProductsInJson(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        // consumer's MyApp directly consumes PaperLegacy;
+                        // MyLib directly consumes PaperExperimental. Both are
+                        // deprecated. Nothing else is reachable, so no
+                        // transitive entries appear (--include-transitive not
+                        // passed).
+                        #expect(products.count == 2, "unexpected products: \(products.map { $0["product"] as? String ?? "?" })")
+
+                        let byProduct = Dictionary(uniqueKeysWithValues: products.compactMap {
+                            (product) -> (String, [String: Any])? in
+                            guard let name = product["product"] as? String else { return nil }
+                            return (name, product)
+                        })
+
+                        let paperLegacy = try #require(byProduct["PaperLegacy"])
+                        #expect(paperLegacy["package"] as? String == "producer")
+                        #expect(paperLegacy["type"] as? String == "library")
+                        #expect(paperLegacy["transitive"] as? String == "direct")
+                        #expect(paperLegacy["message"] as? String == "PaperLegacy is superseded by Paper.")
+                        let paperLegacyReplacement = try #require(paperLegacy["replacement"] as? [String: Any])
+                        #expect(paperLegacyReplacement["kind"] as? String == "renamed")
+                        #expect(paperLegacyReplacement["product"] as? String == "Paper")
+                        #expect(paperLegacy["usedBy"] as? [String] == ["MyApp"])
+                        // Direct entries carry a breadcrumb: [target-hop, product-hop].
+                        let paperLegacyBreadcrumb = try #require(paperLegacy["breadcrumb"] as? [[[String: Any]]])
+                        #expect(paperLegacyBreadcrumb.count == 1)
+                        let paperLegacyPath = try #require(paperLegacyBreadcrumb.first)
+                        #expect(paperLegacyPath.count == 2)
+                        #expect(paperLegacyPath[0]["package"] as? String == "consumer")
+                        #expect(paperLegacyPath[0]["target"] as? String == "MyApp")
+                        #expect(paperLegacyPath[1]["package"] as? String == "producer")
+                        #expect(paperLegacyPath[1]["product"] as? String == "PaperLegacy")
+
+                        let experimental = try #require(byProduct["PaperExperimental"])
+                        #expect(experimental["type"] as? String == "library")
+                        #expect(experimental["transitive"] as? String == "direct")
+                        #expect(experimental["message"] as? String == "PaperExperimental is going away with no replacement.")
+                        #expect(experimental["replacement"] == nil)
+                        #expect(experimental["usedBy"] as? [String] == ["MyLib"])
+                        let experimentalBreadcrumb = try #require(experimental["breadcrumb"] as? [[[String: Any]]])
+                        #expect(experimentalBreadcrumb.count == 1)
+                        let experimentalPath = try #require(experimentalBreadcrumb.first)
+                        #expect(experimentalPath.count == 2)
+                        #expect(experimentalPath[0]["package"] as? String == "consumer")
+                        #expect(experimentalPath[0]["target"] as? String == "MyLib")
+                        #expect(experimentalPath[1]["package"] as? String == "producer")
+                        #expect(experimentalPath[1]["product"] as? String == "PaperExperimental")
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditReportsDirectDeprecatedProductsInText(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "text",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        #expect(
+                            error.stdout.contains("Directly consumed deprecated products:") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperLegacy") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperLegacy is superseded by Paper.") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("Use 'Paper' instead.") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperExperimental") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperExperimental is going away with no replacement.") == true,
+                            "stderr:\n\(error.stderr)",
+                        )
+                        // Nothing transitively reachable or unreachable is
+                        // included without --include-transitive.
+                        #expect(
+                            error.stdout.contains("Transitively reachable") == false,
+                            "unexpected transitive-reachable section:\n\(error.stderr)",
+                        )
+                        #expect(
+                            error.stdout.contains("Transitively unreachable") == false,
+                            "unexpected transitive-unreachable section:\n\(error.stderr)",
+                        )
+                    }
+                }
+            }
+        }
+
+        // MARK: - Exit-code semantics
+
+        @Suite
+        struct ExitCodeSemanticsTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditExitsNonZeroWhenDeprecatedProductsFound(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await #expect(throws: (any Error).self) {
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: ["audit"],
+                            buildSystem: buildSystem,
+                        )
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditExitsZeroWithAllowDeprecationsFlag(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await #expect(throws: Never.self) {
+                        let (_, _) = try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--allow-deprecations",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditRejectsInvalidFormat(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await #expect(throws: (any Error).self) {
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "invalid",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditRejectsInvalidIncludeTransitiveMode(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await #expect(throws: (any Error).self) {
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--include-transitive=bogus",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    }
+                }
+            }
+        }
+
+        // MARK: - Clean package (empty report)
+
+        @Suite
+        struct CleanPackageTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditOnCleanPackageEmitsEmptyReport(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Auditing `producer` directly: no producer target has a
+                // `.product(...)` dependency on any deprecated product, so
+                // there are no direct violations. Its own deprecated products
+                // (paper-tool-old, PaperLegacy, PaperExperimental) exist in the
+                // graph but are unreachable — without --include-transitive
+                // they're omitted.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    let (stdout, _) = try await executeSwiftPackage(
+                        fixturePath.appending("producer"),
+                        configuration: .debug,
+                        extraArgs: [
+                            "audit",
+                            "--format", "json",
+                        ],
+                        buildSystem: buildSystem,
+                    )
+                    let data = Data(stdout.utf8)
+                    let root = try #require(
+                        try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                    )
+                    let deprecated = try #require(root["deprecated"] as? [String: Any])
+                    let products = try #require(deprecated["products"] as? [[String: Any]])
+                    #expect(products.isEmpty, "unexpected products: \(products)")
+                }
+            }
+        }
+
+        // MARK: - Transitive reachable violations (transitive == "transitiveReachable")
+
+        @Suite
+        struct TransitiveReachableViolationsTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditOnConsumerTransitiveReportsNothingByDefault(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // `consumer-transitive` has one target (MyTransitiveApp) that
+                // depends on `.product("MyLib", package: "consumer")`. `MyLib`
+                // is NOT deprecated, so no direct violations. Without
+                // --include-transitive, its transitively-reachable deprecated
+                // product (PaperExperimental) is omitted → empty report.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    let (stdout, _) = try await executeSwiftPackage(
+                        fixturePath.appending("consumer-transitive"),
+                        configuration: .debug,
+                        extraArgs: [
+                            "audit",
+                            "--format", "json",
+                        ],
+                        buildSystem: buildSystem,
+                    )
+                    let data = Data(stdout.utf8)
+                    let root = try #require(
+                        try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                    )
+                    let deprecated = try #require(root["deprecated"] as? [String: Any])
+                    let products = try #require(deprecated["products"] as? [[String: Any]])
+                    #expect(products.isEmpty, "unexpected products: \(products)")
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditOnConsumerTransitiveWithBareIncludeTransitiveReportsReachable(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Bare `--include-transitive` (no value) defaults to
+                // "reachable" mode. PaperExperimental is transitively
+                // reachable via MyTransitiveApp → MyLib →
+                // .product(PaperExperimental, ...).
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        #expect(products.count == 1, "unexpected products: \(products.map { $0["product"] as? String ?? "?" })")
+
+                        let entry = try #require(products.first)
+                        #expect(entry["product"] as? String == "PaperExperimental")
+                        #expect(entry["package"] as? String == "producer")
+                        #expect(entry["transitive"] as? String == "transitiveReachable")
+                        #expect(entry["usedBy"] as? [String] == ["MyTransitiveApp"])
+                        // Breadcrumb: MyTransitiveApp (target) → consumer.MyLib
+                        // (product) → producer.PaperExperimental (product).
+                        let breadcrumb = try #require(entry["breadcrumb"] as? [[[String: Any]]])
+                        let path = try #require(breadcrumb.first)
+                        #expect(path.count == 3)
+                        #expect(path[0]["package"] as? String == "consumer-transitive")
+                        #expect(path[0]["target"] as? String == "MyTransitiveApp")
+                        #expect(path[1]["package"] as? String == "consumer")
+                        #expect(path[1]["product"] as? String == "MyLib")
+                        #expect(path[2]["package"] as? String == "producer")
+                        #expect(path[2]["product"] as? String == "PaperExperimental")
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditIncludeTransitiveEqualsReachableIsSameAsBare(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // `--include-transitive=reachable` is the explicit form of the
+                // bare flag; must produce the same report.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive=reachable",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        #expect(products.count == 1)
+                        let entry = try #require(products.first)
+                        #expect(entry["transitive"] as? String == "transitiveReachable")
+                        #expect(entry["product"] as? String == "PaperExperimental")
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditOnConsumerTransitiveTextEmitsReachableSection(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "text",
+                                "--include-transitive",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        #expect(
+                            error.stdout.contains("Transitively reachable deprecated products:"),
+                            "stdout:\n\(error.stdout)",
+                        )
+                        #expect(
+                            error.stdout.contains("PaperExperimental"),
+                            "stdout:\n\(error.stdout)",
+                        )
+                        // No direct violations on consumer-transitive.
+                        #expect(
+                            !error.stdout.contains("Directly consumed deprecated products:"),
+                            "unexpected direct section:\n\(error.stdout)",
+                        )
+                        // Not in "all" mode → no unreachable section.
+                        #expect(
+                            !error.stdout.contains("Transitively unreachable"),
+                            "unexpected unreachable section:\n\(error.stdout)",
+                        )
+                    }
+                }
+            }
+        }
+
+        // MARK: - Transitive unreachable violations (transitive == "transitiveUnreachable")
+
+        @Suite
+        struct TransitiveUnreachableViolationsTests {
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditWithIncludeTransitiveAllReportsUnreachableOnConsumer(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Auditing `consumer` with --include-transitive=all: MyApp and
+                // MyLib produce direct violations for PaperLegacy and
+                // PaperExperimental. `paper-tool-old` is deprecated in
+                // producer, is in the resolved graph, and no consumer target
+                // reaches it → surfaces as "transitiveUnreachable".
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive=all",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        let byProduct = Dictionary(uniqueKeysWithValues: products.compactMap {
+                            (product) -> (String, [String: Any])? in
+                            guard let name = product["product"] as? String else { return nil }
+                            return (name, product)
+                        })
+                        #expect(byProduct.count == 3, "unexpected products: \(byProduct.keys.sorted())")
+
+                        let legacy = try #require(byProduct["PaperLegacy"])
+                        #expect(legacy["transitive"] as? String == "direct")
+
+                        let experimental = try #require(byProduct["PaperExperimental"])
+                        #expect(experimental["transitive"] as? String == "direct")
+
+                        let tool = try #require(byProduct["paper-tool-old"])
+                        #expect(tool["transitive"] as? String == "transitiveUnreachable")
+                        #expect(tool["package"] as? String == "producer")
+                        #expect(tool["type"] as? String == "executable")
+                        #expect(tool["message"] as? String == "Migrate to the standalone paper-tools package.")
+                        let toolReplacement = try #require(tool["replacement"] as? [String: Any])
+                        #expect(toolReplacement["kind"] as? String == "renamed")
+                        #expect(toolReplacement["package"] as? String == "paper-tools")
+                        #expect(toolReplacement["product"] as? String == "paper-tool")
+                        // Empty usedBy for unreachable entries.
+                        #expect(tool["usedBy"] as? [String] == [])
+                        // Unreachable entries have no breadcrumb.
+                        #expect(tool["breadcrumb"] == nil)
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditWithIncludeTransitiveNonReachableSkipsReachable(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Auditing `consumer-transitive` with
+                // --include-transitive=non-reachable: PaperExperimental is
+                // reachable via MyTransitiveApp → consumer.MyLib → producer.
+                // PaperExperimental, so it MUST be omitted. paper-tool-old
+                // and PaperLegacy are unreachable from consumer-transitive
+                // (PaperLegacy is only consumed by consumer.MyApp, which is
+                // not on any chain from consumer-transitive), so both MUST
+                // be included as `transitiveUnreachable`.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive=non-reachable",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        let byProduct = Dictionary(uniqueKeysWithValues: products.compactMap {
+                            (product) -> (String, [String: Any])? in
+                            guard let name = product["product"] as? String else { return nil }
+                            return (name, product)
+                        })
+
+                        let names = Set(products.compactMap { $0["product"] as? String })
+                        #expect(
+                            names == ["paper-tool-old", "PaperLegacy"],
+                            "unexpected names: \(names)",
+                        )
+
+                        // PaperExperimental is reachable — skipped.
+                        #expect(byProduct["PaperExperimental"] == nil)
+                        // paper-tool-old is unreachable — included.
+                        let tool = try #require(byProduct["paper-tool-old"])
+                        #expect(tool["transitive"] as? String == "transitiveUnreachable")
+                        #expect(tool["usedBy"] as? [String] == [])
+                        #expect(tool["breadcrumb"] == nil)
+                        // PaperLegacy is also unreachable from consumer-transitive
+                        // (only consumer.MyApp reaches it, and MyApp isn't on
+                        // any chain from consumer-transitive).
+                        let legacy = try #require(byProduct["PaperLegacy"])
+                        #expect(legacy["transitive"] as? String == "transitiveUnreachable")
+                        #expect(legacy["usedBy"] as? [String] == [])
+                        #expect(legacy["breadcrumb"] == nil)
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditIncludeTransitiveReachableOmitsUnreachable(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                // Auditing `consumer-transitive` with
+                // --include-transitive=reachable: only `PaperExperimental`
+                // is reachable (via MyTransitiveApp → consumer.MyLib →
+                // producer.PaperExperimental). PaperLegacy and paper-tool-old
+                // are unreachable from consumer-transitive and MUST be
+                // omitted. MyLib is not deprecated so it doesn't appear at all.
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    try await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer-transitive"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "json",
+                                "--include-transitive=reachable",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        let data = Data(error.stdout.utf8)
+                        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                              let deprecated = root["deprecated"] as? [String: Any],
+                              let products = deprecated["products"] as? [[String: Any]] else {
+                            Issue.record("audit output is not valid JSON. stdout:\n\(error.stdout)")
+                            return
+                        }
+                        let names = Set(products.compactMap { $0["product"] as? String })
+                        #expect(
+                            names == ["PaperExperimental"],
+                            "unexpected products: \(names)",
+                        )
+                    }
+                }
+            }
+
+            @Test(
+                arguments: SupportedBuildSystemOnAllPlatforms,
+            )
+            func auditWithIncludeTransitiveAllTextEmitsUnreachableSection(
+                buildSystem: BuildSystemProvider.Kind,
+            ) async throws {
+                try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                    await expectThrowsCommandExecutionError(
+                        try await executeSwiftPackage(
+                            fixturePath.appending("consumer"),
+                            configuration: .debug,
+                            extraArgs: [
+                                "audit",
+                                "--format", "text",
+                                "--include-transitive=all",
+                            ],
+                            buildSystem: buildSystem,
+                        )
+                    ) { error in
+                        #expect(
+                            error.stdout.contains("Directly consumed deprecated products:") == true,
+                            "stdout:\n\(error.stdout)",
+                        )
+                        #expect(
+                            error.stdout.contains("Transitively unreachable deprecated products:") == true,
+                            "stdout:\n\(error.stdout)",
+                        )
+                        #expect(
+                            error.stdout.contains("paper-tool-old") == true,
+                            "stdout:\n\(error.stdout)",
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -106,6 +106,14 @@ struct PackageCommandTests {
     )
     enum PackageResolveCommandTests { }
 
+    @Suite(
+        .tags(
+            .TestSize.large,
+            .Feature.Command.Package.Audit,
+        ),
+    )
+    enum PackageAuditCommandTests { }
+
     @Test(
         arguments: SupportedBuildSystemOnAllPlatforms,
     )

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -97,6 +97,15 @@ private func executeAddURLDependencyAndAssert(
     ),
 )
 struct PackageCommandTests {
+
+    @Suite(
+        .tags(
+            .TestSize.large,
+            .Feature.Command.Package.Resolve,
+        ),
+    )
+    enum PackageResolveCommandTests { }
+
     @Test(
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
@@ -1239,6 +1248,69 @@ struct PackageCommandTests {
                 ]
             )
             // FIXME: We should also test dependencies and targets here.
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Package.DumpPackage,
+            .Feature.Deprecation,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func dumpPackageIncludesProductDeprecation(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let config = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/DeprecatedProducts") { fixturePath in
+            let packageRoot = fixturePath.appending("producer")
+            let (dumpOutput, _) = try await execute(
+                ["dump-package"],
+                packagePath: packageRoot,
+                configuration: config,
+                buildSystem: buildSystem,
+            )
+            let data = Data(dumpOutput.utf8)
+            let root = try #require(
+                try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            )
+            let products = try #require(root["products"] as? [[String: Any]])
+            let byName = Dictionary(
+                uniqueKeysWithValues: products.compactMap { product -> (String, [String: Any])? in
+                    guard let name = product["name"] as? String else { return nil }
+                    return (name, product)
+                },
+            )
+
+            // Control: `Paper` has no `deprecation` key.
+            let paper = try #require(byName["Paper"])
+            #expect(paper["deprecation"] == nil)
+
+            // `PaperLegacy` uses `.renamed("Paper")` (same-package).
+            let paperLegacy = try #require(byName["PaperLegacy"])
+            let legacyDeprecation = try #require(paperLegacy["deprecation"] as? [String: Any])
+            #expect(legacyDeprecation["message"] as? String == "PaperLegacy is superseded by Paper.")
+            let legacyReplacement = try #require(legacyDeprecation["replacement"] as? [String: Any])
+            #expect(legacyReplacement["kind"] as? String == "renamed")
+            #expect(legacyReplacement["product"] as? String == "Paper")
+            #expect(legacyReplacement["package"] == nil)
+
+            // `PaperExperimental` has a message but no replacement.
+            let experimental = try #require(byName["PaperExperimental"])
+            let experimentalDeprecation = try #require(experimental["deprecation"] as? [String: Any])
+            #expect(
+                experimentalDeprecation["message"] as? String
+                    == "PaperExperimental is going away with no replacement.",
+            )
+            #expect(experimentalDeprecation["replacement"] == nil)
+
+            // `paper-tool-old` uses `.renamed(_:package:)` (cross-package).
+            let tool = try #require(byName["paper-tool-old"])
+            let toolDeprecation = try #require(tool["deprecation"] as? [String: Any])
+            let toolReplacement = try #require(toolDeprecation["replacement"] as? [String: Any])
+            #expect(toolReplacement["kind"] as? String == "renamed")
+            #expect(toolReplacement["package"] as? String == "paper-tools")
+            #expect(toolReplacement["product"] as? String == "paper-tool")
         }
     }
 

--- a/Tests/CommandsTests/PackageCommandtests+Resolve.swift
+++ b/Tests/CommandsTests/PackageCommandtests+Resolve.swift
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import _InternalTestSupport
+
+import struct SPMBuildCore.BuildSystemProvider
+
+extension PackageCommandTests.PackageResolveCommandTests {
+
+    @Suite(
+        .tags(
+            .Feature.Deprecation,
+        ),
+    )
+    struct ProductDeprecation {
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func resolveEmitsWarningForConsumerOfDeprecatedProduct(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    try await executeSwiftPackage(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperExperimental' from package 'producer' is unsupported: PaperExperimental is going away with no replacement.",
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                     #expect(
+                        error.stderr.contains(
+                            "warning: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+               }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func resolveEscalatesToErrorViaXswiftcWarningsAsErrors(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    try await executeSwiftPackage(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        extraArgs: [
+                            "resolve",
+                            "-Xswiftc", "-warnings-as-errors",
+                        ],
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func resolveDoesNotWarnForNonConsumingPackage(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/producer") { fixturePath in
+                let (_, stderr) = try await executeSwiftPackage(
+                    fixturePath,
+                    configuration: .debug,
+                    extraArgs: ["resolve"],
+                    buildSystem: buildSystem,
+                )
+                #expect(!stderr.contains("is unsupported"))
+            }
+        }
+    }
+
+
+}

--- a/Tests/CommandsTests/PackageCommandtests+Resolve.swift
+++ b/Tests/CommandsTests/PackageCommandtests+Resolve.swift
@@ -25,7 +25,6 @@ extension PackageCommandTests.PackageResolveCommandTests {
     struct ProductDeprecation {
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func resolveEmitsWarningForConsumerOfDeprecatedProduct(
@@ -56,7 +55,6 @@ extension PackageCommandTests.PackageResolveCommandTests {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func resolveEscalatesToErrorViaXswiftcWarningsAsErrors(
@@ -85,20 +83,53 @@ extension PackageCommandTests.PackageResolveCommandTests {
         }
 
         @Test(
-            // .requireSwift6_5,
             arguments: SupportedBuildSystemOnAllPlatforms,
         )
         func resolveDoesNotWarnForNonConsumingPackage(
             buildSystem: BuildSystemProvider.Kind,
         ) async throws {
             try await fixture(name: "Miscellaneous/DeprecatedProducts/producer") { fixturePath in
-                let (_, stderr) = try await executeSwiftPackage(
+                let (stdout, stderr) = try await executeSwiftPackage(
                     fixturePath,
                     configuration: .debug,
                     extraArgs: ["resolve"],
                     buildSystem: buildSystem,
                 )
-                #expect(!stderr.contains("is unsupported"))
+                #expect(
+                    stderr.contains("is unsupported") == false,
+                    "stderr:\n\(stdout)",
+                )
+                #expect(
+                    stdout.contains("is unsupported") == false,
+                    "stderr:\n\(stderr)",
+                )
+            }
+        }
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func resolveDoesNotWarnAboutProducersOwnProducts(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            // Resolving the producer package should NOT emit a deprecation
+            // diagnostic for any of its OWN products because no producer target
+            // depends on them via `.product()`. A diagnostic about
+            // OldThirdParty (which the producer's `Paper` target does consume)
+            // is acceptable.
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                let (_, stderr) = try await executeSwiftPackage(
+                    fixturePath.appending("producer"),
+                    configuration: .debug,
+                    extraArgs: ["resolve"],
+                    buildSystem: buildSystem,
+                )
+                for productName in ["PaperLegacy", "PaperExperimental", "paper-tool-old"] {
+                    #expect(
+                        stderr.contains("product '\(productName)' from package 'producer' is unsupported") == false,
+                        "producer should not warn about its own product '\(productName)'\nstderr:\n\(stderr)",
+                    )
+                }
             }
         }
     }

--- a/Tests/CommandsTests/TestCommandTests.swift
+++ b/Tests/CommandsTests/TestCommandTests.swift
@@ -2681,5 +2681,43 @@ struct TestCommandTests {
             #expect(XCTestCaseSpecifier.specific("SomeTests/testFoo").normalizedForXCTest() == .specific("SomeTests/testFoo"))
         }
     }
+
+    // MARK: - Product deprecation (SE-NNNN)
+
+    /// Confirms that graph-load-time product-deprecation diagnostics fire
+    /// during `swift test` just as they do during `swift build` / `swift
+    /// package resolve`. This is a smoke test — the detailed matrix of
+    /// severity behavior is covered by `BuildCommandTestCases.ProductDeprecation`
+    /// and `PackageCommandTests.PackageResolveCommandTests.ProductDeprecation`.
+    @Suite(
+        .tags(
+            .Feature.Deprecation,
+        ),
+    )
+    struct ProductDeprecation {
+
+        @Test(
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func warningIsEmittedForConsumerOfDeprecatedProduct(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                let fixturePath = fixturePath.appending("consumer")
+                let (_, stderr) = try await executeSwiftTest(
+                    fixturePath,
+                    configuration: .debug,
+                    buildSystem: buildSystem,
+                    throwIfCommandFails: false,
+                )
+                #expect(
+                    stderr.contains(
+                        "warning: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead.",
+                    ),
+                    "stderr:\n\(stderr)",
+                )
+            }
+        }
+    }
 }
 

--- a/Tests/PackageGraphTests/ModulesGraphTests+ProductDeprecation.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests+ProductDeprecation.swift
@@ -1,0 +1,992 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageModel
+import TSCUtility
+import Testing
+import _InternalTestSupport
+
+@_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
+@testable import PackageGraph
+
+extension ModulesGraphTests {
+
+    @Suite(
+        .tags(
+            .TestSize.medium,
+            .Feature.Deprecation,
+        ),
+    )
+    struct ModulesGraphProductDeprecationTests {
+        // MARK: - Deprecation warning text (per SE-NNNN)
+
+        @Test
+        func deprecation_emitsWarningWithRenamedReplacement() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Paper/source.swift",
+                    "/Producer/Sources/PaperLegacy/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "PaperLegacy", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Paper",
+                                type: .library(.automatic),
+                                targets: ["Paper"],
+                            ),
+                            try ProductDescription(
+                                name: "PaperLegacy",
+                                type: .library(.automatic),
+                                targets: ["PaperLegacy"],
+                                deprecation: ProductDeprecation(
+                                    message: "PaperLegacy is superseded by Paper.",
+                                    replacement: .renamed("Paper"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Paper"),
+                            TargetDescription(name: "PaperLegacy", dependencies: ["Paper"]),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        @Test
+        func deprecation_emitsWarningWithInPackageReplacement() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/paper-tool-old/main.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "paper-tool-old", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "paper-tool-old",
+                                type: .executable,
+                                targets: ["paper-tool-old"],
+                                deprecation: ProductDeprecation(
+                                    message: "Migrate to the standalone paper-tools package.",
+                                    replacement: .renamed("paper-tool", package: "paper-tools"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "paper-tool-old", type: .executable),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'paper-tool-old' from package 'producer' is unsupported: Migrate to the standalone paper-tools package. Use 'paper-tool' from package 'paper-tools' instead.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        @Test
+        func deprecation_emitsWarningWithoutReplacement() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/PaperExperimental/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "PaperExperimental", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "PaperExperimental",
+                                type: .library(.automatic),
+                                targets: ["PaperExperimental"],
+                                deprecation: ProductDeprecation(
+                                    message: "PaperExperimental is going away with no replacement.",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "PaperExperimental"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'PaperExperimental' from package 'producer' is unsupported: PaperExperimental is going away with no replacement.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        @Test
+        func deprecation_emitsBareWarningWhenNoMessageAndNoReplacement() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Bare/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Bare", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Bare",
+                                type: .library(.automatic),
+                                targets: ["Bare"],
+                                deprecation: ProductDeprecation(
+                                    message: nil,
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Bare"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Bare' from package 'producer' is unsupported",
+                    severity: .warning,
+                )
+            }
+        }
+
+        // MARK: - Non-consumer producer emits no diagnostic
+
+        @Test
+        func deprecation_producerAloneEmitsNoDiagnostic() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles: "/Producer/Sources/PaperLegacy/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "PaperLegacy",
+                                type: .library(.automatic),
+                                targets: ["PaperLegacy"],
+                                deprecation: ProductDeprecation(
+                                    message: "old",
+                                    replacement: .renamed("New"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "PaperLegacy"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+            expectNoDiagnostics(observability.diagnostics)
+        }
+
+        // MARK: - Escalation via per-target treatAllWarnings(.error)
+
+        @Test
+        func deprecation_escalatesToErrorWhenConsumerHasTreatAllWarningsError() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .error,
+                )
+            }
+        }
+
+        // MARK: - Escalation via loadModulesGraph(treatWarningsAsErrors:)
+
+        @Test
+        func deprecation_escalatesToErrorWhenTreatWarningsAsErrorsGloballySet() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+                treatWarningsAsErrors: true,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .error,
+                )
+            }
+        }
+
+        // MARK: - Executable and plugin products
+
+        @Test
+        func deprecation_appliesToPluginProduct() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Plugins/OldPlugin/plugin.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "OldPlugin", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "OldPlugin",
+                                type: .plugin,
+                                targets: ["OldPlugin"],
+                                deprecation: ProductDeprecation(
+                                    message: nil,
+                                    replacement: .renamed("NewPlugin"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "OldPlugin",
+                                type: .plugin,
+                                pluginCapability: .buildTool,
+                            ),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'OldPlugin' from package 'producer' is unsupported: Use 'NewPlugin' instead.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        // MARK: - Extended treat-warnings-as-error coverage
+
+        /// `treatAllWarnings(.warning)` (explicit warning level) is a no-op for escalation:
+        /// the deprecation stays a warning.
+        @Test
+        func deprecation_treatAllWarningsWarningLevelDoesNotEscalate() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.warning),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// C-family `treatAllWarnings(.error)` should not escalate SwiftPM's own
+        /// deprecation diagnostic — the flag only applies to the Swift tool.
+        @Test
+        func deprecation_cTreatAllWarningsDoesNotEscalate() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .c,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                    .init(
+                                        tool: .cxx,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// A per-warning escalation via `treatWarning(name:as:)` does not escalate
+        /// the SwiftPM-emitted deprecation diagnostic. Only `treatAllWarnings(.error)`
+        /// on the Swift tool (or the global `-warnings-as-errors`) does.
+        @Test
+        func deprecation_treatSpecificWarningDoesNotEscalate() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatWarning("DeprecatedDeclaration", .error),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// Per-target escalation is scoped to the target that opted in — a second
+        /// consumer target without the setting keeps the plain warning severity.
+        @Test
+        func deprecation_perTargetEscalationDoesNotAffectOtherTargets() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/ConsumerStrict/source.swift",
+                    "/Consumer/Sources/ConsumerLoose/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "ConsumerStrict",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                            TargetDescription(
+                                name: "ConsumerLoose",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            // One error (from ConsumerStrict) and one warning (from ConsumerLoose).
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.checkUnordered(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .error,
+                )
+                result.checkUnordered(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// Two deprecated products in the producer, each consumed by a different
+        /// consumer target. Only the strict consumer's product diagnostic escalates
+        /// to an error; the loose consumer's stays a warning. Each product produces
+        /// exactly one diagnostic (from its one consumer).
+        @Test
+        func deprecation_twoProductsWithPerTargetEscalationScopedIndependently() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/ConsumerStrict/source.swift",
+                    "/Consumer/Sources/ConsumerLoose/source.swift",
+                    "/Producer/Sources/OldA/source.swift",
+                    "/Producer/Sources/OldB/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "ConsumerStrict",
+                                dependencies: [
+                                    .product(name: "OldA", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                            TargetDescription(
+                                name: "ConsumerLoose",
+                                dependencies: [
+                                    .product(name: "OldB", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "OldA",
+                                type: .library(.automatic),
+                                targets: ["OldA"],
+                                deprecation: ProductDeprecation(
+                                    message: "OldA is gone.",
+                                    replacement: .renamed("NewA"),
+                                ),
+                            ),
+                            try ProductDescription(
+                                name: "OldB",
+                                type: .library(.automatic),
+                                targets: ["OldB"],
+                                deprecation: ProductDeprecation(
+                                    message: "OldB is gone.",
+                                    replacement: .renamed("NewB"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "OldA"),
+                            TargetDescription(name: "OldB"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            // Each product is consumed by exactly one target, so we expect one
+            // diagnostic per product with the severity determined by that target's
+            // own escalation setting.
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.checkUnordered(
+                    diagnostic: "product 'OldA' from package 'producer' is unsupported: OldA is gone. Use 'NewA' instead.",
+                    severity: .error,
+                )
+                result.checkUnordered(
+                    diagnostic: "product 'OldB' from package 'producer' is unsupported: OldB is gone. Use 'NewB' instead.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// When both per-target `treatAllWarnings(.error)` and the global
+        /// `treatWarningsAsErrors: true` are set, the diagnostic is still an error
+        /// (idempotence).
+        @Test
+        func deprecation_bothPerTargetAndGlobalEscalationCombine() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+                treatWarningsAsErrors: true,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .error,
+                )
+            }
+        }
+
+        /// Global escalation via `treatWarningsAsErrors: true` still emits **no**
+        /// diagnostic when no consumer references the deprecated product.
+        @Test
+        func deprecation_globalEscalationWithNoConsumerEmitsNothing() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles: "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+                treatWarningsAsErrors: true,
+            )
+            expectNoDiagnostics(observability.diagnostics)
+        }
+    }
+}
+

--- a/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
@@ -39,4 +39,213 @@ final class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
             }
         }
     }
+
+    // MARK: - Product deprecation (SE-NNNN)
+
+    func testProductDeprecationOnLibraryWithSamePackageReplacement() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(
+                        name: "Old",
+                        targets: ["Old"],
+                        deprecated: .unsupported(
+                            message: "Use New instead.",
+                            replacement: .renamed("New")
+                        )
+                    ),
+                ],
+                targets: [
+                    .target(name: "Old"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        XCTAssertEqual(product.name, "Old")
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(deprecation.message, "Use New instead.")
+        XCTAssertEqual(deprecation.replacement, .renamed("New"))
+    }
+
+    func testProductDeprecationOnLibraryWithCrossPackageReplacement() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(
+                        name: "Old",
+                        targets: ["Old"],
+                        deprecated: .unsupported(
+                            message: "Migrate to OtherPkg.",
+                            replacement: .renamed("OtherProduct", package: "other-pkg")
+                        )
+                    ),
+                ],
+                targets: [
+                    .target(name: "Old"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(
+            deprecation.replacement,
+            .renamed("OtherProduct", package: "other-pkg")
+        )
+    }
+
+    func testProductDeprecationOnLibraryWithoutReplacement() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(
+                        name: "Old",
+                        targets: ["Old"],
+                        deprecated: .unsupported(
+                            message: "Retired with no replacement."
+                        )
+                    ),
+                ],
+                targets: [
+                    .target(name: "Old"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(deprecation.message, "Retired with no replacement.")
+        XCTAssertNil(deprecation.replacement)
+    }
+
+    func testProductDeprecationOnLibraryWithEmptyUnsupported() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(
+                        name: "Old",
+                        targets: ["Old"],
+                        deprecated: .unsupported()
+                    ),
+                ],
+                targets: [
+                    .target(name: "Old"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertNil(deprecation.message)
+        XCTAssertNil(deprecation.replacement)
+    }
+
+    func testProductDeprecationOnExecutable() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .executable(
+                        name: "old-tool",
+                        targets: ["old-tool"],
+                        deprecated: .unsupported(
+                            message: "Use new-tool instead.",
+                            replacement: .renamed("new-tool", package: "tools")
+                        )
+                    ),
+                ],
+                targets: [
+                    .executableTarget(name: "old-tool"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        XCTAssertEqual(product.type, .executable)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(deprecation.message, "Use new-tool instead.")
+        XCTAssertEqual(
+            deprecation.replacement,
+            .renamed("new-tool", package: "tools")
+        )
+    }
+
+    func testProductDeprecationOnPlugin() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .plugin(
+                        name: "OldPlugin",
+                        targets: ["OldPlugin"],
+                        deprecated: .unsupported(
+                            message: "Use NewPlugin instead.",
+                            replacement: .renamed("NewPlugin")
+                        )
+                    ),
+                ],
+                targets: [
+                    .plugin(
+                        name: "OldPlugin",
+                        capability: .command(intent: .custom(verb: "old", description: "old plugin"))
+                    ),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        XCTAssertEqual(product.type, .plugin)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(deprecation.replacement, .renamed("NewPlugin"))
+    }
+
+    func testProductWithoutDeprecatedParameterHasNilDeprecation() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(name: "Foo", targets: ["Foo"]),
+                ],
+                targets: [
+                    .target(name: "Foo"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        XCTAssertNil(product.deprecation)
+    }
 }

--- a/Tests/PackageLoadingTests/PackageDescription_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PackageDescription_LoadingTests.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageLoading
+import PackageModel
+import SourceControl
+import _InternalTestSupport
+import Testing
+
+@Suite(
+    .tags(
+        .TestSize.medium
+    )
+)
+struct PackageDescriptionLoadingTestsST {
+
+    @Test(
+        arguments: [
+            ToolsVersion.minimumRequired,
+            ToolsVersion.v6_2,
+            ToolsVersion.v6_3,
+            ToolsVersion.v6_4,
+        ]
+    )
+    func productDeprecatedParameterUnavailableAtV6_2(
+        toolVersion: ToolsVersion,
+    ) async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                products: [
+                    .library(
+                        name: "Foo",
+                        targets: ["Foo"],
+                        deprecated: .unsupported(message: "not yet available")
+                    ),
+                ],
+                targets: [
+                    .target(name: "Foo"),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        await #expect(throws: (any Error).self) {
+            try await PackageDescriptionLoadingTests.loadAndValidateManifest(
+                content,
+                toolsVersion: toolVersion,
+                packageKind: .fileSystem(.root),
+                manifestLoader: ManifestLoader(
+                    toolchain: try! UserToolchain.default,
+                ),
+                observabilityScope: observability.topScope,
+            )
+        }
+    }
+}
+
+private var isWindows: Bool {
+#if os(Windows)
+    true
+#else
+    false
+#endif
+}

--- a/Tests/PackageLoadingTests/ProductDeprecationSerializationTests.swift
+++ b/Tests/PackageLoadingTests/ProductDeprecationSerializationTests.swift
@@ -1,0 +1,317 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import PackageModel
+import Testing
+
+@testable import PackageLoading
+
+@Suite(
+    .tags(
+        .TestSize.small,
+        .FunctionalArea.Manifest,
+        .Feature.Deprecation,
+    ),
+)
+struct ProductDeprecationSerializationTests {
+
+    // MARK: - Serialization.Product.Deprecation.Replacement wire format
+
+    @Test
+    func replacementSamePackageEncodesToWireFormat() throws {
+        let replacement: Serialization.Product.Deprecation.Replacement = .renamed("NewName")
+        let encoded = try JSONEncoder().encode(replacement)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["kind"] as? String == "renamed")
+        #expect(json["product"] as? String == "NewName")
+        #expect(json["package"] == nil)
+    }
+
+    @Test
+    func replacementCrossPackageEncodesToWireFormat() throws {
+        let replacement: Serialization.Product.Deprecation.Replacement = .renamed(
+            "prod",
+            package: "pkg",
+        )
+        let encoded = try JSONEncoder().encode(replacement)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["kind"] as? String == "renamed")
+        #expect(json["product"] as? String == "prod")
+        #expect(json["package"] as? String == "pkg")
+    }
+
+    @Test
+    func replacementSamePackageDecodesFromWireFormat() throws {
+        let json = #"{"kind":"renamed","product":"NewName"}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.Replacement.self,
+            from: data,
+        )
+        guard case .renamed(let product, let package) = decoded else {
+            Issue.record("expected .renamed case, got \(decoded)")
+            return
+        }
+        #expect(product == "NewName")
+        #expect(package == nil)
+    }
+
+    @Test
+    func replacementCrossPackageDecodesFromWireFormat() throws {
+        let json = #"{"kind":"renamed","product":"prod","package":"pkg"}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.Replacement.self,
+            from: data,
+        )
+        guard case .renamed(let product, let package) = decoded else {
+            Issue.record("expected .renamed case, got \(decoded)")
+            return
+        }
+        #expect(product == "prod")
+        #expect(package == "pkg")
+    }
+
+    @Test
+    func replacementSamePackageRoundTrips() throws {
+        let original: Serialization.Product.Deprecation.Replacement = .renamed("Foo")
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.Replacement.self,
+            from: encoded,
+        )
+        guard case .renamed(let product, let package) = decoded else {
+            Issue.record("expected .renamed case, got \(decoded)")
+            return
+        }
+        #expect(product == "Foo")
+        #expect(package == nil)
+    }
+
+    @Test
+    func replacementCrossPackageRoundTrips() throws {
+        let original: Serialization.Product.Deprecation.Replacement = .renamed(
+            "q",
+            package: "p",
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.Replacement.self,
+            from: encoded,
+        )
+        guard case .renamed(let product, let package) = decoded else {
+            Issue.record("expected .renamed case, got \(decoded)")
+            return
+        }
+        #expect(product == "q")
+        #expect(package == "p")
+    }
+
+    // MARK: - Serialization.Product.Deprecation Codable
+
+    @Test
+    func deprecationWithMessageAndReplacementRoundTrips() throws {
+        let original = Serialization.Product.Deprecation(
+            message: "Use New instead.",
+            replacement: .renamed("New"),
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.self,
+            from: encoded,
+        )
+        #expect(decoded.message == "Use New instead.")
+        let replacement = try #require(decoded.replacement)
+        guard case .renamed(let product, let package) = replacement else {
+            Issue.record("expected .renamed replacement, got \(replacement)")
+            return
+        }
+        #expect(product == "New")
+        #expect(package == nil)
+    }
+
+    @Test
+    func deprecationWithMessageOnlyRoundTrips() throws {
+        let original = Serialization.Product.Deprecation(
+            message: "Retired.",
+            replacement: nil,
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.self,
+            from: encoded,
+        )
+        #expect(decoded.message == "Retired.")
+        #expect(decoded.replacement == nil)
+    }
+
+    @Test
+    func deprecationEmptyRoundTrips() throws {
+        let original = Serialization.Product.Deprecation(
+            message: nil,
+            replacement: nil,
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.self,
+            from: encoded,
+        )
+        #expect(decoded.message == nil)
+        #expect(decoded.replacement == nil)
+    }
+
+    // MARK: - Wire → model conversion (Serialization.Product → ProductDescription)
+
+    @Test
+    func wireProductWithoutDeprecationConvertsToModelWithNilDeprecation() throws {
+        let wire = makeWireProduct(
+            name: "Foo",
+            productType: .library(type: .automatic),
+            deprecation: nil,
+        )
+        let model = try ProductDescription(wire)
+        #expect(model.name == "Foo")
+        #expect(model.deprecation == nil)
+    }
+
+    @Test
+    func wireProductWithSamePackageReplacementConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "OldLib",
+            productType: .library(type: .automatic),
+            deprecation: .init(
+                message: "Use NewLib instead.",
+                replacement: .renamed("NewLib"),
+            ),
+        )
+        let model = try ProductDescription(wire)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == "Use NewLib instead.")
+        #expect(deprecation.replacement == .renamed("NewLib"))
+    }
+
+    @Test
+    func wireProductWithCrossPackageReplacementConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "old-tool",
+            productType: .executable,
+            deprecation: .init(
+                message: "Migrate to new-tool.",
+                replacement: .renamed("new-tool", package: "tools"),
+            ),
+        )
+        let model = try ProductDescription(wire)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == "Migrate to new-tool.")
+        #expect(deprecation.replacement == .renamed("new-tool", package: "tools"))
+    }
+
+    @Test
+    func wireProductWithNoReplacementConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "Retired",
+            productType: .library(type: .automatic),
+            deprecation: .init(
+                message: "Gone.",
+                replacement: nil,
+            ),
+        )
+        let model = try ProductDescription(wire)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == "Gone.")
+        #expect(deprecation.replacement == nil)
+    }
+
+    @Test
+    func wireProductWithEmptyDeprecationConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "Foo",
+            productType: .library(type: .automatic),
+            deprecation: .init(
+                message: nil,
+                replacement: nil,
+            ),
+        )
+        let model = try ProductDescription(wire)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == nil)
+        #expect(deprecation.replacement == nil)
+    }
+
+    @Test
+    func wirePluginProductWithDeprecationConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "OldPlugin",
+            productType: .plugin,
+            deprecation: .init(
+                message: nil,
+                replacement: .renamed("NewPlugin"),
+            ),
+        )
+        let model = try ProductDescription(wire)
+        #expect(model.type == .plugin)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == nil)
+        #expect(deprecation.replacement == .renamed("NewPlugin"))
+    }
+
+    // MARK: - End-to-end wire → JSON → wire → model
+
+    @Test
+    func fullPipelineEndToEnd() throws {
+        let originalWire = makeWireProduct(
+            name: "OldLib",
+            productType: .library(type: .automatic),
+            deprecation: .init(
+                message: "Use NewLib instead.",
+                replacement: .renamed("NewLib"),
+            ),
+        )
+
+        let jsonData = try JSONEncoder().encode(originalWire)
+        let decodedWire = try JSONDecoder().decode(Serialization.Product.self, from: jsonData)
+        let model = try ProductDescription(decodedWire)
+
+        #expect(model.name == "OldLib")
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == "Use NewLib instead.")
+        #expect(deprecation.replacement == .renamed("NewLib"))
+    }
+
+    // MARK: - Helpers
+
+    /// Constructs a `Serialization.Product` value across both `ENABLE_APPLE_PRODUCT_TYPES`
+    /// build configurations so tests compile whether or not the flag is defined.
+    private func makeWireProduct(
+        name: String,
+        productType: Serialization.Product.ProductType,
+        deprecation: Serialization.Product.Deprecation?,
+    ) -> Serialization.Product {
+        #if ENABLE_APPLE_PRODUCT_TYPES
+        return Serialization.Product(
+            name: name,
+            targets: [name],
+            productType: productType,
+            deprecation: deprecation,
+            settings: [],
+        )
+        #else
+        return Serialization.Product(
+            name: name,
+            targets: [name],
+            productType: productType,
+            deprecation: deprecation,
+        )
+        #endif
+    }
+}

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import _InternalTestSupport
+import Foundation
 import PackageModel
 import XCTest
 
@@ -1272,5 +1273,93 @@ class ManifestTests: XCTestCase {
                 XCTAssertEqual(dependency.name, "Boo")
             }
         }
+    }
+
+    func testManifestEncodingIncludesProductDeprecation() throws {
+        let products = try [
+            ProductDescription(
+                name: "PaperLegacy",
+                type: .library(.automatic),
+                targets: ["PaperLegacy"],
+                deprecation: ProductDeprecation(
+                    message: "PaperLegacy is superseded by Paper.",
+                    replacement: .renamed("Paper"),
+                ),
+            ),
+            ProductDescription(
+                name: "paper-tool-old",
+                type: .executable,
+                targets: ["paper-tool-old"],
+                deprecation: ProductDeprecation(
+                    message: "Migrate to the standalone paper-tools package.",
+                    replacement: .renamed("paper-tool", package: "paper-tools"),
+                ),
+            ),
+            ProductDescription(
+                name: "PaperExperimental",
+                type: .library(.automatic),
+                targets: ["PaperExperimental"],
+                deprecation: ProductDeprecation(
+                    message: "PaperExperimental is going away with no replacement.",
+                    replacement: nil,
+                ),
+            ),
+            ProductDescription(
+                name: "Paper",
+                type: .library(.automatic),
+                targets: ["Paper"],
+            ),
+        ]
+        let targets = try [
+            TargetDescription(name: "Paper"),
+            TargetDescription(name: "PaperLegacy"),
+            TargetDescription(name: "PaperExperimental"),
+            TargetDescription(name: "paper-tool-old"),
+        ]
+        let manifest = Manifest.createRootManifest(
+            displayName: "Paper",
+            path: "/Paper",
+            products: products,
+            targets: targets,
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(manifest)
+        let root = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any],
+        )
+        let productsJSON = try XCTUnwrap(root["products"] as? [[String: Any]])
+        XCTAssertEqual(productsJSON.count, 4)
+
+        let byName = Dictionary(uniqueKeysWithValues: productsJSON.map { product -> (String, [String: Any]) in
+            let name = product["name"] as? String ?? ""
+            return (name, product)
+        })
+
+        let renamedProduct = try XCTUnwrap(byName["PaperLegacy"])
+        let renamedDeprecation = try XCTUnwrap(renamedProduct["deprecation"] as? [String: Any])
+        XCTAssertEqual(renamedDeprecation["message"] as? String, "PaperLegacy is superseded by Paper.")
+        let renamedReplacement = try XCTUnwrap(renamedDeprecation["replacement"] as? [String: Any])
+        XCTAssertEqual(renamedReplacement["kind"] as? String, "renamed")
+        XCTAssertEqual(renamedReplacement["product"] as? String, "Paper")
+        XCTAssertNil(renamedReplacement["package"])
+
+        let crossPackageProduct = try XCTUnwrap(byName["paper-tool-old"])
+        let crossPackageDeprecation = try XCTUnwrap(crossPackageProduct["deprecation"] as? [String: Any])
+        let crossPackageReplacement = try XCTUnwrap(crossPackageDeprecation["replacement"] as? [String: Any])
+        XCTAssertEqual(crossPackageReplacement["kind"] as? String, "renamed")
+        XCTAssertEqual(crossPackageReplacement["package"] as? String, "paper-tools")
+        XCTAssertEqual(crossPackageReplacement["product"] as? String, "paper-tool")
+
+        let noReplacementProduct = try XCTUnwrap(byName["PaperExperimental"])
+        let noReplacementDeprecation = try XCTUnwrap(noReplacementProduct["deprecation"] as? [String: Any])
+        XCTAssertEqual(
+            noReplacementDeprecation["message"] as? String,
+            "PaperExperimental is going away with no replacement.",
+        )
+        XCTAssertNil(noReplacementDeprecation["replacement"])
+
+        let controlProduct = try XCTUnwrap(byName["Paper"])
+        XCTAssertNil(controlProduct["deprecation"])
     }
 }

--- a/Tests/PackageModelTests/ProductDeprecationTests.swift
+++ b/Tests/PackageModelTests/ProductDeprecationTests.swift
@@ -1,0 +1,215 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import PackageModel
+import Testing
+
+@Suite(
+    .tags(
+        .TestSize.small,
+        .FunctionalArea.Manifest,
+        .Feature.Deprecation,
+    ),
+)
+struct ProductDeprecationTests {
+
+    // MARK: - ProductDescription.deprecation storage
+
+    @Test
+    func productDescriptionWithoutDeprecation() throws {
+        let product = try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"])
+        #expect(product.deprecation == nil)
+    }
+
+    @Test
+    func productDescriptionWithDeprecationRenamed() throws {
+        let deprecation = ProductDeprecation(
+            message: "Use Bar instead.",
+            replacement: .renamed("Bar")
+        )
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let productDeprecation = try #require(product.deprecation)
+        #expect(productDeprecation.message == "Use Bar instead.")
+        #expect(productDeprecation.replacement == .renamed("Bar"))
+    }
+
+    @Test
+    func productDescriptionWithDeprecationInOtherPackage() throws {
+        let deprecation = ProductDeprecation(
+            message: "Migrate to other-package.",
+            replacement: .renamed("OtherProduct", package: "other-package")
+        )
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let productDeprecation = try #require(product.deprecation)
+        #expect(productDeprecation.replacement == .renamed("OtherProduct", package: "other-package"))
+    }
+
+    @Test
+    func productDescriptionWithDeprecationNoMessageNoReplacement() throws {
+        let deprecation = ProductDeprecation(message: nil, replacement: nil)
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let productDeprecation = try #require(product.deprecation)
+        #expect(productDeprecation.message == nil)
+        #expect(productDeprecation.replacement == nil)
+    }
+
+    // MARK: - ProductDescription Codable round-trip
+
+    @Test
+    func productDescriptionRoundTripNoDeprecation() throws {
+        let product = try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"])
+        let encoded = try JSONEncoder().encode(product)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: encoded)
+        #expect(decoded.name == product.name)
+        #expect(decoded.deprecation == nil)
+    }
+
+    @Test
+    func productDescriptionRoundTripRenamedReplacement() throws {
+        let deprecation = ProductDeprecation(
+            message: "Use Bar instead.",
+            replacement: .renamed("Bar")
+        )
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let encoded = try JSONEncoder().encode(product)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: encoded)
+
+        let decodedDeprecation = try #require(decoded.deprecation)
+        #expect(decodedDeprecation.message == "Use Bar instead.")
+        #expect(decodedDeprecation.replacement == .renamed("Bar"))
+    }
+
+    @Test
+    func productDescriptionRoundTripCrossPackageReplacement() throws {
+        let deprecation = ProductDeprecation(
+            message: "Move to other package.",
+            replacement: .renamed("prod", package: "pkg")
+        )
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .executable,
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let encoded = try JSONEncoder().encode(product)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: encoded)
+        let decodedDeprecation = try #require(decoded.deprecation)
+        #expect(decodedDeprecation.replacement == .renamed("prod", package: "pkg"))
+    }
+
+    @Test
+    func productDescriptionRoundTripNoMessageNoReplacement() throws {
+        let deprecation = ProductDeprecation(message: nil, replacement: nil)
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let encoded = try JSONEncoder().encode(product)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: encoded)
+        let decodedDeprecation = try #require(decoded.deprecation)
+        #expect(decodedDeprecation.message == nil)
+        #expect(decodedDeprecation.replacement == nil)
+    }
+
+    // MARK: - Legacy JSON without deprecation field
+
+    @Test
+    func legacyJSONWithoutDeprecationFieldDecodes() throws {
+        let legacyJSON = #"{"name":"Foo","targets":["Foo"],"type":{"library":["automatic"]},"settings":[]}"#
+        let data = Data(legacyJSON.utf8)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: data)
+        #expect(decoded.name == "Foo")
+        #expect(decoded.deprecation == nil)
+    }
+
+    // MARK: - Replacement discriminated Codable wire format
+
+    @Test
+    func replacementSamePackageEncodesAsKindAndProduct() throws {
+        let replacement: ProductDeprecation.Replacement = .renamed("NewName")
+        let encoded = try JSONEncoder().encode(replacement)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["kind"] as? String == "renamed")
+        #expect(json["product"] as? String == "NewName")
+        #expect(json["package"] == nil)
+    }
+
+    @Test
+    func replacementCrossPackageEncodesAsKindProductAndPackage() throws {
+        let replacement: ProductDeprecation.Replacement = .renamed("prod", package: "pkg")
+        let encoded = try JSONEncoder().encode(replacement)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["kind"] as? String == "renamed")
+        #expect(json["product"] as? String == "prod")
+        #expect(json["package"] as? String == "pkg")
+    }
+
+    @Test
+    func replacementDecodesSamePackageWireFormat() throws {
+        let json = #"{"kind":"renamed","product":"NewName"}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(ProductDeprecation.Replacement.self, from: data)
+        #expect(decoded == .renamed("NewName"))
+    }
+
+    @Test
+    func replacementDecodesCrossPackageWireFormat() throws {
+        let json = #"{"kind":"renamed","product":"prod","package":"pkg"}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(ProductDeprecation.Replacement.self, from: data)
+        #expect(decoded == .renamed("prod", package: "pkg"))
+    }
+
+    // MARK: - Hashable and Equatable
+
+    @Test
+    func productDeprecationEquality() {
+        let a = ProductDeprecation(message: "m", replacement: .renamed("N"))
+        let b = ProductDeprecation(message: "m", replacement: .renamed("N"))
+        let c = ProductDeprecation(message: "m", replacement: .renamed("Other"))
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test
+    func productDeprecationHashable() {
+        let a = ProductDeprecation(message: "m", replacement: .renamed("N"))
+        let b = ProductDeprecation(message: "m", replacement: .renamed("N"))
+        var set = Set<ProductDeprecation>()
+        set.insert(a)
+        set.insert(b)
+        #expect(set.count == 1)
+    }
+}


### PR DESCRIPTION
- [Swift Evolution Proposal](https://github.com/swiftlang/swift-evolution/pull/3401)
- [Pitch thread](https://forums.swift.org/t/pitch-deprecating-package-products-in-the-package-manifest/88468)

Completes SE-NNNN by adding the on-demand audit surface. Builds on the plumbing and build-time warning from the previous commit.

The new `swift package audit` command loads the resolved package graph and reports every deprecated product it finds, grouped by producing package. Output is human-readable by default and can be switched to JSON for tooling. The report includes which of the current package's targets consume each deprecated product; `--include-transitive` also lists deprecated products that are reachable through the graph but not directly consumed. The command exits with a non-zero status when findings exist, which is convenient for CI, unless `--allow-deprecations` is passed for interactive use.

Along the way, this commit adds a way to suppress the graph-load-time deprecation diagnostics that were introduced in the previous commit, threaded through the workspace and graph-loading APIs. The audit command opts out of those diagnostics because it produces its own structured report, and because a consumer target with `.treatAllWarnings(as: .error)` in the graph would otherwise escalate a deprecation to a hard error and prevent the audit from completing.

The `DeprecatedProducts` fixture is extended with a `third-party` sub-package that vends its own deprecated product, and the `producer` sub-package now depends on it. That gives every test — build, resolve, audit, and `dump-package` — a realistic three-package graph to exercise including the transitive path, without needing a separate fixture per scenario. A few existing "producer doesn't warn about its own products" tests were updated to match the new fixture shape.

A smoke test also confirms that `swift test` emits deprecation diagnostics during graph load, matching what `swift build` and `swift package resolve` already do.

Coverage: pure-logic unit tests for the report builder and text renderer, end-to-end tests for the audit command across every flag combination, and updates to the existing build/resolve/`swift test` tests. All tests pass locally on both the native and swiftbuild build systems.

Blocked on: #10400
Blocked on: #10411