### PR TITLE
Restore disambiguated framework names for automatic library products

### DIFF
--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -26,7 +26,6 @@ import class Basics.ThreadSafeArrayStore
 
 import enum PackageModel.BuildConfiguration
 import enum PackageModel.BuildSettings
-import class PackageModel.BinaryModule
 import class PackageModel.ClangModule
 import struct PackageModel.ConfigurationCondition
 import class PackageModel.Manifest
@@ -923,20 +922,6 @@ extension PackageGraph.ResolvedProduct {
         self.modules.anySatisfy { !$0.isBinary }
     }
 
-    /// Whether this product vends a prebuilt binary framework (an XCFramework) whose name matches the
-    /// product's own name.
-    var hasCollidingBinaryFrameworkTargets: Bool {
-        self.modules.contains { module in
-            guard let binaryModule = module.underlying as? BinaryModule else { return false }
-            switch binaryModule.kind {
-            case .xcframework:
-                return module.name == self.name
-            case .artifactsArchive, .unknown:
-                return false
-            }
-        }
-    }
-
     /// Returns the corresponding *system library* module, if this is a system library product.
     var systemModule: SystemLibraryModule? {
         guard self.isSystemLibraryProduct else { return nil }
@@ -1199,6 +1184,11 @@ extension ProjectModel.BuildSettings {
 
         // Are we building a framework?
         if !createDylibForDynamicProducts {
+            // Disambiguate the framework's name for automatic library products
+            if let product, product.type == .library(.automatic) {
+                self[.PRODUCT_NAME] = PackagePIFBuilder.computePackageProductFrameworkName(productName: productName)
+            }
+
             // Apply delegate overrides for *executable name* and *bundle identifier prefix* on frameworks.
             // This can be used by SwiftPM clients to disambiguate framework names and bundle IDs, if necessary.
             if let product {

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -26,6 +26,7 @@ import class Basics.ThreadSafeArrayStore
 
 import enum PackageModel.BuildConfiguration
 import enum PackageModel.BuildSettings
+import class PackageModel.BinaryModule
 import class PackageModel.ClangModule
 import struct PackageModel.ConfigurationCondition
 import class PackageModel.Manifest
@@ -920,6 +921,20 @@ extension PackageGraph.ResolvedProduct {
 
     var hasSourceTargets: Bool {
         self.modules.anySatisfy { !$0.isBinary }
+    }
+
+    /// Whether this product vends a prebuilt binary framework (an XCFramework) whose name matches the
+    /// product's own name.
+    var hasCollidingBinaryFrameworkTargets: Bool {
+        self.modules.contains { module in
+            guard let binaryModule = module.underlying as? BinaryModule else { return false }
+            switch binaryModule.kind {
+            case .xcframework:
+                return module.name == self.name
+            case .artifactsArchive, .unknown:
+                return false
+            }
+        }
     }
 
     /// Returns the corresponding *system library* module, if this is a system library product.

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -1184,7 +1184,9 @@ extension ProjectModel.BuildSettings {
 
         // Are we building a framework?
         if !createDylibForDynamicProducts {
-            // Disambiguate the framework's name for automatic library products
+            // Disambiguate the framework's name for automatic library products so the built.
+            // We deliberately scope this to automatic products to match the
+            // previous PIF builder behavior
             if let product, product.type == .library(.automatic) {
                 self[.PRODUCT_NAME] = PackagePIFBuilder.computePackageProductFrameworkName(productName: productName)
             }

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -623,7 +623,9 @@ extension PackagePIFProjectBuilder {
 
         // Also create a dynamic product for use by development-time features such as Previews and Swift Playgrounds.
         // If all targets this product is comprised of are binaries, we should *not* create a dynamic variant.
-        if libraryType == .automatic && libraryProduct.hasSourceTargets && pifBuilder.createDynamicVariantsForLibraryProducts {
+        // If this product vends a binary framework whose name matches the product's, we should *not* create a dynamic variant.
+        if libraryType == .automatic && libraryProduct.hasSourceTargets && pifBuilder.createDynamicVariantsForLibraryProducts && !libraryProduct.hasCollidingBinaryFrameworkTargets
+        {
             var dynamicLibraryVariant = try self.buildLibraryProduct(
                 libraryProduct,
                 type: .dynamic,

--- a/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFProjectBuilder+Products.swift
@@ -623,9 +623,7 @@ extension PackagePIFProjectBuilder {
 
         // Also create a dynamic product for use by development-time features such as Previews and Swift Playgrounds.
         // If all targets this product is comprised of are binaries, we should *not* create a dynamic variant.
-        // If this product vends a binary framework whose name matches the product's, we should *not* create a dynamic variant.
-        if libraryType == .automatic && libraryProduct.hasSourceTargets && pifBuilder.createDynamicVariantsForLibraryProducts && !libraryProduct.hasCollidingBinaryFrameworkTargets
-        {
+        if libraryType == .automatic && libraryProduct.hasSourceTargets && pifBuilder.createDynamicVariantsForLibraryProducts {
             var dynamicLibraryVariant = try self.buildLibraryProduct(
                 libraryProduct,
                 type: .dynamic,

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -31,6 +31,7 @@ extension PIFBuilderParameters {
         temporaryDirectory: Basics.AbsolutePath,
         addLocalRpaths: PackagePIFBuilder.AddLocalRpaths,
         shouldCreateDylibForDynamicProducts: Bool = false,
+        createDynamicVariantsForLibraryProducts: Bool = false,
         pluginScriptRunner: PluginScriptRunner? = nil,
         hostBuildProductsPath: Basics.AbsolutePath? = nil
     ) throws -> Self {
@@ -39,7 +40,7 @@ extension PIFBuilderParameters {
             enableTestability: false,
             shouldCreateDylibForDynamicProducts: shouldCreateDylibForDynamicProducts,
             materializeStaticArchiveProductsForRootPackages: true,
-            createDynamicVariantsForLibraryProducts: false,
+            createDynamicVariantsForLibraryProducts: createDynamicVariantsForLibraryProducts,
             toolchainLibDir: temporaryDirectory.appending(component: "toolchain-lib-dir"),
             pkgConfigDirectories: [],
             supportedSwiftVersions: [.v4, .v4_2, .v5, .v6],
@@ -839,6 +840,209 @@ struct PIFBuilderTests {
             #expect(productTarget.productName == "$(WRAPPER_NAME)")
         }
     }
+
+    @Test
+    func binaryFrameworkProductWithStubTargetDoesNotSynthesizeCollidingDynamicVariant() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let fs = InMemoryFileSystem(
+            emptyFiles: [
+                "/Widget/Sources/_WidgetStub/WidgetStub.swift",
+            ]
+        )
+        // A framework-style XCFramework whose embedded library is `Widget.framework`.
+        try fs.createDirectory("/Widget/Widget.xcframework", recursive: true)
+        try fs.writeFileContents(
+            "/Widget/Widget.xcframework/Info.plist",
+            string: """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>AvailableLibraries</key>
+                <array>
+                    <dict>
+                        <key>LibraryIdentifier</key>
+                        <string>macos-arm64</string>
+                        <key>LibraryPath</key>
+                        <string>Widget.framework</string>
+                        <key>SupportedArchitectures</key>
+                        <array>
+                            <string>arm64</string>
+                        </array>
+                        <key>SupportedPlatform</key>
+                        <string>macos</string>
+                    </dict>
+                </array>
+                <key>CFBundlePackageType</key>
+                <string>XFWK</string>
+                <key>XCFrameworkFormatVersion</key>
+                <string>1.0</string>
+            </dict>
+            </plist>
+            """
+        )
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                .createRootManifest(
+                    displayName: "Widget",
+                    path: "/Widget",
+                    toolsVersion: .v6_2,
+                    products: [
+                        .init(name: "Widget", type: .library(.automatic), targets: ["Widget", "_WidgetStub"]),
+                    ],
+                    targets: [
+                        .init(name: "Widget", path: "Widget.xcframework", type: .binary),
+                        .init(name: "_WidgetStub"),
+                    ]
+                )
+            ],
+            binaryArtifacts: [
+                .plain("widget"): [
+                    "Widget": .init(kind: .xcframework, originURL: nil, path: "/Widget/Widget.xcframework"),
+                ],
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root,
+                addLocalRpaths: .always,
+                shouldCreateDylibForDynamicProducts: false,
+                // Xcode enables this so it can vend dynamic frameworks to Previews / Playgrounds.
+                createDynamicVariantsForLibraryProducts: true
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        let widgetProject = try pif.workspace.project(named: "Widget")
+
+        // No dynamic framework variant should be synthesized for a product whose buildable artifact is
+        // a same-named binary Widget.framework
+        let dynamicVariantName = PackagePIFBuilder.targetName(forProductName: "Widget", suffix: .dynamic)
+        let dynamicVariant = widgetProject.underlying.targets.first { $0.common.name == dynamicVariantName }
+
+        if case .target(let dynamicTarget) = dynamicVariant {
+            let isCollidingFramework = dynamicTarget.productType == .framework
+                && dynamicTarget.productName == "$(WRAPPER_NAME)"
+            #expect(
+                !isCollidingFramework,
+                "A dynamic 'Widget.framework' variant was synthesized for a binary-backed product"
+            )
+        }
+        #expect(
+            dynamicVariant == nil,
+            "No dynamic variant ('\(dynamicVariantName)') should be synthesized for a product vending a binary framework"
+        )
+    }
+
+    @Test
+    func libraryProductWithDifferentlyNamedBinaryFrameworkStillSynthesizesDynamicVariant() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+
+        let fs = InMemoryFileSystem(
+            emptyFiles: [
+                "/Media/Sources/MediaKit/MediaKit.swift",
+            ]
+        )
+        try fs.createDirectory("/Media/Codec.xcframework", recursive: true)
+        try fs.writeFileContents(
+            "/Media/Codec.xcframework/Info.plist",
+            string: """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>AvailableLibraries</key>
+                <array>
+                    <dict>
+                        <key>LibraryIdentifier</key>
+                        <string>macos-arm64</string>
+                        <key>LibraryPath</key>
+                        <string>Codec.framework</string>
+                        <key>SupportedArchitectures</key>
+                        <array>
+                            <string>arm64</string>
+                        </array>
+                        <key>SupportedPlatform</key>
+                        <string>macos</string>
+                    </dict>
+                </array>
+                <key>CFBundlePackageType</key>
+                <string>XFWK</string>
+                <key>XCFrameworkFormatVersion</key>
+                <string>1.0</string>
+            </dict>
+            </plist>
+            """
+        )
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                .createRootManifest(
+                    displayName: "Media",
+                    path: "/Media",
+                    toolsVersion: .v6_2,
+                    products: [
+                        .init(name: "Media", type: .library(.automatic), targets: ["MediaKit", "Codec"]),
+                    ],
+                    targets: [
+                        .init(name: "MediaKit"),
+                        .init(name: "Codec", path: "Codec.xcframework", type: .binary),
+                    ]
+                )
+            ],
+            binaryArtifacts: [
+                .plain("media"): [
+                    "Codec": .init(kind: .xcframework, originURL: nil, path: "/Media/Codec.xcframework"),
+                ],
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root,
+                addLocalRpaths: .always,
+                shouldCreateDylibForDynamicProducts: false,
+                createDynamicVariantsForLibraryProducts: true
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+        #expect(!observability.hasErrorDiagnostics)
+
+        let mediaProject = try pif.workspace.project(named: "Media")
+
+        // The `Media.framework` dynamic variant cannot collide with the vended `Codec.framework`, so it
+        // should still be synthesized to support Previews/Playgrounds
+        let dynamicVariantName = PackagePIFBuilder.targetName(forProductName: "Media", suffix: .dynamic)
+        let dynamicVariant = mediaProject.underlying.targets.first { $0.common.name == dynamicVariantName }
+
+        guard case .target(let dynamicTarget) = dynamicVariant else {
+            Issue.record("Expected a dynamic framework variant '\(dynamicVariantName)' to be synthesized")
+            return
+        }
+        #expect(dynamicTarget.productType == .framework)
+        #expect(dynamicTarget.productName == "$(WRAPPER_NAME)")
+    }
+
 
     @Test
     func mainModuleProductMetadataUsesMainModuleName() async throws {

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -842,7 +842,7 @@ struct PIFBuilderTests {
     }
 
     @Test
-    func binaryFrameworkProductWithStubTargetDoesNotSynthesizeCollidingDynamicVariant() async throws {
+    func binaryFrameworkProductWithStubTargetSynthesizesDisambiguatedDynamicVariant() async throws {
         let observability = ObservabilitySystem.makeForTesting()
 
         let fs = InMemoryFileSystem(
@@ -927,23 +927,22 @@ struct PIFBuilderTests {
 
         let widgetProject = try pif.workspace.project(named: "Widget")
 
-        // No dynamic framework variant should be synthesized for a product whose buildable artifact is
-        // a same-named binary Widget.framework
         let dynamicVariantName = PackagePIFBuilder.targetName(forProductName: "Widget", suffix: .dynamic)
-        let dynamicVariant = widgetProject.underlying.targets.first { $0.common.name == dynamicVariantName }
+        let dynamicVariant = try widgetProject.target(named: dynamicVariantName)
 
-        if case .target(let dynamicTarget) = dynamicVariant {
-            let isCollidingFramework = dynamicTarget.productType == .framework
-                && dynamicTarget.productName == "$(WRAPPER_NAME)"
+        guard case .target(let dynamicTarget) = dynamicVariant else {
+            Issue.record("Expected a dynamic framework variant '\(dynamicVariantName)' to be synthesized")
+            return
+        }
+        #expect(dynamicTarget.productType == .framework)
+
+        for configuration in BuildConfiguration.allCases {
+            let productName = try dynamicVariant.buildConfig(named: configuration).settings[.PRODUCT_NAME]
             #expect(
-                !isCollidingFramework,
-                "A dynamic 'Widget.framework' variant was synthesized for a binary-backed product"
+                productName != "Widget",
+                "Dynamic framework variant must not be named 'Widget', which collides with the vended Widget.framework"
             )
         }
-        #expect(
-            dynamicVariant == nil,
-            "No dynamic variant ('\(dynamicVariantName)') should be synthesized for a product vending a binary framework"
-        )
     }
 
     @Test


### PR DESCRIPTION
Restore disambiguated framework names for automatic library products

### Motivation:

A library product that bundles a binary framework of the same name collided when the bundled framework included a stub target.

### Modifications:

Check if the product name would conflict with the embedded binary name

