### PR TITLE
Don't allow freeing the SQLite connection while it's in use

### DIFF
--- a/Sources/Basics/SQLite.swift
+++ b/Sources/Basics/SQLite.swift
@@ -35,8 +35,12 @@ package final class SQLite {
     /// The configuration for the database.
     package let configuration: Configuration
 
-    /// Pointer to the database.
-    let db: OpaquePointer
+    /// Pointer to the database, or `nil` once the database has been closed.
+    private var db: OpaquePointer?
+
+    /// Serializes use of ``db`` against ``close()``, so that the pointer cannot be freed while
+    /// another thread is handing it to SQLite. See rdar://181557882.
+    private let dbLock = NSLock()
 
     /// Create or open the database at the given path.
     ///
@@ -79,24 +83,27 @@ package final class SQLite {
 
     /// Prepare the given query.
     package func prepare(query: String) throws -> PreparedStatement {
-        try PreparedStatement(db: self.db, query: query)
+        try self.withDB { try PreparedStatement(db: $0, query: query) }
     }
 
     /// Directly execute the given query.
     ///
     /// Note: Use withCString for string arguments.
+    /// Note: `callback` is invoked while the database is locked, so it must not call back into
+    /// this database.
     package func exec(query queryString: String, args: [CVarArg] = [], _ callback: SQLiteExecCallback? = nil) throws {
         let query = withVaList(args) { ptr in
             sqlite3_vmprintf(queryString, ptr)
         }
+        defer { sqlite3_free(query) }
 
         let wcb = callback.map { CallbackWrapper($0) }
         let callbackCtx = wcb.map { Unmanaged.passUnretained($0).toOpaque() }
 
         var err: UnsafeMutablePointer<Int8>?
-        try Self.checkError { sqlite3_exec(db, query, sqlite_callback, callbackCtx, &err) }
-
-        sqlite3_free(query)
+        try self.withDB { db in
+            try Self.checkError { sqlite3_exec(db, query, sqlite_callback, callbackCtx, &err) }
+        }
 
         if let err {
             let errorString = String(cString: err)
@@ -105,8 +112,29 @@ package final class SQLite {
         }
     }
 
+    /// Close the database, releasing the underlying connection.
+    ///
+    /// Closing an already closed database is a no-op. Closing fails while prepared statements
+    /// created from this database are still alive, in which case the connection stays usable and
+    /// the close can be retried.
     package func close() throws {
-        try Self.checkError { sqlite3_close(db) }
+        try self.dbLock.withLock {
+            guard let db = self.db else {
+                return
+            }
+            try Self.checkError { sqlite3_close(db) }
+            self.db = nil
+        }
+    }
+
+    /// Run `body` with the database connection, guaranteeing it is not closed for the duration.
+    private func withDB<T>(_ body: (OpaquePointer) throws -> T) throws -> T {
+        try self.dbLock.withLock {
+            guard let db = self.db else {
+                throw StringError("database is closed")
+            }
+            return try body(db)
+        }
     }
 
     package typealias SQLiteExecCallback = ([Column]) -> Void

--- a/Sources/Basics/SQLite.swift
+++ b/Sources/Basics/SQLite.swift
@@ -12,6 +12,7 @@
 
 import TSCBasic
 import Foundation
+import Synchronization
 
 #if SWIFT_PACKAGE && (os(Windows) || os(Android))
 #if USE_IMPL_ONLY_IMPORTS
@@ -28,7 +29,7 @@ import SPMSQLite3
 #endif
 
 /// A minimal SQLite wrapper.
-package final class SQLite {
+package final class SQLite: Sendable {
     /// The location of the database.
     package let location: Location
 
@@ -36,11 +37,10 @@ package final class SQLite {
     package let configuration: Configuration
 
     /// Pointer to the database, or `nil` once the database has been closed.
-    private var db: OpaquePointer?
-
-    /// Serializes use of ``db`` against ``close()``, so that the pointer cannot be freed while
-    /// another thread is handing it to SQLite. See rdar://181557882.
-    private let dbLock = NSLock()
+    ///
+    /// Guarded so that the pointer cannot be freed by ``close()`` while another thread is handing
+    /// it to SQLite. See rdar://181557882.
+    private let db: Mutex<OpaquePointer?>
 
     /// Create or open the database at the given path.
     ///
@@ -65,7 +65,7 @@ package final class SQLite {
         guard let db = handle else {
             throw StringError("Unable to open database at \(self.location)")
         }
-        self.db = db
+        self.db = Mutex(db)
         try Self.checkError({ sqlite3_extended_result_codes(db, 1) }, description: "Unable to configure database")
         try Self.checkError(
             { sqlite3_busy_timeout(db, self.configuration.busyTimeoutMilliseconds) },
@@ -118,22 +118,22 @@ package final class SQLite {
     /// created from this database are still alive, in which case the connection stays usable and
     /// the close can be retried.
     package func close() throws {
-        try self.dbLock.withLock {
-            guard let db = self.db else {
+        try self.db.withLock { db in
+            guard let handle = db else {
                 return
             }
-            try Self.checkError { sqlite3_close(db) }
-            self.db = nil
+            try Self.checkError { sqlite3_close(handle) }
+            db = nil
         }
     }
 
     /// Run `body` with the database connection, guaranteeing it is not closed for the duration.
     private func withDB<T>(_ body: (OpaquePointer) throws -> T) throws -> T {
-        try self.dbLock.withLock {
-            guard let db = self.db else {
+        try self.db.withLock { db in
+            guard let handle = db else {
                 throw StringError("database is closed")
             }
-            return try body(db)
+            return try body(handle)
         }
     }
 
@@ -337,10 +337,6 @@ package final class SQLite {
         case databaseFull
     }
 }
-
-// Explicitly mark this class as non-Sendable
-@available(*, unavailable)
-extension SQLite: Sendable {}
 
 private func sqlite_callback(
     _ ctx: UnsafeMutableRawPointer?,

--- a/Tests/BasicsTests/SQLiteTests.swift
+++ b/Tests/BasicsTests/SQLiteTests.swift
@@ -16,7 +16,7 @@ import Dispatch
 import Testing
 
 struct SQLiteTests {
-    @Test
+    @Test(.tags(Tag.TestSize.small))
     func preparingAfterCloseThrows() throws {
         let db = try SQLite(location: .memory)
         try db.close()
@@ -26,7 +26,7 @@ struct SQLiteTests {
         }
     }
 
-    @Test
+    @Test(.tags(Tag.TestSize.small))
     func executingAfterCloseThrows() throws {
         let db = try SQLite(location: .memory)
         try db.close()
@@ -36,14 +36,14 @@ struct SQLiteTests {
         }
     }
 
-    @Test
+    @Test(.tags(Tag.TestSize.small))
     func closingMoreThanOnceSucceeds() throws {
         let db = try SQLite(location: .memory)
         try db.close()
         try db.close()
     }
 
-    @Test
+    @Test(.tags(Tag.TestSize.small))
     func closingWithAliveStatementFailsAndLeavesDatabaseUsable() throws {
         let db = try SQLite(location: .memory)
         try db.exec(query: "CREATE TABLE test (id INTEGER);")
@@ -57,7 +57,7 @@ struct SQLiteTests {
         try db.close()
     }
 
-    @Test
+    @Test(.tags(Tag.TestSize.small))
     func preparingConcurrentlyWithCloseDoesNotUseFreedHandle() throws {
         for _ in 0 ..< 50 {
             let db = try SQLite(location: .memory)

--- a/Tests/BasicsTests/SQLiteTests.swift
+++ b/Tests/BasicsTests/SQLiteTests.swift
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+
+@testable import Basics
+import Testing
+
+struct SQLiteTests {
+    @Test
+    func preparingAfterCloseThrows() throws {
+        let db = try SQLite(location: .memory)
+        try db.close()
+
+        #expect(throws: StringError("database is closed")) {
+            try db.prepare(query: "SELECT id FROM test;")
+        }
+    }
+
+    @Test
+    func executingAfterCloseThrows() throws {
+        let db = try SQLite(location: .memory)
+        try db.close()
+
+        #expect(throws: StringError("database is closed")) {
+            try db.exec(query: "SELECT id FROM test;")
+        }
+    }
+
+    @Test
+    func closingMoreThanOnceSucceeds() throws {
+        let db = try SQLite(location: .memory)
+        try db.close()
+        try db.close()
+    }
+
+    @Test
+    func closingWithAliveStatementFailsAndLeavesDatabaseUsable() throws {
+        let db = try SQLite(location: .memory)
+        try db.exec(query: "CREATE TABLE test (id INTEGER);")
+        let statement = try db.prepare(query: "SELECT id FROM test;")
+
+        #expect(throws: (any Error).self) {
+            try db.close()
+        }
+
+        try statement.finalize()
+        try db.close()
+    }
+
+    @Test
+    func preparingConcurrentlyWithCloseDoesNotUseFreedHandle() throws {
+        for _ in 0 ..< 50 {
+            let db = try SQLite(location: .memory)
+            try db.exec(query: "CREATE TABLE test (id INTEGER);")
+
+            let group = DispatchGroup()
+            for _ in 0 ..< 4 {
+                DispatchQueue.sharedConcurrent.async(group: group) {
+                    for _ in 0 ..< 25 {
+                        // Both outcomes are valid: the statement is prepared on a live
+                        // connection, or preparing fails because the connection is closed.
+                        guard let statement = try? db.prepare(query: "SELECT id FROM test;") else {
+                            continue
+                        }
+                        try? statement.finalize()
+                    }
+                }
+            }
+            DispatchQueue.sharedConcurrent.async(group: group) {
+                try? db.close()
+            }
+
+            group.wait()
+            try db.close()
+        }
+    }
+}


### PR DESCRIPTION
`SQLite` handed out its `sqlite3*` pointer and freed it in `close()` with nothing coordinating the two, so one thread could close the connection while another was still inside `sqlite3_prepare_v2`.

Keep the pointer private behind a lock so `prepare` and `exec` can't overlap with `close`, and throw once its closed instead of dereferencing freed memory.