### PR TITLE
fix(package-cli): accept interspersed global options

### DIFF
--- a/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
+++ b/Sources/Commands/PackageCommands/SwiftPackageCommand.swift
@@ -100,6 +100,91 @@ public struct SwiftPackageCommand: AsyncParsableCommand {
     public static var _errorLabel: String { "error" }
 
     public init() {}
+
+    public static func main() async {
+        do {
+            var command = try Self.parseAsRootWithInterspersedGlobalOptions(
+                Array(CommandLine.arguments.dropFirst()),
+            )
+            if var asyncCommand = command as? any AsyncParsableCommand {
+                try await asyncCommand.run()
+            } else {
+                try command.run()
+            }
+        } catch {
+            Self.exit(withError: error)
+        }
+    }
+
+    /// Parses `swift package` arguments while allowing global options to be interspersed with subcommand options.
+    ///
+    /// ArgumentParser shares an option group between a command and its subcommands by reusing the first decoded
+    /// instance of that group. If parsing of the parent stops at a subcommand or passthrough option, a later global
+    /// option is therefore left unconsumed by the shared group. Preserve the normal parser behavior for valid command
+    /// lines, and only retry failed parses after moving progressively larger, stable prefixes of recognized global
+    /// options to the front.
+    static func parseAsRootWithInterspersedGlobalOptions(
+        _ arguments: [String],
+    ) throws -> any ParsableCommand {
+        do {
+            return try Self.parseAsRoot(arguments)
+        } catch {
+            let originalError = error
+            let globalOptionRanges = Self.globalOptionRanges(in: arguments)
+
+            for upperBound in globalOptionRanges.indices {
+                let rangesToMove = globalOptionRanges[...upperBound]
+                let reorderedArguments = Self.movingOptionsToFront(
+                    in: arguments,
+                    ranges: rangesToMove,
+                )
+                guard reorderedArguments != arguments else {
+                    continue
+                }
+
+                if let command = try? Self.parseAsRoot(reorderedArguments) {
+                    return command
+                }
+            }
+
+            throw originalError
+        }
+    }
+
+    private static func globalOptionRanges(in arguments: [String]) -> [Range<Int>] {
+        var result: [Range<Int>] = []
+        var index = arguments.startIndex
+
+        while index < arguments.endIndex {
+            if arguments[index] == "--" {
+                break
+            } else if (try? GlobalOptions.parse([arguments[index]])) != nil {
+                result.append(index ..< (index + 1))
+                index += 1
+            } else if index + 1 < arguments.endIndex,
+                      (try? GlobalOptions.parse([arguments[index], arguments[index + 1]])) != nil
+            {
+                result.append(index ..< (index + 2))
+                index += 2
+            } else {
+                index += 1
+            }
+        }
+
+        return result
+    }
+
+    private static func movingOptionsToFront(
+        in arguments: [String],
+        ranges: ArraySlice<Range<Int>>,
+    ) -> [String] {
+        let movedIndices = Set(ranges.flatMap(\.self))
+        let movedArguments = ranges.flatMap { arguments[$0] }
+        let remainingArguments = arguments.indices.compactMap { index in
+            movedIndices.contains(index) ? nil : arguments[index]
+        }
+        return movedArguments + remainingArguments
+    }
 }
 
 extension SwiftPackageCommand {

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -97,6 +97,87 @@ private func executeAddURLDependencyAndAssert(
     ),
 )
 struct PackageCommandTests {
+    @Suite(
+        .tags(
+            .Feature.Command.Package.General,
+        ),
+    )
+    struct ArgumentOrderingTests {
+        @Test(
+            .bug("https://github.com/swiftlang/swift-package-manager/issues/8418"),
+        )
+        func globalOptionAfterSubcommandOption() throws {
+            let packagePath = AbsolutePath("/tmp/example")
+            let parsedCommand = try SwiftPackageCommand.parseAsRootWithInterspersedGlobalOptions([
+                "init",
+                "--type", "empty",
+                "--package-path", packagePath.pathString,
+            ])
+            let command = try #require(parsedCommand as? SwiftPackageCommand.Init)
+
+            #expect(command.initMode == .empty)
+            #expect(command.globalOptions.locations.packageDirectory == packagePath)
+        }
+
+        @Test(
+            .bug("https://github.com/swiftlang/swift-package-manager/issues/8425"),
+        )
+        func globalOptionAfterImplicitPluginOption() throws {
+            let parsedCommand = try SwiftPackageCommand.parseAsRootWithInterspersedGlobalOptions([
+                "--allow-network-connections", "all",
+                "-Xswiftc", "-static-stdlib",
+                "build-container-image",
+                "--repository", "localhost:5555/example",
+            ])
+            let command = try #require(parsedCommand as? SwiftPackageCommand.DefaultCommand)
+
+            #expect(command.globalOptions.build.swiftCompilerFlags == ["-static-stdlib"])
+            if case .all(let ports) = command.pluginOptions.allowNetworkConnections {
+                #expect(ports.isEmpty)
+            } else {
+                Issue.record("Expected all network connections to be allowed.")
+            }
+            #expect(command.remaining == [
+                "build-container-image",
+                "--repository", "localhost:5555/example",
+            ])
+        }
+
+        @Test(
+            .bug("https://github.com/swiftlang/swift-package-manager/issues/8425"),
+        )
+        func globalOptionAfterExplicitPluginSubcommand() throws {
+            let parsedCommand = try SwiftPackageCommand.parseAsRootWithInterspersedGlobalOptions([
+                "plugin",
+                "--allow-network-connections", "all",
+                "--swift-sdk", "swift-6.0.3-RELEASE_static-linux-0.0.1",
+                "MyPlugin",
+                "--verbose",
+            ])
+            let command = try #require(parsedCommand as? PluginCommand)
+
+            #expect(command.globalOptions.build.swiftSDKSelector == "swift-6.0.3-RELEASE_static-linux-0.0.1")
+            if case .all(let ports) = command.pluginOptions.allowNetworkConnections {
+                #expect(ports.isEmpty)
+            } else {
+                Issue.record("Expected all network connections to be allowed.")
+            }
+            #expect(command.command == "MyPlugin")
+            #expect(command.arguments == ["--verbose"])
+        }
+
+        @Test
+        func globalOptionAfterTerminatorIsNotReordered() {
+            #expect(throws: (any Error).self) {
+                try SwiftPackageCommand.parseAsRootWithInterspersedGlobalOptions([
+                    "init",
+                    "--",
+                    "--package-path", "/tmp/example",
+                ])
+            }
+        }
+    }
+
     @Test(
         arguments: SupportedBuildSystemOnAllPlatforms,
     )


### PR DESCRIPTION
Fixes #8425
Fixes #8418

## Summary

Allow global `swift package` options to be interspersed with subcommand and command-plugin options.

Swift Argument Parser reuses the first decoded instance of a shared option group across a command hierarchy. When parsing the parent command stops at a subcommand-specific or passthrough option, a later global option remains unconsumed and is reported as unknown. As a result, otherwise valid `swift package` invocations can fail based only on option order.

## Changes

- Preserve the existing parsing path for valid command lines.
- Retry failed parses after moving recognized `GlobalOptions` to a stable prefix.
- Preserve the relative order of global options and their values.
- Stop reordering at the `--` terminator.
- Keep arguments after a command plugin’s invocation verb in the plugin passthrough.
- Add regression coverage for:
  - `--package-path` following `swift package init` options.
  - `-Xswiftc -static-stdlib` following an implicit plugin option.
  - `--swift-sdk` following an explicit plugin option.
  - Global-looking plugin passthrough arguments.
  - Arguments following `--`.

## Alternatives considered

Fixing shared option-group decoding in Swift Argument Parser was considered. That would affect all Argument Parser clients and require a broader design discussion; this change keeps the compatibility behavior scoped to `SwiftPackageCommand`.

Changing the default plugin command from passthrough parsing to unrecognized-argument parsing was rejected because arguments such as `--help`, `--version`, and `--verbose` must continue reaching the plugin after its invocation verb.

Special-casing only the options reported in the issues was also rejected. Handling all existing `GlobalOptions` keeps the behavior consistent and avoids repeating the same failure for other global options.

## Notes

This adds no new command-line options or plugin capabilities.

Valid command lines continue through the existing parser unchanged. Reordering is attempted only after parsing fails, and the original error is preserved when no reordered command parses successfully.

Arguments after `--` and command-plugin passthrough arguments remain unchanged.

## Testing

- `swift test --filter PackageCommandTests.ArgumentOrderingTests --filter PackageCommandTests.CommandPluginTests.commandPluginArgumentsNotSwallowed --filter PackageCommandTests.unknownOption --filter PackageCommandTests.InitHelpUsageTests`
  - 9 focused tests passed across 4 suites.
- Verified reordered `swift package init` and explicit plugin invocations with the built `swift-package` executable.
- Verified the implicit plugin reproduction reaches plugin resolution instead of reporting `Unknown option '-Xswiftc'`.
- SwiftFormat lint on all changed Swift ranges.