### PR TITLE
fix(package-loading): clarify missing public headers diagnostics

### DIFF
--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -57,6 +57,9 @@ public enum ModuleError: Swift.Error {
     /// The public headers directory is at an invalid path.
     case invalidPublicHeadersDirectory(String)
 
+    /// The required public headers directory does not exist.
+    case missingPublicHeadersDirectory(target: String, path: String)
+
     /// The sources of a target are overlapping with another target.
     case overlappingSources(target: String, sources: [AbsolutePath])
 
@@ -125,7 +128,10 @@ extension ModuleError: CustomStringConvertible {
                 (cycle.path + cycle.cycle).joined(separator: " -> ") +
                 " -> " + cycle.cycle[0]
         case .invalidPublicHeadersDirectory(let name):
-            return "public headers (\"include\") directory path for '\(name)' is invalid or not contained in the target"
+            return "public headers directory path for target '\(name)' must be contained within the target directory"
+        case .missingPublicHeadersDirectory(let target, let path):
+            return "target '\(target)' is missing required public headers directory '\(path)'; " +
+                "create it or configure 'publicHeadersPath' in Package.swift"
         case .overlappingSources(let target, let sources):
             return "target '\(target)' has overlapping sources: " +
                 sources.map(\.description).joined(separator: ", ")
@@ -1042,8 +1048,11 @@ public final class PackageBuilder {
                 )
                 moduleMapType = moduleMapGenerator.determineModuleMapType(observabilityScope: self.observabilityScope)
             } else if moduleKind == .library, self.manifest.toolsVersion >= .v5_5 {
-                // If this clang target is a library, it must contain "include" directory.
-                throw ModuleError.invalidPublicHeadersDirectory(potentialModule.name)
+                // If this clang target is a library, it must contain a public headers directory.
+                throw ModuleError.missingPublicHeadersDirectory(
+                    target: potentialModule.name,
+                    path: publicHeaderComponent
+                )
             } else {
                 moduleMapType = .none
             }

--- a/Tests/FunctionalTests/CFamilyTargetTests.swift
+++ b/Tests/FunctionalTests/CFamilyTargetTests.swift
@@ -159,7 +159,11 @@ struct CFamilyTargetTestCase {
             }
 
             let errString = "\(error)"
-            let missingIncludeDirStr = "\(ModuleError.invalidPublicHeadersDirectory("Cfactorial"))"
+            let missingIncludeDir = ModuleError.missingPublicHeadersDirectory(
+                target: "Cfactorial",
+                path: "include"
+            )
+            let missingIncludeDirStr = "\(missingIncludeDir)"
             #expect(errString.contains(missingIncludeDirStr))
         }
     }

--- a/Tests/PackageLoadingTests/PackageBuilderTests.swift
+++ b/Tests/PackageLoadingTests/PackageBuilderTests.swift
@@ -872,6 +872,43 @@ struct PackageBuilderTests {
         }
     }
 
+    @Test(
+        .bug("https://github.com/swiftlang/swift-package-manager/issues/7734"),
+        arguments: [
+            (publicHeadersPath: nil, expectedPath: "include"),
+            (publicHeadersPath: "includes", expectedPath: "includes"),
+        ]
+    )
+    func missingPublicHeadersDirectory(
+        publicHeadersPath: String?,
+        expectedPath: String
+    ) throws {
+        let fs = InMemoryFileSystem(emptyFiles:
+            "/Sources/Foo/Foo.c"
+        )
+
+        let manifest = try Manifest.createRootManifest(
+            displayName: "Foo",
+            toolsVersion: .v5_5,
+            targets: [
+                TargetDescription(
+                    name: "Foo",
+                    publicHeadersPath: publicHeadersPath
+                ),
+            ]
+        )
+
+        try PackageBuilderTester(manifest, in: fs) { _, diagnostics in
+            let expectedDiagnostic =
+                "target 'Foo' is missing required public headers directory '\(expectedPath)'; " +
+                "create it or configure 'publicHeadersPath' in Package.swift"
+            diagnostics.check(
+                diagnostic: .equal(expectedDiagnostic),
+                severity: .error
+            )
+        }
+    }
+
     @Test
     func testInvalidPublicHeadersPath() throws {
         let fs = InMemoryFileSystem(emptyFiles:
@@ -1879,7 +1916,13 @@ struct PackageBuilderTests {
             )
 
             try PackageBuilderTester(manifest, in: fs) { _, diagnostics in
-                diagnostics.check(diagnostic: "public headers (\"include\") directory path for 'Foo' is invalid or not contained in the target", severity: .error)
+                let expectedDiagnostic =
+                    "public headers directory path for target 'Foo' must be contained " +
+                    "within the target directory"
+                diagnostics.check(
+                    diagnostic: .equal(expectedDiagnostic),
+                    severity: .error
+                )
             }
 
             manifest = Manifest.createRootManifest(
@@ -1889,7 +1932,13 @@ struct PackageBuilderTests {
                 ]
             )
             try PackageBuilderTester(manifest, in: fs) { _, diagnostics in
-                diagnostics.check(diagnostic: "public headers (\"include\") directory path for 'Bar' is invalid or not contained in the target", severity: .error)
+                let expectedDiagnostic =
+                    "public headers directory path for target 'Bar' must be contained " +
+                    "within the target directory"
+                diagnostics.check(
+                    diagnostic: .equal(expectedDiagnostic),
+                    severity: .error
+                )
             }
         }
 


### PR DESCRIPTION
Fixes #7734

## Summary

Report a dedicated, actionable diagnostic when a C-family library target’s public headers directory is missing.

SwiftPM currently uses the same error for a missing directory and a configured path outside the target. For custom `publicHeadersPath` values, the message also refers to the default `include` directory, which can send users toward the wrong fix.

## Changes

- Add a dedicated `missingPublicHeadersDirectory` error containing the target and expected path.
- Suggest creating the directory or configuring `publicHeadersPath`.
- Reserve `invalidPublicHeadersDirectory` for paths outside the target directory.
- Add parameterized coverage for default and custom public headers paths.
- Update the functional regression test for the new diagnostic.

## Alternatives considered

Updating the existing error message with the selected path was considered. However, a missing directory and a path outside the target require different remedies, so separate errors provide clearer guidance.

## Notes

The validation behavior is unchanged. C-family library targets using tools version 5.5 or later still require a public headers directory; this change only improves the resulting diagnostics.

## Testing

- `swift test --filter PackageBuilderTests.missingPublicHeadersDirectory --filter PackageBuilderTests.testManifestTargetDeclErrors`
- `swift test --filter CFamilyTargetTestCase.noIncludeDirCheck`
- SwiftFormat lint on all changed Swift ranges