### PR TITLE
Adopt Mutex where a lock guards a single value

### DIFF
--- a/Sources/Basics/Cancellator.swift
+++ b/Sources/Basics/Cancellator.swift
@@ -12,6 +12,7 @@
 
 import Dispatch
 import Foundation
+import Synchronization
 import class TSCBasic.Thread
 #if canImport(WinSDK)
 import WinSDK
@@ -28,8 +29,8 @@ public final class Cancellator: Cancellable, Sendable {
     private let registry = ThreadSafeKeyValueStore<String, (name: String, handler: CancellationHandler)>()
     private let cancelling = ThreadSafeBox<Bool>(false)
 
-    private static let signalHandlerLock = NSLock()
-    private static var isSignalHandlerInstalled = false
+    /// Whether the signal handlers have been installed. Guards installation so it happens at most once.
+    private static let isSignalHandlerInstalled = Mutex<Bool>(false)
 
     public init(observabilityScope: ObservabilityScope?) {
         self.observabilityScope = observabilityScope
@@ -42,8 +43,8 @@ public final class Cancellator: Cancellable, Sendable {
 
     /// Installs signal handlers to terminate sub-processes on cancellation.
     public func installSignalHandlers() {
-        Self.signalHandlerLock.withLock {
-            precondition(!Self.isSignalHandlerInstalled)
+        Self.isSignalHandlerInstalled.withLock { isInstalled in
+            precondition(!isInstalled)
 
             #if os(Windows)
             // Closures passed to `SetConsoleCtrlHandler` can't capture context, working around that with a global.
@@ -93,7 +94,7 @@ public final class Cancellator: Cancellable, Sendable {
             interruptSignalSource.resume()
             #endif
 
-            Self.isSignalHandlerInstalled = true
+            isInstalled = true
         }
     }
 

--- a/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
+++ b/Sources/Basics/HTTPClient/LegacyHTTPClient.swift
@@ -14,11 +14,11 @@ import _Concurrency
 import Dispatch
 import struct Foundation.Data
 import struct Foundation.Date
-import class Foundation.NSLock
 import class Foundation.OperationQueue
 import func Foundation.pow
 import struct Foundation.URL
 import struct Foundation.UUID
+import Synchronization
 
 // MARK: - LegacyHTTPClient
 
@@ -49,8 +49,7 @@ public final class LegacyHTTPClient: Cancellable {
     private var outstandingRequests = ThreadSafeKeyValueStore<UUID, OutstandingRequest>()
 
     // static to share across instances of the http client
-    private static let hostsErrorsLock = NSLock()
-    private static var hostsErrors = [String: [Date]]()
+    private static let hostsErrors = Mutex<[String: [Date]]>([:])
 
     public init(configuration: LegacyHTTPClientConfiguration = .init(), handler: Handler? = nil) {
         self.configuration = configuration
@@ -276,11 +275,11 @@ public final class LegacyHTTPClient: Cancellable {
             guard let host = request.url.host else {
                 return
             }
-            Self.hostsErrorsLock.withLock {
+            Self.hostsErrors.withLock { hostsErrors in
                 // Avoid copy-on-write: remove entry from dictionary before mutating
-                var errors = Self.hostsErrors.removeValue(forKey: host) ?? []
+                var errors = hostsErrors.removeValue(forKey: host) ?? []
                 errors.append(Date())
-                Self.hostsErrors[host] = errors
+                hostsErrors[host] = errors
             }
         }
     }
@@ -292,17 +291,20 @@ public final class LegacyHTTPClient: Cancellable {
 
         switch strategy {
         case .hostErrors(let maxErrors, let age):
-            if let host = request.url.host, let errors = (Self.hostsErrorsLock.withLock { Self.hostsErrors[host] }) {
-                if errors.count >= maxErrors, let lastError = errors.last, let age = age.timeInterval() {
-                    return Date().timeIntervalSince(lastError) <= age
-                } else if errors.count >= maxErrors {
-                    // reset aged errors
-                    Self.hostsErrorsLock.withLock {
-                        Self.hostsErrors[host] = nil
-                    }
-                }
+            guard let host = request.url.host else {
+                return false
             }
-            return false
+            return Self.hostsErrors.withLock { hostsErrors in
+                guard let errors = hostsErrors[host], errors.count >= maxErrors else {
+                    return false
+                }
+                if let lastError = errors.last, let age = age.timeInterval() {
+                    return Date().timeIntervalSince(lastError) <= age
+                }
+                // reset aged errors
+                hostsErrors[host] = nil
+                return false
+            }
         }
     }
 }

--- a/Sources/Commands/CommandWorkspaceDelegate.swift
+++ b/Sources/Commands/CommandWorkspaceDelegate.swift
@@ -14,12 +14,12 @@ import Basics
 import CoreCommands
 import Dispatch
 import class Foundation.ByteCountFormatter
-import class Foundation.NSLock
 import struct Foundation.URL
 import OrderedCollections
 import PackageGraph
 import PackageModel
 import SPMBuildCore
+import Synchronization
 import Workspace
 
 import protocol TSCBasic.OutputByteStream
@@ -37,12 +37,10 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     /// The progress of binary downloads.
-    private var binaryDownloadProgress = OrderedCollections.OrderedDictionary<String, DownloadProgress>()
-    private let binaryDownloadProgressLock = NSLock()
+    private let binaryDownloadProgress = Mutex(OrderedCollections.OrderedDictionary<String, DownloadProgress>())
 
     /// The progress of package  fetch operations.
-    private var fetchProgress = OrderedCollections.OrderedDictionary<PackageIdentity, FetchProgress>()
-    private let fetchProgressLock = NSLock()
+    private let fetchProgress = Mutex(OrderedCollections.OrderedDictionary<PackageIdentity, FetchProgress>())
 
     private let observabilityScope: ObservabilityScope
 
@@ -71,14 +69,14 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
             return
         }
 
-        self.fetchProgressLock.withLock {
-            let progress = self.fetchProgress.values.reduce(0) { $0 + $1.progress }
-            let total = self.fetchProgress.values.reduce(0) { $0 + $1.total }
+        self.fetchProgress.withLock { fetchProgress in
+            let progress = fetchProgress.values.reduce(0) { $0 + $1.progress }
+            let total = fetchProgress.values.reduce(0) { $0 + $1.total }
 
-            if progress == total && !self.fetchProgress.isEmpty {
-                self.fetchProgress.removeAll()
+            if progress == total && !fetchProgress.isEmpty {
+                fetchProgress.removeAll()
             } else {
-                self.fetchProgress[package] = nil
+                fetchProgress[package] = nil
             }
         }
 
@@ -86,15 +84,15 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     func fetchingPackage(package: PackageIdentity, packageLocation: String?, progress: Int64, total: Int64?) {
-        let (step, total, packages) = self.fetchProgressLock.withLock { () -> (Int64, Int64, String) in
-            self.fetchProgress[package] = FetchProgress(
+        let (step, total, packages) = self.fetchProgress.withLock { fetchProgress -> (Int64, Int64, String) in
+            fetchProgress[package] = FetchProgress(
                 progress: progress,
                 total: total ?? progress
             )
 
-            let progress = self.fetchProgress.values.reduce(0) { $0 + $1.progress }
-            let total = self.fetchProgress.values.reduce(0) { $0 + $1.total }
-            let packages = self.fetchProgress.keys.map { $0.description }.joined(separator: ", ")
+            let progress = fetchProgress.values.reduce(0) { $0 + $1.progress }
+            let total = fetchProgress.values.reduce(0) { $0 + $1.total }
+            let packages = fetchProgress.keys.map { $0.description }.joined(separator: ", ")
             return (progress, total, packages)
         }
         self.progressHandler(step, total, "Fetching \(packages)")
@@ -149,14 +147,14 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
             return
         }
 
-        self.binaryDownloadProgressLock.withLock {
-            let progress = self.binaryDownloadProgress.values.reduce(0) { $0 + $1.bytesDownloaded }
-            let total = self.binaryDownloadProgress.values.reduce(0) { $0 + $1.totalBytesToDownload }
+        self.binaryDownloadProgress.withLock { binaryDownloadProgress in
+            let progress = binaryDownloadProgress.values.reduce(0) { $0 + $1.bytesDownloaded }
+            let total = binaryDownloadProgress.values.reduce(0) { $0 + $1.totalBytesToDownload }
 
-            if progress == total && !self.binaryDownloadProgress.isEmpty {
-                self.binaryDownloadProgress.removeAll()
+            if progress == total && !binaryDownloadProgress.isEmpty {
+                binaryDownloadProgress.removeAll()
             } else {
-                self.binaryDownloadProgress[url] = nil
+                binaryDownloadProgress[url] = nil
             }
         }
 
@@ -168,21 +166,22 @@ final class CommandWorkspaceDelegate: WorkspaceDelegate {
     }
 
     func downloadingBinaryArtifact(from url: String, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
-        let (step, total, text) = self.binaryDownloadProgressLock.withLock { () -> (Int64, Int64, String) in
-            self.binaryDownloadProgress[url] = DownloadProgress(
-                bytesDownloaded: bytesDownloaded,
-                totalBytesToDownload: totalBytesToDownload ?? bytesDownloaded
-            )
+        let (step, total, text) = self.binaryDownloadProgress
+            .withLock { binaryDownloadProgress -> (Int64, Int64, String) in
+                binaryDownloadProgress[url] = DownloadProgress(
+                    bytesDownloaded: bytesDownloaded,
+                    totalBytesToDownload: totalBytesToDownload ?? bytesDownloaded
+                )
 
-            let stepBytes = self.binaryDownloadProgress.values.reduce(0, { $0 + $1.bytesDownloaded })
-            let totalBytes = self.binaryDownloadProgress.values.reduce(0, { $0 + $1.totalBytesToDownload })
-            let artifacts = self.binaryDownloadProgress.keys.joined(separator: ", ")
+                let stepBytes = binaryDownloadProgress.values.reduce(0, { $0 + $1.bytesDownloaded })
+                let totalBytes = binaryDownloadProgress.values.reduce(0, { $0 + $1.totalBytesToDownload })
+                let artifacts = binaryDownloadProgress.keys.joined(separator: ", ")
 
-            let formattedStep = ByteCountFormatter.string(fromByteCount: stepBytes, countStyle: .file)
-            let formattedTotal = ByteCountFormatter.string(fromByteCount: totalBytes, countStyle: .file)
-            let percentage = totalBytes > 0 ? (stepBytes * 100) / totalBytes : 0
-            return (percentage, 100, "Downloading \(artifacts) (\(formattedStep) / \(formattedTotal))")
-        }
+                let formattedStep = ByteCountFormatter.string(fromByteCount: stepBytes, countStyle: .file)
+                let formattedTotal = ByteCountFormatter.string(fromByteCount: totalBytes, countStyle: .file)
+                let percentage = totalBytes > 0 ? (stepBytes * 100) / totalBytes : 0
+                return (percentage, 100, "Downloading \(artifacts) (\(formattedStep) / \(formattedTotal))")
+            }
 
         self.progressHandler(step, total, text)
     }

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -13,12 +13,13 @@
 import Basics
 import _Concurrency
 import Dispatch
-import class Foundation.NSLock
+import Foundation
 import PackageFingerprint
 import PackageGraph
 import PackageLoading
 import PackageModel
 import SourceControl
+import Synchronization
 
 import struct TSCBasic.RegEx
 
@@ -68,8 +69,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     private let observabilityScope: ObservabilityScope
 
     /// The cached dependency information.
-    private var dependenciesCache = [String: [ProductFilter: (Manifest, [Constraint])]]()
-    private var dependenciesCacheLock = NSLock()
+    private let dependenciesCache = Mutex<[String: [ProductFilter: (Manifest, [Constraint])]]>([:])
 
     private var knownVersionsCache = ThreadSafeBox<[Version: String]?>()
     private var manifestsCache = ThrowingAsyncKeyValueMemoizer<String, Manifest>()
@@ -323,12 +323,12 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         productFilter: ProductFilter,
         getDependencies: () async throws -> (Manifest, [Constraint])
     ) async throws -> (Manifest, [Constraint]) {
-        if let result = (self.dependenciesCacheLock.withLock { self.dependenciesCache[identifier, default: [:]][productFilter] }) {
+        if let result = (self.dependenciesCache.withLock { $0[identifier, default: [:]][productFilter] }) {
             return result
         }
         let result = try await getDependencies()
-        self.dependenciesCacheLock.withLock {
-            self.dependenciesCache[identifier, default: [:]][productFilter] = result
+        self.dependenciesCache.withLock {
+            $0[identifier, default: [:]][productFilter] = result
         }
         return result
     }

--- a/Sources/Workspace/ResolvedFileWatcher.swift
+++ b/Sources/Workspace/ResolvedFileWatcher.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import Basics
-import class Foundation.NSLock
 import PackageModel
 import PackageGraph
+import Synchronization
 
 import struct TSCBasic.ByteString
 
@@ -24,13 +24,12 @@ import class TSCUtility.FSWatch
 /// This is not intended to be used directly by clients.
 final class ResolvedFileWatcher {
     private var fswatch: FSWatch!
-    private var existingValue: ByteString?
-    private let valueLock = NSLock()
+    private let existingValue = Mutex<ByteString?>(nil)
     private let resolvedFile: TSCAbsolutePath
 
     public func updateValue() {
-        valueLock.withLock {
-            self.existingValue = try? localFileSystem.readFileContents(resolvedFile)
+        self.existingValue.withLock {
+            $0 = try? localFileSystem.readFileContents(resolvedFile)
         }
     }
 
@@ -45,12 +44,12 @@ final class ResolvedFileWatcher {
             let hasResolvedFile = paths.contains{ $0.appending(component: resolvedFile.basename) == resolvedFile }
             guard hasResolvedFile else { return }
 
-            self.valueLock.withLock {
+            self.existingValue.withLock { existingValue in
                 // Compute the contents of the resolved file and fire the onChange block
                 // if its value is different than existing value.
                 let newValue: ByteString? = try? localFileSystem.readFileContents(resolvedFile)
-                if self.existingValue != newValue {
-                    self.existingValue = newValue
+                if existingValue != newValue {
+                    existingValue = newValue
                     onChange()
                 }
             }

--- a/Tests/BasicsTests/LegacyHTTPClientTests.swift
+++ b/Tests/BasicsTests/LegacyHTTPClientTests.swift
@@ -511,6 +511,39 @@ final class LegacyHTTPClientTests: XCTestCase {
         XCTAssertEqual(count.get(), total, "expected results count to match")
     }
 
+    func testHostCircuitBreakerNeverAge() {
+        let maxErrors = 5
+        let errorCode = Int.random(in: 500 ..< 600)
+
+        let host = "http://tes-\(UUID().uuidString).com"
+        let httpClient = LegacyHTTPClient(handler: { _, _, completion in
+            completion(.success(LegacyHTTPClient.Response(statusCode: errorCode)))
+        })
+        // `.never` has no time interval, so recorded errors are reset rather than tripping the breaker.
+        httpClient.configuration.circuitBreakerStrategy = .hostErrors(maxErrors: maxErrors, age: .never)
+
+        // Drive well past `maxErrors`; none of these should circuit break.
+        let sync = DispatchGroup()
+        let count = ThreadSafeBox<Int>(0)
+        let total = maxErrors * 3
+        (0 ..< total).forEach { index in
+            sync.enter()
+            httpClient.get(URL("\(host)/\(index)/foo")) { result in
+                defer { sync.leave() }
+                count.increment()
+                switch result {
+                case .failure(let error):
+                    XCTFail("unexpected failure \(error)")
+                case .success(let response):
+                    XCTAssertEqual(response.statusCode, errorCode, "expected status code to match")
+                }
+            }
+        }
+
+        XCTAssertEqual(sync.wait(timeout: .now() + .seconds(1)), .success, "should not timeout")
+        XCTAssertEqual(count.get(), total, "expected results count to match")
+    }
+
     func testExceedsDownloadSizeLimitProgress() throws {
         let maxSize: Int64 = 50
 


### PR DESCRIPTION
Migrate to `Mutex` wherever an `NSLock` guards a single value. Also fix a race in `shouldCircuidBreak` in LegacyHTTPClient that read a host's errors under two separate lock aquisitions, where the state could change between the two reads.
