### PR TITLE
CMake: Remove phantom edges and clean up policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,16 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-if(POLICY CMP0091)
-  cmake_policy(SET CMP0091 NEW)
-endif()
-
 cmake_minimum_required(VERSION 3.24)
+
+if(POLICY CMP0157) # CMake 3.29
+  # New Swift compilation mode.
+  cmake_policy(SET CMP0157 NEW)
+endif()
+if(POLICY CMP0195) # CMake 4.1
+  # Swift modules in build trees use the Swift module directory structure.
+  cmake_policy(SET CMP0195 NEW)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -58,19 +58,16 @@ if(SwiftPM_ENABLE_RUNTIME)
   # This is unnecessary with the split runtime build, but is left here to
   # minimize disruption.
   set_target_properties(CompilerPluginSupport PROPERTIES
-    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI)
   set_target_properties(PackageDescription PROPERTIES
-    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI)
   set_target_properties(PackagePlugin PROPERTIES
-    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
     OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI

--- a/Sources/Runtimes/CMakeLists.txt
+++ b/Sources/Runtimes/CMakeLists.txt
@@ -8,8 +8,14 @@
 
 cmake_minimum_required(VERSION 3.29)
 
-if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
+if(CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
+  # Disable the new Swift compilation mode, which requires the new driver.
   cmake_policy(SET CMP0157 OLD)
+endif()
+
+if(POLICY CMP0195) # CMake 4.1
+  # Swift modules in build trees use the Swift module directory structure.
+  cmake_policy(SET CMP0195 NEW)
 endif()
 
 project(SwiftPMRuntime

--- a/Sources/Runtimes/cmake/modules/EmitSwiftInterface.cmake
+++ b/Sources/Runtimes/cmake/modules/EmitSwiftInterface.cmake
@@ -15,8 +15,6 @@
 # TODO: CMake should learn how to model library evolution and generate this
 #       stuff automatically.
 
-
-# Generate a swift interface file for the target if library evolution is enabled
 function(emit_swift_interface target)
   # Generate the target-variant binary swift module when performing zippered
   # build
@@ -37,17 +35,25 @@ function(emit_swift_interface target)
     message(STATUS "Removing regular file ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule to support nested swiftmodule generation")
     file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
   endif()
-  target_compile_options(${target} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule>")
+
+  set(_cmp0195_status "OLD")
+  if(POLICY CMP0195)
+    cmake_policy(GET CMP0195 _cmp0195_status)
+  endif()
+  if(NOT _cmp0195_status STREQUAL "NEW")
+    target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule>")
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule"
+        DEPENDS ${target})
+    target_sources(${target}
+        INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule>)
+  endif()
+
   if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
     target_compile_options(${target} PRIVATE
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.swiftmodule>")
   endif()
-  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule"
-    DEPENDS ${target})
-  target_sources(${target}
-    INTERFACE
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule>)
 
   # Generate textual swift interfaces is library-evolution is enabled
   if(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION)

--- a/Sources/swift-bootstrap/CMakeLists.txt
+++ b/Sources/swift-bootstrap/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-bootstrap
     main.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-bootstrap PROPERTIES
+  Swift_MODULE_NAME swift_bootstrap)
+
 target_link_libraries(swift-bootstrap PRIVATE
   ArgumentParser
   Basics

--- a/Sources/swift-build/CMakeLists.txt
+++ b/Sources/swift-build/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-build
     Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-build PROPERTIES
+  Swift_MODULE_NAME swift_build)
+
 target_link_libraries(swift-build PRIVATE
     Commands)
 

--- a/Sources/swift-experimental-sdk/CMakeLists.txt
+++ b/Sources/swift-experimental-sdk/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-experimental-sdk
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-experimental-sdk PROPERTIES
+  Swift_MODULE_NAME swift_experimental_sdk)
+
 target_link_libraries(swift-experimental-sdk PRIVATE
   SwiftSDKCommand)
 

--- a/Sources/swift-package-collection/CMakeLists.txt
+++ b/Sources/swift-package-collection/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-package-collection
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-package-collection PROPERTIES
+  Swift_MODULE_NAME swift_package_collection)
+
 target_link_libraries(swift-package-collection PRIVATE
   PackageCollectionsCommand)
 

--- a/Sources/swift-package-registry/CMakeLists.txt
+++ b/Sources/swift-package-registry/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-package-registry
   runner.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-package-registry PROPERTIES
+  Swift_MODULE_NAME swift_package_registry)
+
 target_link_libraries(swift-package-registry PRIVATE
   PackageRegistryCommand)
 

--- a/Sources/swift-package/CMakeLists.txt
+++ b/Sources/swift-package/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-package
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-package PROPERTIES
+  Swift_MODULE_NAME swift_package)
+
 target_link_libraries(swift-package PRIVATE
   Commands
   TSCBasic)

--- a/Sources/swift-run/CMakeLists.txt
+++ b/Sources/swift-run/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-run
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-run PROPERTIES
+  Swift_MODULE_NAME swift_run)
+
 target_link_libraries(swift-run PRIVATE
   Commands)
 

--- a/Sources/swift-sdk/CMakeLists.txt
+++ b/Sources/swift-sdk/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-sdk
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-sdk PROPERTIES
+  Swift_MODULE_NAME swift_sdk)
+
 target_link_libraries(swift-sdk PRIVATE
   SwiftSDKCommand)
 

--- a/Sources/swift-test/CMakeLists.txt
+++ b/Sources/swift-test/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 add_executable(swift-test
   Entrypoint.swift)
+# TODO: Remove this once the minimum CMake version is 4.4.
+set_target_properties(swift-test PROPERTIES
+  Swift_MODULE_NAME swift_test)
+
 target_link_libraries(swift-test PRIVATE
   Commands)
 


### PR DESCRIPTION
Incorrect setting of some CMake properties resulted in phantom edges in the build graph.

### Motivation:

Manually setting `Swift_MODULE_DIRECTORY` has no effect on the built files, but introduced phantom edges in the build graph, resulting in incremental builds triggering a full re-build in this project.

### Modifications:

These changes also clean up old policies already set via cmake_minimum_required() and opts in to CMP0157 and CMP0195.
* Remove old policies already set via `cmake_minimum_required()`.
* Opt-in to CMP0157. This is the new Swift build model, which has been the default since CMake 3.29.
* Opt-in to CMP0195. This applies the new Swift module directory structure, which allows us to skip manually passing `-emit-module-path`.

### Result:

Incremental builds are a no-op. The Windows toolchain still builds.