### PR TITLE
Use SBOM metadata timestamp for SPDX creation info

### DIFF
--- a/Sources/SBOMModel/Converter/SPDXConverter.swift
+++ b/Sources/SBOMModel/Converter/SPDXConverter.swift
@@ -46,6 +46,7 @@ internal struct SPDXConverter {
 
     internal static func convertToAgent(from metadata: SBOMMetadata?) async -> [any SPDXObject] {
         guard let metadata,
+              let timestamp = metadata.timestamp,
               let creators = metadata.creators,
               !creators.isEmpty
         else {
@@ -61,7 +62,7 @@ internal struct SPDXConverter {
                 type: .CreationInfo,
                 specVersion: creator.version,
                 createdBy: [creatorID],
-                created: "1970-01-01T00:00:00Z"
+                created: timestamp
             )
             let tool = SPDXAgent(
                 id: creatorID,

--- a/Tests/SBOMModelTests/SPDXConverterTests.swift
+++ b/Tests/SBOMModelTests/SPDXConverterTests.swift
@@ -86,7 +86,7 @@ struct SPDXConverterTests {
         #expect(creationInfoUnwrapped.type == .CreationInfo)
         #expect(creationInfoUnwrapped.specVersion == "3.0.1")
         #expect(creationInfoUnwrapped.createdBy == ["urn:spdx:tool-1"])
-        #expect(creationInfoUnwrapped.created == "1970-01-01T00:00:00Z")
+        #expect(creationInfoUnwrapped.created == "2025-01-01T00:00:00Z")
 
         let agent = result[3] as? SPDXAgent
         let agentUnwrapped = try #require(agent)
@@ -139,6 +139,7 @@ struct SPDXConverterTests {
         let creationInfo1Unwrapped = try #require(creationInfo1)
         #expect(creationInfo1Unwrapped.id == "urn:spdx:tool-1:creationInfo")
         #expect(creationInfo1Unwrapped.createdBy == ["urn:spdx:tool-1"])
+        #expect(creationInfo1Unwrapped.created == "2025-01-01T00:00:00Z")
 
         let agent1 = result[3] as? SPDXAgent
         let agent1Unwrapped = try #require(agent1)
@@ -162,6 +163,7 @@ struct SPDXConverterTests {
         let creationInfo2Unwrapped = try #require(creationInfo2)
         #expect(creationInfo2Unwrapped.id == "urn:spdx:tool-2:creationInfo")
         #expect(creationInfo2Unwrapped.createdBy == ["urn:spdx:tool-2"])
+        #expect(creationInfo2Unwrapped.created == "2025-01-01T00:00:00Z")
 
         let agent2 = result[7] as? SPDXAgent
         let agent2Unwrapped = try #require(agent2)


### PR DESCRIPTION
Use the SBOM metadata timestamp when generating SPDX `CreationInfo` objects for creator agents.

### Motivation:

SPDX creator agents currently receive a hard-coded `1970-01-01T00:00:00Z` creation timestamp, even when the SBOM metadata contains the actual generation time. This makes generated SPDX documents contain misleading creation metadata.

Fixes #10354.

### Modifications:

- Propagate the SBOM metadata timestamp to each creator agent's `SPDXCreationInfo`.
- Update regression coverage for both single-creator and multiple-creator documents.

### Result:

Generated SPDX creator metadata now uses the SBOM generation timestamp instead of the Unix epoch.

### Testing:

- `swift test --filter SPDXConverterTests` (33 tests)
- `swift test --filter SBOMModelTests` (196 tests)
