### PR TITLE
Restore ordered delivery of repository and registry delegate callbacks

### DIFF
--- a/Sources/Basics/CMakeLists.txt
+++ b/Sources/Basics/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(Basics
   Concurrency/ConcurrencyHelpers.swift
   Concurrency/NSLock+Extensions.swift
   Concurrency/SendableBox.swift
+  Concurrency/SerialEventQueue.swift
   Concurrency/ThreadSafeArrayStore.swift
   Concurrency/ThreadSafeBox.swift
   Concurrency/ThreadSafeKeyValueStore.swift

--- a/Sources/Basics/Concurrency/SerialEventQueue.swift
+++ b/Sources/Basics/Concurrency/SerialEventQueue.swift
@@ -19,16 +19,22 @@ import _Concurrency
 /// queue and calls the sink. 
 /// 
 /// Because delivery is serialized, a slow sink delays the events queued behind it.
+///
+/// Releasing the queue cancels delivery, so any events still queued are dropped.
+/// Call ``finish()`` first to wait for them.
 package final class SerialEventQueue<Sink: Sendable>: Sendable {
     private typealias Event = @Sendable (Sink) -> Void
 
     private let events: AsyncStream<Event>.Continuation
+    private let task: Task<Void, Never>
 
     package init(_ sink: Sink) {
         let (stream, continuation) = AsyncStream.makeStream(of: Event.self, bufferingPolicy: .unbounded)
         self.events = continuation
 
-        Task {
+        // Captures `sink` and `stream`, never `self`, so the queue stays
+        // deallocatable and `deinit` can tear this down.
+        self.task = Task {
             for await event in stream {
                 event(sink)
             }
@@ -36,11 +42,20 @@ package final class SerialEventQueue<Sink: Sendable>: Sendable {
     }
 
     deinit {
+        self.task.cancel()
         self.events.finish()
     }
 
     /// Enqueues `event`, to be delivered after every event emitted before it.
     package func emit(_ event: @escaping @Sendable (Sink) -> Void) {
         self.events.yield(event)
+    }
+
+    /// Stops accepting events and waits for the ones already emitted to be
+    /// delivered. Events emitted afterwards are ignored. Calling this more than
+    /// once is safe.
+    package func finish() async {
+        self.events.finish()
+        await self.task.value
     }
 }

--- a/Sources/Basics/Concurrency/SerialEventQueue.swift
+++ b/Sources/Basics/Concurrency/SerialEventQueue.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import _Concurrency
+
+/// Delivers events to a sink one at a time, in the order they were emitted,
+/// without blocking the emitter.
+///
+/// ``emit(_:)`` returns as soon as the event is queued; a single task drains the
+/// queue and calls the sink. 
+/// 
+/// Because delivery is serialized, a slow sink delays the events queued behind it.
+package final class SerialEventQueue<Sink: Sendable>: Sendable {
+    private typealias Event = @Sendable (Sink) -> Void
+
+    private let events: AsyncStream<Event>.Continuation
+
+    package init(_ sink: Sink) {
+        let (stream, continuation) = AsyncStream.makeStream(of: Event.self, bufferingPolicy: .unbounded)
+        self.events = continuation
+
+        Task {
+            for await event in stream {
+                event(sink)
+            }
+        }
+    }
+
+    deinit {
+        self.events.finish()
+    }
+
+    /// Enqueues `event`, to be delivered after every event emitted before it.
+    package func emit(_ event: @escaping @Sendable (Sink) -> Void) {
+        self.events.yield(event)
+    }
+}

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -27,7 +27,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
     private let path: Basics.AbsolutePath
     private let cachePath: Basics.AbsolutePath?
     private let registryClient: RegistryClient
-    private let delegate: RegistryDownloadManagerDelegateProxy?
+    private let delegate: SerialEventQueue<RegistryDownloadsManagerDelegate>?
 
     struct PackageLookup: Hashable {
         let package: PackageIdentity
@@ -48,7 +48,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
         self.path = path
         self.cachePath = cachePath
         self.registryClient = registryClient
-        self.delegate = RegistryDownloadManagerDelegateProxy(delegate)
+        self.delegate = delegate.map { SerialEventQueue($0) }
     }
 
     public func lookup(
@@ -81,10 +81,8 @@ public class RegistryDownloadsManager: AsyncCancellable {
                     // inform delegate that we are starting to fetch
                     // calculate if cached (for delegate call) outside queue as it may change while queue is processing
                     let isCached = self.cachePath.map { self.fileSystem.exists($0.appending(packageRelativePath)) } ?? false
-                    Task {
-                        let details = FetchDetails(fromCache: isCached, updatedCache: false)
-                        await delegate?.willFetch(package: package, version: version, fetchDetails: details)
-                    }
+                    let details = FetchDetails(fromCache: isCached, updatedCache: false)
+                    delegate?.emit { $0.willFetch(package: package, version: version, fetchDetails: details) }
 
                     // make sure destination is free.
                     try? self.fileSystem.removeFileTree(packagePath)
@@ -99,14 +97,10 @@ public class RegistryDownloadsManager: AsyncCancellable {
                         )
                         // inform delegate that we finished to fetch
                         let duration = start.distance(to: .now())
-                        Task {
-                            await delegate?.didFetch(package: package, version: version, result: .success(result), duration: duration)
-                        }
+                        delegate?.emit { $0.didFetch(package: package, version: version, result: .success(result), duration: duration) }
                     } catch {
                         let duration = start.distance(to: .now())
-                        Task {
-                            await delegate?.didFetch(package: package, version: version, result: .failure(error), duration: duration)
-                        }
+                        delegate?.emit { $0.didFetch(package: package, version: version, result: .failure(error), duration: duration) }
                         throw error
                     }
                     return packagePath
@@ -233,8 +227,8 @@ public class RegistryDownloadsManager: AsyncCancellable {
         // utility to update progress
 
         @Sendable func updateDownloadProgress(downloaded: Int64, total: Int64?) {
-            Task {
-                await delegate?.fetching(
+            delegate?.emit {
+                $0.fetching(
                     package: package,
                     version: version,
                     bytesDownloaded: downloaded,
@@ -308,6 +302,10 @@ public class RegistryDownloadsManager: AsyncCancellable {
 }
 
 /// Delegate to notify clients about actions being performed by RegistryManager.
+///
+/// Callbacks are delivered one at a time, in the order they were emitted, on an
+/// unspecified task. Delivery is serialized to preserve that order, so a slow
+/// implementation delays the callbacks queued behind it.
 public protocol RegistryDownloadsManagerDelegate: Sendable {
     /// Called when a package is about to be fetched.
     func willFetch(package: PackageIdentity, version: Version, fetchDetails: RegistryDownloadsManager.FetchDetails)
@@ -322,34 +320,6 @@ public protocol RegistryDownloadsManagerDelegate: Sendable {
 
     /// Called every time the progress of a repository fetch operation updates.
     func fetching(package: PackageIdentity, version: Version, bytesDownloaded: Int64, totalBytesToDownload: Int64?)
-}
-
-actor RegistryDownloadManagerDelegateProxy {
-    private let delegate: RegistryDownloadsManagerDelegate
-
-    init?(_ delegate: RegistryDownloadsManagerDelegate?) {
-        guard let delegate else {
-            return nil
-        }
-        self.delegate = delegate
-    }
-
-    func willFetch(package: PackageIdentity, version: Version, fetchDetails: RegistryDownloadsManager.FetchDetails) {
-        self.delegate.willFetch(package: package, version: version, fetchDetails: fetchDetails)
-    }
-
-    func didFetch(
-        package: PackageIdentity,
-        version: Version,
-        result: Result<RegistryDownloadsManager.FetchDetails, Error>,
-        duration: DispatchTimeInterval
-    ) {
-        self.delegate.didFetch(package: package, version: version, result: result, duration: duration)
-    }
-
-    func fetching(package: PackageIdentity, version: Version, bytesDownloaded: Int64, totalBytesToDownload: Int64?) {
-        self.delegate.fetching(package: package, version: version, bytesDownloaded: bytesDownloaded, totalBytesToDownload: totalBytesToDownload)
-    }
 }
 
 extension Dictionary where Key == RegistryDownloadsManager.PackageLookup {

--- a/Sources/SourceControl/RepositoryManager.swift
+++ b/Sources/SourceControl/RepositoryManager.swift
@@ -34,7 +34,7 @@ public class RepositoryManager: Cancellable {
     private let provider: RepositoryProvider
 
     /// The delegate interface.
-    private let delegate: RepositoryManagerDelegateProxy?
+    private let delegate: SerialEventQueue<RepositoryManagerDelegate>?
 
     /// The filesystem to operate on.
     private let fileSystem: FileSystem
@@ -80,7 +80,7 @@ public class RepositoryManager: Cancellable {
         self.cacheLocalPackages = cacheLocalPackages
 
         self.provider = provider
-        self.delegate = RepositoryManagerDelegateProxy(delegate)
+        self.delegate = delegate.map { SerialEventQueue($0) }
 
         // this queue and semaphore is used to limit the amount of concurrent git operations taking place
         let maxConcurrentOperations = max(1, maxConcurrentOperations ?? (3 * Concurrency.maxOperations / 4))
@@ -194,7 +194,6 @@ public class RepositoryManager: Cancellable {
         let relativePath = try repositorySpecifier.storagePath()
         let repositoryPath = self.path.appending(relativePath)
         let handle = RepositoryHandle(manager: self, repository: repositorySpecifier, subpath: relativePath)
-        let delegate = self.delegate
 
         // check if a repository already exists
         // errors when trying to check if a repository already exists are legitimate
@@ -211,15 +210,11 @@ public class RepositoryManager: Cancellable {
             if self.fetchRequired(repository: repository, updateStrategy: updateStrategy) {
                 let start = DispatchTime.now()
 
-                Task {
-                    await delegate?.willUpdate(package: package, repository: handle.repository)
-                }
+                self.delegate?.emit { $0.willUpdate(package: package, repository: handle.repository) }
 
                 try await self.fetchAsync(repository)
                 let duration = start.distance(to: .now())
-                Task {
-                    await delegate?.didUpdate(package: package, repository: handle.repository, duration: duration)
-                }
+                self.delegate?.emit { $0.didUpdate(package: package, repository: handle.repository, duration: duration) }
             }
 
             return handle
@@ -228,10 +223,8 @@ public class RepositoryManager: Cancellable {
         // inform delegate that we are starting to fetch
         // calculate if cached (for delegate call) outside queue as it may change while queue is processing
         let isCached = self.cachePath.map { self.fileSystem.exists($0.appending(handle.subpath)) } ?? false
-        Task {
-            let details = FetchDetails(fromCache: isCached, updatedCache: false)
-            await delegate?.willFetch(package: package, repository: handle.repository, details: details)
-        }
+        let details = FetchDetails(fromCache: isCached, updatedCache: false)
+        self.delegate?.emit { $0.willFetch(package: package, repository: handle.repository, details: details) }
 
         // perform the fetch
         let start = DispatchTime.now()
@@ -248,16 +241,12 @@ public class RepositoryManager: Cancellable {
             )
             // inform delegate fetch is done
             let duration = start.distance(to: .now())
-            Task {
-                await delegate?.didFetch(package: package, repository: handle.repository, result: .success(result), duration: duration)
-            }
+            self.delegate?.emit { $0.didFetch(package: package, repository: handle.repository, result: .success(result), duration: duration) }
             return handle
         } catch {
             // inform delegate fetch is done
             let duration = start.distance(to: .now())
-            Task {
-                await delegate?.didFetch(package: package, repository: handle.repository, result: .failure(error), duration: duration)
-            }
+            self.delegate?.emit { $0.didFetch(package: package, repository: handle.repository, result: .failure(error), duration: duration) }
             throw error
         }
     }
@@ -295,9 +284,8 @@ public class RepositoryManager: Cancellable {
         // utility to update progress
         func updateFetchProgress(progress: FetchProgress) -> Void {
             if let total = progress.totalSteps {
-                let delegate = self.delegate
-                Task {
-                    await delegate?.fetching(
+                self.delegate?.emit {
+                    $0.fetching(
                         package: package,
                         repository: handle.repository,
                         objectsFetched: progress.step,
@@ -624,6 +612,10 @@ public enum RepositoryUpdateStrategy: Sendable {
 }
 
 /// Delegate to notify clients about actions being performed by RepositoryManager.
+///
+/// Callbacks are delivered one at a time, in the order they were emitted, on an
+/// unspecified task. Delivery is serialized to preserve that order, so a slow
+/// implementation delays the callbacks queued behind it.
 public protocol RepositoryManagerDelegate: Sendable {
     /// Called when a repository is about to be fetched.
     func willFetch(package: PackageIdentity, repository: RepositorySpecifier, details: RepositoryManager.FetchDetails)
@@ -640,39 +632,6 @@ public protocol RepositoryManagerDelegate: Sendable {
     /// Called when a repository has finished updating from its remote.
     func didUpdate(package: PackageIdentity, repository: RepositorySpecifier, duration: DispatchTimeInterval)
 }
-
-/// Actor to proxy the delegate methods to the actual delegate, ensuring serialized delegate calls.
-fileprivate actor RepositoryManagerDelegateProxy {
-    private let delegate: RepositoryManagerDelegate
-
-    init?(_ delegate: RepositoryManagerDelegate?) {
-        guard let delegate else {
-            return nil
-        }
-        self.delegate = delegate
-    }
-
-    func willFetch(package: PackageIdentity, repository: RepositorySpecifier, details: RepositoryManager.FetchDetails) {
-        delegate.willFetch(package: package, repository: repository, details: details)
-    }
-
-    func fetching(package: PackageIdentity, repository: RepositorySpecifier, objectsFetched: Int, totalObjectsToFetch: Int) {
-        delegate.fetching(package: package, repository: repository, objectsFetched: objectsFetched, totalObjectsToFetch: totalObjectsToFetch)
-    }
-
-    func didFetch(package: PackageIdentity, repository: RepositorySpecifier, result: Result<RepositoryManager.FetchDetails, Error>, duration: DispatchTimeInterval) {
-        delegate.didFetch(package: package, repository: repository, result: result, duration: duration)
-    }
-
-    func willUpdate(package: PackageIdentity, repository: RepositorySpecifier) {
-        delegate.willUpdate(package: package, repository: repository)
-    }
-
-    func didUpdate(package: PackageIdentity, repository: RepositorySpecifier, duration: DispatchTimeInterval) {
-        delegate.didUpdate(package: package, repository: repository, duration: duration)
-    }
-}
-
 
 extension RepositoryManager.RepositoryHandle: CustomStringConvertible {
     public var description: String {

--- a/Tests/BasicsTests/SerialEventQueueTests.swift
+++ b/Tests/BasicsTests/SerialEventQueueTests.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Foundation
+
+@testable import Basics
+import Testing
+
+@Suite(
+    .tags(
+        Tag.TestSize.small,
+    )
+)
+struct SerialEventQueueTests {
+    /// A sink that records what it received, in arrival order.
+    final class Recorder: Sendable {
+        private let _values = ThreadSafeArrayStore<Int>()
+        private let onReceive: (@Sendable (Int) -> Void)?
+
+        init(onReceive: (@Sendable (Int) -> Void)? = .none) {
+            self.onReceive = onReceive
+        }
+
+        var values: [Int] {
+            self._values.get()
+        }
+
+        func receive(_ value: Int) {
+            self.onReceive?(value)
+            self._values.append(value)
+        }
+    }
+
+    @Test
+    func deliversEventsInEmissionOrder() async throws {
+        let recorder = Recorder()
+        let queue = SerialEventQueue(recorder)
+
+        let expected = Array(0 ..< 1_000)
+        for value in expected {
+            queue.emit { $0.receive(value) }
+        }
+
+        await drain(queue)
+        #expect(recorder.values == expected)
+    }
+
+    /// Emitting must not wait on the sink, even while the sink is busy.
+    @Test
+    func doesNotBlockTheEmitter() {
+        let sinkEntered = DispatchSemaphore(value: 0)
+        let sinkMayReturn = DispatchSemaphore(value: 0)
+        let recorder = Recorder { _ in
+            sinkEntered.signal()
+            sinkMayReturn.wait()
+        }
+        let queue = SerialEventQueue(recorder)
+
+        queue.emit { $0.receive(0) }
+        #expect(sinkEntered.wait(timeout: .now() + 5) == .success, "sink was never called")
+
+        // The sink is parked in its first callback. Emitting has to return anyway;
+        // reaching the end of this test at all is the assertion.
+        queue.emit { $0.receive(1) }
+        sinkMayReturn.signal()
+    }
+
+    /// Waits for previously emitted events to be delivered. A sentinel event is
+    /// delivered only after everything emitted ahead of it, so this needs nothing
+    /// from the queue beyond the ordering it already guarantees.
+    private func drain(_ queue: SerialEventQueue<Recorder>) async {
+        await withCheckedContinuation { continuation in
+            queue.emit { _ in continuation.resume() }
+        }
+    }
+
+    /// Events already enqueued are still delivered once the queue is released.
+    @Test
+    func drainsBufferedEventsAfterRelease() async throws {
+        let recorder = Recorder()
+        let expected = Array(0 ..< 100)
+
+        do {
+            let queue = SerialEventQueue(recorder)
+            for value in expected {
+                queue.emit { $0.receive(value) }
+            }
+        }
+
+        let deadline = ContinuousClock.now + .seconds(5)
+        while recorder.values != expected, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(recorder.values == expected)
+    }
+}

--- a/Tests/BasicsTests/SerialEventQueueTests.swift
+++ b/Tests/BasicsTests/SerialEventQueueTests.swift
@@ -51,7 +51,7 @@ struct SerialEventQueueTests {
             queue.emit { $0.receive(value) }
         }
 
-        await drain(queue)
+        await queue.finish()
         #expect(recorder.values == expected)
     }
 
@@ -75,32 +75,52 @@ struct SerialEventQueueTests {
         sinkMayReturn.signal()
     }
 
-    /// Waits for previously emitted events to be delivered. A sentinel event is
-    /// delivered only after everything emitted ahead of it, so this needs nothing
-    /// from the queue beyond the ordering it already guarantees.
-    private func drain(_ queue: SerialEventQueue<Recorder>) async {
-        await withCheckedContinuation { continuation in
-            queue.emit { _ in continuation.resume() }
-        }
-    }
-
-    /// Events already enqueued are still delivered once the queue is released.
+    /// Finishing waits for everything already queued, even when the sink is slow
+    /// enough that none of it could have been delivered yet.
     @Test
-    func drainsBufferedEventsAfterRelease() async throws {
-        let recorder = Recorder()
-        let expected = Array(0 ..< 100)
-
-        do {
-            let queue = SerialEventQueue(recorder)
-            for value in expected {
-                queue.emit { $0.receive(value) }
+    func finishWaitsForQueuedEvents() async throws {
+        let recorder = Recorder { value in
+            if value == 0 {
+                Thread.sleep(forTimeInterval: 0.1)
             }
         }
+        let queue = SerialEventQueue(recorder)
 
-        let deadline = ContinuousClock.now + .seconds(5)
-        while recorder.values != expected, ContinuousClock.now < deadline {
-            try await Task.sleep(for: .milliseconds(10))
+        let expected = Array(0 ..< 100)
+        for value in expected {
+            queue.emit { $0.receive(value) }
         }
+
+        await queue.finish()
         #expect(recorder.values == expected)
+    }
+
+    /// Finishing twice is safe, and the second call does not stall waiting on a
+    /// delivery task that has already completed.
+    @Test
+    func finishIsIdempotent() async throws {
+        let recorder = Recorder()
+        let queue = SerialEventQueue(recorder)
+
+        queue.emit { $0.receive(0) }
+        await queue.finish()
+        await queue.finish()
+
+        #expect(recorder.values == [0])
+    }
+
+    /// Events emitted after finishing are ignored rather than delivered late.
+    @Test
+    func ignoresEventsEmittedAfterFinish() async throws {
+        let recorder = Recorder()
+        let queue = SerialEventQueue(recorder)
+
+        queue.emit { $0.receive(0) }
+        await queue.finish()
+
+        queue.emit { $0.receive(1) }
+        await queue.finish()
+
+        #expect(recorder.values == [0])
     }
 }


### PR DESCRIPTION
### Motivation:

`RepositoryManager` and `RegistryDownloadsManager` fired each delegate callback from its own unstructured Task:

```swift
    Task { await delegate?.willFetch(...) }
    ...
    Task { await delegate?.didFetch(...) }
```

Two independently created tasks start in whatever order the executor picks, so nothing stopped `didFetch` starting before `willFetch`. The actor proxy they awaited serializes the calls it receives, but it can't do anything about the order they arrive in.

Before #8721 these went through `delegateQueue.async { ... }` and every caller passed `.sharedConcurrent`. A concurrent queue dequeues FIFO, so delivery started in order while the callbacks still ran independently. Moving to Task dropped the ordering and didn't put anything back.

### Modifications:

Add `SerialEventQueue` to Basics, basically an AsyncStream that a single task drains, holding the delegate it delivers to. `emit` yields into the stream and returns, so it doesn't block the caller, and the drain task calls the delegate one event at a time in the order they were emitted.

Both managers hold one directly now and emit through it. That replaces the two `DelegateProxy` types (which had turned into pass-throughs restating every protocol method).

### Result:

Callbacks are delivered in the order they were emitted, so `didFetch` can no longer land before `willFetch`.

The tradeoff is that a slow delegate now delays the callbacks queued behind it, which the old `.sharedConcurrent` dispatch didn't do. Ordering callbacks means waiting on them, so I dont think theres a way around that short of a queue per package. These delegates format a string and write a line, so realistically it shouldn't matter.

Also stops allocating when theres no delegate. `Task { await delegate?.foo() }` allocated and enqueued a task even when delegate was nil, which the registry progress handler did once per chunk received.
