### PR TITLE
Adopt Mutex in the ThreadSafe wrappers

### DIFF
--- a/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeArrayStore.swift
@@ -10,77 +10,70 @@
 //
 //===----------------------------------------------------------------------===//
 
-import class Foundation.NSLock
+import Synchronization
 
 /// Thread-safe array like structure
-public final class ThreadSafeArrayStore<Value> {
-    private var underlying: [Value]
-    private let lock = NSLock()
+public final class ThreadSafeArrayStore<Value: Sendable> {
+    private let underlying: Mutex<[Value]>
 
     public init(_ seed: [Value] = []) {
-        self.underlying = seed
+        self.underlying = Mutex(seed)
     }
 
     public subscript(index: Int) -> Value? {
-        self.lock.withLock {
-            self.underlying[index]
+        self.underlying.withLock {
+            $0[index]
         }
     }
 
     public func get() -> [Value] {
-        self.lock.withLock {
-            self.underlying
-        }
+        self.underlying.withLock { $0 }
     }
 
     @discardableResult
     public func clear() -> [Value] {
-        self.lock.withLock {
-            let underlying = self.underlying
-            self.underlying.removeAll()
-            return underlying
+        self.underlying.withLock { underlying in
+            let existing = underlying
+            underlying.removeAll()
+            return existing
         }
     }
 
     @discardableResult
     public func append(_ item: Value) -> Int {
-        self.lock.withLock {
-            self.underlying.append(item)
-            return self.underlying.count
+        self.underlying.withLock {
+            $0.append(item)
+            return $0.count
         }
     }
 
     @discardableResult
     public func append(contentsOf items: [Value]) -> Int {
-        self.lock.withLock {
-            self.underlying.append(contentsOf: items)
-            return self.underlying.count
+        self.underlying.withLock {
+            $0.append(contentsOf: items)
+            return $0.count
         }
     }
 
     public var count: Int {
-        self.lock.withLock {
-            self.underlying.count
-        }
+        self.underlying.withLock { $0.count }
     }
 
     public var isEmpty: Bool {
-        self.lock.withLock {
-            self.underlying.isEmpty
+        self.underlying.withLock { $0.isEmpty }
+    }
+
+    public func map<NewValue: Sendable>(_ transform: (Value) -> NewValue) -> [NewValue] {
+        self.underlying.withLock {
+            $0.map(transform)
         }
     }
 
-    public func map<NewValue>(_ transform: (Value) -> NewValue) -> [NewValue] {
-        self.lock.withLock {
-            self.underlying.map(transform)
-        }
-    }
-
-    public func compactMap<NewValue>(_ transform: (Value) throws -> NewValue?) rethrows -> [NewValue] {
-        try self.lock.withLock {
-            try self.underlying.compactMap(transform)
+    public func compactMap<NewValue: Sendable>(_ transform: (Value) throws -> NewValue?) rethrows -> [NewValue] {
+        try self.underlying.withLock {
+            try $0.compactMap(transform)
         }
     }
 }
 
-extension ThreadSafeArrayStore: @unchecked Sendable where Value: Sendable {}
+extension ThreadSafeArrayStore: Sendable {}

--- a/Sources/Basics/Concurrency/ThreadSafeBox.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeBox.swift
@@ -10,19 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-import class Foundation.NSLock
+import Synchronization
 
 /// Thread-safe value boxing structure that provides synchronized access to a wrapped value.
 @dynamicMemberLookup
-public final class ThreadSafeBox<Value> {
-    private var underlying: Value
-    private let lock = NSLock()
+public final class ThreadSafeBox<Value: Sendable> {
+    private let underlying: Mutex<Value>
 
     /// Creates a new thread-safe box with the given initial value.
     ///
     /// - Parameter seed: The initial value to store in the box.
     public init(_ seed: Value) {
-        self.underlying = seed
+        self.underlying = Mutex(seed)
     }
 
     /// Atomically mutates the stored value by applying a transformation function.
@@ -33,9 +32,8 @@ public final class ThreadSafeBox<Value> {
     /// - Parameter body: A closure that takes the current value and returns a new value.
     /// - Throws: Any error thrown by the transformation function.
     public func mutate(body: (Value) throws -> Value) rethrows {
-        try self.lock.withLock {
-            let value = try body(self.underlying)
-            self.underlying = value
+        try self.underlying.withLock { value in
+            value = try body(value)
         }
     }
 
@@ -48,8 +46,8 @@ public final class ThreadSafeBox<Value> {
     /// - Parameter body: A closure that receives an inout reference to the current value.
     /// - Throws: Any error thrown by the transformation function.
     public func mutate(body: (inout Value) throws -> Void) rethrows {
-        try self.lock.withLock {
-            try body(&self.underlying)
+        try self.underlying.withLock {
+            try body(&$0)
         }
     }
 
@@ -57,17 +55,15 @@ public final class ThreadSafeBox<Value> {
     ///
     /// - Returns: A copy of the current value stored in the box.
     public func get() -> Value {
-        self.lock.withLock {
-            self.underlying
-        }
+        self.underlying.withLock { $0 }
     }
 
     /// Atomically replaces the current value with a new value.
     ///
     /// - Parameter newValue: The new value to store in the box.
     public func put(_ newValue: Value) {
-        self.lock.withLock {
-            self.underlying = newValue
+        self.underlying.withLock {
+            $0 = newValue
         }
     }
 
@@ -78,9 +74,9 @@ public final class ThreadSafeBox<Value> {
     ///
     /// - Parameter keyPath: A key path to a property of the wrapped value.
     /// - Returns: The value of the specified property.
-    public subscript<T>(dynamicMember keyPath: KeyPath<Value, T>) -> T {
-        self.lock.withLock {
-            self.underlying[keyPath: keyPath]
+    public subscript<T: Sendable>(dynamicMember keyPath: KeyPath<Value, T>) -> T {
+        self.underlying.withLock {
+            $0[keyPath: keyPath]
         }
     }
 
@@ -88,15 +84,15 @@ public final class ThreadSafeBox<Value> {
     ///
     /// - Parameter keyPath: A writable key path to a property of the wrapped value.
     /// - Returns: The value of the specified property when getting.
-    public subscript<T>(dynamicMember keyPath: WritableKeyPath<Value, T>) -> T {
+    public subscript<T: Sendable>(dynamicMember keyPath: WritableKeyPath<Value, T>) -> T {
         get {
-            self.lock.withLock {
-                self.underlying[keyPath: keyPath]
+            self.underlying.withLock {
+                $0[keyPath: keyPath]
             }
         }
         set {
-            self.lock.withLock {
-                self.underlying[keyPath: keyPath] = newValue
+            self.underlying.withLock {
+                $0[keyPath: keyPath] = newValue
             }
         }
     }
@@ -107,16 +103,16 @@ extension ThreadSafeBox {
     /// Creates a new thread-safe box initialized with nil for optional value types.
     ///
     /// This convenience initializer is only available when the wrapped value type is optional.
-    public convenience init<Wrapped>() where Value == Wrapped? {
+    public convenience init<Wrapped: Sendable>() where Value == Wrapped? {
         self.init(nil)
     }
 
     /// Takes the stored optional value, setting it to nil.
     /// - Returns: The previously stored value, or nil if none was present.
-    public func takeValue<Wrapped>() -> Value where Value == Wrapped? {
-        self.lock.withLock {
-            guard let value = self.underlying else { return nil }
-            self.underlying = nil
+    public func takeValue<Wrapped: Sendable>() -> Value where Value == Wrapped? {
+        self.underlying.withLock { underlying in
+            guard let value = underlying else { return nil }
+            underlying = nil
             return value
         }
     }
@@ -124,9 +120,9 @@ extension ThreadSafeBox {
     /// Atomically sets the stored optional value to nil.
     ///
     /// This method is only available when the wrapped value type is optional.
-    public func clear<Wrapped>() where Value == Wrapped? {
-        self.lock.withLock {
-            self.underlying = nil
+    public func clear<Wrapped: Sendable>() where Value == Wrapped? {
+        self.underlying.withLock {
+            $0 = nil
         }
     }
 
@@ -136,9 +132,9 @@ extension ThreadSafeBox {
     ///
     /// - Parameter defaultValue: The value to return if the stored value is nil.
     /// - Returns: The stored value if not nil, otherwise the default value.
-    public func get<Wrapped>(default defaultValue: Wrapped) -> Wrapped where Value == Wrapped? {
-        self.lock.withLock {
-            self.underlying ?? defaultValue
+    public func get<Wrapped: Sendable>(default defaultValue: Wrapped) -> Wrapped where Value == Wrapped? {
+        self.underlying.withLock {
+            $0 ?? defaultValue
         }
     }
 
@@ -152,13 +148,15 @@ extension ThreadSafeBox {
     /// - Returns: The cached value or the newly computed value.
     /// - Throws: Any error thrown by the computation closure.
     @discardableResult
-    public func memoize<Wrapped>(body: () throws -> Wrapped) rethrows -> Wrapped where Value == Wrapped? {
-        try self.lock.withLock {
-            if let value = self.underlying {
+    public func memoize<Wrapped: Sendable>(body: () throws -> Wrapped) rethrows -> Wrapped
+        where Value == Wrapped?
+    {
+        try self.underlying.withLock { underlying in
+            if let value = underlying {
                 return value
             }
             let value = try body()
-            self.underlying = value
+            underlying = value
             return value
         }
     }
@@ -176,13 +174,15 @@ extension ThreadSafeBox {
     /// - Returns: The cached value or the newly computed value (which may be nil).
     /// - Throws: Any error thrown by the computation closure.
     @discardableResult
-    public func memoizeOptional<Wrapped>(body: () throws -> Wrapped?) rethrows -> Wrapped? where Value == Wrapped? {
-        try self.lock.withLock {
-            if let value = self.underlying {
+    public func memoizeOptional<Wrapped: Sendable>(body: () throws -> Wrapped?) rethrows -> Wrapped?
+        where Value == Wrapped?
+    {
+        try self.underlying.withLock { underlying in
+            if let value = underlying {
                 return value
             }
             let value = try body()
-            self.underlying = value
+            underlying = value
             return value
         }
     }
@@ -193,8 +193,8 @@ extension ThreadSafeBox where Value == Int {
     ///
     /// This method is only available when the wrapped value type is Int.
     public func increment() {
-        self.lock.withLock {
-            self.underlying = self.underlying + 1
+        self.underlying.withLock {
+            $0 += 1
         }
     }
 
@@ -202,8 +202,8 @@ extension ThreadSafeBox where Value == Int {
     ///
     /// This method is only available when the wrapped value type is Int.
     public func decrement() {
-        self.lock.withLock {
-            self.underlying = self.underlying - 1
+        self.underlying.withLock {
+            $0 -= 1
         }
     }
 }
@@ -221,4 +221,4 @@ extension ThreadSafeBox where Value == String {
     }
 }
 
-extension ThreadSafeBox: @unchecked Sendable where Value: Sendable {}
+extension ThreadSafeBox: Sendable {}

--- a/Sources/Basics/Concurrency/ThreadSafeKeyValueStore.swift
+++ b/Sources/Basics/Concurrency/ThreadSafeKeyValueStore.swift
@@ -12,7 +12,7 @@
 
 import _Concurrency
 
-import class Foundation.NSLock
+import Synchronization
 
 /// Thread-safe dictionary with async memoization
 public actor ThrowingAsyncKeyValueMemoizer<Key: Hashable & Sendable, Value: Sendable> {
@@ -91,84 +91,77 @@ public actor AsyncThrowingValueMemoizer<Value: Sendable> {
 }
 
 /// Thread-safe dictionary like structure.
-public final class ThreadSafeKeyValueStore<Key, Value> where Key: Hashable {
-    private var underlying: [Key: Value]
-    private let lock = NSLock()
+public final class ThreadSafeKeyValueStore<Key: Sendable, Value: Sendable> where Key: Hashable {
+    private let underlying: Mutex<[Key: Value]>
 
     public init(_ seed: [Key: Value] = [:]) {
-        self.underlying = seed
+        self.underlying = Mutex(seed)
     }
 
     public func get() -> [Key: Value] {
-        self.lock.withLock {
-            self.underlying
-        }
+        self.underlying.withLock { $0 }
     }
 
     public subscript(key: Key) -> Value? {
         get {
-            self.lock.withLock {
-                self.underlying[key]
+            self.underlying.withLock {
+                $0[key]
             }
         } set {
-            self.lock.withLock {
-                self.underlying[key] = newValue
+            self.underlying.withLock {
+                $0[key] = newValue
             }
         }
     }
 
     @discardableResult
     public func memoize(_ key: Key, body: () throws -> Value) rethrows -> Value {
-        try self.lock.withLock {
-            try self.underlying.memoize(key: key, body: body)
+        try self.underlying.withLock {
+            try $0.memoize(key: key, body: body)
         }
     }
 
     @discardableResult
     public func removeValue(forKey key: Key) -> Value? {
-        self.lock.withLock {
-            self.underlying.removeValue(forKey: key)
+        self.underlying.withLock {
+            $0.removeValue(forKey: key)
         }
     }
 
     @discardableResult
     public func clear() -> [Key: Value] {
-        self.lock.withLock {
-            let underlying = self.underlying
-            self.underlying.removeAll()
-            return underlying
+        self.underlying.withLock { underlying in
+            let existing = underlying
+            underlying.removeAll()
+            return existing
         }
     }
 
     public var count: Int {
-        self.lock.withLock {
-            self.underlying.count
-        }
+        self.underlying.withLock { $0.count }
     }
 
     public var isEmpty: Bool {
-        self.lock.withLock {
-            self.underlying.isEmpty
-        }
+        self.underlying.withLock { $0.isEmpty }
     }
 
     public func contains(_ key: Key) -> Bool {
-        self.lock.withLock {
-            self.underlying.keys.contains(key)
+        self.underlying.withLock {
+            $0.keys.contains(key)
         }
     }
 
-    public func map<T>(_ transform: ((key: Key, value: Value)) throws -> T) rethrows -> [T] {
-        try self.lock.withLock {
-            try self.underlying.map(transform)
+    public func map<T: Sendable>(_ transform: ((key: Key, value: Value)) throws -> T) rethrows -> [T] {
+        try self.underlying.withLock {
+            try $0.map(transform)
         }
     }
 
-    public func mapValues<T>(_ transform: (Value) throws -> T) rethrows -> [Key: T] {
-        try self.lock.withLock {
-            try self.underlying.mapValues(transform)
+    public func mapValues<T: Sendable>(_ transform: (Value) throws -> T) rethrows -> [Key: T] {
+        try self.underlying.withLock {
+            try $0.mapValues(transform)
         }
     }
 }
 
-extension ThreadSafeKeyValueStore: @unchecked Sendable where Key: Sendable, Value: Sendable {}
+extension ThreadSafeKeyValueStore: Sendable {}


### PR DESCRIPTION
`ThreadSafeBox`, `ThreadSafeArrayStore` and `ThreadSafeKeyValueStore` each paired an `NSLock` with the property it protected. Move the value inside a `Mutex` so it can't be reached without taking the lock, which lets all three drop `@unchecked Sendable` for a conformance the compiler actually checks.

`Mutex.withLock` hands back `inout sending Value`, so the generic parameters that were previously unconstrained now require `Sendable`. Existing code that uses the ThreadSafe wrappers already satisfies this constraint.
