### PR TITLE
Fix SwiftPM’s existing `.exact(...)` requirement to match the complete parsed version identifier, including build metadata.

### DIFF
--- a/Sources/Basics/Version+Extensions.swift
+++ b/Sources/Basics/Version+Extensions.swift
@@ -23,4 +23,37 @@ extension Version {
             try? self.init(versionString: tag, usesLenientParsing: true)
         }
     }
+
+    /// Returns whether this version and `other` have the same parsed version identifier.
+    ///
+    /// Unlike `Version.==`, which models SemVer precedence equality, this comparison includes
+    /// build metadata.
+    package func hasSameIdentifier(as other: Version) -> Bool {
+        self.major == other.major &&
+            self.minor == other.minor &&
+            self.patch == other.patch &&
+            self.prereleaseIdentifiers == other.prereleaseIdentifiers &&
+            self.buildMetadataIdentifiers == other.buildMetadataIdentifiers
+    }
+}
+
+/// A hashable key for the complete parsed identity of a semantic version.
+package struct VersionIdentifierKey: Hashable {
+    package let version: Version
+
+    package init(_ version: Version) {
+        self.version = version
+    }
+
+    package static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.version.hasSameIdentifier(as: rhs.version)
+    }
+
+    package func hash(into hasher: inout Hasher) {
+        hasher.combine(self.version.major)
+        hasher.combine(self.version.minor)
+        hasher.combine(self.version.patch)
+        hasher.combine(self.version.prereleaseIdentifiers)
+        hasher.combine(self.version.buildMetadataIdentifiers)
+    }
 }

--- a/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
+++ b/Sources/PackageFingerprint/FilePackageFingerprintStorage.swift
@@ -94,7 +94,7 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
             try self.loadFromDisk(reference: reference)
         }
 
-        guard let fingerprints = packageFingerprints[version] else {
+        guard let fingerprints = packageFingerprints[VersionIdentifierKey(version)] else {
             throw PackageFingerprintStorageError.notFound
         }
         return fingerprints
@@ -109,7 +109,8 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
         try self.withLock {
             var packageFingerprints = try self.loadFromDisk(reference: reference)
 
-            if let existing = packageFingerprints[version]?[fingerprint.origin.kind]?[fingerprint.contentType] {
+            let versionKey = VersionIdentifierKey(version)
+            if let existing = packageFingerprints[versionKey]?[fingerprint.origin.kind]?[fingerprint.contentType] {
                 // Error if we try to write a different fingerprint
                 guard fingerprint == existing else {
                     throw PackageFingerprintStorageError.conflict(given: fingerprint, existing: existing)
@@ -118,17 +119,17 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
                 return
             }
 
-            var fingerprintsForVersion = packageFingerprints.removeValue(forKey: version) ?? [:]
+            var fingerprintsForVersion = packageFingerprints.removeValue(forKey: versionKey) ?? [:]
             var fingerprintsForKind = fingerprintsForVersion.removeValue(forKey: fingerprint.origin.kind) ?? [:]
             fingerprintsForKind[fingerprint.contentType] = fingerprint
             fingerprintsForVersion[fingerprint.origin.kind] = fingerprintsForKind
-            packageFingerprints[version] = fingerprintsForVersion
+            packageFingerprints[versionKey] = fingerprintsForVersion
 
             try self.saveToDisk(reference: reference, fingerprints: packageFingerprints)
         }
     }
 
-    private func loadFromDisk(reference: FingerprintReference) throws -> PackageFingerprints {
+    private func loadFromDisk(reference: FingerprintReference) throws -> PackageFingerprintsByVersionIdentifier {
         let path = try self.directoryPath.appending(component: reference.fingerprintsFilename)
 
         guard self.fileSystem.exists(path) else {
@@ -143,7 +144,10 @@ public struct FilePackageFingerprintStorage: PackageFingerprintStorage {
         return try StorageModel.decode(data: data, decoder: self.decoder)
     }
 
-    private func saveToDisk(reference: FingerprintReference, fingerprints: PackageFingerprints) throws {
+    private func saveToDisk(
+        reference: FingerprintReference,
+        fingerprints: PackageFingerprintsByVersionIdentifier
+    ) throws {
         if !self.fileSystem.exists(self.directoryPath) {
             try self.fileSystem.createDirectory(self.directoryPath, recursive: true)
         }
@@ -218,7 +222,7 @@ private enum StorageModel {
                 self.versionFingerprints = versionFingerprints
             }
 
-            func packageFingerprints() throws -> PackageFingerprints {
+            func packageFingerprints() throws -> PackageFingerprintsByVersionIdentifier {
                 try Dictionary(
                     throwingUniqueKeysWithValues: self.versionFingerprints.map { version, fingerprintsForVersion in
                         let fingerprintsByKind = try Dictionary(
@@ -253,14 +257,14 @@ private enum StorageModel {
                                 return (kind, fingerprintsByContentType)
                             }
                         )
-                        return (Version(stringLiteral: version), fingerprintsByKind)
+                        return (VersionIdentifierKey(Version(stringLiteral: version)), fingerprintsByKind)
                     }
                 )
             }
         }
     }
 
-    static func decode(data: Data, decoder: JSONDecoder) throws -> PackageFingerprints {
+    static func decode(data: Data, decoder: JSONDecoder) throws -> PackageFingerprintsByVersionIdentifier {
         let schemaVersion = try decoder.decode(SchemaVersion.self, from: data)
         switch schemaVersion.version {
         case .some(2):
@@ -297,9 +301,12 @@ private enum StorageModel {
         }
     }
 
-    static func encode(packageFingerprints: PackageFingerprints, encoder: JSONEncoder) throws -> Data {
+    static func encode(
+        packageFingerprints: PackageFingerprintsByVersionIdentifier,
+        encoder: JSONEncoder
+    ) throws -> Data {
         let container = Container.V2(versionFingerprints: try Dictionary(
-            throwingUniqueKeysWithValues: packageFingerprints.map { version, fingerprintsForVersion in
+            throwingUniqueKeysWithValues: packageFingerprints.map { versionKey, fingerprintsForVersion in
                 let fingerprintsByKind = try Dictionary(
                     throwingUniqueKeysWithValues: fingerprintsForVersion.map { kind, fingerprintsForKind in
                         let fingerprintsByContentType = try Dictionary(
@@ -323,7 +330,7 @@ private enum StorageModel {
                         return (kind.rawValue, fingerprintsByContentType)
                     }
                 )
-                return (version.description, fingerprintsByKind)
+                return (versionKey.version.description, fingerprintsByKind)
             }
         ))
         return try encoder.encode(container)

--- a/Sources/PackageFingerprint/Model.swift
+++ b/Sources/PackageFingerprint/Model.swift
@@ -89,6 +89,10 @@ extension Fingerprint {
 
 public typealias PackageFingerprints = [Version: [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]]]
 
+package typealias PackageFingerprintsByVersionIdentifier = [
+    VersionIdentifierKey: [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]]
+]
+
 public enum FingerprintCheckingMode: String {
     case strict
     case warn

--- a/Sources/PackageGraph/BoundVersion.swift
+++ b/Sources/PackageGraph/BoundVersion.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import struct TSCUtility.Version
 
 /// A bound version for a package within an assignment.
@@ -29,6 +30,37 @@ public enum BoundVersion: Equatable, Hashable {
 
     /// The package assignment is this revision.
     case revision(String, branch: String? = nil)
+}
+
+extension BoundVersion {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.excluded, .excluded), (.unversioned, .unversioned):
+            true
+        case (.version(let lhs), .version(let rhs)):
+            VersionIdentifierKey(lhs) == VersionIdentifierKey(rhs)
+        case (.revision(let lhsRevision, let lhsBranch), .revision(let rhsRevision, let rhsBranch)):
+            lhsRevision == rhsRevision && lhsBranch == rhsBranch
+        default:
+            false
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .excluded:
+            hasher.combine(0)
+        case .version(let version):
+            hasher.combine(1)
+            hasher.combine(VersionIdentifierKey(version))
+        case .unversioned:
+            hasher.combine(2)
+        case .revision(let revision, let branch):
+            hasher.combine(3)
+            hasher.combine(revision)
+            hasher.combine(branch)
+        }
+    }
 }
 
 extension BoundVersion: CustomStringConvertible {

--- a/Sources/PackageGraph/Resolution/PubGrub/DiagnosticReportBuilder.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/DiagnosticReportBuilder.swift
@@ -275,7 +275,7 @@ struct DiagnosticReportBuilder {
         switch term.requirement {
         case .any:
             return true
-        case .empty, .exact, .ranges:
+        case .empty, .exact, .ranges, ._set:
             return false
         case .range(let range):
             // container expected to be cached at this point
@@ -345,6 +345,8 @@ struct DiagnosticReportBuilder {
                 return $0.lowerBound.description + "..<" + $0.upperBound.description
             }.joined(separator: ", ") + "}"
             return "\(name) \(ranges)"
+        case ._set:
+            return "\(name) \(term.requirement.description)"
         }
     }
 

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubDependencyResolver.swift
@@ -251,7 +251,7 @@ public struct PubGrubDependencyResolver {
             switch assignment.term.requirement {
             case .exact(let version):
                 boundVersion = .version(version)
-            case .range, .any, .empty, .ranges:
+            case .range, .any, .empty, .ranges, ._set:
                 throw InternalError("unexpected requirement value for assignment \(assignment.term)")
             }
 

--- a/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
+++ b/Sources/PackageGraph/Resolution/PubGrub/PubGrubPackageContainer.swift
@@ -93,7 +93,10 @@ final class PubGrubPackageContainer {
                     return pinnedVersion
                 } else {
                     // Make sure the pinned version is still available
-                    let version = try await self.underlying.versionsDescending().first { pinnedVersion == $0 }
+                    let pinnedKey = VersionIdentifierKey(pinnedVersion)
+                    let version = try await self.underlying.versionsDescending().first {
+                        VersionIdentifierKey($0) == pinnedKey
+                    }
                     if version != nil {
                         return version
                     }
@@ -105,24 +108,24 @@ final class PubGrubPackageContainer {
         return try await self.underlying.versionsDescending().first { versionSet.contains($0) }
     }
 
-    /// Compute the bounds of incompatible tools version starting from the given version.
-    private func computeIncompatibleToolsVersionBounds(fromVersion: Version) async throws -> VersionSetSpecifier {
+    /// Compute the incompatible identifiers adjacent to the given version.
+    private func computeIncompatibleToolsVersionRequirement(fromVersion: Version) async throws -> VersionSetSpecifier {
         // TODO: do we really want to compute this for an assert?
         // assert(!self.underlying.isToolsVersionCompatible(at: fromVersion))
         let versions: [Version] = try await self.underlying.versionsAscending()
 
         // This is guaranteed to be present.
-        let idx = versions.firstIndex(of: fromVersion)!
+        let fromVersionKey = VersionIdentifierKey(fromVersion)
+        let idx = versions.firstIndex { VersionIdentifierKey($0) == fromVersionKey }!
 
-        var lowerBound = fromVersion
-        var upperBound = fromVersion
+        var incompatibleVersions = [fromVersion]
 
         for version in versions.dropFirst(idx + 1) {
             let isToolsVersionCompatible = await self.underlying.isToolsVersionCompatible(at: version)
             if isToolsVersionCompatible {
                 break
             }
-            upperBound = version
+            incompatibleVersions.append(version)
         }
 
         for version in versions.dropLast(versions.count - idx).reversed() {
@@ -130,29 +133,12 @@ final class PubGrubPackageContainer {
             if isToolsVersionCompatible {
                 break
             }
-            lowerBound = version
+            incompatibleVersions.append(version)
         }
 
-        // If lower and upper bounds didn't change then this is the sole incompatible version.
-        if lowerBound == upperBound {
-            return .exact(lowerBound)
+        return incompatibleVersions.reduce(.empty) { result, version in
+            result.union(.exact(version))
         }
-
-        // If lower bound is the first version then we can use 0 as the sentinel. This
-        // will end up producing a better diagnostic since we can omit the lower bound.
-        if lowerBound == versions.first {
-            lowerBound = "0.0.0"
-        }
-
-        if upperBound == versions.last {
-            // If upper bound is the last version then we can use the next major version as the sentinel.
-            // This will end up producing a better diagnostic since we can omit the upper bound.
-            upperBound = Version(upperBound.major + 1, 0, 0)
-        } else {
-            // Use the next patch since the upper bound needs to be inclusive here.
-            upperBound = upperBound.nextPatch()
-        }
-        return .range(lowerBound ..< upperBound.nextPatch())
     }
 
     /// Returns the incompatibilities of a package at the given version.
@@ -164,7 +150,7 @@ final class PubGrubPackageContainer {
     ) async throws -> [Incompatibility] {
         // FIXME: It would be nice to compute bounds for this as well.
         if await !self.underlying.isToolsVersionCompatible(at: version) {
-            let requirement = try await self.computeIncompatibleToolsVersionBounds(fromVersion: version)
+            let requirement = try await self.computeIncompatibleToolsVersionRequirement(fromVersion: version)
             let toolsVersion = try await self.underlying.toolsVersion(for: version)
             return try [Incompatibility(
                 Term(node, requirement),

--- a/Sources/PackageGraph/ResolvedPackagesStore.swift
+++ b/Sources/PackageGraph/ResolvedPackagesStore.swift
@@ -67,6 +67,20 @@ public final class ResolvedPackagesStore {
                 return revision
             }
         }
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case (.version(let lhsVersion, let lhsRevision), .version(let rhsVersion, let rhsRevision)):
+                VersionIdentifierKey(lhsVersion) == VersionIdentifierKey(rhsVersion) &&
+                    lhsRevision == rhsRevision
+            case (.branch(let lhsName, let lhsRevision), .branch(let rhsName, let rhsRevision)):
+                lhsName == rhsName && lhsRevision == rhsRevision
+            case (.revision(let lhs), .revision(let rhs)):
+                lhs == rhs
+            default:
+                false
+            }
+        }
     }
 
     private let mirrors: DependencyMirrors

--- a/Sources/PackageGraph/VersionSetSpecifier.swift
+++ b/Sources/PackageGraph/VersionSetSpecifier.swift
@@ -10,7 +10,26 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import struct TSCUtility.Version
+
+/// The canonical representation used for version sets that cannot be expressed by a range alone.
+///
+/// This is public only because it is carried by a public enum. SwiftPM constructs these values
+/// internally while resolving dependencies.
+@_spi(SwiftPMInternal)
+public struct _VersionSetSpecifierSet {
+    package let ranges: [Range<Version>]
+    package let identifierOverrides: [VersionIdentifierKey: Bool]
+
+    package init(
+        ranges: [Range<Version>],
+        identifierOverrides: [VersionIdentifierKey: Bool]
+    ) {
+        self.ranges = ranges
+        self.identifierOverrides = identifierOverrides
+    }
+}
 
 /// An abstract definition for a set of versions.
 public enum VersionSetSpecifier: Hashable {
@@ -28,63 +47,39 @@ public enum VersionSetSpecifier: Hashable {
 
     /// A range of disjoint versions (sorted).
     case ranges([Range<Version>])
+
+    /// A resolver-only set containing ranges and identifier-specific membership overrides.
+    @_spi(SwiftPMInternal)
+    case _set(_VersionSetSpecifierSet)
 }
 
 extension VersionSetSpecifier: Equatable {
     public static func ==(lhs: VersionSetSpecifier, rhs: VersionSetSpecifier) -> Bool {
-        switch (lhs, rhs) {
-        // Basic cases.
-        case (.any, .any):
-            return true
-        case (.empty, .empty):
-            return true
-        case (let .range(lhsRange), let .range(rhsRange)):
-            return lhsRange == rhsRange
-        case (let .exact(lhsExact), let .exact(rhsExact)):
-            return lhsExact == rhsExact
-        case (let .ranges(lhsRanges), let .ranges(rhsRanges)):
-            return lhsRanges == rhsRanges
-
-        // Empty is equivalent to an empty list of ranges or if the list contains one range where the lower bound equals the upper bound.
-        case (.empty, let .ranges(ranges)):
-            fallthrough
-        case (let .ranges(ranges), .empty):
-            return ranges.isEmpty || (ranges.count == 1 && ranges[0].lowerBound == ranges[0].upperBound)
-
-        // Empty is equivalent to a range where the lower bound equals the upper bound.
-        case (.empty, let .range(range)):
-            fallthrough
-        case (let .range(range), .empty):
-            return range.upperBound == range.lowerBound
-
-        // Exact is equal to a range that spans a single patch.
-        case (let .exact(exact), let .range(range)):
-            fallthrough
-        case (let .range(range), let .exact(exact)):
-            return range.lowerBound == exact && range.upperBound == exact.nextPatch()
-
-        // Exact is also equal to a list of ranges with one entry that spans a single patch.
-        case (let .exact(exact), let .ranges(ranges)):
-            fallthrough
-        case (let .ranges(ranges), let .exact(exact)):
-            return ranges.count == 1 && ranges[0].lowerBound == exact && ranges[0].upperBound == exact.nextPatch()
-
-        // A range is equal to a list of ranges with that one range.
-        case (let .range(range), let .ranges(ranges)):
-            fallthrough
-        case (let .ranges(ranges), let .range(range)):
-            return ranges.count == 1 && ranges[0] == range
-
-        default:
+        if case .any = lhs {
+            if case .any = rhs { return true }
             return false
         }
+        if case .any = rhs { return false }
+        return lhs.canonicalSet.isEqual(to: rhs.canonicalSet)
+    }
+}
+
+extension VersionSetSpecifier {
+    public func hash(into hasher: inout Hasher) {
+        if case .any = self {
+            hasher.combine(0)
+            return
+        }
+
+        hasher.combine(1)
+        self.canonicalSet.hash(into: &hasher)
     }
 }
 
 extension VersionSetSpecifier {
     var isExact: Bool {
         switch self {
-        case .any, .empty, .range, .ranges:
+        case .any, .empty, .range, .ranges, ._set:
             return false
         case .exact:
             return true
@@ -98,81 +93,15 @@ extension VersionSetSpecifier {
     }
 
     public static func union(from ranges: [Swift.Range<Version>]) -> VersionSetSpecifier {
-        switch ranges.count {
-        case 0:
-            return .empty
-        case 1:
-            let range = ranges[0]
-            // FIXME: Can we avoid this? testConflict1 goes into a loop if we don't do this.
-            if range.lowerBound.nextPatch() == range.upperBound {
-                return .exact(range.lowerBound)
-            }
-            return .range(range)
-        default:
-            let ranges = ranges.sorted(by: { $0.lowerBound < $1.lowerBound })
-
-            var result: [Range<Version>] = []
-            for range in ranges {
-                // We can merge if next range starts immediately after this one or if they overlap.
-                if let last = result.last, last.upperBound == range.lowerBound || range.overlaps(last) || last.lowerBound.nextPatch() == range.lowerBound {
-                    let newResult: Range<Version>
-
-                    if range.lowerBound == range.upperBound {
-                        // 1.0.0..<1.0.1 U 1.0.1..<1.0.1 is 1.0.0..<1.0.2
-                        let version = range.lowerBound
-                        if last.upperBound == version {
-                            newResult = last.lowerBound ..< version.nextPatch()
-                        } else {
-                            continue
-                        }
-                    } else {
-                        let lower = min(last.lowerBound, range.lowerBound)
-                        let upper = max(last.upperBound, range.upperBound)
-                        newResult = lower ..< upper
-                    }
-
-                    result[result.count - 1] = newResult
-                } else {
-                    result.append(range)
-                }
-            }
-
-            if result.count == 1 {
-                return .range(result[0])
-            }
-            return .ranges(result)
-        }
+        Self.makeSet(ranges: ranges, identifierOverrides: [:])
     }
 
     public func union(_ rhs: VersionSetSpecifier) -> VersionSetSpecifier {
         switch (self, rhs) {
         case (_, .any), (.any, _):
             return .any
-        case (.empty, _):
-            return rhs
-        case (_, .empty):
-            return self
-        case (.exact(let v1), .exact(let v2)):
-            if v1 == v2 {
-                return self
-            }
-            return VersionSetSpecifier.union(from: [v1..<v1, v2..<v2])
-
-        case (.range(let v2), .exact(let v1)),
-             (.exact(let v1), .range(let v2)):
-            return VersionSetSpecifier.union(from: [v1..<v1, v2])
-
-        case (.ranges(let ranges), .exact(let exact)), (.exact(let exact), .ranges(let ranges)):
-            return VersionSetSpecifier.union(from: [exact..<exact] + ranges)
-
-        case (.range(let lhs), .range(let rhs)):
-            return VersionSetSpecifier.union(from: [lhs, rhs])
-
-        case (.ranges(let ranges), .range(let range)), (.range(let range), .ranges(let ranges)):
-            return VersionSetSpecifier.union(from: [range] + ranges)
-
-        case (.ranges(let r1), .ranges(let r2)):
-            return VersionSetSpecifier.union(from: r1 + r2)
+        default:
+            return Self.combine(self.canonicalSet, rhs.canonicalSet, base: Self.unionRanges, membership: { $0 || $1 })
         }
     }
 }
@@ -189,62 +118,9 @@ extension VersionSetSpecifier {
             return .empty
         case (_, .empty):
             return .empty
-        case (.range(let lhs), .range(let rhs)):
-            if let result = VersionSetSpecifier.intersection(lhs, rhs) {
-                return .range(result)
-            }
-            return .empty
-        case (.exact(let v), _):
-            if rhs.contains(v) {
-                return self
-            }
-            return .empty
-        case (_, .exact(let v)):
-            if contains(v) {
-                return rhs
-            }
-            return .empty
-
-        case (.ranges(let ranges), .range(let range)), (.range(let range), .ranges(let ranges)):
-            return .intersection(ranges, [range])
-        case (.ranges(let lhs), .ranges(let rhs)):
-             return .intersection(lhs, rhs)
+        default:
+            return Self.combine(self.canonicalSet, rhs.canonicalSet, base: Self.intersectRanges, membership: { $0 && $1 })
         }
-    }
-
-    fileprivate static func intersection(_ lhs: Range<Version>, _ rhs: Range<Version>) -> Range<Version>? {
-        let start = Swift.max(lhs.lowerBound, rhs.lowerBound)
-        let end = Swift.min(lhs.upperBound, rhs.upperBound)
-        if start < end {
-            return start..<end
-        }
-        return nil
-    }
-
-    fileprivate static func intersection(_ lhs: [Range<Version>], _ rhs: [Range<Version>]) -> VersionSetSpecifier {
-        var lhsItr = lhs.makeIterator()
-        var rhsItr = rhs.makeIterator()
-
-        var currentLhs = lhsItr.next()
-        var currentRhs = rhsItr.next()
-
-        var result: [Range<Version>] = []
-
-        while let lhs = currentLhs, let rhs = currentRhs {
-            if let current = VersionSetSpecifier.intersection(lhs, rhs) {
-                result.append(current)
-            }
-
-            // Move the one with lower upper bound so large ranges have a chance to match multiple
-            // small ranges they contain.
-            if lhs.upperBound < rhs.upperBound {
-                currentLhs = lhsItr.next()
-            } else {
-                currentRhs = rhsItr.next()
-            }
-        }
-
-        return .union(from: result)
     }
 }
 
@@ -259,191 +135,8 @@ extension VersionSetSpecifier {
             return .empty
         case (_, .empty):
             return self
-        case (.exact(let v1), .exact(let v2)):
-            if v1 == v2 {
-                return .empty
-            }
-            return self
-
-        case (.exact(let lhs), .range(let rhs)):
-            if rhs.contains(version: lhs) {
-                return .empty
-            }
-            return .exact(lhs)
-        case (.range(let lhs), .exact(let rhs)):
-            if !lhs.contains(version: rhs) {
-                return .range(lhs)
-            }
-
-            if lhs.lowerBound == rhs {
-                // Return empty if the range is empty. This means upper and lower bounds are equal since the range is half-open and there are no negative results here.
-                if lhs.lowerBound == lhs.upperBound {
-                    return .empty
-                }
-                // If there is exactly one patch between lower and upper bound, the range represent the lower bound as an exact version. So the range is empty in this case as well.
-                if lhs.lowerBound.nextPatch() == lhs.upperBound {
-                    return .empty
-                }
-                return .range(rhs.nextPatch()..<lhs.upperBound)
-            }
-
-            return .union(from: [lhs.lowerBound..<rhs, rhs.nextPatch()..<lhs.upperBound])
-
-        case (.ranges(let ranges), .exact(let exact)):
-            var result = [Range<Version>]()
-
-            for range in ranges {
-                // FIXME: is this worth merging with the logic in (range, exact) case above?
-                if !range.contains(version: exact) {
-                    result.append(range)
-                } else if range.lowerBound == exact {
-                    if range.lowerBound == range.upperBound {
-                        continue
-                    }
-
-                    if exact.nextPatch() < range.upperBound {
-                        result.append(exact.nextPatch()..<range.upperBound)
-                    }
-                } else {
-                    result += [range.lowerBound..<exact]
-                    if exact.nextPatch() < range.upperBound {
-                        result += [exact.nextPatch()..<range.upperBound]
-                    }
-                }
-            }
-            return .union(from: result)
-
-        case (.exact(let exact), .ranges(let ranges)):
-            for range in ranges {
-                if range.contains(version: exact) {
-                    return .empty
-                }
-            }
-            return self
-
-        case (.range(let lhs), .range(let rhs)):
-            if lhs == rhs { return .empty }
-            if !lhs.overlaps(rhs) { return .range(lhs) }
-
-            var result = [Range<Version>]()
-            if lhs.lowerBound < rhs.lowerBound {
-                result.append(lhs.lowerBound..<rhs.lowerBound)
-            }
-
-            if rhs.upperBound < lhs.upperBound {
-                result.append(rhs.upperBound..<lhs.upperBound)
-            }
-            return .union(from: result)
-
-        case (.range(let inputRange), .ranges(let ranges)):
-            var result = [Range<Version>]()
-            var lhs = inputRange
-            for range in ranges {
-                // Skip the ranges that don't overlap with the current lhs range.
-                // FIXME: We can exit the loop early when the range goes above lhs.
-                if !range.overlaps(lhs) { continue }
-
-                let diff = VersionSetSpecifier.range(lhs).difference(.range(range))
-                switch diff {
-                case .empty:
-                    return .empty
-                case .any:
-                    fatalError("unexpected any result")
-                case .exact(let v):
-                    lhs = v..<v.nextPatch()
-                case .range(let r):
-                    lhs = r
-                case .ranges(let rs):
-                    // If the difference end up being a disjoint set, append the first one to
-                    // our result and continue reducing the second set.
-                    precondition(rs.count == 2, "expected 2 elements in ranges \(rs)")
-                    result.append(rs[0])
-                    lhs = rs[1]
-                }
-            }
-            return .union(from: result + [lhs])
-
-        case (.ranges(_), .range(let r)):
-            return self.difference(.ranges([r]))
-
-        case (.ranges(let lhs), .ranges(let rhs)):
-            // Based on the difference method in https://github.com/dart-lang/pub_semver/blob/master/lib/src/version_union.dart     //ignore-unacceptable-language
-            var lhsItr = lhs.makeIterator()
-            var rhsItr = rhs.makeIterator()
-
-            var currentLHS = lhsItr.next()!
-            var currentRHS = rhsItr.next()!
-
-            var result: [Range<Version>] = []
-
-            func moveRHS() -> Bool {
-                if let value = rhsItr.next() {
-                    currentRHS = value
-                    return true
-                }
-
-                // RHS is done so add remaining on LHS ranges to the final result.
-                result.append(currentLHS)
-                while let value = lhsItr.next() {
-                    result.append(value)
-                }
-                return false
-            }
-
-            func moveLHS(addCurrentLHS: Bool = true) -> Bool {
-                if addCurrentLHS {
-                    result.append(currentLHS)
-                }
-
-                if let value = lhsItr.next() {
-                    currentLHS = value
-                    return true
-                }
-                return false
-            }
-
-            outer: while true {
-                if currentRHS.isLowerThan(currentLHS) {
-                    if !moveRHS() { break outer }
-                    continue
-                }
-
-                if currentRHS.isHigherThan(currentLHS) {
-                    if !moveLHS() { break outer }
-                    continue
-                }
-
-                var diff = VersionSetSpecifier.range(currentLHS).difference(.range(currentRHS))
-                // Transform exact to a range so it is handled in the range case below.
-                if case .exact(let v) = diff {
-                    diff = .range(v..<v.nextPatch())
-                }
-
-                switch diff {
-                case .empty:
-                    if !moveLHS(addCurrentLHS: false) { break outer }
-                case .any, .exact:
-                    fatalError("Unexpected result \(diff)")
-                case .range(let r):
-                    currentLHS = r
-                    // Move the one with lower upper bound so large ranges have a chance to match multiple
-                    // small ranges they contain.
-                    if currentLHS.upperBound < currentRHS.upperBound {
-                        if !moveRHS() { break outer }
-                    } else {
-                        if !moveLHS() { break outer }
-                    }
-                case .ranges(let rs):
-                    // If the difference end up being a disjoint set, append the first one to
-                    // our result and continue reducing the second set.
-                    precondition(rs.count == 2, "expected 2 elements in ranges \(rs)")
-                    result.append(rs[0])
-                    currentLHS = rs[1]
-                    if !moveRHS() { break outer }
-                }
-            }
-
-            return .union(from: result)
+        default:
+            return Self.combine(self.canonicalSet, rhs.canonicalSet, base: Self.subtractRanges, membership: { $0 && !$1 })
         }
     }
 }
@@ -461,7 +154,172 @@ extension VersionSetSpecifier {
         case .any:
             return true
         case .exact(let v):
-            return v == version
+            return VersionIdentifierKey(v) == VersionIdentifierKey(version)
+        case ._set(let set):
+            return set.contains(version)
+        }
+    }
+}
+
+private extension VersionSetSpecifier {
+    var canonicalSet: _VersionSetSpecifierSet {
+        switch self {
+        case .any:
+            preconditionFailure("the universal set has no finite range representation")
+        case .empty:
+            return .init(ranges: [], identifierOverrides: [:])
+        case .range(let range):
+            return .init(ranges: Self.normalizeRanges([range]), identifierOverrides: [:])
+        case .ranges(let ranges):
+            return .init(ranges: Self.normalizeRanges(ranges), identifierOverrides: [:])
+        case .exact(let version):
+            return .init(ranges: [], identifierOverrides: [VersionIdentifierKey(version): true])
+        case ._set(let set):
+            return Self.canonicalize(set)
+        }
+    }
+
+    static func combine(
+        _ lhs: _VersionSetSpecifierSet,
+        _ rhs: _VersionSetSpecifierSet,
+        base operation: ([Range<Version>], [Range<Version>]) -> [Range<Version>],
+        membership: (Bool, Bool) -> Bool
+    ) -> VersionSetSpecifier {
+        let ranges = operation(lhs.ranges, rhs.ranges)
+        let keys = Set(lhs.identifierOverrides.keys).union(rhs.identifierOverrides.keys)
+        var overrides: [VersionIdentifierKey: Bool] = [:]
+
+        for key in keys {
+            let included = membership(lhs.contains(key.version), rhs.contains(key.version))
+            if included != Self.ranges(ranges, contain: key.version) {
+                overrides[key] = included
+            }
+        }
+
+        return Self.makeSet(ranges: ranges, identifierOverrides: overrides)
+    }
+
+    static func makeSet(
+        ranges: [Range<Version>],
+        identifierOverrides: [VersionIdentifierKey: Bool]
+    ) -> VersionSetSpecifier {
+        let set = Self.canonicalize(.init(ranges: ranges, identifierOverrides: identifierOverrides))
+        if set.ranges.isEmpty {
+            if set.identifierOverrides.isEmpty {
+                return .empty
+            }
+            if set.identifierOverrides.count == 1,
+               let override = set.identifierOverrides.first,
+               override.value
+            {
+                return .exact(override.key.version)
+            }
+        }
+        if set.identifierOverrides.isEmpty {
+            if set.ranges.count == 1 {
+                return .range(set.ranges[0])
+            }
+            return .ranges(set.ranges)
+        }
+        return ._set(set)
+    }
+
+    static func canonicalize(_ set: _VersionSetSpecifierSet) -> _VersionSetSpecifierSet {
+        let ranges = Self.normalizeRanges(set.ranges)
+        let overrides = set.identifierOverrides.filter { key, included in
+            included != Self.ranges(ranges, contain: key.version)
+        }
+        return .init(ranges: ranges, identifierOverrides: overrides)
+    }
+
+    static func normalizeRanges(_ ranges: [Range<Version>]) -> [Range<Version>] {
+        let sorted = ranges
+            .filter { $0.lowerBound < $0.upperBound }
+            .sorted { lhs, rhs in
+                if lhs.lowerBound == rhs.lowerBound {
+                    return lhs.upperBound < rhs.upperBound
+                }
+                return lhs.lowerBound < rhs.lowerBound
+            }
+        var result: [Range<Version>] = []
+        for range in sorted {
+            if let last = result.last, range.lowerBound <= last.upperBound {
+                result[result.count - 1] = last.lowerBound..<max(last.upperBound, range.upperBound)
+            } else {
+                result.append(range)
+            }
+        }
+        return result
+    }
+
+    static func unionRanges(_ lhs: [Range<Version>], _ rhs: [Range<Version>]) -> [Range<Version>] {
+        Self.normalizeRanges(lhs + rhs)
+    }
+
+    static func intersectRanges(_ lhs: [Range<Version>], _ rhs: [Range<Version>]) -> [Range<Version>] {
+        var result: [Range<Version>] = []
+        for left in lhs {
+            for right in rhs {
+                let lower = max(left.lowerBound, right.lowerBound)
+                let upper = min(left.upperBound, right.upperBound)
+                if lower < upper {
+                    result.append(lower..<upper)
+                }
+            }
+        }
+        return Self.normalizeRanges(result)
+    }
+
+    static func subtractRanges(_ lhs: [Range<Version>], _ rhs: [Range<Version>]) -> [Range<Version>] {
+        var result: [Range<Version>] = []
+        for left in lhs {
+            var fragments = [left]
+            for right in rhs {
+                fragments = fragments.flatMap { fragment -> [Range<Version>] in
+                    guard fragment.overlaps(right) else { return [fragment] }
+                    var remainder: [Range<Version>] = []
+                    if fragment.lowerBound < right.lowerBound {
+                        remainder.append(fragment.lowerBound..<min(fragment.upperBound, right.lowerBound))
+                    }
+                    if right.upperBound < fragment.upperBound {
+                        remainder.append(max(fragment.lowerBound, right.upperBound)..<fragment.upperBound)
+                    }
+                    return remainder
+                }
+            }
+            result.append(contentsOf: fragments)
+        }
+        return Self.normalizeRanges(result)
+    }
+
+    static func ranges(_ ranges: [Range<Version>], contain version: Version) -> Bool {
+        ranges.contains { $0.contains(version: version) }
+    }
+}
+
+private extension _VersionSetSpecifierSet {
+    func contains(_ version: Version) -> Bool {
+        self.identifierOverrides[VersionIdentifierKey(version)] ??
+            self.ranges.contains { $0.contains(version: version) }
+    }
+
+    func isEqual(to other: Self) -> Bool {
+        self.ranges == other.ranges && self.identifierOverrides == other.identifierOverrides
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.ranges.count)
+        for range in self.ranges {
+            hasher.combine(range.lowerBound)
+            hasher.combine(range.upperBound)
+        }
+        let overrides = self.identifierOverrides.sorted { lhs, rhs in
+            lhs.key.version.description < rhs.key.version.description
+        }
+        hasher.combine(overrides.count)
+        for (key, included) in overrides {
+            hasher.combine(key)
+            hasher.combine(included)
         }
     }
 }
@@ -477,6 +335,9 @@ extension VersionSetSpecifier {
             range.supportsPrereleases
         case .ranges(let ranges):
             ranges.contains(where: \.supportsPrereleases)
+        case ._set(let set):
+            set.ranges.contains(where: \.supportsPrereleases) ||
+                set.identifierOverrides.contains { $0.value && $0.key.version.supportsPrerelease }
         }
     }
 
@@ -494,6 +355,17 @@ extension VersionSetSpecifier {
             .ranges(ranges.map { $0.withoutPrerelease })
         case .exact(let version):
             .exact(version.withoutPrerelease)
+        case ._set(let set):
+            Self.makeSet(
+                ranges: set.ranges.map { $0.withoutPrerelease },
+                identifierOverrides: Dictionary(
+                    grouping: set.identifierOverrides,
+                    by: { VersionIdentifierKey($0.key.version.withoutPrerelease) }
+                ).compactMapValues { overrides in
+                    let memberships = Set(overrides.map(\.value))
+                    return memberships.count == 1 ? memberships.first : nil
+                }
+            )
         }
     }
 }
@@ -525,19 +397,29 @@ extension VersionSetSpecifier: CustomStringConvertible {
             return range.lowerBound.description + "..<" + upperBound.description
         case .exact(let version):
             return version.description
+        case ._set(let set):
+            let base = Self.union(from: set.ranges).description
+            let included = set.identifierOverrides
+                .filter(\.value)
+                .map { $0.key.version.description }
+                .sorted()
+            let excluded = set.identifierOverrides
+                .filter { !$0.value }
+                .map { $0.key.version.description }
+                .sorted()
+            var components = base == "empty" ? [] : [base]
+            if !included.isEmpty {
+                components.append("include {\(included.joined(separator: ", "))}")
+            }
+            if !excluded.isEmpty {
+                components.append("exclude {\(excluded.joined(separator: ", "))}")
+            }
+            return components.joined(separator: ", ")
         }
     }
 }
 
 fileprivate extension Range where Bound == Version {
-    func isLowerThan(_ other: Range<Bound>) -> Bool {
-        return self.lowerBound < other.lowerBound && self.upperBound < other.upperBound
-    }
-
-    func isHigherThan(_ other: Range<Bound>) -> Bool {
-        return other.isLowerThan(self)
-    }
-
     var supportsPrereleases: Bool {
         self.lowerBound.supportsPrerelease || self.upperBound.supportsPrerelease
     }

--- a/Sources/PackageModel/EnabledTrait.swift
+++ b/Sources/PackageModel/EnabledTrait.swift
@@ -76,16 +76,17 @@ public struct EnabledTraitsMap {
     public typealias Value = EnabledTraits
 
     struct VersionedTraits {
-        var map: [Version: EnabledTraits] = [:]
+        var map: [VersionIdentifierKey: EnabledTraits] = [:]
 
         public func at(_ version: Version) -> EnabledTraits {
-            self.map[version] ?? ["default"]
+            self.map[VersionIdentifierKey(version)] ?? ["default"]
         }
 
         public mutating func set(_ version: Version, enabledTraits: EnabledTraits) {
-            let oldTraits = self.map[version] ?? []
+            let key = VersionIdentifierKey(version)
+            let oldTraits = self.map[key] ?? []
             let newTraits = oldTraits.union(enabledTraits)
-            self.map[version] = newTraits
+            self.map[key] = newTraits
         }
     }
 
@@ -720,4 +721,3 @@ extension IdentifiableSet where Element == EnabledTrait {
         return updatedContents
     }
 }
-

--- a/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
+++ b/Sources/PackageModel/Manifest/PackageDependencyDescription.swift
@@ -519,6 +519,40 @@ extension PackageDependency.SourceControl.Requirement: CustomStringConvertible {
     }
 }
 
+extension PackageDependency.SourceControl.Requirement {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.exact(let lhs), .exact(let rhs)):
+            return VersionIdentifierKey(lhs) == VersionIdentifierKey(rhs)
+        case (.range(let lhs), .range(let rhs)):
+            return lhs == rhs
+        case (.revision(let lhs), .revision(let rhs)):
+            return lhs == rhs
+        case (.branch(let lhs), .branch(let rhs)):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .exact(let version):
+            hasher.combine(0)
+            hasher.combine(VersionIdentifierKey(version))
+        case .range(let range):
+            hasher.combine(1)
+            hasher.combine(range)
+        case .revision(let revision):
+            hasher.combine(2)
+            hasher.combine(revision)
+        case .branch(let branch):
+            hasher.combine(3)
+            hasher.combine(branch)
+        }
+    }
+}
+
 extension PackageDependency.Registry.Requirement: CustomStringConvertible {
     public var description: String {
         switch self {
@@ -526,6 +560,30 @@ extension PackageDependency.Registry.Requirement: CustomStringConvertible {
             return version.description
         case .range(let range):
             return range.description
+        }
+    }
+}
+
+extension PackageDependency.Registry.Requirement {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.exact(let lhs), .exact(let rhs)):
+            return VersionIdentifierKey(lhs) == VersionIdentifierKey(rhs)
+        case (.range(let lhs), .range(let rhs)):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .exact(let version):
+            hasher.combine(0)
+            hasher.combine(VersionIdentifierKey(version))
+        case .range(let range):
+            hasher.combine(1)
+            hasher.combine(range)
         }
     }
 }

--- a/Sources/PackageRegistry/RegistryClient.swift
+++ b/Sources/PackageRegistry/RegistryClient.swift
@@ -418,7 +418,11 @@ public final class RegistryClient: AsyncCancellable {
         timeout: DispatchTimeInterval?,
         observabilityScope: ObservabilityScope
     ) async throws -> Serialization.VersionMetadata {
-        let cacheKey = MetadataCacheKey(registry: registry, package: package, version: version)
+        let cacheKey = MetadataCacheKey(
+            registry: registry,
+            package: package,
+            version: VersionIdentifierKey(version)
+        )
         if let cached = self.metadataCache[cacheKey], cached.expires > .now() {
             return cached.metadata
         }
@@ -1534,7 +1538,7 @@ public final class RegistryClient: AsyncCancellable {
     private struct MetadataCacheKey: Hashable {
         let registry: Registry
         let package: PackageIdentity.RegistryIdentity
-        let version: Version
+        let version: VersionIdentifierKey
     }
 }
 
@@ -2318,7 +2322,11 @@ private struct RegistryClientSignatureValidationDelegate: SignatureValidation.De
         version: TSCUtility.Version,
         completion: (Bool) -> Void
     ) {
-        let responseCacheKey = ResponseCacheKey(registry: registry, package: package, version: version)
+        let responseCacheKey = ResponseCacheKey(
+            registry: registry,
+            package: package,
+            version: VersionIdentifierKey(version)
+        )
         if let cachedResponse = self.onUnsignedResponseCache[responseCacheKey] {
             return completion(cachedResponse)
         }
@@ -2345,7 +2353,11 @@ private struct RegistryClientSignatureValidationDelegate: SignatureValidation.De
         version: TSCUtility.Version,
         completion: (Bool) -> Void
     ) {
-        let responseCacheKey = ResponseCacheKey(registry: registry, package: package, version: version)
+        let responseCacheKey = ResponseCacheKey(
+            registry: registry,
+            package: package,
+            version: VersionIdentifierKey(version)
+        )
         if let cachedResponse = self.onUntrustedResponseCache[responseCacheKey] {
             return completion(cachedResponse)
         }
@@ -2369,7 +2381,7 @@ private struct RegistryClientSignatureValidationDelegate: SignatureValidation.De
     private struct ResponseCacheKey: Hashable {
         let registry: Registry
         let package: PackageModel.PackageIdentity
-        let version: TSCUtility.Version
+        let version: VersionIdentifierKey
     }
 }
 

--- a/Sources/PackageRegistry/RegistryDownloadsManager.swift
+++ b/Sources/PackageRegistry/RegistryDownloadsManager.swift
@@ -31,7 +31,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
 
     struct PackageLookup: Hashable {
         let package: PackageIdentity
-        let version: Version
+        let version: VersionIdentifierKey
     }
 
     private var pendingLookups = [PackageLookup: Task<Basics.AbsolutePath, Error>]()
@@ -68,7 +68,7 @@ public class RegistryDownloadsManager: AsyncCancellable {
             return packagePath
         }
 
-        let lookupId = PackageLookup(package: package, version: version)
+        let lookupId = PackageLookup(package: package, version: VersionIdentifierKey(version))
         let task = await withCheckedContinuation { continuation in
             self.pendingLookupsLock.lock()
             defer { self.pendingLookupsLock.unlock() }

--- a/Sources/PackageRegistry/SigningEntityTOFU.swift
+++ b/Sources/PackageRegistry/SigningEntityTOFU.swift
@@ -204,7 +204,7 @@ struct PackageSigningEntityTOFU {
             }
         // Or is the package going from having a signer to .none?
         case .none:
-            let versionSigningEntities = packageSigners.versionSigningEntities
+            let versionSigningEntities = packageSigners.versionIdentifierSigningEntities
             // If the given version is semantically newer than any signed version,
             // then it must be signed. (i.e., when a package starts being signed
             // at a version, then all future versions must be signed.)
@@ -223,10 +223,11 @@ struct PackageSigningEntityTOFU {
             //     seen a signed 2.x release yet, so we assume 2.x releases are not signed.
             //     (this might be controversial)
             let olderSignedVersions = versionSigningEntities.keys
+                .map(\.version)
                 .filter { $0.major == version.major && $0 < version }
                 .sorted(by: >)
             for olderSignedVersion in olderSignedVersions {
-                if let olderVersionSigner = versionSigningEntities[olderSignedVersion]?.first {
+                if let olderVersionSigner = versionSigningEntities[VersionIdentifierKey(olderSignedVersion)]?.first {
                     try self.handleSigningEntityForPackageChanged(
                         registry: registry,
                         package: package,

--- a/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/FilePackageSigningEntityStorage.swift
@@ -146,7 +146,7 @@ public struct FilePackageSigningEntityStorage: PackageSigningEntityStorage {
 
         if var existingSigner = packageSigners.signers.removeValue(forKey: signingEntity) {
             existingSigner.origins.insert(origin)
-            existingSigner.versions.insert(version)
+            existingSigner.add(version: version)
             packageSigners.signers[signingEntity] = existingSigner
         } else {
             let signer = PackageSigner(

--- a/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
+++ b/Sources/PackageSigning/SigningEntity/PackageSigningEntityStorage.swift
@@ -98,16 +98,83 @@ extension SigningEntity {
 public struct PackageSigner: Codable {
     public let signingEntity: SigningEntity
     public internal(set) var origins: Set<SigningEntity.Origin>
-    public internal(set) var versions: Set<Version>
+    private var versionsByIdentifier: [VersionIdentifierKey: Version]
+
+    /// Versions signed by this entity, grouped using semantic-version precedence.
+    ///
+    /// SwiftPM uses the complete identifier internally when looking up a signer.
+    public var versions: Set<Version> {
+        Set(self.versionsByIdentifier.values)
+    }
 
     public init(
         signingEntity: SigningEntity,
         origins: Set<SigningEntity.Origin>,
         versions: Set<Version>
     ) {
+        self.init(
+            signingEntity: signingEntity,
+            origins: origins,
+            versionIdentifiers: Array(versions)
+        )
+    }
+
+    /// Creates a signer with versions distinguished by their complete parsed identifiers.
+    public init(
+        signingEntity: SigningEntity,
+        origins: Set<SigningEntity.Origin>,
+        versionIdentifiers: [Version]
+    ) {
         self.signingEntity = signingEntity
         self.origins = origins
-        self.versions = versions
+        self.versionsByIdentifier = Dictionary(
+            versionIdentifiers.map { (VersionIdentifierKey($0), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    /// Versions signed by this entity, distinguished by their complete parsed identifiers.
+    public var versionIdentifiers: [Version] {
+        self.versionsByIdentifier.values.sorted { lhs, rhs in
+            if lhs == rhs {
+                return lhs.description < rhs.description
+            }
+            return lhs < rhs
+        }
+    }
+
+    package func contains(version: Version) -> Bool {
+        self.versionsByIdentifier[VersionIdentifierKey(version)] != nil
+    }
+
+    package mutating func add(version: Version) {
+        self.versionsByIdentifier[VersionIdentifierKey(version)] = version
+    }
+
+    package mutating func add(origin: SigningEntity.Origin) {
+        self.origins.insert(origin)
+    }
+
+    private enum CodingKeys: CodingKey {
+        case signingEntity
+        case origins
+        case versions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            signingEntity: try container.decode(SigningEntity.self, forKey: .signingEntity),
+            origins: try container.decode(Set<SigningEntity.Origin>.self, forKey: .origins),
+            versionIdentifiers: try container.decode([Version].self, forKey: .versions)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.signingEntity, forKey: .signingEntity)
+        try container.encode(self.origins, forKey: .origins)
+        try container.encode(self.versionIdentifiers, forKey: .versions)
     }
 }
 
@@ -139,8 +206,18 @@ public struct PackageSigners {
         return versionSigningEntities
     }
 
+    package var versionIdentifierSigningEntities: [VersionIdentifierKey: Set<SigningEntity>] {
+        var versionSigningEntities = [VersionIdentifierKey: Set<SigningEntity>]()
+        for (signingEntity, signer) in self.signers {
+            for version in signer.versionIdentifiers {
+                versionSigningEntities[VersionIdentifierKey(version), default: []].insert(signingEntity)
+            }
+        }
+        return versionSigningEntities
+    }
+
     public func signingEntities(of version: Version) -> Set<SigningEntity> {
-        Set(self.signers.values.filter { $0.versions.contains(version) }.map(\.signingEntity))
+        Set(self.signers.values.filter { $0.contains(version: version) }.map(\.signingEntity))
     }
 }
 

--- a/Sources/Runtimes/PackageDescription/PackageDependency.swift
+++ b/Sources/Runtimes/PackageDescription/PackageDependency.swift
@@ -749,6 +749,9 @@ extension Package.Dependency {
 
     /// Adds a remote package dependency that uses an exact version requirement.
     ///
+    /// Every parsed version component, including prerelease and build metadata,
+    /// must match the selected package version.
+    ///
     /// Specifying exact version requirements are not recommended as
     /// they can cause conflicts in your dependency graph when other packages depend on this package.
     /// As Swift packages follow the semantic versioning convention,
@@ -776,6 +779,9 @@ extension Package.Dependency {
     }
 
     /// Adds a remote package dependency that uses an exact version requirement.
+    ///
+    /// Every parsed version component, including prerelease and build metadata,
+    /// must match the selected package version.
     ///
     /// Specifying exact version requirements are not recommended as
     /// they can cause conflicts in your dependency graph when other packages depend on this package.
@@ -926,6 +932,9 @@ extension Package.Dependency {
 
     /// Adds a remote package dependency with an exact version requirement.
     ///
+    /// Every parsed version component, including prerelease and build metadata,
+    /// must match the selected package version.
+    ///
     /// Specifying exact version requirements are not recommended as
     /// they can cause conflicts in your dependency graph when multiple other packages depend on a package.
     /// Because Swift packages follow the semantic versioning convention,
@@ -953,6 +962,9 @@ extension Package.Dependency {
     }
 
     /// Adds a remote package dependency with an exact version requirement.
+    ///
+    /// Every parsed version component, including prerelease and build metadata,
+    /// must match the selected package version.
     ///
     /// Specifying exact version requirements are not recommended as
     /// they can cause conflicts in your dependency graph when multiple other packages depend on a package.

--- a/Sources/Runtimes/PackageDescription/PackageRequirement.swift
+++ b/Sources/Runtimes/PackageDescription/PackageRequirement.swift
@@ -71,6 +71,8 @@ extension Package.Dependency {
 @available(_PackageDescription, deprecated: 5.6)
 extension Package.Dependency.Requirement {
     /// Returns a requirement for the given exact version.
+    /// Every parsed version component, including prerelease and build metadata,
+    /// must match the selected package version.
     ///
     /// Specifying exact version requirements are not recommended as they can
     /// cause conflicts in your dependency graph when multiple other packages
@@ -179,7 +181,8 @@ extension Package.Dependency {
     /// requirements before publishing a version of your package.
     @available(_PackageDescription, introduced: 5.6)
     public enum SourceControlRequirement {
-        /// An exact version based requirement.
+        /// An exact version based requirement. Every parsed component, including
+        /// prerelease and build metadata, must match.
         case exact(Version)
         /// A requirement based on a range of versions.
         case range(Range<Version>)
@@ -205,7 +208,8 @@ extension Package.Dependency {
     /// visit the [Semantic Versioning 2.0.0](https://semver.org) website.
     @available(_PackageDescription, introduced: 999)
     public enum RegistryRequirement {
-        /// A requirement based on an exact version.
+        /// A requirement based on an exact version. Every parsed component,
+        /// including prerelease and build metadata, must match.
         case exact(Version)
         /// A requirement based on a range of versions.
         case range(Range<Version>)

--- a/Sources/Workspace/CheckoutState.swift
+++ b/Sources/Workspace/CheckoutState.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import struct TSCUtility.Version
 import struct SourceControl.Revision
 
@@ -20,6 +21,38 @@ public enum CheckoutState: Equatable, Hashable {
     case revision(_ revision: Revision)
     case version(_ version: Version, revision: Revision)
     case branch(name: String, revision: Revision)
+}
+
+extension CheckoutState {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.revision(let lhs), .revision(let rhs)):
+            lhs == rhs
+        case (.version(let lhsVersion, let lhsRevision), .version(let rhsVersion, let rhsRevision)):
+            VersionIdentifierKey(lhsVersion) == VersionIdentifierKey(rhsVersion) &&
+                lhsRevision == rhsRevision
+        case (.branch(let lhsName, let lhsRevision), .branch(let rhsName, let rhsRevision)):
+            lhsName == rhsName && lhsRevision == rhsRevision
+        default:
+            false
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .revision(let revision):
+            hasher.combine(0)
+            hasher.combine(revision)
+        case .version(let version, let revision):
+            hasher.combine(1)
+            hasher.combine(VersionIdentifierKey(version))
+            hasher.combine(revision)
+        case .branch(let name, let revision):
+            hasher.combine(2)
+            hasher.combine(name)
+            hasher.combine(revision)
+        }
+    }
 }
 
 extension CheckoutState: CustomStringConvertible {

--- a/Sources/Workspace/ManagedDependency.swift
+++ b/Sources/Workspace/ManagedDependency.swift
@@ -171,6 +171,25 @@ extension Workspace {
     }
 }
 
+extension Workspace.ManagedDependency.State {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.fileSystem(let lhs), .fileSystem(let rhs)):
+            return lhs == rhs
+        case (.sourceControlCheckout(let lhs), .sourceControlCheckout(let rhs)):
+            return lhs == rhs
+        case (.registryDownload(let lhsVersion, let lhsURL), .registryDownload(let rhsVersion, let rhsURL)):
+            return VersionIdentifierKey(lhsVersion) == VersionIdentifierKey(rhsVersion) && lhsURL == rhsURL
+        case (.edited(let lhsDependency, let lhsPath), .edited(let rhsDependency, let rhsPath)):
+            return lhsDependency == rhsDependency && lhsPath == rhsPath
+        case (.custom(let lhsVersion, let lhsPath), .custom(let rhsVersion, let rhsPath)):
+            return VersionIdentifierKey(lhsVersion) == VersionIdentifierKey(rhsVersion) && lhsPath == rhsPath
+        default:
+            return false
+        }
+    }
+}
+
 extension Workspace.ManagedDependency: CustomStringConvertible {
     public var description: String {
         return "<ManagedDependency: \(self.packageRef.identity) \(self.state)>"

--- a/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/RegistryPackageContainer.swift
@@ -33,10 +33,10 @@ public class RegistryPackageContainer: PackageContainer {
     private let identityLookupCache: Workspace.IdentityLookupCache
 
     private var knownVersionsCache = AsyncThrowingValueMemoizer<[Version]>()
-    private var toolsVersionsCache = ThrowingAsyncKeyValueMemoizer<Version, ToolsVersion>()
-    private var validToolsVersionsCache = AsyncKeyValueMemoizer<Version, Bool>()
-    private var manifestsCache = ThrowingAsyncKeyValueMemoizer<Version, Manifest>()
-    private var availableManifestsCache = ThreadSafeKeyValueStore<Version, (manifests: [String: (toolsVersion: ToolsVersion, content: String?)], fileSystem: FileSystem)>()
+    private var toolsVersionsCache = ThrowingAsyncKeyValueMemoizer<VersionIdentifierKey, ToolsVersion>()
+    private var validToolsVersionsCache = AsyncKeyValueMemoizer<VersionIdentifierKey, Bool>()
+    private var manifestsCache = ThrowingAsyncKeyValueMemoizer<VersionIdentifierKey, Manifest>()
+    private var availableManifestsCache = ThreadSafeKeyValueStore<VersionIdentifierKey, (manifests: [String: (toolsVersion: ToolsVersion, content: String?)], fileSystem: FileSystem)>()
 
     public init(
         package: PackageReference,
@@ -63,7 +63,7 @@ public class RegistryPackageContainer: PackageContainer {
     // MARK: - PackageContainer
 
     public func isToolsVersionCompatible(at version: Version) async -> Bool {
-        await self.validToolsVersionsCache.memoize(version) {
+        await self.validToolsVersionsCache.memoize(VersionIdentifierKey(version)) {
             do {
                 let toolsVersion = try await self.toolsVersion(for: version)
                 try toolsVersion.validateToolsVersion(self.currentToolsVersion, packageIdentity: self.package.identity)
@@ -75,7 +75,7 @@ public class RegistryPackageContainer: PackageContainer {
     }
 
     public func toolsVersion(for version: Version) async throws -> ToolsVersion {
-        try await self.toolsVersionsCache.memoize(version) {
+        try await self.toolsVersionsCache.memoize(VersionIdentifierKey(version)) {
             let result = try await self.getAvailableManifestsFilesystem(version: version)
             // find the manifest path and parse it's tools-version
             let manifestPath = try ManifestLoader.findManifest(packagePath: .root, fileSystem: result.fileSystem, currentToolsVersion: self.currentToolsVersion)
@@ -89,7 +89,7 @@ public class RegistryPackageContainer: PackageContainer {
                 package: self.package.identity,
                 observabilityScope: self.observabilityScope
             )
-            return metadata.versions.sorted(by: >)
+            return metadata.versions.sorted(by: Self.versionDescending)
         }
     }
 
@@ -199,7 +199,8 @@ public class RegistryPackageContainer: PackageContainer {
 
     private func getAvailableManifestsFilesystem(version: Version) async throws -> (manifests: [String: (toolsVersion: ToolsVersion, content: String?)], fileSystem: FileSystem) {
         // try cached first
-        if let availableManifests = self.availableManifestsCache[version] {
+        let key = VersionIdentifierKey(version)
+        if let availableManifests = self.availableManifestsCache[key] {
             return availableManifests
         }
 
@@ -218,7 +219,7 @@ public class RegistryPackageContainer: PackageContainer {
             let content = manifest.value.content ?? "// swift-tools-version:\(manifest.value.toolsVersion)"
             try fileSystem.writeFileContents(AbsolutePath.root.appending(component: manifest.key), string: content)
         }
-        self.availableManifestsCache[version] = (manifests: manifests, fileSystem: fileSystem)
+        self.availableManifestsCache[key] = (manifests: manifests, fileSystem: fileSystem)
         return (manifests: manifests, fileSystem: fileSystem)
     }
 }
@@ -228,5 +229,14 @@ public class RegistryPackageContainer: PackageContainer {
 extension RegistryPackageContainer: CustomStringConvertible {
     public var description: String {
         return "RegistryPackageContainer(\(package.identity))"
+    }
+}
+
+extension RegistryPackageContainer {
+    private static func versionDescending(_ lhs: Version, _ rhs: Version) -> Bool {
+        if lhs == rhs {
+            return lhs.description > rhs.description
+        }
+        return lhs > rhs
     }
 }

--- a/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
+++ b/Sources/Workspace/PackageContainer/SourceControlPackageContainer.swift
@@ -22,7 +22,6 @@ import SourceControl
 
 import struct TSCBasic.RegEx
 
-import enum TSCUtility.Git
 import struct TSCUtility.Version
 
 /// Adaptor to expose an individual repository as a package container.
@@ -71,14 +70,14 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     private var dependenciesCache = [String: [ProductFilter: (Manifest, [Constraint])]]()
     private var dependenciesCacheLock = NSLock()
 
-    private var knownVersionsCache = ThreadSafeBox<[Version: String]?>()
+    private var knownVersionsCache = ThreadSafeBox<[VersionIdentifierKey: KnownVersionTag]?>()
     private var manifestsCache = ThrowingAsyncKeyValueMemoizer<String, Manifest>()
-    private var toolsVersionsCache = ThreadSafeKeyValueStore<Version, ToolsVersion>()
+    private var toolsVersionsCache = ThreadSafeKeyValueStore<VersionIdentifierKey, ToolsVersion>()
     private var identityLookupCache: Workspace.IdentityLookupCache
 
     /// This is used to remember if tools version of a particular version is
     /// valid or not.
-    internal var validToolsVersionsCache = ThreadSafeKeyValueStore<Version, Bool>()
+    internal var validToolsVersionsCache = ThreadSafeKeyValueStore<VersionIdentifierKey, Bool>()
 
     init(
         package: PackageReference,
@@ -113,11 +112,16 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     }
 
     // Compute the map of known versions.
-    private func knownVersions() throws -> [Version: String] {
+    private func knownVersions() throws -> [VersionIdentifierKey: KnownVersionTag] {
         try self.knownVersionsCache.memoize {
-            let knownVersionsWithDuplicates = Git.convertTagsToVersionMap(tags: try repository.getTags(), toolsVersion: self.currentToolsVersion)
+            let knownVersionsWithDuplicates = Self.convertTagsToVersionMap(
+                tags: try repository.getTags(),
+                toolsVersion: self.currentToolsVersion
+            )
 
-            return knownVersionsWithDuplicates.mapValues { tags -> String in
+            return knownVersionsWithDuplicates.mapValues { knownVersion -> KnownVersionTag in
+                let tags = knownVersion.tags
+                let tag: String
                 if tags.count > 1 {
                     // FIXME: Warn if the two tags point to different git references.
 
@@ -134,16 +138,18 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
                         }
                         return componentCounts.0 < componentCounts.1
                     }
-                    return tagsSortedBySpecificity.last!
+                    tag = tagsSortedBySpecificity.last!
+                } else {
+                    assert(tags.count == 1, "Unexpected number of tags")
+                    tag = tags[0]
                 }
-                assert(tags.count == 1, "Unexpected number of tags")
-                return tags[0]
+                return KnownVersionTag(version: knownVersion.version, tag: tag)
             }
         }
     }
 
     public func versionsAscending() throws -> [Version] {
-        [Version](try self.knownVersions().keys).sorted()
+        try self.knownVersions().values.map(\.version).sorted(by: Self.versionAscending)
     }
 
     /// The available version list (in reverse order).
@@ -151,19 +157,20 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         let reversedVersions = try await self.versionsDescending()
         var appropriateVersions: [Version] = []
         for version in reversedVersions {
-            if let cached = self.validToolsVersionsCache[version] {
+            let key = VersionIdentifierKey(version)
+            if let cached = self.validToolsVersionsCache[key] {
                 if cached { appropriateVersions.append(version) }
                 continue
             }
             let isValid = await self.isToolsVersionCompatible(at: version)
-            self.validToolsVersionsCache[version] = isValid
+            self.validToolsVersionsCache[key] = isValid
             if isValid { appropriateVersions.append(version) }
         }
         return appropriateVersions
     }
 
     public func getTag(for version: Version) -> String? {
-        return try? self.knownVersions()[version]
+        return try? self.knownVersions()[VersionIdentifierKey(version)]?.tag
     }
 
     func checkIntegrity(version: Version, revision: Revision) throws {
@@ -245,8 +252,8 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     }
 
     private func readToolsVersion(for version: Version) throws -> ToolsVersion {
-        try self.toolsVersionsCache.memoize(version) {
-            guard let tag = try self.knownVersions()[version] else {
+        try self.toolsVersionsCache.memoize(VersionIdentifierKey(version)) {
+            guard let tag = try self.knownVersions()[VersionIdentifierKey(version)]?.tag else {
                 throw StringError("unknown tag \(version)")
             }
             let fileSystem = try repository.openFileView(tag: tag)
@@ -259,7 +266,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     public func getDependencies(at version: Version, productFilter: ProductFilter, _ enabledTraits: EnabledTraits = ["default"]) async throws -> [Constraint] {
         do {
             return try await self.getCachedDependencies(forIdentifier: version.description, productFilter: productFilter) {
-                guard let tag = try self.knownVersions()[version] else {
+                guard let tag = try self.knownVersions()[VersionIdentifierKey(version)]?.tag else {
                     throw StringError("unknown tag \(version)")
                 }
                 return try await self.loadDependencies(tag: tag, version: version, productFilter: productFilter, enabledTraits: enabledTraits)
@@ -365,7 +372,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         var version: Version?
         switch boundVersion {
         case .version(let v):
-            guard let tag = try self.knownVersions()[v] else {
+            guard let tag = try self.knownVersions()[VersionIdentifierKey(v)]?.tag else {
                 throw StringError("unknown tag \(v)")
             }
             version = v
@@ -386,7 +393,7 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
         var version: Version?
         switch boundVersion {
         case .version(let v):
-            guard let tag = try self.knownVersions()[v] else {
+            guard let tag = try self.knownVersions()[VersionIdentifierKey(v)]?.tag else {
                 throw StringError("unknown tag \(v)")
             }
             version = v
@@ -486,25 +493,46 @@ internal final class SourceControlPackageContainer: PackageContainer, CustomStri
     }
 }
 
-extension Git {
-    fileprivate static func convertTagsToVersionMap(tags: [String], toolsVersion: ToolsVersion) -> [Version: [String]] {
+extension SourceControlPackageContainer {
+    private struct KnownVersionTag {
+        let version: Version
+        let tag: String
+    }
+
+    private struct KnownVersionTags {
+        let version: Version
+        var tags: [String]
+    }
+
+    private static func convertTagsToVersionMap(
+        tags: [String],
+        toolsVersion: ToolsVersion
+    ) -> [VersionIdentifierKey: KnownVersionTags] {
         // First, check if we need to restrict the tag set to version-specific tags.
-        var knownVersions: [Version: [String]] = [:]
-        var versionSpecificKnownVersions: [Version: [String]] = [:]
+        var knownVersions: [VersionIdentifierKey: KnownVersionTags] = [:]
+        var versionSpecificKnownVersions: [VersionIdentifierKey: KnownVersionTags] = [:]
 
         for tag in tags {
             for versionSpecificKey in toolsVersion.versionSpecificKeys {
                 if tag.hasSuffix(versionSpecificKey) {
                     let trimmedTag = String(tag.dropLast(versionSpecificKey.count))
                     if let version = Version(tag: trimmedTag) {
-                        versionSpecificKnownVersions[version, default: []].append(tag)
+                        let key = VersionIdentifierKey(version)
+                        versionSpecificKnownVersions[
+                            key,
+                            default: KnownVersionTags(version: version, tags: [])
+                        ].tags.append(tag)
                     }
                     break
                 }
             }
 
             if let version = Version(tag: tag) {
-                knownVersions[version, default: []].append(tag)
+                let key = VersionIdentifierKey(version)
+                knownVersions[
+                    key,
+                    default: KnownVersionTags(version: version, tags: [])
+                ].tags.append(tag)
             }
         }
         // Check if any version specific tags were found.
@@ -515,5 +543,12 @@ extension Git {
         } else {
             return knownVersions
         }
+    }
+
+    private static func versionAscending(_ lhs: Version, _ rhs: Version) -> Bool {
+        if lhs == rhs {
+            return lhs.description < rhs.description
+        }
+        return lhs < rhs
     }
 }

--- a/Sources/Workspace/Workspace+Dependencies.swift
+++ b/Sources/Workspace/Workspace+Dependencies.swift
@@ -20,6 +20,7 @@ import struct Basics.RelativePath
 import enum Basics.SignpostName
 import struct Basics.SourceControlURL
 import class Basics.ThreadSafeKeyValueStore
+import struct Basics.VersionIdentifierKey
 import class Dispatch.DispatchGroup
 import struct Dispatch.DispatchTime
 import enum Dispatch.DispatchTimeInterval
@@ -1083,6 +1084,19 @@ extension Workspace {
                     return "\(revision) \(branch ?? "")"
                 case .unversioned:
                     return "unversioned"
+                }
+            }
+
+            public static func == (lhs: Self, rhs: Self) -> Bool {
+                switch (lhs, rhs) {
+                case (.version(let lhs), .version(let rhs)):
+                    return VersionIdentifierKey(lhs) == VersionIdentifierKey(rhs)
+                case (.revision(let lhsRevision, let lhsBranch), .revision(let rhsRevision, let rhsBranch)):
+                    return lhsRevision == rhsRevision && lhsBranch == rhsBranch
+                case (.unversioned, .unversioned):
+                    return true
+                default:
+                    return false
                 }
             }
         }

--- a/Sources/Workspace/Workspace+Prebuilts.swift
+++ b/Sources/Workspace/Workspace+Prebuilts.swift
@@ -595,7 +595,10 @@ extension Workspace {
         }
 
         for prebuilt in await self.state.prebuilts.prebuilts {
-            if !addedPrebuilts.contains(where: { $0.identity == prebuilt.identity && $0.version == prebuilt.version }) {
+            if !addedPrebuilts.contains(where: {
+                $0.identity == prebuilt.identity &&
+                    VersionIdentifierKey($0.version) == VersionIdentifierKey(prebuilt.version)
+            }) {
                 await self.state.prebuilts.remove(packageIdentity: prebuilt.identity, targetName: prebuilt.libraryName)
             }
         }

--- a/Sources/Workspace/Workspace+ResolvedPackages.swift
+++ b/Sources/Workspace/Workspace+ResolvedPackages.swift
@@ -13,6 +13,7 @@
 import SourceControl
 
 import class Basics.ObservabilityScope
+import struct Basics.VersionIdentifierKey
 import class PackageGraph.ResolvedPackagesStore
 import struct PackageModel.PackageReference
 import struct PackageModel.ToolsVersion
@@ -171,7 +172,8 @@ extension ResolvedPackagesStore.ResolutionState {
     func equals(_ checkoutState: CheckoutState) -> Bool {
         switch (self, checkoutState) {
         case (.version(let lversion, let lrevision), .version(let rversion, let rrevision)):
-            return lversion == rversion && lrevision == rrevision.identifier
+            return VersionIdentifierKey(lversion) == VersionIdentifierKey(rversion) &&
+                lrevision == rrevision.identifier
         case (.branch(let lbranch, let lrevision), .branch(let rbranch, let rrevision)):
             return lbranch == rbranch && lrevision == rrevision.identifier
         case (.revision(let lrevision), .revision(let rrevision)):
@@ -181,10 +183,10 @@ extension ResolvedPackagesStore.ResolutionState {
         }
     }
 
-    func equals(_: Version) -> Bool {
+    func equals(_ otherVersion: Version) -> Bool {
         switch self {
         case .version(let version, _):
-            return version == version
+            return VersionIdentifierKey(version) == VersionIdentifierKey(otherVersion)
         default:
             return false
         }

--- a/Sources/_InternalTestSupport/MockManifestLoader.swift
+++ b/Sources/_InternalTestSupport/MockManifestLoader.swift
@@ -42,6 +42,16 @@ public final class MockManifestLoader: ManifestLoaderProtocol {
             self.url = url
             self.version = version
         }
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.url == rhs.url &&
+                lhs.version.map(VersionIdentifierKey.init) == rhs.version.map(VersionIdentifierKey.init)
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(self.url)
+            hasher.combine(self.version.map(VersionIdentifierKey.init))
+        }
     }
 
     public let manifests: ThreadSafeKeyValueStore<Key, Manifest>

--- a/Sources/_InternalTestSupport/MockPackageContainer.swift
+++ b/Sources/_InternalTestSupport/MockPackageContainer.swift
@@ -34,7 +34,20 @@ public class MockPackageContainer: CustomPackageContainer {
     public var unversionedDeps: [MockPackageContainer.Constraint] = []
 
     /// Contains the versions for which the dependencies were requested by resolver using getDependencies().
-    public var requestedVersions: Set<Version> = []
+    private var requestedVersionsByIdentifier: [VersionIdentifierKey: Version] = [:]
+
+    public var requestedVersions: Set<Version> {
+        Set(self.requestedVersionsByIdentifier.values)
+    }
+
+    package var requestedVersionIdentifiers: [Version] {
+        self.requestedVersionsByIdentifier.values.sorted { lhs, rhs in
+            if lhs == rhs {
+                return lhs.description < rhs.description
+            }
+            return lhs < rhs
+        }
+    }
 
     public let _versions: [Version]
     public func toolsVersionsAppropriateVersionsDescending() async throws -> [Version] {
@@ -46,7 +59,7 @@ public class MockPackageContainer: CustomPackageContainer {
     }
 
     public func getDependencies(at version: Version, productFilter: ProductFilter, _ enabledTraits: EnabledTraits = ["default"]) -> [MockPackageContainer.Constraint] {
-        requestedVersions.insert(version)
+        requestedVersionsByIdentifier[VersionIdentifierKey(version)] = version
         return getDependencies(at: version.description, productFilter: productFilter, enabledTraits)
     }
 

--- a/Sources/_InternalTestSupport/MockPackageFingerprintStorage.swift
+++ b/Sources/_InternalTestSupport/MockPackageFingerprintStorage.swift
@@ -19,14 +19,16 @@ import PackageModel
 import struct TSCUtility.Version
 
 public class MockPackageFingerprintStorage: PackageFingerprintStorage {
-    private var packageFingerprints: [PackageIdentity: [Version: [Fingerprint
+    private var packageFingerprints: [PackageIdentity: [VersionIdentifierKey: [Fingerprint
             .Kind: [Fingerprint.ContentType: Fingerprint]]]]
     private let lock = NSLock()
 
     public init(_ packageFingerprints: [PackageIdentity: [Version: [Fingerprint
             .Kind: [Fingerprint.ContentType: Fingerprint]]]] = [:])
     {
-        self.packageFingerprints = packageFingerprints
+        self.packageFingerprints = packageFingerprints.mapValues { fingerprints in
+            Dictionary(uniqueKeysWithValues: fingerprints.map { (VersionIdentifierKey($0.key), $0.value) })
+        }
     }
 
     public func get(
@@ -34,7 +36,9 @@ public class MockPackageFingerprintStorage: PackageFingerprintStorage {
         version: Version,
         observabilityScope: ObservabilityScope
     ) throws -> [Fingerprint.Kind: [Fingerprint.ContentType: Fingerprint]] {
-        guard let fingerprints = self.lock.withLock({ self.packageFingerprints[package]?[version] }) else {
+        guard let fingerprints = self.lock.withLock({
+            self.packageFingerprints[package]?[VersionIdentifierKey(version)]
+        }) else {
             throw PackageFingerprintStorageError.notFound
         }
         return fingerprints
@@ -48,7 +52,8 @@ public class MockPackageFingerprintStorage: PackageFingerprintStorage {
     ) throws {
         try self.lock.withLock {
             var versionFingerprints = self.packageFingerprints.removeValue(forKey: package) ?? [:]
-            var fingerprintsForVersion = versionFingerprints.removeValue(forKey: version) ?? [:]
+            let versionKey = VersionIdentifierKey(version)
+            var fingerprintsForVersion = versionFingerprints.removeValue(forKey: versionKey) ?? [:]
             var fingerprintsForKind = fingerprintsForVersion.removeValue(forKey: fingerprint.origin.kind) ?? [:]
 
             if let existing = fingerprintsForKind[fingerprint.contentType] {
@@ -62,7 +67,7 @@ public class MockPackageFingerprintStorage: PackageFingerprintStorage {
 
             fingerprintsForKind[fingerprint.contentType] = fingerprint
             fingerprintsForVersion[fingerprint.origin.kind] = fingerprintsForKind
-            versionFingerprints[version] = fingerprintsForVersion
+            versionFingerprints[versionKey] = fingerprintsForVersion
             self.packageFingerprints[package] = versionFingerprints
         }
     }

--- a/Sources/_InternalTestSupport/MockPackageSigningEntityStorage.swift
+++ b/Sources/_InternalTestSupport/MockPackageSigningEntityStorage.swift
@@ -158,16 +158,10 @@ public class MockPackageSigningEntityStorage: PackageSigningEntityStorage {
         let packageSigners = self.packageSigners[package] ?? PackageSigners()
 
         let packageSigner: PackageSigner
-        if let existingSigner = packageSigners.signers[signingEntity] {
-            var origins = existingSigner.origins
-            origins.insert(origin)
-            var versions = existingSigner.versions
-            versions.insert(version)
-            packageSigner = PackageSigner(
-                signingEntity: signingEntity,
-                origins: origins,
-                versions: versions
-            )
+        if var existingSigner = packageSigners.signers[signingEntity] {
+            existingSigner.add(origin: origin)
+            existingSigner.add(version: version)
+            packageSigner = existingSigner
         } else {
             packageSigner = PackageSigner(
                 signingEntity: signingEntity,

--- a/Sources/_InternalTestSupport/MockWorkspace.swift
+++ b/Sources/_InternalTestSupport/MockWorkspace.swift
@@ -1022,7 +1022,12 @@ public final class MockWorkspace {
             case .checkout(let checkoutState):
                 switch (checkoutState, pin.state) {
                 case (.version(let checkoutVersion), .version(let pinVersion, _)):
-                    XCTAssertEqual(pinVersion, checkoutVersion, file: file, line: line)
+                    XCTAssertEqual(
+                        VersionIdentifierKey(pinVersion),
+                        VersionIdentifierKey(checkoutVersion),
+                        file: file,
+                        line: line
+                    )
                 case (.revision(let checkoutRevision), .revision(let pinRevision)):
                     XCTAssertEqual(checkoutRevision, pinRevision, file: file, line: line)
                 case (.branch(let checkoutBranch), .branch(let pinBranch, _)):
@@ -1034,7 +1039,12 @@ public final class MockWorkspace {
                 guard case .version(let pinVersion, _) = pin.state else {
                     return XCTFail("invalid pin state \(pin.state)", file: file, line: line)
                 }
-                XCTAssertEqual(pinVersion, downloadVersion, file: file, line: line)
+                XCTAssertEqual(
+                    VersionIdentifierKey(pinVersion),
+                    VersionIdentifierKey(downloadVersion),
+                    file: file,
+                    line: line
+                )
             case .edited, .local, .custom:
                 XCTFail("Unimplemented", file: file, line: line)
             }

--- a/Tests/BasicsTests/VersionIdentifierKeyTests.swift
+++ b/Tests/BasicsTests/VersionIdentifierKeyTests.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Testing
+import struct TSCUtility.Version
+
+struct VersionIdentifierKeyTests {
+    @Test
+    func distinguishesBuildMetadataWithoutChangingVersionEquality() {
+        let plain = Version("1.2.3")
+        let debug = Version("1.2.3+debug")
+        let release = Version("1.2.3+release")
+
+        #expect(plain == debug)
+        #expect(debug == release)
+        #expect(VersionIdentifierKey(plain) != VersionIdentifierKey(debug))
+        #expect(VersionIdentifierKey(debug) != VersionIdentifierKey(release))
+        #expect(Set([plain, debug, release]).count == 1)
+        #expect(Set([plain, debug, release].map(VersionIdentifierKey.init)).count == 3)
+    }
+}

--- a/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
+++ b/Tests/PackageFingerprintTests/FilePackageFingerprintStorageTests.swift
@@ -399,6 +399,38 @@ final class FilePackageFingerprintStorageTests: XCTestCase {
         XCTAssertEqual(scmFingerprints?[.sourceCode]?.origin.url, sourceControlURL)
         XCTAssertEqual(scmFingerprints?[.sourceCode]?.value, "gitHash-1.0.0")
     }
+
+    func testBuildMetadataVariantsRoundTripIndependently() throws {
+        let fileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath("/fingerprints")
+        let package = PackageIdentity.plain("mona.LinkedList")
+        let registryURL = URL("https://example.packages.com")
+        let variants: [(Version, String)] = [
+            (Version("1.0.0"), "plain"),
+            (Version("1.0.0+debug"), "debug"),
+            (Version("1.0.0+release"), "release"),
+        ]
+
+        let storage = FilePackageFingerprintStorage(fileSystem: fileSystem, directoryPath: directoryPath)
+        for (version, value) in variants {
+            try storage.put(
+                package: package,
+                version: version,
+                fingerprint: .init(origin: .registry(registryURL), value: value, contentType: .sourceCode)
+            )
+        }
+
+        let reloaded = FilePackageFingerprintStorage(fileSystem: fileSystem, directoryPath: directoryPath)
+        for (version, value) in variants {
+            let fingerprint = try reloaded.get(
+                package: package,
+                version: version,
+                kind: .registry,
+                contentType: .sourceCode
+            )
+            XCTAssertEqual(fingerprint.value, value)
+        }
+    }
 }
 
 extension PackageFingerprintStorage {

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -493,6 +493,11 @@ final class PubGrubTests: XCTestCase {
             state.derive(Term(node: .root(package: bRef), requirement: .exact("1.1.0"), isPositive: false), cause: cause)
         }
 
+        let remainingBVersions = ["1.3.0", "1.2.0", "1.1.0"].reduce(
+            VersionSetSpecifier.range("1.1.0" ..< "1.3.1")
+        ) { requirement, version in
+            requirement.difference(.exact(Version(version)!))
+        }
         let conflict = Incompatibility(
             terms: .init([
                 Term(node: .root(package: aRef),
@@ -500,7 +505,7 @@ final class PubGrubTests: XCTestCase {
                      isPositive: true
                 ),
                 Term(node: .root(package: bRef),
-                     requirement: .ranges(["1.1.1" ..< "1.2.0", "1.2.1" ..< "1.3.0"]),
+                     requirement: remainingBVersions,
                      isPositive: true
                 )
             ]),
@@ -554,6 +559,8 @@ final class PubGrubTests: XCTestCase {
             state.derive(Term(node: .root(package: bRef), requirement: .exact("1.1.0"), isPositive: false), cause: cause)
         }
 
+        let remainingBVersions = VersionSetSpecifier.range("1.1.0" ..< "1.2.0")
+            .difference(.exact("1.1.0"))
         let conflict = Incompatibility(
             terms: .init([
                 Term(node: .root(package: aRef),
@@ -561,7 +568,7 @@ final class PubGrubTests: XCTestCase {
                      isPositive: true
                 ),
                 Term(node: .root(package: bRef),
-                     requirement: .ranges(["1.1.1" ..< "1.2.0"]),
+                     requirement: remainingBVersions,
                      isPositive: true
                 )
             ]),
@@ -1456,6 +1463,35 @@ final class PubGrubTests: XCTestCase {
         ])
     }
 
+    func testPinnedResolvedPackagePreservesVersionIdentifier() async throws {
+        try builder.serve("a", at: v1, with: [
+            "a": ["b": (.versionSet(v1Range), .specific(["b"]))],
+        ])
+        try builder.serve("b", at: ["1.0.0+debug", "1.0.0+release"])
+
+        let dependencies = try builder.create(dependencies: [
+            "a": (.versionSet(.exact(v1)), .specific(["a"])),
+            "b": (.versionSet(v1Range), .specific(["b"])),
+        ])
+        let resolvedPackagesStore = try builder.create(resolvedPackages: [
+            "a": (.version(v1), .specific(["a"])),
+            "b": (.version("1.0.0+debug"), .specific(["b"])),
+        ])
+
+        let resolver = builder.create(resolvedPackages: resolvedPackagesStore.resolvedPackages)
+        let result = try await resolver.solve(root: rootNode, constraints: dependencies)
+
+        AssertResult(Result.success(result.bindings), [
+            ("a", .version(v1)),
+            ("b", .version("1.0.0+debug")),
+        ])
+        let pinnedBinding = try XCTUnwrap(result.bindings.first { $0.package.identity == .plain("b") })
+        guard case .version(let version) = pinnedBinding.boundVersion else {
+            return XCTFail("expected version binding for pinned package")
+        }
+        XCTAssertEqual(version.description, "1.0.0+debug")
+    }
+
     func testPartialResolvedPackages() async throws {
         // This checks that we can drop resolved packages that are not valid anymore but still keep the ones
         // which fit the constraints.
@@ -1485,6 +1521,87 @@ final class PubGrubTests: XCTestCase {
             ("b", .version(v1_1)),
             ("c", .version(v1))
         ])
+    }
+
+    func testExactSelectsFullVersionIdentifier() async throws {
+        try builder.serve("a", at: ["1.0.0", "1.0.0+debug", "1.0.0+release"])
+        let dependencies = try builder.create(dependencies: [
+            "a": (.versionSet(.exact("1.0.0+debug")), .specific(["a"])),
+        ])
+
+        let result = await builder.create().solve(constraints: dependencies)
+        AssertResult(result, [("a", .version("1.0.0+debug"))])
+    }
+
+    func testPlainExactDoesNotSelectMetadataVariant() async throws {
+        try builder.serve("a", at: ["1.0.0+debug", "1.0.0+release"])
+        let dependencies = try builder.create(dependencies: [
+            "a": (.versionSet(.exact("1.0.0")), .specific(["a"])),
+        ])
+
+        let result = await builder.create().solve(constraints: dependencies)
+        guard case .failure = result else {
+            return XCTFail("expected exact plain identifier to be unavailable")
+        }
+    }
+
+    func testConflictingMetadataSpecificTransitiveRequirements() async throws {
+        try builder.serve("a", at: ["1.0.0+debug", "1.0.0+release"])
+        try builder.serve("b", at: "1.0.0", with: [
+            "b": ["a": (.versionSet(.exact("1.0.0+debug")), .specific(["a"]))],
+        ])
+        try builder.serve("c", at: "1.0.0", with: [
+            "c": ["a": (.versionSet(.exact("1.0.0+release")), .specific(["a"]))],
+        ])
+        let dependencies = try builder.create(dependencies: [
+            "b": (.versionSet(.exact("1.0.0")), .specific(["b"])),
+            "c": (.versionSet(.exact("1.0.0")), .specific(["c"])),
+        ])
+
+        let result = await builder.create().solve(constraints: dependencies)
+        guard case .failure = result else {
+            return XCTFail("expected metadata-specific exact requirements to conflict")
+        }
+    }
+
+    func testRangeAndPinPreserveSelectedIdentifier() async throws {
+        try builder.serve("a", at: ["1.0.0", "1.0.0+debug", "1.0.0+release"])
+        let dependencies = try builder.create(dependencies: [
+            "a": (.versionSet(.range("1.0.0"..<"2.0.0")), .specific(["a"])),
+        ])
+        let resolvedPackagesStore = try builder.create(resolvedPackages: [
+            "a": (.version("1.0.0+debug"), .specific(["a"])),
+        ])
+
+        let result = await builder.create(resolvedPackages: resolvedPackagesStore.resolvedPackages)
+            .solve(constraints: dependencies)
+        AssertResult(result, [("a", .version("1.0.0+debug"))])
+    }
+
+    func testMissingPinnedIdentifierFallsBackToAvailableVariant() async throws {
+        try builder.serve("a", at: ["1.0.0", "1.0.0+release"])
+        let dependencies = try builder.create(dependencies: [
+            "a": (.versionSet(.range("1.0.0"..<"2.0.0")), .specific(["a"])),
+        ])
+        let resolvedPackagesStore = try builder.create(resolvedPackages: [
+            "a": (.version("1.0.0+debug"), .specific(["a"])),
+        ])
+
+        let result = await builder.create(resolvedPackages: resolvedPackagesStore.resolvedPackages)
+            .solve(constraints: dependencies)
+        AssertResult(result, [("a", .version("1.0.0+release"))])
+    }
+
+    func testToolsVersionIncompatibilityDoesNotWidenAcrossMetadataVariants() async throws {
+        try builder.serve("a", at: "1.0.0")
+        try builder.serve("a", at: "1.0.0+debug", toolsVersion: .v5)
+        try builder.serve("a", at: "1.0.0+release")
+        let dependencies = try builder.create(dependencies: [
+            "a": (.versionSet(.exact("1.0.0+release")), .specific(["a"])),
+        ])
+
+        let result = await builder.create().solve(constraints: dependencies)
+        AssertResult(result, [("a", .version("1.0.0+release"))])
     }
 
     func testMissingResolvedPackage() async throws {
@@ -3217,7 +3334,7 @@ public class MockContainer: PackageContainer {
 
     /// The list of versions that have incompatible tools version.
     var toolsVersion: ToolsVersion = ToolsVersion.current
-    var versionsToolsVersions = [Version: ToolsVersion]()
+    var versionsToolsVersions = [VersionIdentifierKey: ToolsVersion]()
 
     private var _versions: [BoundVersion]
 
@@ -3252,7 +3369,7 @@ public class MockContainer: PackageContainer {
     public func toolsVersion(for version: Version) throws -> ToolsVersion {
         struct NotFound: Error {}
 
-        guard let version = versionsToolsVersions[version] else {
+        guard let version = versionsToolsVersions[VersionIdentifierKey(version)] else {
             throw NotFound()
         }
         return version
@@ -3301,6 +3418,9 @@ public class MockContainer: PackageContainer {
             .sorted(by: { lhs, rhs -> Bool in
                 guard case .version(let lv) = lhs, case .version(let rv) = rhs else {
                     return true
+                }
+                if lv == rv {
+                    return lv.description < rv.description
                 }
                 return lv < rv
             })
@@ -3475,7 +3595,7 @@ class DependencyGraphBuilder {
         let container = self.containers[packageReference.identity.description] ?? MockContainer(package: packageReference)
 
         if case .version(let v) = version {
-            container.versionsToolsVersions[v] = toolsVersion ?? container.toolsVersion
+            container.versionsToolsVersions[VersionIdentifierKey(v)] = toolsVersion ?? container.toolsVersion
         }
 
         container.appendVersion(version)

--- a/Tests/PackageGraphTests/PubGrubTests.swift
+++ b/Tests/PackageGraphTests/PubGrubTests.swift
@@ -180,6 +180,34 @@ final class PubGrubTests: XCTestCase {
         XCTAssertEqual(Term("¬a^1.5.0").relation(with: "¬a^1.0.0"), .overlap)
     }
 
+    func testMetadataSpecificTermRelations() throws {
+        let node = DependencyResolutionNode.empty(package: "a")
+        let plain = Term(node, .exact("1.0.0"))
+        let debug = Term(node, .exact("1.0.0+debug"))
+        let notPlain = plain.inverse
+        let notDebug = debug.inverse
+        let range = Term(node, .range("1.0.0"..<"2.0.0"))
+
+        XCTAssertEqual(plain.relation(with: debug), .disjoint)
+        XCTAssertEqual(debug.relation(with: plain), .disjoint)
+        XCTAssertEqual(plain.relation(with: range), .subset)
+        XCTAssertEqual(debug.relation(with: notPlain), .subset)
+        XCTAssertEqual(plain.relation(with: notPlain), .disjoint)
+        XCTAssertEqual(notPlain.relation(with: debug), .overlap)
+        XCTAssertEqual(notPlain.relation(with: notDebug), .overlap)
+
+        let rangeWithoutDebug = try XCTUnwrap(range.intersect(with: notDebug))
+        XCTAssertTrue(rangeWithoutDebug.requirement.contains("1.0.0"))
+        XCTAssertFalse(rangeWithoutDebug.requirement.contains("1.0.0+debug"))
+        XCTAssertTrue(rangeWithoutDebug.requirement.contains("1.0.0+release"))
+
+        let excludingBoth = try XCTUnwrap(notPlain.intersect(with: notDebug))
+        XCTAssertFalse(excludingBoth.isPositive)
+        XCTAssertTrue(excludingBoth.requirement.contains("1.0.0"))
+        XCTAssertTrue(excludingBoth.requirement.contains("1.0.0+debug"))
+        XCTAssertFalse(excludingBoth.requirement.contains("1.0.0+release"))
+    }
+
     func testTermIsValidDecision() {
         let solution100_150 = PartialSolution(assignments: [
             .derivation("a^1.0.0", cause: _cause, decisionLevel: 1),

--- a/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
+++ b/Tests/PackageGraphTests/VersionSetSpecifierTests.swift
@@ -14,11 +14,12 @@ import Foundation
 import TSCUtility
 import XCTest
 
-import PackageGraph
+import struct Basics.VersionIdentifierKey
+@_spi(SwiftPMInternal) import PackageGraph
 
 final class VersionSetSpecifierTests: XCTestCase {
     func testUnion() {
-        XCTAssertEqual(VersionSetSpecifier.union(from: ["1.0.0"..<"1.0.1"]), .exact("1.0.0"))
+        XCTAssertEqual(VersionSetSpecifier.union(from: ["1.0.0"..<"1.0.1"]), .range("1.0.0"..<"1.0.1"))
         XCTAssertEqual(VersionSetSpecifier.union(from: ["1.0.0"..<"1.0.5"]), .range("1.0.0"..<"1.0.5"))
         XCTAssertEqual(VersionSetSpecifier.union(from: ["1.0.0"..<"1.0.6", "1.0.5"..<"1.0.9"]), .range("1.0.0"..<"1.0.9"))
         XCTAssertEqual(VersionSetSpecifier.union(from: ["1.0.0"..<"1.0.5", "1.0.5"..<"1.0.9"]), .range("1.0.0"..<"1.0.9"))
@@ -27,9 +28,12 @@ final class VersionSetSpecifierTests: XCTestCase {
         XCTAssertEqual(VersionSetSpecifier.exact("1.0.0").union(.exact("1.0.0")), .exact("1.0.0"))
 
         let ranges1 = VersionSetSpecifier.union(from: ["1.0.0"..<"1.1.0", "1.1.1"..<"2.0.0"])
-        XCTAssertEqual(ranges1.union(.exact("1.1.0")), .range("1.0.0"..<"2.0.0"))
+        let unionWithExact = ranges1.union(.exact("1.1.0"))
+        XCTAssertTrue(unionWithExact.contains("1.1.0"))
+        XCTAssertFalse(unionWithExact.contains("1.1.0+debug"))
+        XCTAssertTrue(unionWithExact.contains("1.1.1"))
 
-        XCTAssertEqual(VersionSetSpecifier.union(from: ["1.0.0"..<"1.0.0", "1.0.1"..<"2.0.0"]), .range("1.0.0"..<"2.0.0"))
+        XCTAssertEqual(VersionSetSpecifier.union(from: ["1.0.0"..<"1.0.0", "1.0.1"..<"2.0.0"]), .range("1.0.1"..<"2.0.0"))
     }
 
     func testIntersection() {
@@ -57,10 +61,12 @@ final class VersionSetSpecifierTests: XCTestCase {
         }
 
         XCTAssertEqual(VersionSetSpecifier.range("1.0.0"..<"2.0.0").difference(.exact("2.0.0")), .range("1.0.0"..<"2.0.0"))
-        XCTAssertEqual(VersionSetSpecifier.range("1.0.0"..<"2.0.0").difference(.exact("1.0.0")), .range("1.0.1"..<"2.0.0"))
-        XCTAssertEqual(VersionSetSpecifier.range("1.0.0"..<"2.0.0").difference(.exact("1.5.0")), .ranges(["1.0.0"..<"1.5.0", "1.5.1"..<"2.0.0"]))
+        XCTAssertFalse(VersionSetSpecifier.range("1.0.0"..<"2.0.0").difference(.exact("1.0.0")).contains("1.0.0"))
+        XCTAssertTrue(VersionSetSpecifier.range("1.0.0"..<"2.0.0").difference(.exact("1.0.0")).contains("1.0.0+debug"))
+        XCTAssertFalse(VersionSetSpecifier.range("1.0.0"..<"2.0.0").difference(.exact("1.5.0")).contains("1.5.0"))
+        XCTAssertTrue(VersionSetSpecifier.range("1.0.0"..<"2.0.0").difference(.exact("1.5.0")).contains("1.5.0+debug"))
         XCTAssertEqual(VersionSetSpecifier.range("2.0.0"..<"2.0.0").difference(.exact("2.0.0")), .empty)
-        XCTAssertEqual(VersionSetSpecifier.range("2.0.0"..<"2.0.1").difference(.exact("2.0.0")), .empty)
+        XCTAssertTrue(VersionSetSpecifier.range("2.0.0"..<"2.0.1").difference(.exact("2.0.0")).contains("2.0.0+debug"))
 
         XCTAssertEqual(VersionSetSpecifier.exact("1.0.0").difference(.range("1.0.0"..<"2.0.0")), .empty)
         XCTAssertEqual(VersionSetSpecifier.exact("3.0.0").difference(.range("1.0.0"..<"2.0.0")), .exact("3.0.0"))
@@ -68,8 +74,8 @@ final class VersionSetSpecifierTests: XCTestCase {
         XCTAssertEqual(VersionSetSpecifier.exact("3.0.0").difference(.any), .empty)
 
         XCTAssertEqual(VersionSetSpecifier.ranges(["1.0.0"..<"2.0.0", "3.0.0"..<"4.0.0"]).difference(.exact("2.0.0")), .ranges(["1.0.0"..<"2.0.0", "3.0.0"..<"4.0.0"]))
-        XCTAssertEqual(VersionSetSpecifier.ranges(["1.0.0"..<"2.0.0", "3.0.0"..<"4.0.0"]).difference(.exact("1.0.0")), .ranges(["1.0.1"..<"2.0.0", "3.0.0"..<"4.0.0"]))
-        XCTAssertEqual(VersionSetSpecifier.ranges(["1.0.0"..<"2.0.0", "3.0.0"..<"4.0.0"]).difference(.exact("3.5.0")), .ranges(["1.0.0"..<"2.0.0", "3.0.0"..<"3.5.0", "3.5.1"..<"4.0.0"]))
+        XCTAssertFalse(VersionSetSpecifier.ranges(["1.0.0"..<"2.0.0", "3.0.0"..<"4.0.0"]).difference(.exact("1.0.0")).contains("1.0.0"))
+        XCTAssertFalse(VersionSetSpecifier.ranges(["1.0.0"..<"2.0.0", "3.0.0"..<"4.0.0"]).difference(.exact("3.5.0")).contains("3.5.0"))
 
         XCTAssertEqual(VersionSetSpecifier.ranges(["1.0.0"..<"1.0.0", "3.0.0"..<"4.0.0"]).difference(.exact("1.0.0")), .range("3.0.0"..<"4.0.0"))
 
@@ -91,15 +97,16 @@ final class VersionSetSpecifierTests: XCTestCase {
 
         XCTAssertEqual(VersionSetSpecifier.range("1.0.0"..<"5.0.0").difference(.ranges(["1.0.0"..<"2.0.0", "3.0.0"..<"4.0.0"])), .ranges(["2.0.0"..<"3.0.0", "4.0.0"..<"5.0.0"]))
         XCTAssertEqual(VersionSetSpecifier.range("1.0.0"..<"2.0.0").difference(.range("1.0.0"..<"1.8.0")), .range("1.8.0"..<"2.0.0"))
-        XCTAssertEqual(VersionSetSpecifier.range("1.0.0"..<"5.0.0").difference(.ranges(["1.0.0"..<"2.0.0", "2.0.1"..<"5.0.0"])), .exact("2.0.0"))
-        XCTAssertEqual(VersionSetSpecifier.ranges(["3.2.1"..<"3.2.4", "3.2.5"..<"4.0.0"]).difference(.ranges(["3.2.1"..<"3.2.3", "3.2.3"..<"4.0.0"])), .exact("3.2.3"))
+        XCTAssertEqual(VersionSetSpecifier.range("1.0.0"..<"5.0.0").difference(.ranges(["1.0.0"..<"2.0.0", "2.0.1"..<"5.0.0"])), .range("2.0.0"..<"2.0.1"))
+        XCTAssertEqual(VersionSetSpecifier.ranges(["3.2.1"..<"3.2.4", "3.2.5"..<"4.0.0"]).difference(.ranges(["3.2.1"..<"3.2.3", "3.2.3"..<"4.0.0"])), .empty)
 
         XCTAssertEqual(VersionSetSpecifier.ranges(["1.0.0"..<"2.0.0", "2.0.1"..<"5.0.0"]).difference(.ranges(["1.0.0"..<"2.0.0", "2.0.1"..<"5.0.0"])), .empty)
         XCTAssertEqual(VersionSetSpecifier.ranges(["0.0.0"..<"0.9.1", "1.0.0"..<"2.0.0", "2.0.1"..<"5.0.0"]).difference(.ranges(["1.0.0"..<"1.4.0", "2.4.1"..<"4.0.0"])), .ranges(["0.0.0"..<"0.9.1", "1.4.0"..<"2.0.0", "2.0.1"..<"2.4.1", "4.0.0"..<"5.0.0"]))
 
         XCTAssertEqual(VersionSetSpecifier.ranges(["1.0.0"..<"2.0.0", "2.0.1"..<"5.0.0"]).difference(.range("1.0.0"..<"2.0.0")), .range("2.0.1"..<"5.0.0"))
-        XCTAssertEqual(VersionSetSpecifier.ranges(["3.2.0"..<"3.2.3", "3.2.4"..<"4.0.0"]).difference(.exact("3.2.2")), .ranges(["3.2.0"..<"3.2.2", "3.2.4"..<"4.0.0"]))
-        XCTAssertEqual(VersionSetSpecifier.ranges(["3.2.0"..<"3.2.1", "3.2.3"..<"4.0.0"]).difference(.exact("3.2.0")), .range("3.2.3"..<"4.0.0"))
+        XCTAssertFalse(VersionSetSpecifier.ranges(["3.2.0"..<"3.2.3", "3.2.4"..<"4.0.0"]).difference(.exact("3.2.2")).contains("3.2.2"))
+        XCTAssertTrue(VersionSetSpecifier.ranges(["3.2.0"..<"3.2.3", "3.2.4"..<"4.0.0"]).difference(.exact("3.2.2")).contains("3.2.2+other"))
+        XCTAssertFalse(VersionSetSpecifier.ranges(["3.2.0"..<"3.2.1", "3.2.3"..<"4.0.0"]).difference(.exact("3.2.0")).contains("3.2.0"))
 
 
         XCTAssertEqual(VersionSetSpecifier.exact("1.0.0-beta").difference(.exact("1.0.0-beta")), .empty)
@@ -111,8 +118,9 @@ final class VersionSetSpecifierTests: XCTestCase {
         XCTAssertEqual(VersionSetSpecifier.range("2.0.0-beta"..<"2.0.0-beta").difference(.range("1.0.0-beta"..<"2.0.0")), .range("2.0.0-beta"..<"2.0.0-beta"))
 
         XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.exact("2.0.0")), .range("1.0.0-beta"..<"2.0.0"))
-        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.exact("1.0.0-beta")), .range("1.0.0-beta.0"..<"2.0.0"))
-        XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.exact("1.0.0-beta.5")), .ranges(["1.0.0-beta"..<"1.0.0-beta.5", "1.0.0-beta.5.0"..<"2.0.0"]))
+        XCTAssertFalse(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.exact("1.0.0-beta")).contains("1.0.0-beta"))
+        XCTAssertTrue(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.exact("1.0.0-beta")).contains("1.0.0-beta+other"))
+        XCTAssertFalse(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.exact("1.0.0-beta.5")).contains("1.0.0-beta.5"))
 
         XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta"..<"2.0.0").difference(.range("1.0.0-beta.3" ..< "2.0.0")), .range("1.0.0-beta"..<"1.0.0-beta.3"))
         XCTAssertEqual(VersionSetSpecifier.range("1.0.0-beta.5"..<"1.0.0-beta.30").difference(.range("1.0.0-beta.10" ..< "2.0.0")), .range("1.0.0-beta.5"..<"1.0.0-beta.10"))
@@ -140,17 +148,56 @@ final class VersionSetSpecifierTests: XCTestCase {
         XCTAssertTrue(VersionSetSpecifier.empty == VersionSetSpecifier.range("2.0.0"..<"2.0.0"))
         XCTAssertTrue(VersionSetSpecifier.range("2.0.0"..<"2.0.0") == VersionSetSpecifier.empty)
 
-        // Exact is equal to a range that spans a single patch.
-        XCTAssertTrue(VersionSetSpecifier.exact("2.0.1") == VersionSetSpecifier.range("2.0.1"..<"2.0.2"))
-        XCTAssertTrue(VersionSetSpecifier.range("2.0.1"..<"2.0.2") == VersionSetSpecifier.exact("2.0.1"))
+        // Exact identifies one parsed identifier, while a range includes all identifiers at each precedence.
+        XCTAssertFalse(VersionSetSpecifier.exact("2.0.1") == VersionSetSpecifier.range("2.0.1"..<"2.0.2"))
+        XCTAssertFalse(VersionSetSpecifier.range("2.0.1"..<"2.0.2") == VersionSetSpecifier.exact("2.0.1"))
 
-        // Exact is also equal to a list of ranges with one entry that spans a single patch.
-        XCTAssertTrue(VersionSetSpecifier.exact("2.0.1") == VersionSetSpecifier.ranges(["2.0.1"..<"2.0.2"]))
-        XCTAssertTrue(VersionSetSpecifier.ranges(["2.0.1"..<"2.0.2"]) == VersionSetSpecifier.exact("2.0.1"))
+        XCTAssertFalse(VersionSetSpecifier.exact("2.0.1") == VersionSetSpecifier.ranges(["2.0.1"..<"2.0.2"]))
+        XCTAssertFalse(VersionSetSpecifier.ranges(["2.0.1"..<"2.0.2"]) == VersionSetSpecifier.exact("2.0.1"))
 
         // A range is equal to a list of ranges with that one range.
         XCTAssertTrue(VersionSetSpecifier.range("2.0.1"..<"2.0.2") == VersionSetSpecifier.ranges(["2.0.1"..<"2.0.2"]))
         XCTAssertTrue(VersionSetSpecifier.ranges(["2.0.1"..<"2.0.2"]) == VersionSetSpecifier.range("2.0.1"..<"2.0.2"))
+    }
+
+    func testExactIdentifierSemantics() {
+        let plain = VersionSetSpecifier.exact("1.2.3")
+        let debug = VersionSetSpecifier.exact("1.2.3+debug")
+        let release = VersionSetSpecifier.exact("1.2.3+release")
+
+        XCTAssertNotEqual(plain, debug)
+        XCTAssertNotEqual(debug, release)
+        XCTAssertTrue(plain.contains("1.2.3"))
+        XCTAssertFalse(plain.contains("1.2.3+debug"))
+        XCTAssertTrue(debug.contains("1.2.3+debug"))
+        XCTAssertFalse(debug.contains("1.2.3"))
+        XCTAssertEqual(Set([plain, debug, release]).count, 3)
+
+        let enclosingRange = VersionSetSpecifier.range("1.0.0"..<"2.0.0")
+        XCTAssertEqual(debug.intersection(enclosingRange), debug)
+        XCTAssertEqual(plain.intersection(debug), .empty)
+    }
+
+    func testCompositeIdentifierOverrides() {
+        let plain = VersionSetSpecifier.exact("1.2.3")
+        let debug = VersionSetSpecifier.exact("1.2.3+debug")
+        let release = VersionSetSpecifier.exact("1.2.3+release")
+        let variants = plain.union(debug).union(release)
+
+        XCTAssertTrue(variants.contains("1.2.3"))
+        XCTAssertTrue(variants.contains("1.2.3+debug"))
+        XCTAssertTrue(variants.contains("1.2.3+release"))
+        XCTAssertFalse(variants.contains("1.2.3+other"))
+        XCTAssertEqual(variants.intersection(debug), debug)
+        XCTAssertEqual(variants.difference(debug), plain.union(release))
+
+        let range = VersionSetSpecifier.range("1.0.0"..<"2.0.0")
+        let excludingDebug = range.difference(debug)
+        XCTAssertTrue(excludingDebug.contains("1.2.3"))
+        XCTAssertFalse(excludingDebug.contains("1.2.3+debug"))
+        XCTAssertTrue(excludingDebug.contains("1.2.3+release"))
+        XCTAssertEqual(excludingDebug.union(debug), range)
+        XCTAssertEqual(excludingDebug.intersection(debug), .empty)
     }
 
     func testPrereleases() {
@@ -176,5 +223,22 @@ final class VersionSetSpecifierTests: XCTestCase {
             "0.0.1" ..< "0.0.2",
             "0.0.1" ..< "2.0.0",
         ]).supportsPrereleases)
+    }
+
+    func testCompositePrereleaseNormalization() {
+        let variants = VersionSetSpecifier.exact("1.0.0-alpha+debug")
+            .union(.exact("1.0.0-beta+debug"))
+        XCTAssertEqual(variants.withoutPrereleases, .exact("1.0.0+debug"))
+
+        let conflictingOverrides = VersionSetSpecifier._set(
+            _VersionSetSpecifierSet(
+                ranges: [],
+                identifierOverrides: [
+                    VersionIdentifierKey("1.0.0-alpha+debug"): true,
+                    VersionIdentifierKey("1.0.0-beta+debug"): false,
+                ]
+            )
+        )
+        XCTAssertEqual(conflictingOverrides.withoutPrereleases, .empty)
     }
 }

--- a/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
@@ -39,4 +39,42 @@ final class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
             }
         }
     }
+
+    func testExactVersionIdentifierDependencies() async throws {
+        let content = """
+            import PackageDescription
+
+            let package = Package(
+                name: "MyPackage",
+                dependencies: [
+                    .package(url: "http://localhost/foo", exact: "1.1.1+debug"),
+                    .package(id: "org.foo", exact: "1.1.1+release"),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, validationDiagnostics) = try await loadAndValidateManifest(
+            content,
+            observabilityScope: observability.topScope
+        )
+        XCTAssertNoDiagnostics(observability.diagnostics)
+        XCTAssertNoDiagnostics(validationDiagnostics)
+
+        let dependencies = Dictionary(
+            uniqueKeysWithValues: manifest.dependencies.map { ($0.identity.description, $0) }
+        )
+        XCTAssertEqual(
+            dependencies["foo"],
+            .remoteSourceControl(
+                identity: .plain("foo"),
+                url: "http://localhost/foo",
+                requirement: .exact("1.1.1+debug")
+            )
+        )
+        XCTAssertEqual(
+            dependencies["org.foo"],
+            .registry(identity: "org.foo", requirement: .exact("1.1.1+release"))
+        )
+    }
 }

--- a/Tests/PackageModelTests/EnabledTraitVersionIdentityTests.swift
+++ b/Tests/PackageModelTests/EnabledTraitVersionIdentityTests.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@testable import PackageModel
+import Testing
+import struct TSCUtility.Version
+
+struct EnabledTraitVersionIdentityTests {
+    @Test
+    func isolatesEqualPrecedenceVersionIdentifiers() {
+        var traits = EnabledTraitsMap.VersionedTraits()
+        let plain = Version("1.2.3")
+        let debug = Version("1.2.3+debug")
+        let release = Version("1.2.3+release")
+
+        traits.set(plain, enabledTraits: ["Plain"])
+        traits.set(debug, enabledTraits: ["Debug"])
+        traits.set(release, enabledTraits: ["Release"])
+
+        #expect(traits.at(plain) == ["Plain"])
+        #expect(traits.at(debug) == ["Debug"])
+        #expect(traits.at(release) == ["Release"])
+    }
+}

--- a/Tests/PackageModelTests/PackageDependencyRequirementTests.swift
+++ b/Tests/PackageModelTests/PackageDependencyRequirementTests.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import PackageModel
+import Testing
+import struct TSCUtility.Version
+
+struct PackageDependencyRequirementTests {
+    @Test
+    func sourceControlExactRequirementsUseFullIdentifiers() {
+        let plain = PackageDependency.SourceControl.Requirement.exact(Version("1.2.3"))
+        let debug = PackageDependency.SourceControl.Requirement.exact(Version("1.2.3+debug"))
+        let release = PackageDependency.SourceControl.Requirement.exact(Version("1.2.3+release"))
+
+        #expect(plain != debug)
+        #expect(debug != release)
+        #expect(Set([plain, debug, release]).count == 3)
+
+        let debugRange = PackageDependency.SourceControl.Requirement.range(
+            Version("1.2.3+debug") ..< Version("2.0.0")
+        )
+        let releaseRange = PackageDependency.SourceControl.Requirement.range(
+            Version("1.2.3+release") ..< Version("2.0.0")
+        )
+        #expect(debugRange == releaseRange)
+        #expect(Set([debugRange, releaseRange]).count == 1)
+    }
+
+    @Test
+    func registryExactRequirementsUseFullIdentifiers() {
+        let plain = PackageDependency.Registry.Requirement.exact(Version("1.2.3"))
+        let debug = PackageDependency.Registry.Requirement.exact(Version("1.2.3+debug"))
+        let release = PackageDependency.Registry.Requirement.exact(Version("1.2.3+release"))
+
+        #expect(plain != debug)
+        #expect(debug != release)
+        #expect(Set([plain, debug, release]).count == 3)
+
+        let debugRange = PackageDependency.Registry.Requirement.range(
+            Version("1.2.3+debug") ..< Version("2.0.0")
+        )
+        let releaseRange = PackageDependency.Registry.Requirement.range(
+            Version("1.2.3+release") ..< Version("2.0.0")
+        )
+        #expect(debugRange == releaseRange)
+        #expect(Set([debugRange, releaseRange]).count == 1)
+    }
+}

--- a/Tests/PackageRegistryTests/RegistryClientTests.swift
+++ b/Tests/PackageRegistryTests/RegistryClientTests.swift
@@ -560,6 +560,71 @@ fileprivate var availabilityURL = URL("\(registryURL)/availability")
         }
     }
 
+    @Test func packageVersionMetadataCacheUsesFullIdentifiers() async throws {
+        let debug = Version("1.1.1+debug")
+        let release = Version("1.1.1+release")
+        let requests = ThreadSafeArrayStore<URL>()
+        let handler: HTTPClient.Implementation = { request, _ in
+            requests.append(request.url)
+            let requestedVersion: Version
+            switch request.url {
+            case releasesURL.appending(component: debug.description):
+                requestedVersion = debug
+            case releasesURL.appending(component: release.description):
+                requestedVersion = release
+            default:
+                throw StringError("unexpected metadata URL: \(request.url)")
+            }
+
+            let data = """
+            {
+                "id": "mona.LinkedList",
+                "version": "\(requestedVersion)",
+                "resources": [{
+                    "name": "source-archive",
+                    "type": "application/zip",
+                    "checksum": "\(requestedVersion.description)"
+                }],
+                "metadata": {
+                    "author": { "name": "\(requestedVersion.description)" }
+                }
+            }
+            """.data(using: .utf8)!
+            return .init(
+                statusCode: 200,
+                headers: .init([
+                    .init(name: "Content-Length", value: "\(data.count)"),
+                    .init(name: "Content-Type", value: "application/json"),
+                    .init(name: "Content-Version", value: "1"),
+                ]),
+                body: data
+            )
+        }
+
+        var configuration = RegistryConfiguration()
+        configuration.defaultRegistry = Registry(url: registryURL, supportsAvailability: false)
+        let registryClient = makeRegistryClient(
+            configuration: configuration,
+            httpClient: HTTPClient(implementation: handler)
+        )
+
+        #expect(try await registryClient.getPackageVersionMetadata(
+            package: identity,
+            version: debug
+        ).author?.name == debug.description)
+        #expect(try await registryClient.getPackageVersionMetadata(
+            package: identity,
+            version: release
+        ).author?.name == release.description)
+        _ = try await registryClient.getPackageVersionMetadata(package: identity, version: debug)
+        _ = try await registryClient.getPackageVersionMetadata(package: identity, version: release)
+
+        #expect(requests.get() == [
+            releasesURL.appending(component: debug.description),
+            releasesURL.appending(component: release.description),
+        ])
+    }
+
     func getPackageVersionMetadata_404() async throws {
         let serverErrorHandler = ServerErrorHandler(
             method: .get,

--- a/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
+++ b/Tests/PackageRegistryTests/RegistryDownloadsManagerTests.swift
@@ -352,6 +352,55 @@ final class RegistryDownloadsManagerTests: XCTestCase {
             }
         }
     }
+
+    func testConcurrentBuildMetadataVariantsAreIndependent() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fileSystem = InMemoryFileSystem()
+        let registry = MockRegistry(
+            filesystem: fileSystem,
+            identityResolver: DefaultIdentityResolver(),
+            checksumAlgorithm: MockHashAlgorithm(),
+            fingerprintStorage: MockPackageFingerprintStorage(),
+            signingEntityStorage: MockPackageSigningEntityStorage()
+        )
+        let package = PackageIdentity.plain("test.variants")
+        let debug = Version("1.0.0+debug")
+        let release = Version("1.0.0+release")
+        let source = InMemoryRegistryPackageSource(
+            fileSystem: fileSystem,
+            path: .root.appending(components: "registry", "server", package.description)
+        )
+        try source.writePackageContent()
+        registry.addPackage(identity: package, versions: [debug, release], source: source)
+
+        let downloadsPath = AbsolutePath.root.appending(components: "registry", "downloads")
+        let manager = RegistryDownloadsManager(
+            fileSystem: fileSystem,
+            path: downloadsPath,
+            cachePath: nil,
+            registryClient: registry.registryClient,
+            delegate: nil
+        )
+
+        async let debugPath = manager.lookup(
+            package: package,
+            version: debug,
+            observabilityScope: observability.topScope
+        )
+        async let releasePath = manager.lookup(
+            package: package,
+            version: release,
+            observabilityScope: observability.topScope
+        )
+        let (resolvedDebugPath, resolvedReleasePath) = try await (debugPath, releasePath)
+
+        XCTAssertEqual(resolvedDebugPath, try downloadsPath.appending(package.downloadPath(version: debug)))
+        XCTAssertEqual(resolvedReleasePath, try downloadsPath.appending(package.downloadPath(version: release)))
+        XCTAssertNotEqual(resolvedDebugPath, resolvedReleasePath)
+        XCTAssertTrue(fileSystem.isDirectory(resolvedDebugPath))
+        XCTAssertTrue(fileSystem.isDirectory(resolvedReleasePath))
+        XCTAssertNoDiagnostics(observability.diagnostics)
+    }
 }
 
 private final class MockRegistryDownloadsManagerDelegate: RegistryDownloadsManagerDelegate, @unchecked Sendable {

--- a/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
+++ b/Tests/PackageSigningTests/FilePackageSigningEntityStorageTests.swift
@@ -447,6 +447,66 @@ struct FilePackageSigningEntityStorageTests {
             return true
         }
     }
+
+    @Test
+    func buildMetadataVariantsRoundTripIndependently() throws {
+        let fileSystem = InMemoryFileSystem()
+        let directoryPath = AbsolutePath("/signing")
+        let package = PackageIdentity.plain("mona.LinkedList")
+        let signer = SigningEntity.recognized(
+            type: .adp,
+            name: "Variant Signer",
+            organizationalUnit: "SwiftPM Variant Unit",
+            organization: "SwiftPM Test"
+        )
+        let debug = Version("1.0.0+debug")
+        let release = Version("1.0.0+release")
+
+        let packageSigner = PackageSigner(
+            signingEntity: signer,
+            origins: [.registry(URL("https://example.com"))],
+            versionIdentifiers: [release, debug, debug]
+        )
+        #expect(packageSigner.versionIdentifiers.map(\.description) == [debug.description, release.description])
+        #expect(packageSigner.versions.count == 1)
+
+        let storage = FilePackageSigningEntityStorage(fileSystem: fileSystem, directoryPath: directoryPath)
+        try storage.put(
+            package: package,
+            version: debug,
+            signingEntity: signer,
+            origin: .registry(URL("https://example.com"))
+        )
+        try storage.put(
+            package: package,
+            version: release,
+            signingEntity: signer,
+            origin: .registry(URL("https://example.com"))
+        )
+
+        let reloaded = FilePackageSigningEntityStorage(fileSystem: fileSystem, directoryPath: directoryPath)
+        let packageSigners = try reloaded.get(package: package)
+        #expect(packageSigners.signingEntities(of: debug) == [signer])
+        #expect(packageSigners.signingEntities(of: release) == [signer])
+        #expect(packageSigners.signingEntities(of: Version("1.0.0")).isEmpty)
+        #expect(packageSigners.signers[signer]?.versionIdentifiers.map(\.description) == [
+            debug.description,
+            release.description,
+        ])
+        #expect(packageSigners.signers[signer]?.versions.count == 1)
+
+        let storedData: Data = try fileSystem.readFileContents(
+            directoryPath.appending(component: package.signedVersionsFilename)
+        )
+        let storedJSON = try #require(JSONSerialization.jsonObject(with: storedData) as? [String: Any])
+        let storedSigners = try #require(storedJSON["signers"] as? [[String: Any]])
+        #expect(storedSigners.count == 1)
+        #expect(storedSigners.allSatisfy {
+            Set($0.keys) == ["origins", "signingEntity", "versions"]
+        })
+        let storedVersions = try #require(storedSigners.first?["versions"] as? [String])
+        #expect(storedVersions == [debug.description, release.description])
+    }
 }
 
 extension PackageSigningEntityStorage {

--- a/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/RegistryPackageContainerTests.swift
@@ -340,6 +340,75 @@ final class RegistryPackageContainerTests: XCTestCase {
         }
     }
 
+    func testMetadataDistinctVersionsAreOrderedAndCachedSeparately() async throws {
+        let fs = InMemoryFileSystem()
+        try fs.createMockToolchain()
+
+        let packageIdentity = PackageIdentity.plain("org.foo")
+        let packagePath = AbsolutePath.root
+        let registryClient = try makeRegistryClient(
+            packageIdentity: packageIdentity,
+            packageVersion: "1.0.0",
+            packagePath: packagePath,
+            fileSystem: fs,
+            releasesRequestHandler: { _, _ in
+                let metadata = RegistryClient.Serialization.PackageMetadata(
+                    releases: [
+                        "1.0.0+debug": .init(url: .none, problem: .none),
+                        "1.0.0": .init(url: .none, problem: .none),
+                        "1.0.0+release": .init(url: .none, problem: .none),
+                    ]
+                )
+                return HTTPClientResponse(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Version": "1",
+                        "Content-Type": "application/json",
+                    ],
+                    body: try! JSONEncoder.makeWithDefaults().encode(metadata)
+                )
+            },
+            manifestRequestHandler: { request, _ in
+                let toolsVersion: ToolsVersion
+                if request.url.absoluteString.contains("release") {
+                    toolsVersion = .v6_4
+                } else if request.url.absoluteString.contains("debug") {
+                    toolsVersion = .v5_5
+                } else {
+                    toolsVersion = .v5_4
+                }
+                return HTTPClientResponse(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Version": "1",
+                        "Content-Type": "text/x-swift",
+                    ],
+                    body: Data("// swift-tools-version:\(toolsVersion)".utf8)
+                )
+            }
+        )
+        let provider = try Workspace._init(
+            fileSystem: fs,
+            environment: .mockEnvironment,
+            location: .init(forRootPackage: packagePath, fileSystem: fs),
+            customHostToolchain: .mockHostToolchain(fs),
+            customManifestLoader: MockManifestLoader(manifests: [:]),
+            customRegistryClient: registryClient
+        )
+
+        let container = try await provider.getContainer(
+            for: .registry(identity: packageIdentity)
+        )
+        let versions = try await container.versionsDescending()
+        XCTAssertEqual(versions, ["1.0.0+release", "1.0.0+debug", "1.0.0"])
+        let plainToolsVersion = try await container.toolsVersion(for: "1.0.0")
+        let debugToolsVersion = try await container.toolsVersion(for: "1.0.0+debug")
+        let releaseToolsVersion = try await container.toolsVersion(for: "1.0.0+release")
+        XCTAssertEqual(plainToolsVersion, .v5_4)
+        XCTAssertEqual(debugToolsVersion, .v5_5)
+        XCTAssertEqual(releaseToolsVersion, .v6_4)
+    }
+
     func makeRegistryClient(
         packageIdentity: PackageIdentity,
         packageVersion: Version,

--- a/Tests/WorkspaceTests/ResolvedPackagesStoreTests.swift
+++ b/Tests/WorkspaceTests/ResolvedPackagesStoreTests.swift
@@ -86,14 +86,15 @@ final class ResolvedPackagesStoreTests: XCTestCase {
             var store = try ResolvedPackagesStore(packageResolvedFile: packageResolvedFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
             store.track(
                 packageRef: .localSourceControl(identity: identity, path: path),
-                state: .version("1.2.3", revision: revision)
+                state: .version("1.2.3+debug", revision: revision)
             )
             try store.saveState(toolsVersion: ToolsVersion.current, originHash: .none)
             store = try ResolvedPackagesStore(packageResolvedFile: packageResolvedFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
 
             let resolution = store.resolvedPackages[identity]!
-            XCTAssertEqual(resolution.state, .version("1.2.3", revision: revision))
-            XCTAssertEqual(resolution.state.description, "1.2.3")
+            XCTAssertEqual(resolution.state, .version("1.2.3+debug", revision: revision))
+            XCTAssertEqual(resolution.state.description, "1.2.3+debug")
+            XCTAssertNotEqual(resolution.state, .version("1.2.3+release", revision: revision))
         }
 
         // Test source control branch resolution.
@@ -144,14 +145,15 @@ final class ResolvedPackagesStoreTests: XCTestCase {
             var store = try ResolvedPackagesStore(packageResolvedFile: packageResolvedFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
             store.track(
                 packageRef: .registry(identity: identity),
-                state: .version("1.2.3", revision: .none)
+                state: .version("1.2.3+release", revision: .none)
             )
             try store.saveState(toolsVersion: ToolsVersion.current, originHash: .none)
             store = try ResolvedPackagesStore(packageResolvedFile: packageResolvedFile, workingDirectory: .root, fileSystem: fs, mirrors: .init())
 
             let resolution = store.resolvedPackages[identity]!
-            XCTAssertEqual(resolution.state, .version("1.2.3", revision: .none))
-            XCTAssertEqual(resolution.state.description, "1.2.3")
+            XCTAssertEqual(resolution.state, .version("1.2.3+release", revision: .none))
+            XCTAssertEqual(resolution.state.description, "1.2.3+release")
+            XCTAssertNotEqual(resolution.state, .version("1.2.3+debug", revision: .none))
         }
     }
 

--- a/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
+++ b/Tests/WorkspaceTests/SourceControlPackageContainerTests.swift
@@ -243,10 +243,10 @@ final class SourceControlPackageContainerTests: XCTestCase {
             let container = try await provider.getContainer(for: ref) as! SourceControlPackageContainer
             XCTAssertTrue(container.validToolsVersionsCache.isEmpty)
             let v = try await container.toolsVersionsAppropriateVersionsDescending()
-            XCTAssertEqual(container.validToolsVersionsCache["1.0.0"], false)
-            XCTAssertEqual(container.validToolsVersionsCache["1.0.1"], true)
-            XCTAssertEqual(container.validToolsVersionsCache["1.0.2"], true)
-            XCTAssertEqual(container.validToolsVersionsCache["1.0.3"], true)
+            XCTAssertEqual(container.validToolsVersionsCache[VersionIdentifierKey("1.0.0")], false)
+            XCTAssertEqual(container.validToolsVersionsCache[VersionIdentifierKey("1.0.1")], true)
+            XCTAssertEqual(container.validToolsVersionsCache[VersionIdentifierKey("1.0.2")], true)
+            XCTAssertEqual(container.validToolsVersionsCache[VersionIdentifierKey("1.0.3")], true)
             XCTAssertEqual(v, ["1.0.3", "1.0.2", "1.0.1"])
         }
 
@@ -322,6 +322,75 @@ final class SourceControlPackageContainerTests: XCTestCase {
         let container = try await provider.getContainer(for: ref)
         let v = try await container.toolsVersionsAppropriateVersionsDescending()
         XCTAssertEqual(v, ["1.0.4-alpha", "1.0.2-dev.2", "1.0.2-dev", "1.0.1", "1.0.0", "1.0.0-beta.1", "1.0.0-alpha.1"])
+    }
+
+    func testMetadataDistinctTagsAndCaches() async throws {
+        try XCTSkipOnWindows(because: "https://github.com/swiftlang/swift-package-manager/issues/8578")
+
+        let fs = InMemoryFileSystem()
+        try fs.createMockToolchain()
+
+        let repoPath = AbsolutePath.root
+        let filePath = repoPath.appending("Package.swift")
+        let specifier = RepositorySpecifier(path: repoPath)
+        let repo = InMemoryGitRepository(path: repoPath, fs: fs)
+        try repo.createDirectory(repoPath, recursive: true)
+
+        try repo.writeFileContents(filePath, string: "// swift-tools-version:5.4\n")
+        try repo.commit()
+        try repo.tag(name: "1.0.0")
+
+        try repo.writeFileContents(filePath, string: "// swift-tools-version:5.5\n// debug\n")
+        try repo.commit()
+        try repo.tag(name: "1.0.0+debug")
+
+        try repo.writeFileContents(filePath, string: "// swift-tools-version:6.4\n")
+        try repo.commit()
+        try repo.tag(name: "1.0.0+release")
+
+        let inMemoryRepositoryProvider = InMemoryGitRepositoryProvider()
+        inMemoryRepositoryProvider.add(specifier: specifier, repository: repo)
+
+        let repositoryManagerPath = AbsolutePath.root.appending("repoManager")
+        try fs.createDirectory(repositoryManagerPath, recursive: true)
+        let repositoryManager = RepositoryManager(
+            fileSystem: fs,
+            path: repositoryManagerPath,
+            provider: inMemoryRepositoryProvider,
+            delegate: MockRepositoryManagerDelegate()
+        )
+        let provider = try Workspace._init(
+            fileSystem: fs,
+            environment: .mockEnvironment,
+            location: .init(forRootPackage: repoPath, fileSystem: fs),
+            customHostToolchain: .mockHostToolchain(fs),
+            customManifestLoader: MockManifestLoader(manifests: [:]),
+            customRepositoryManager: repositoryManager
+        )
+
+        let reference = PackageReference.localSourceControl(
+            identity: PackageIdentity(path: repoPath),
+            path: repoPath
+        )
+        let container = try await provider.getContainer(for: reference) as! SourceControlPackageContainer
+
+        let versions = try await container.versionsDescending()
+        XCTAssertEqual(versions, ["1.0.0+release", "1.0.0+debug", "1.0.0"])
+        XCTAssertEqual(container.getTag(for: "1.0.0"), "1.0.0")
+        XCTAssertEqual(container.getTag(for: "1.0.0+debug"), "1.0.0+debug")
+        XCTAssertEqual(container.getTag(for: "1.0.0+release"), "1.0.0+release")
+
+        let revisions = try ["1.0.0", "1.0.0+debug", "1.0.0+release"].map {
+            try container.getRevision(forTag: $0).identifier
+        }
+        XCTAssertEqual(Set(revisions).count, 3)
+
+        let plainToolsVersion = try await container.toolsVersion(for: "1.0.0")
+        let debugToolsVersion = try await container.toolsVersion(for: "1.0.0+debug")
+        let releaseToolsVersion = try await container.toolsVersion(for: "1.0.0+release")
+        XCTAssertEqual(plainToolsVersion, .v5_4)
+        XCTAssertEqual(debugToolsVersion, .v5_5)
+        XCTAssertEqual(releaseToolsVersion, .v6_4)
     }
 
     func testSimultaneousVersions() async throws {

--- a/Tests/WorkspaceTests/VersionIdentityStateTests.swift
+++ b/Tests/WorkspaceTests/VersionIdentityStateTests.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import Testing
+@testable import Workspace
+import struct TSCUtility.Version
+
+struct VersionIdentityStateTests {
+    @Test
+    func managedDependencyStatesUseFullIdentifiers() {
+        let plain = Version("1.0.0")
+        let debug = Version("1.0.0+debug")
+        let release = Version("1.0.0+release")
+
+        #expect(
+            Workspace.ManagedDependency.State.registryDownload(version: plain, scmUrl: nil) !=
+                .registryDownload(version: debug, scmUrl: nil)
+        )
+        #expect(
+            Workspace.ManagedDependency.State.registryDownload(version: debug, scmUrl: nil) !=
+                .registryDownload(version: release, scmUrl: nil)
+        )
+        #expect(
+            Workspace.ManagedDependency.State.custom(version: debug, path: "/package") !=
+                .custom(version: release, path: "/package")
+        )
+    }
+
+    @Test
+    func packageStateChangesUseFullIdentifiers() {
+        let plain = Workspace.PackageStateChange.Requirement.version(Version("1.0.0"))
+        let debug = Workspace.PackageStateChange.Requirement.version(Version("1.0.0+debug"))
+        let release = Workspace.PackageStateChange.Requirement.version(Version("1.0.0+release"))
+
+        #expect(plain != debug)
+        #expect(debug != release)
+    }
+}

--- a/Tests/WorkspaceTests/WorkspaceTests.swift
+++ b/Tests/WorkspaceTests/WorkspaceTests.swift
@@ -3939,6 +3939,190 @@ final class WorkspaceTests: XCTestCase {
         }
     }
 
+    func testExactVersionIdentifierResolution() async throws {
+        let sandbox = AbsolutePath("/tmp/exact-version-identifier")
+        let fs = InMemoryFileSystem()
+        let debugVersion: Version = "1.0.0+debug"
+        let debugRevision = "debug-revision"
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: fs,
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [MockTarget(name: "Root", dependencies: ["Foo"])],
+                    dependencies: [
+                        .sourceControl(path: "./Foo", requirement: .exact(debugVersion)),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [MockTarget(name: "Foo")],
+                    products: [MockProduct(name: "Foo", modules: ["Foo"])],
+                    versions: ["1.0.0", debugVersion.description, "1.0.0+release"],
+                    revisionProvider: { version in
+                        version == debugVersion.description ? debugRevision : "revision-\(version)"
+                    }
+                ),
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "foo", at: .checkout(.version(debugVersion)))
+        }
+        workspace.checkResolved { result in
+            result.check(dependency: "foo", at: .checkout(.version(debugVersion)))
+            guard let state = result.store.resolvedPackages["foo"]?.state,
+                  case .version(let version, let revision) = state
+            else {
+                return XCTFail("expected a version pin")
+            }
+            XCTAssertEqual(VersionIdentifierKey(version), VersionIdentifierKey(debugVersion))
+            XCTAssertEqual(revision, debugRevision)
+        }
+
+        try await workspace.closeWorkspace(resetState: true, resetResolvedFile: false)
+        try await workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "foo", at: .checkout(.version(debugVersion)))
+        }
+
+        try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        workspace.checkResolved { result in
+            result.check(dependency: "foo", at: .checkout(.version(debugVersion)))
+        }
+
+        let missingWorkspace = try await MockWorkspace(
+            sandbox: AbsolutePath("/tmp/exact-version-identifier-missing"),
+            fileSystem: InMemoryFileSystem(),
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [MockTarget(name: "Root", dependencies: ["Foo"])],
+                    dependencies: [
+                        .sourceControl(path: "./Foo", requirement: .exact(debugVersion)),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Foo",
+                    targets: [MockTarget(name: "Foo")],
+                    products: [MockProduct(name: "Foo", modules: ["Foo"])],
+                    versions: ["1.0.0", "1.0.0+release"]
+                ),
+            ]
+        )
+
+        try await missingWorkspace.checkPackageGraphFailure(roots: ["Root"], deps: []) { diagnostics in
+            XCTAssertTrue(diagnostics.contains {
+                $0.message == "Dependencies could not be resolved because no versions of 'foo' match the requirement 1.0.0+debug and root depends on 'foo' 1.0.0+debug."
+            })
+        }
+    }
+
+    func testExactVersionIdentifierResolutionFromRegistry() async throws {
+        let sandbox = AbsolutePath("/tmp/exact-registry-version-identifier")
+        let debugVersion: Version = "1.0.0+debug"
+
+        let workspace = try await MockWorkspace(
+            sandbox: sandbox,
+            fileSystem: InMemoryFileSystem(),
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "Root",
+                            dependencies: [.product(name: "Foo", package: "org.foo")]
+                        ),
+                    ],
+                    dependencies: [
+                        .registry(identity: "org.foo", requirement: .exact(debugVersion)),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Foo",
+                    identity: "org.foo",
+                    targets: [MockTarget(name: "Foo")],
+                    products: [MockProduct(name: "Foo", modules: ["Foo"])],
+                    versions: ["1.0.0", debugVersion.description, "1.0.0+release"]
+                ),
+            ]
+        )
+
+        try await workspace.checkPackageGraph(roots: ["Root"]) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "org.foo", at: .registryDownload(debugVersion))
+        }
+        workspace.checkResolved { result in
+            result.check(dependency: "org.foo", at: .registryDownload(debugVersion))
+        }
+
+        try await workspace.closeWorkspace(resetState: true, resetResolvedFile: false)
+        try await workspace.checkPackageGraph(roots: ["Root"], forceResolvedVersions: true) { _, diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        await workspace.checkManagedDependencies { result in
+            result.check(dependency: "org.foo", at: .registryDownload(debugVersion))
+        }
+
+        try await workspace.checkUpdate(roots: ["Root"]) { diagnostics in
+            XCTAssertNoDiagnostics(diagnostics)
+        }
+        workspace.checkResolved { result in
+            result.check(dependency: "org.foo", at: .registryDownload(debugVersion))
+        }
+
+        let missingWorkspace = try await MockWorkspace(
+            sandbox: AbsolutePath("/tmp/exact-registry-version-identifier-missing"),
+            fileSystem: InMemoryFileSystem(),
+            roots: [
+                MockPackage(
+                    name: "Root",
+                    targets: [
+                        MockTarget(
+                            name: "Root",
+                            dependencies: [.product(name: "Foo", package: "org.foo")]
+                        ),
+                    ],
+                    dependencies: [
+                        .registry(identity: "org.foo", requirement: .exact(debugVersion)),
+                    ]
+                ),
+            ],
+            packages: [
+                MockPackage(
+                    name: "Foo",
+                    identity: "org.foo",
+                    targets: [MockTarget(name: "Foo")],
+                    products: [MockProduct(name: "Foo", modules: ["Foo"])],
+                    versions: ["1.0.0", "1.0.0+release"]
+                ),
+            ]
+        )
+
+        try await missingWorkspace.checkPackageGraphFailure(roots: ["Root"], deps: []) { diagnostics in
+            XCTAssertTrue(diagnostics.contains {
+                $0.message == "Dependencies could not be resolved because no versions of 'org.foo' match the requirement 1.0.0+debug and root depends on 'org.foo' 1.0.0+debug."
+            })
+        }
+    }
+
     func testResolvedFileSchemeToolsVersion() async throws {
         for pair in [
             (ToolsVersion.v5_2, ToolsVersion.v5_2),

--- a/Tests/_InternalTestSupportTests/VersionIdentityTestSupportTests.swift
+++ b/Tests/_InternalTestSupportTests/VersionIdentityTestSupportTests.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import _InternalTestSupport
+import struct TSCUtility.Version
+
+struct VersionIdentityTestSupportTests {
+    @Test
+    func manifestLoaderKeysUseFullIdentifiers() {
+        let plain = MockManifestLoader.Key(url: "/package", version: Version("1.0.0"))
+        let debug = MockManifestLoader.Key(url: "/package", version: Version("1.0.0+debug"))
+        let release = MockManifestLoader.Key(url: "/package", version: Version("1.0.0+release"))
+
+        #expect(plain != debug)
+        #expect(debug != release)
+        #expect(Set([plain, debug, release]).count == 3)
+    }
+}


### PR DESCRIPTION
Fix SwiftPM’s existing `.exact(...)` requirement to match the complete parsed version identifier, including build metadata.

### Motivation:

Fixes #10391.

Related bugs:

- #6675
- [swiftlang/swift#80711](https://github.com/swiftlang/swift/issues/80711), transferred to #9716

[Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html#spec-item-10) specifies that build metadata (`+...`) is ignored when determining version precedence. SwiftPM correctly follows that rule for version ordering and ranges.

SemVer does not define what “exact” means for dependency resolution. Exact requirements are a SwiftPM concept.

Currently, SwiftPM also ignores build metadata when matching `.exact(...)`. As reported in [#6675](https://github.com/swiftlang/swift-package-manager/issues/6675), this can cause SwiftPM to resolve a source-control tag to the wrong commit. The issue now tracked as [#9716](https://github.com/swiftlang/swift-package-manager/issues/9716) also demonstrates that changing between metadata-distinct identifiers can conflict with a previously recorded revision.

For example:

```swift
.exact("1.0.0+debug")
```

may currently select `1.0.0`, `1.0.0+release`, or another published version with the same SemVer precedence.

There are legitimate reasons to publish variants that share the same precedence, such as `1.0.0+debug` and `1.0.0+release`. When a developer includes build metadata in an exact requirement, the expected behavior is to select that complete version identifier.

I previously wrote [SE-0534](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0534-swiftpm-exact-literal-version-matching.md), which proposed adding `.exactLiteral(...)` for this purpose. Following its [review](https://forums.swift.org/t/review-se-0534-opt-in-exact-matching-for-version-identifiers-with-build-metadata/87815), the Ecosystem Steering Group [rejected the proposed API](https://forums.swift.org/t/rejected-se-0534-opt-in-exact-matching-for-version-identifiers/88571), while agreeing that the existing behavior is a bug.

The group’s preference was to fix `.exact(...)` in place without adding a second form of exact matching. It also expected the behavior change to have a very small blast radius because the existing behavior has no legitimate dependents.

This PR implements that bug fix.

### Modifications:

The implementation keeps two intentionally different relations on versions:

```text
SemVer precedence:
1.0.0+debug == 1.0.0+release

Complete identifier identity:
1.0.0+debug != 1.0.0+release
```

SwiftPM cannot change global `Version` equality without also changing established SemVer precedence behavior. This PR therefore introduces a separate package-internal identity for places that must distinguish complete version identifiers.

- Introduce a complete-identifier key containing every parsed version component, including build metadata. Global `Version` equality and ordering remain precedence-based.
- Make source-control and registry `.exact` requirements use complete identifier identity for equality and hashing.
- Make `.exact` containment and set operations identifier-specific while keeping ranges precedence-based.
- Extend the resolver’s internal version-set algebra to represent precedence ranges together with finite identifier-specific inclusions and exclusions.
- Preserve metadata-distinct source-control tags and registry releases during enumeration and lookup. Only tag spellings that parse to the same complete identifier are reconciled.
- Carry complete identity through PubGrub decisions, candidate selection, pinned-version lookup, conflict resolution, and tools-version incompatibilities.
- Preserve complete identity through workspace state, managed dependencies, package-state changes, prebuilt reconciliation, checkout state, and `Package.resolved` reuse.
- Use complete identity at version-specific cache and persistence boundaries, including manifests, tools versions, dependencies, fingerprints, registry metadata and downloads, signing state, and enabled traits.
- Preserve existing persisted schemas through internal identity-aware storage and custom encoding where necessary.
- Document that `.exact(...)` matches every parsed version component.

This change does not alter:

- SemVer precedence or range behavior
- global `Version` equality or ordering
- manifest syntax or public requirement cases
- persisted lockfile, fingerprint-store, or signing-store schemas
- tools-version compatibility
- existing tag-mutation or fingerprint policy

#### Testing

Added coverage for:

- complete version-identifier equality and hashing
- source-control and registry requirement equality and hashing
- `.exact` equality, hashing, containment, intersection, union, and difference
- unions of equal-precedence identifiers and identifier-specific range exclusions
- composite set canonicalization and prerelease normalization
- positive and negative PubGrub term relations
- exact selection, conflicting transitive exact requirements, and pinned-version identifier reuse
- real manifest loading for metadata-bearing source-control and registry exact requirements
- backtracking, missing variants, and tools-version incompatibilities
- source-control tag enumeration, lookup, and cache isolation
- registry release enumeration, lookup, metadata caching, and concurrent download isolation
- fingerprint and signing-store isolation and round trips
- signing-store schema compatibility
- enabled-trait and manifest-loader cache isolation
- managed dependency and package-state identity
- source-control version-and-revision lockfile round trips
- registry version lockfile round trips
- fresh resolution, resolved-file reuse, explicit update, and missing-variant failure

Validated with targeted Basics, PackageModel, PackageFingerprint, PackageSigning, PackageRegistry, PackageGraph, and Workspace suites:

```
xcrun swift test --filter 'VersionIdentifierKeyTests|PackageDependencyRequirementTests|EnabledTraitVersionIdentityTests|FilePackageFingerprintStorageTests|FilePackageSigningEntityStorageTests|PackageSigningEntityTOFUTests|PackageVersionMetadata.packageVersionMetadataCacheUsesFullIdentifiers|RegistryDownloadsManagerTests.testConcurrentBuildMetadataVariantsAreIndependent|VersionSetSpecifierTests|PubGrubTests|VersionIdentityStateTests|VersionIdentityTestSupportTests|SourceControlPackageContainerTests|RegistryPackageContainerTests|PackageDescriptionNextLoadingTests.testExactVersionIdentifierDependencies|WorkspaceTests.testExactVersionIdentifierResolution|ResolvedPackagesStoreTests'

xcrun swift build --build-tests
```

### Result:

`.exact(...)` now matches one complete parsed version identifier:

- `.exact("1.0.0")` matches only `1.0.0`.
- `.exact("1.0.0+debug")` matches only `1.0.0+debug`.
- `.exact("1.0.0+release")` matches only `1.0.0+release`.

Ranges remain precedence-based and continue to admit every available identifier at an included SemVer precedence position.

Metadata-distinct source-control tags and registry releases remain independently selectable and retain their identity through resolution, download, signing and fingerprint state, checkout, managed dependency state, and lockfile reuse.
