### PR TITLE
Use Mutex over NSLock in Environment

### DIFF
--- a/Sources/Basics/Environment/Environment.swift
+++ b/Sources/Basics/Environment/Environment.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Synchronization
 
 #if canImport(Glibc)
 import Glibc
@@ -24,23 +25,6 @@ import Android
 #else
 import Darwin.C
 #endif
-
-// FIXME: Use Synchronization.Mutex when available
-private final class Mutex<T>: @unchecked Sendable {
-    var lock: NSLock
-    var value: T
-
-    init(value: T) {
-        self.lock = .init()
-        self.value = value
-    }
-
-    func withLock<U>(_ body: (inout T) -> U) -> U {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return body(&self.value)
-    }
-}
 
 // FIXME: This should come from Foundation
 // FIXME: package (public required by users)
@@ -124,7 +108,7 @@ extension Environment {
 // MARK: - Global Environment
 
 extension Environment {
-    fileprivate static let _cachedCurrent = Mutex<Self?>(value: nil)
+    fileprivate static let _cachedCurrent = Mutex<Self?>(nil)
 
     /// Vends a copy of the current process's environment variables.
     ///

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -14,7 +14,6 @@ import _Concurrency
 import ArgumentParser
 import Basics
 import Dispatch
-import class Foundation.NSLock
 import class Foundation.ProcessInfo
 import PackageFingerprint
 import PackageGraph


### PR DESCRIPTION
Now that the deployment target is high enough we can start to leverage Mutex over NSLock. Start by removing a placeholder Mutex implementation and using the real one.
