### PR TITLE
SE-####: Allow deprecating package products

### DIFF
--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Package.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:999.0
+import PackageDescription
+
+let package = Package(
+    name: "consumer",
+    dependencies: [
+        .package(path: "../producer"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyApp",
+            dependencies: [
+                .product(name: "PaperLegacy", package: "producer"),
+            ],
+        ),
+        .target(
+            name: "MyLib",
+            dependencies: [
+                .product(name: "PaperExperimental", package: "producer"),
+            ],
+            swiftSettings: [
+                .treatAllWarnings(as: .error),
+            ],
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Sources/MyApp/main.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Sources/MyApp/main.swift
@@ -1,0 +1,8 @@
+import PaperLegacy
+
+@main
+struct MyApp {
+    static func main() {
+        print("MyApp using PaperLegacy \(paperLegacyVersion())")
+    }
+}

--- a/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Sources/MyLib/MyLib.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/consumer/Sources/MyLib/MyLib.swift
@@ -1,0 +1,5 @@
+import PaperExperimental
+
+public func myLibExperimentalName() -> String {
+    return paperExperimentalName()
+}

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Package.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version:999.0
+import PackageDescription
+
+let package = Package(
+    name: "producer",
+    products: [
+        .library(
+            name: "Paper",
+            targets: ["Paper"],
+        ),
+        .library(
+            name: "PaperLegacy",
+            targets: ["PaperLegacy"],
+            deprecated: .unsupported(
+                message: "PaperLegacy is superseded by Paper.",
+                replacement: .renamed("Paper"),
+            ),
+        ),
+        .library(
+            name: "PaperExperimental",
+            targets: ["PaperExperimental"],
+            deprecated: .unsupported(
+                message: "PaperExperimental is going away with no replacement.",
+            ),
+        ),
+        .executable(
+            name: "paper-tool-old",
+            targets: ["paper-tool-old"],
+            deprecated: .unsupported(
+                message: "Migrate to the standalone paper-tools package.",
+                replacement: .renamed("paper-tool", package: "paper-tools"),
+            ),
+        ),
+    ],
+    targets: [
+        .target(name: "Paper"),
+        .target(name: "PaperLegacy", dependencies: ["Paper"]),
+        .target(name: "PaperExperimental"),
+        .executableTarget(name: "paper-tool-old"),
+    ]
+)

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/Paper/Paper.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/Paper/Paper.swift
@@ -1,0 +1,1 @@
+public func paperVersion() -> String { "1.0" }

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/PaperExperimental/PaperExperimental.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/PaperExperimental/PaperExperimental.swift
@@ -1,0 +1,1 @@
+public func paperExperimentalName() -> String { "experimental" }

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/PaperLegacy/PaperLegacy.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/PaperLegacy/PaperLegacy.swift
@@ -1,0 +1,2 @@
+import Paper
+public func paperLegacyVersion() -> String { paperVersion() }

--- a/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/paper-tool-old/main.swift
+++ b/Fixtures/Miscellaneous/DeprecatedProducts/producer/Sources/paper-tool-old/main.swift
@@ -1,0 +1,6 @@
+@main
+struct PaperToolOld {
+    static func main() {
+        print("paper-tool-old")
+    }
+}

--- a/Sources/CoreCommands/SwiftCommandState.swift
+++ b/Sources/CoreCommands/SwiftCommandState.swift
@@ -833,6 +833,14 @@ public final class SwiftCommandState {
             observabilityScope: self.observabilityScope
         )
 
+        // Also load the full module graph so graph-level diagnostics (e.g. product
+        // deprecation warnings) surface during a plain `swift package resolve`.
+        // `loadPackageGraph` will honor `-Xswiftc -warnings-as-errors` and escalate
+        // those diagnostics accordingly.
+        if !self.observabilityScope.errorsReported {
+            _ = try await self.loadPackageGraph(exitOnError: false)
+        }
+
         // Throw if there were errors when loading the graph.
         // The actual errors will be printed before exiting.
         guard !self.observabilityScope.errorsReported else {
@@ -879,13 +887,21 @@ public final class SwiftCommandState {
             // package graph load attempts to also fail due to sharing the same `errorsReported` bit.
             let packageGraphObservabilityScope = self.observabilityScope.makeChildScope(description: "Loading Package Graph")
 
+            // Detect `-warnings-as-errors` in the user-supplied swift compiler flags so
+            // SwiftPM's own graph-time diagnostics (e.g. product-deprecation warnings)
+            // are escalated to errors consistently with the compiler's own behavior.
+            let treatWarningsAsErrors = WarningControlFlags.containsWarningsAsErrors(
+                self.options.build.swiftCompilerFlags,
+            )
+
             // Fetch and load the package graph.
             let graph = try await workspace.loadPackageGraph(
                 rootInput: self.getWorkspaceRoot(),
                 explicitProduct: explicitProduct,
                 forceResolvedVersions: self.options.resolver.forceResolvedVersions,
                 testEntryPointPath: testEntryPointPath,
-                observabilityScope: packageGraphObservabilityScope
+                observabilityScope: packageGraphObservabilityScope,
+                treatWarningsAsErrors: treatWarningsAsErrors,
             )
 
             // Throw if there were errors when loading the graph.

--- a/Sources/PackageGraph/ModulesGraph+Loading.swift
+++ b/Sources/PackageGraph/ModulesGraph+Loading.swift
@@ -40,7 +40,8 @@ extension ModulesGraph {
         observabilityScope: ObservabilityScope,
         productsFilter: ((Product) -> Bool)? = nil,
         modulesFilter: ((Module) -> Bool)? = nil,
-        enabledTraitsMap: EnabledTraitsMap
+        enabledTraitsMap: EnabledTraitsMap,
+        treatWarningsAsErrors: Bool = false,
     ) throws -> ModulesGraph {
         let observabilityScope = observabilityScope.makeChildScope(description: "Loading Package Graph")
 
@@ -211,7 +212,8 @@ extension ModulesGraph {
             fileSystem: fileSystem,
             observabilityScope: observabilityScope,
             productsFilter: productsFilter,
-            modulesFilter: modulesFilter
+            modulesFilter: modulesFilter,
+            treatWarningsAsErrors: treatWarningsAsErrors,
         )
 
         let rootPackages = resolvedPackages.filter { root.manifests.values.contains($0.manifest) }
@@ -389,7 +391,8 @@ private func createResolvedPackages(
     fileSystem: FileSystem,
     observabilityScope: ObservabilityScope,
     productsFilter: ((Product) -> Bool)?,
-    modulesFilter: ((Module) -> Bool)?
+    modulesFilter: ((Module) -> Bool)?,
+    treatWarningsAsErrors: Bool,
 ) throws -> IdentifiableSet<ResolvedPackage> {
     // Create package builder objects from the input manifests.
     var packageBuilders: [ResolvedPackageBuilder] = nodes.compactMap { node in
@@ -786,6 +789,22 @@ private func createResolvedPackages(
                 }
 
                 moduleBuilder.dependencies.append(.product(product, conditions: conditions))
+
+                // Emit a diagnostic if the consumed product is deprecated.
+                if let deprecation = product.product.deprecation {
+                    let severity: Diagnostic.Severity = shouldEscalateProductDeprecationToError(
+                        consumer: moduleBuilder.module,
+                        globalTreatWarningsAsErrors: treatWarningsAsErrors,
+                    ) ? .error : .warning
+                    let text = formatProductDeprecationDiagnostic(
+                        product: product.product,
+                        producingPackage: product.packageBuilder.package.identity,
+                        deprecation: deprecation,
+                    )
+                    packageObservabilityScope.emit(
+                        .init(severity: severity, message: text, metadata: nil),
+                    )
+                }
             }
         }
     }
@@ -1644,4 +1663,56 @@ private final class ResolvedPackageBuilder: ResolvedBuilder<ResolvedPackage> {
             platformVersionProvider: self.platformVersionProvider
         )
     }
+}
+
+// MARK: - Product deprecation diagnostics (SE-NNNN)
+
+/// Formats the diagnostic text for a deprecated product consumed by a target,
+/// matching the wording specified in the proposal:
+///
+/// `product 'X' from package 'Y' is unsupported[: <message> [Use 'N' instead.| Use 'N' from package 'P' instead.]]`
+internal func formatProductDeprecationDiagnostic(
+    product: Product,
+    producingPackage: PackageIdentity,
+    deprecation: ProductDeprecation,
+) -> String {
+    var text = "product '\(product.name)' from package '\(producingPackage.description)' is unsupported"
+    var trailing: [String] = []
+    if let message = deprecation.message, !message.isEmpty {
+        trailing.append(message)
+    }
+    if let replacement = deprecation.replacement {
+        trailing.append(replacement.formattedInstruction)
+    }
+    if !trailing.isEmpty {
+        text += ": " + trailing.joined(separator: " ")
+    }
+    return text
+}
+
+/// Decides whether SwiftPM's product-deprecation diagnostic should be emitted as
+/// an error rather than a warning, honoring:
+///
+/// 1. The build-invocation-level `treatWarningsAsErrors` flag (equivalent to
+///    `-Xswiftc -warnings-as-errors` at build time).
+/// 2. The consumer target's own Swift build settings — specifically
+///    `.treatAllWarnings(.error)` on the Swift tool.
+///
+/// Other warning-level controls (per-warning `treatWarning(name:as:)`, C/C++
+/// `treatAllWarnings`) do NOT affect the severity of this diagnostic — it is
+/// SwiftPM-emitted, not compiler-emitted.
+internal func shouldEscalateProductDeprecationToError(
+    consumer: Module,
+    globalTreatWarningsAsErrors: Bool,
+) -> Bool {
+    if globalTreatWarningsAsErrors {
+        return true
+    }
+    // `.treatAllWarnings(as: .error)` on the Swift tool is compiled into a
+    // `-warnings-as-errors` Swift-compiler flag stored under `OTHER_SWIFT_FLAGS`
+    // in the target's build-settings assignment table. Its presence in any
+    // assignment for this target means the consumer opted into escalation.
+    let swiftFlags = consumer.buildSettings.assignments[.OTHER_SWIFT_FLAGS]?
+        .flatMap(\.values) ?? []
+    return swiftFlags.contains("-warnings-as-errors")
 }

--- a/Sources/PackageGraph/ModulesGraph.swift
+++ b/Sources/PackageGraph/ModulesGraph.swift
@@ -467,7 +467,8 @@ public func loadModulesGraph(
     customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
     observabilityScope: ObservabilityScope,
     traitConfiguration: TraitConfiguration = .default,
-    enabledTraitsMap: EnabledTraitsMap = .init()
+    enabledTraitsMap: EnabledTraitsMap = .init(),
+    treatWarningsAsErrors: Bool = false,
 ) throws -> ModulesGraph {
     let rootManifests = manifests.filter(\.packageKind.isRoot).spm_createDictionary { ($0.path, $0) }
     let externalManifests = try manifests.filter { !$0.packageKind.isRoot }
@@ -504,6 +505,7 @@ public func loadModulesGraph(
         observabilityScope: observabilityScope,
         productsFilter: nil,
         modulesFilter: nil,
-        enabledTraitsMap: enabledTraitsMap
+        enabledTraitsMap: enabledTraitsMap,
+        treatWarningsAsErrors: treatWarningsAsErrors,
     )
 }

--- a/Sources/PackageLoading/ManifestJSONParser.swift
+++ b/Sources/PackageLoading/ManifestJSONParser.swift
@@ -500,10 +500,35 @@ extension ProductDescription {
         case .library(let type):
             productType = .library(.init(type))
         }
+
+        let modelDeprecation: PackageModel.ProductDeprecation? = product.deprecation.map { wire in
+            let modelReplacement = wire.replacement.map { r -> PackageModel.ProductDeprecation.Replacement in
+                switch r {
+                case .renamed(let product, let package):
+                    return .renamed(product, package: package)
+                }
+            }
+            return PackageModel.ProductDeprecation(
+                message: wire.message,
+                replacement: modelReplacement,
+            )
+        }
+
         #if ENABLE_APPLE_PRODUCT_TYPES
-        try self.init(name: product.name, type: productType, targets: product.targets, settings: product.settings.map { .init($0) })
+        try self.init(
+            name: product.name,
+            type: productType,
+            targets: product.targets,
+            settings: product.settings.map { .init($0) },
+            deprecation: modelDeprecation,
+        )
         #else
-        try self.init(name: product.name, type: productType, targets: product.targets)
+        try self.init(
+            name: product.name,
+            type: productType,
+            targets: product.targets,
+            deprecation: modelDeprecation,
+        )
         #endif
     }
 }

--- a/Sources/PackageLoading/PackageBuilder.swift
+++ b/Sources/PackageLoading/PackageBuilder.swift
@@ -1595,7 +1595,15 @@ public final class PackageBuilder {
                 }
             }
 
-            try append(Product(package: self.identity, name: product.name, type: product.type, modules: modules))
+            try append(
+                Product(
+                    package: self.identity,
+                    name: product.name,
+                    type: product.type,
+                    modules: modules,
+                    deprecation: product.deprecation,
+                )
+            )
         }
 
         // Add implicit executables - for root packages and for dependency plugins.

--- a/Sources/PackageManagerDocs/Documentation.docc/Dependencies/AddingDependencies.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Dependencies/AddingDependencies.md
@@ -115,6 +115,7 @@ For more information on creating a binary target, see [Creating a multiplatform 
 
 - <doc:ResolvingPackageVersions>
 - <doc:PackageTraits>
+- <doc:DeprecatingProducts>
 - <doc:ResolvingDependencyFailures>
 - <doc:AddingSystemLibraryDependency>
 - <doc:ExampleSystemLibraryPkgConfig>

--- a/Sources/PackageManagerDocs/Documentation.docc/Dependencies/DeprecatingProducts.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Dependencies/DeprecatingProducts.md
@@ -1,0 +1,137 @@
+# Deprecating package products
+
+Signal to consumers that a product should no longer be used, optionally
+pointing them at a replacement.
+
+## Overview
+
+When you evolve a package, you sometimes need to steer consumers off of a
+product you can no longer support — because it's been superseded by a
+better-designed replacement, moved to a different package, or is being
+retired entirely. Swift Package Manager lets you record that intent
+directly in `Package.swift`, so consumers see a diagnostic at build time
+and can survey the state of their dependency graph on demand.
+
+Use the `deprecated:` parameter on `.library(...)`, `.executable(...)`, or
+`.plugin(...)` to mark a product as unsupported. The parameter accepts a
+value produced by `Product.Deprecation.unsupported(message:replacement:)`.
+Both `message:` and `replacement:` are optional — omit them both to signal
+a bare "unsupported" state with no additional guidance.
+
+```swift
+// swift-tools-version: 6.5
+import PackageDescription
+
+let package = Package(
+    name: "Paper",
+    products: [
+        .library(name: "Paper", targets: ["Paper"]),
+
+        // Replaced by another product in the same package.
+        .library(
+            name: "PaperLegacy",
+            targets: ["PaperLegacy"],
+            deprecated: .unsupported(
+                message: "PaperLegacy is superseded by Paper.",
+                replacement: .renamed("Paper")
+            )
+        ),
+
+        // Retired with no advertised replacement.
+        .library(
+            name: "PaperExperimental",
+            targets: ["PaperExperimental"],
+            deprecated: .unsupported(
+                message: "PaperExperimental is going away with no replacement."
+            )
+        ),
+
+        // Superseded by a product in another package.
+        .executable(
+            name: "paper-tool-old",
+            targets: ["paper-tool-old"],
+            deprecated: .unsupported(
+                message: "Migrate to the standalone paper-tools package.",
+                replacement: .renamed("paper-tool", package: "paper-tools")
+            )
+        ),
+    ],
+    targets: [
+        .target(name: "Paper"),
+        .target(name: "PaperLegacy", dependencies: ["Paper"]),
+        .target(name: "PaperExperimental"),
+        .executableTarget(name: "paper-tool-old"),
+    ]
+)
+```
+
+The `deprecated:` parameter is optional and defaults to `nil`. Existing
+packages are unaffected.
+
+### Describing the replacement
+
+`Product.Deprecation.Replacement` has a single factory,
+`.renamed(_ product:package:)`, that identifies the product a consumer
+should adopt in place of the unsupported product.
+
+- Omit `package:` when the replacement lives in the same package as the
+  deprecated product. Example: `.renamed("Paper")`.
+- Pass `package:` when the replacement lives in a different package that
+  consumers must already depend on. Example:
+  `.renamed("paper-tool", package: "paper-tools")`.
+
+Swift Package Manager does not verify that a replacement product actually
+exists in the referenced package — unresolved names are surfaced as-is in
+the diagnostic, mirroring how `@available(_, renamed:)` behaves in the
+Swift compiler.
+
+## Diagnostic behavior for consumers
+
+When a consumer package's target depends on a deprecated product, Swift
+Package Manager emits a warning through its diagnostic system during graph
+resolution. `swift build`, `swift test` and `swift package resolve` all
+surface the diagnostic. The warning text is derived from the `message:`
+(if any) and the `replacement:` locator:
+
+- Same-package replacement — appended sentence: `Use 'X' instead.`
+- Cross-package replacement — appended sentence:
+  `Use 'X' from package 'P' instead.`
+- No replacement — no additional sentence; the message alone is emitted.
+
+The warning is emitted once per consuming target that references the
+deprecated product. It is emitted by SwiftPM itself (not by the Swift
+compiler), so it applies uniformly to libraries, executables, and plugins.
+
+If the consuming target opts into `.treatAllWarnings(as: .error)` in its
+Swift build settings, or if the build invocation passes
+`-Xswiftc -warnings-as-errors`, the deprecation diagnostic is escalated
+from a warning to an error, matching how the compiler treats its own
+deprecation diagnostics.
+
+## Interaction with `dump-package`
+
+The output of <doc:PackageDumpPackage> gains an optional `deprecation`
+object on each deprecated product, with the following shape:
+
+```json
+{
+  "message": "PaperLegacy is superseded by Paper.",
+  "replacement": {
+    "kind": "renamed",
+    "product": "Paper"
+  }
+}
+```
+
+The `replacement` object always has `kind: "renamed"` and a `product`
+string. A `package` field is present only when the replacement lives in a
+different package. Products without a `deprecated:` argument have no
+`deprecation` key in the dumped JSON, so existing consumers of
+`dump-package` output are unaffected.
+
+## Tools-version requirement
+
+Manifests that declare `deprecated:` require a Swift tools-version of
+`6.5` or later. Older tools versions parse the manifest without
+recognizing the parameter, matching how other version-gated `Package.swift`
+API is handled.

--- a/Sources/PackageManagerDocs/Documentation.docc/Development.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Development.md
@@ -1,0 +1,6 @@
+# SwiftPM 999.0 Release Notes
+
+
+## SE-#### Allow deprecating package products
+
+read more <doc:DeprecatingProducts>

--- a/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/Documentation.md
@@ -37,6 +37,7 @@ The Swift Package Manager lets you share your code as a package, depend on and u
 - <doc:AddingDependencies>
 - <doc:UsingSwiftPackageRegistry>
 - <doc:BundlingResources>
+- <doc:DeprecatingProducts>
 
 ### Targets
 - <doc:CreatingCLanguageTargets>

--- a/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes.md
+++ b/Sources/PackageManagerDocs/Documentation.docc/ReleaseNotes.md
@@ -11,3 +11,4 @@
 - <doc:5.5>
 - <doc:5.4>
 - <doc:5.3>
+- <doc:Development>

--- a/Sources/PackageModel/Manifest/ProductDescription.swift
+++ b/Sources/PackageModel/Manifest/ProductDescription.swift
@@ -27,11 +27,15 @@ public struct ProductDescription: Hashable, Codable, Sendable {
     /// The product-specific settings declared for this product.
     public let settings: [ProductSetting]
 
+    /// The deprecation information declared for the product, if any.
+    public let deprecation: ProductDeprecation?
+
     public init(
         name: String,
         type: ProductType,
         targets: [String],
-        settings: [ProductSetting] = []
+        settings: [ProductSetting] = [],
+        deprecation: ProductDeprecation? = nil,
     ) throws {
         guard type != .test else {
             throw InternalError("Declaring test products isn't supported: \(name):\(targets)")
@@ -40,6 +44,81 @@ public struct ProductDescription: Hashable, Codable, Sendable {
         self.type = type
         self.targets = targets
         self.settings = settings
+        self.deprecation = deprecation
+    }
+}
+
+/// The deprecation state of a product declared in a package manifest.
+public struct ProductDeprecation: Hashable, Codable, Sendable {
+    /// The product a consumer should adopt in place of an unsupported product.
+    ///
+    /// This enum is non-frozen: additional cases may be introduced in future evolution.
+    public enum Replacement: Hashable, Sendable {
+        /// The replacement product. When `package` is nil the replacement lives
+        /// in the same package as the deprecated product; otherwise it lives in
+        /// the named package (which the consumer must already depend on).
+        case renamed(_ product: String, package: String? = nil)
+    }
+
+    /// An author-supplied human-readable explanation of the deprecation.
+    public let message: String?
+
+    /// The product a consumer should adopt in place of the unsupported product.
+    public let replacement: Replacement?
+
+    public init(
+        message: String?,
+        replacement: Replacement?,
+    ) {
+        self.message = message
+        self.replacement = replacement
+    }
+}
+
+extension ProductDeprecation.Replacement: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case product
+        case package
+    }
+
+    private enum Kind: String, Codable {
+        case renamed
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .renamed(let product, let package):
+            try container.encode(Kind.renamed, forKey: .kind)
+            try container.encode(product, forKey: .product)
+            try container.encodeIfPresent(package, forKey: .package)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .renamed:
+            self = .renamed(
+                try container.decode(String.self, forKey: .product),
+                package: try container.decodeIfPresent(String.self, forKey: .package),
+            )
+        }
+    }
+}
+
+extension ProductDeprecation.Replacement {
+    /// A human-readable sentence pointing the consumer at the replacement,
+    /// suitable for appending to a deprecation diagnostic.
+    public var formattedInstruction: String {
+        switch self {
+        case .renamed(let product, nil):
+            return "Use '\(product)' instead."
+        case .renamed(let product, let package?):
+            return "Use '\(product)' from package '\(package)' instead."
+        }
     }
 }
 

--- a/Sources/PackageModel/Product.swift
+++ b/Sources/PackageModel/Product.swift
@@ -36,6 +36,9 @@ public class Product: Identifiable {
     /// Was this product implicitly created
     public let isImplicit: Bool
 
+    /// The deprecation information declared for this product, if any.
+    public let deprecation: ProductDeprecation?
+
     /// The suffix for REPL product name.
     public static let replProductSuffix: String = "__REPL"
 
@@ -45,7 +48,8 @@ public class Product: Identifiable {
         type: ProductType,
         modules: [Module],
         testEntryPointPath: AbsolutePath? = nil,
-        isImplicit: Bool = false
+        isImplicit: Bool = false,
+        deprecation: ProductDeprecation? = nil,
     ) throws {
         guard !modules.isEmpty else {
             throw InternalError("Targets cannot be empty")
@@ -67,6 +71,7 @@ public class Product: Identifiable {
         self.modules = modules
         self.testEntryPointPath = testEntryPointPath
         self.isImplicit = isImplicit
+        self.deprecation = deprecation
     }
 }
 

--- a/Sources/PackageModel/ToolsVersion.swift
+++ b/Sources/PackageModel/ToolsVersion.swift
@@ -36,6 +36,7 @@ public struct ToolsVersion: Equatable, Hashable, Codable, Sendable {
     public static let v6_2 = ToolsVersion(version: "6.2.0")
     public static let v6_3 = ToolsVersion(version: "6.3.0")
     public static let v6_4 = ToolsVersion(version: "6.4.0")
+    public static let v6_5 = ToolsVersion(version: "6.5.0")
     public static let vNext = ToolsVersion(version: "999.0.0")
 
     /// The current tools version in use.

--- a/Sources/Runtimes/PackageDescription/PackageDescriptionSerialization.swift
+++ b/Sources/Runtimes/PackageDescription/PackageDescriptionSerialization.swift
@@ -260,9 +260,51 @@ enum Serialization {
             case plugin
         }
 
+        struct Deprecation: Codable {
+            enum Replacement: Codable {
+                case renamed(_ product: String, package: String? = nil)
+
+                private enum CodingKeys: String, CodingKey {
+                    case kind
+                    case product
+                    case package
+                }
+
+                private enum Kind: String, Codable {
+                    case renamed
+                }
+
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self {
+                    case .renamed(let product, let package):
+                        try container.encode(Kind.renamed, forKey: .kind)
+                        try container.encode(product, forKey: .product)
+                        try container.encodeIfPresent(package, forKey: .package)
+                    }
+                }
+
+                init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    let kind = try container.decode(Kind.self, forKey: .kind)
+                    switch kind {
+                    case .renamed:
+                        self = .renamed(
+                            try container.decode(String.self, forKey: .product),
+                            package: try container.decodeIfPresent(String.self, forKey: .package),
+                        )
+                    }
+                }
+            }
+
+            let message: String?
+            let replacement: Replacement?
+        }
+
         let name: String
         let targets: [String]
         let productType: ProductType
+        let deprecation: Deprecation?
 
         #if ENABLE_APPLE_PRODUCT_TYPES
         let settings: [ProductSetting]

--- a/Sources/Runtimes/PackageDescription/PackageDescriptionSerializationConversion.swift
+++ b/Sources/Runtimes/PackageDescription/PackageDescriptionSerializationConversion.swift
@@ -363,6 +363,7 @@ extension Serialization.Product {
         self.name = executable.name
         self.targets = executable.targets
         self.productType = .executable
+        self.deprecation = executable.deprecation.map(Serialization.Product.Deprecation.init)
         #if ENABLE_APPLE_PRODUCT_TYPES
         self.settings = executable.settings.map { .init($0) }
         #endif
@@ -373,6 +374,7 @@ extension Serialization.Product {
         self.targets = library.targets
         let libraryType = library.type.map { ProductType.LibraryType($0) } ?? .automatic
         self.productType = .library(type: libraryType)
+        self.deprecation = library.deprecation.map(Serialization.Product.Deprecation.init)
         #if ENABLE_APPLE_PRODUCT_TYPES
         self.settings = []
         #endif
@@ -382,9 +384,26 @@ extension Serialization.Product {
         self.name = plugin.name
         self.targets = plugin.targets
         self.productType = .plugin
+        self.deprecation = plugin.deprecation.map(Serialization.Product.Deprecation.init)
         #if ENABLE_APPLE_PRODUCT_TYPES
         self.settings = []
         #endif
+    }
+}
+
+extension Serialization.Product.Deprecation {
+    init(_ deprecation: PackageDescription.Product.Deprecation) {
+        self.message = deprecation.message
+        self.replacement = deprecation.replacement.map(Replacement.init)
+    }
+}
+
+extension Serialization.Product.Deprecation.Replacement {
+    init(_ replacement: PackageDescription.Product.Deprecation.Replacement) {
+        switch replacement.storage {
+        case .renamed(let product, let package):
+            self = .renamed(product, package: package)
+        }
     }
 }
 

--- a/Sources/Runtimes/PackageDescription/Product.swift
+++ b/Sources/Runtimes/PackageDescription/Product.swift
@@ -63,23 +63,38 @@ public class Product {
     /// The name of the package product.
     public let name: String
 
-    init(name: String) {
+    /// The deprecation declared for this product, if any.
+    let deprecation: Deprecation?
+
+    init(
+        name: String,
+        deprecation: Deprecation? = nil,
+    ) {
         self.name = name
+        self.deprecation = deprecation
     }
 
     /// The executable product of a Swift package.
     public final class Executable: Product, @unchecked Sendable {
         /// The names of the targets in this product.
         public let targets: [String]
-        
+
         /// Any specific product settings that apply to this product.
         @_spi(PackageProductSettings)
         public let settings: [ProductSetting]
 
-        init(name: String, targets: [String], settings: [ProductSetting]) {
+        init(
+            name: String,
+            targets: [String],
+            settings: [ProductSetting],
+            deprecation: Deprecation? = nil,
+        ) {
             self.targets = targets
             self.settings = settings
-            super.init(name: name)
+            super.init(
+                name: name,
+                deprecation: deprecation,
+            )
         }
     }
 
@@ -102,10 +117,18 @@ public class Product {
         /// based on the client's preference.
         public let type: LibraryType?
 
-        init(name: String, type: LibraryType? = nil, targets: [String]) {
+        init(
+            name: String,
+            type: LibraryType? = nil,
+            targets: [String],
+            deprecation: Deprecation? = nil,
+        ) {
             self.type = type
             self.targets = targets
-            super.init(name: name)
+            super.init(
+                name: name,
+                deprecation: deprecation,
+            )
         }
     }
 
@@ -114,9 +137,16 @@ public class Product {
         /// The name of the plug-in target to vend as a product.
         public let targets: [String]
 
-        init(name: String, targets: [String]) {
+        init(
+            name: String,
+            targets: [String],
+            deprecation: Deprecation? = nil,
+        ) {
             self.targets = targets
-            super.init(name: name)
+            super.init(
+                name: name,
+                deprecation: deprecation,
+            )
         }
     }
 
@@ -187,6 +217,130 @@ public class Product {
     ) -> Product {
         return Plugin(name: name, targets: targets)
     }
+
+    /// Creates a library product that a package consumer can adopt, with an optional
+    /// deprecation declaration.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the library product.
+    ///   - type: The optional type of the library.
+    ///   - targets: The targets that are bundled into the library product.
+    ///   - deprecated: An optional ``Product/Deprecation`` value describing the deprecation
+    ///     state of the product. When set, consumers of the product see a warning at
+    ///     build time.
+    ///
+    /// - Returns: A `Product` instance.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func library(
+        name: String,
+        type: Library.LibraryType? = nil,
+        targets: [String],
+        deprecated: Deprecation? = nil,
+    ) -> Product {
+        return Library(
+            name: name,
+            type: type,
+            targets: targets,
+            deprecation: deprecated,
+        )
+    }
+
+    /// Creates an executable package product with an optional deprecation declaration.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the executable product.
+    ///   - targets: The targets to bundle into an executable product.
+    ///   - deprecated: An optional ``Product/Deprecation`` value describing the deprecation
+    ///     state of the product.
+    /// - Returns: A `Product` instance.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func executable(
+        name: String,
+        targets: [String],
+        deprecated: Deprecation? = nil,
+    ) -> Product {
+        return Executable(
+            name: name,
+            targets: targets,
+            settings: [],
+            deprecation: deprecated,
+        )
+    }
+
+    /// Defines a plugin product with an optional deprecation declaration.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the plugin product.
+    ///   - targets: The plugin targets to vend as a product.
+    ///   - deprecated: An optional ``Product/Deprecation`` value describing the deprecation
+    ///     state of the product.
+    /// - Returns: A `Product` instance.
+    @available(_PackageDescription, introduced: 999.0)
+    public static func plugin(
+        name: String,
+        targets: [String],
+        deprecated: Deprecation? = nil,
+    ) -> Product {
+        return Plugin(
+            name: name,
+            targets: targets,
+            deprecation: deprecated,
+        )
+    }
+}
+
+extension Product {
+    /// Describes the deprecation state of a package product.
+    ///
+    /// Values of this type are constructed exclusively through the static factory below.
+    /// The type intentionally exposes no public properties so future evolution can add
+    /// deprecation metadata without a source or ABI break.
+    public struct Deprecation: Sendable, Equatable {
+        // Storage is internal so PackageDescriptionSerializationConversion can read it.
+        internal let message: String?
+        internal let replacement: Replacement?
+
+        /// Marks a product as unsupported.
+        ///
+        /// - Parameters:
+        ///   - message: A human-readable explanation of the deprecation.
+        ///   - replacement: An optional locator identifying the product consumers should
+        ///     adopt instead. When `nil`, the product is retired with no advertised
+        ///     replacement.
+        public static func unsupported(
+            message: String? = nil,
+            replacement: Replacement? = nil,
+        ) -> Deprecation {
+            return Deprecation(
+                message: message,
+                replacement: replacement,
+            )
+        }
+
+        /// Identifies the product a consumer should adopt in place of an unsupported product.
+        ///
+        /// Values of this type are constructed exclusively through the static factories below.
+        public struct Replacement: Sendable, Equatable {
+            internal enum Storage: Sendable, Equatable {
+                case renamed(product: String, package: String?)
+            }
+            internal let storage: Storage
+
+            /// The replacement product a consumer should adopt.
+            ///
+            /// - Parameters:
+            ///   - product: The name of the replacement product.
+            ///   - package: The identity of the package that vends the replacement.
+            ///     Omit (or pass `nil`) when the replacement lives in the same
+            ///     package as the deprecated product.
+            public static func renamed(
+                _ product: String,
+                package: String? = nil,
+            ) -> Replacement {
+                return Replacement(storage: .renamed(product: product, package: package))
+            }
+        }
+    }
 }
 
 
@@ -237,18 +391,18 @@ public enum ProductSetting: Equatable {
             // Named asset in an asset catalog.
             case asset(String)
         }
-        
+
         /// Represents a family of device types that an application can support.
         public enum DeviceFamily: String, Equatable {
             case phone
             case pad
             case mac
         }
-        
+
         /// Represents a condition on a particular device family.
         public struct DeviceFamilyCondition: Equatable {
             public var deviceFamilies: [DeviceFamily]
-            
+
             public init(deviceFamilies: [DeviceFamily]) {
                 self.deviceFamilies = deviceFamilies
             }
@@ -256,7 +410,7 @@ public enum ProductSetting: Equatable {
                 return DeviceFamilyCondition(deviceFamilies: deviceFamilies)
             }
         }
-        
+
         /// Represents a supported device interface orientation.
         public enum InterfaceOrientation: Equatable {
             case portrait(_ condition: DeviceFamilyCondition? = nil)
@@ -269,7 +423,7 @@ public enum ProductSetting: Equatable {
             public static var landscapeRight: Self { landscapeRight(nil) }
             public static var landscapeLeft: Self { landscapeLeft(nil) }
         }
-        
+
         /// A capability required by the device.
         public enum Capability: Equatable {
             case appTransportSecurity(configuration: AppTransportSecurityConfiguration, _ condition: DeviceFamilyCondition? = nil)
@@ -294,7 +448,7 @@ public enum ProductSetting: Equatable {
             case speechRecognition(purposeString: String, _ condition: DeviceFamilyCondition? = nil)
             case userTracking(purposeString: String, _ condition: DeviceFamilyCondition? = nil)
         }
-        
+
         public struct AppTransportSecurityConfiguration: Equatable {
             public var allowsArbitraryLoadsInWebContent: Bool? = nil
             public var allowsArbitraryLoadsForMedia: Bool? = nil
@@ -326,13 +480,13 @@ public enum ProductSetting: Equatable {
                     self.requiresCertificateTransparency = requiresCertificateTransparency
                 }
             }
-            
+
             public struct PinnedDomain: Equatable {
                 public var domainName: String
                 public var includesSubdomains : Bool? = nil
                 public var pinnedCAIdentities : [[String: String]]? = nil
                 public var pinnedLeafIdentities : [[String: String]]? = nil
-                
+
                 public init(
                     domainName: String,
                     includesSubdomains: Bool? = nil,
@@ -345,7 +499,7 @@ public enum ProductSetting: Equatable {
                     self.pinnedLeafIdentities = pinnedLeafIdentities
                 }
             }
-            
+
             public init(
                 allowsArbitraryLoadsInWebContent: Bool? = nil,
                 allowsArbitraryLoadsForMedia: Bool? = nil,
@@ -395,7 +549,7 @@ public enum ProductSetting: Equatable {
                 }
             }
         }
-        
+
         public struct AppCategory: Equatable, ExpressibleByStringLiteral {
             public var rawValue: String
 

--- a/Sources/Workspace/Workspace.swift
+++ b/Sources/Workspace/Workspace.swift
@@ -1001,7 +1001,8 @@ extension Workspace {
         customXCTestMinimumDeploymentTargets: [PackageModel.Platform: PlatformVersion]? = .none,
         testEntryPointPath: AbsolutePath? = nil,
         expectedSigningEntities: [PackageIdentity: RegistryReleaseMetadata.SigningEntity] = [:],
-        observabilityScope: ObservabilityScope
+        observabilityScope: ObservabilityScope,
+        treatWarningsAsErrors: Bool = false,
     ) async throws -> ModulesGraph {
         let start = DispatchTime.now()
         self.delegate?.willLoadGraph()
@@ -1062,7 +1063,8 @@ extension Workspace {
             testEntryPointPath: testEntryPointPath,
             fileSystem: self.fileSystem,
             observabilityScope: observabilityScope,
-            enabledTraitsMap: self.enabledTraitsMap
+            enabledTraitsMap: self.enabledTraitsMap,
+            treatWarningsAsErrors: treatWarningsAsErrors,
         )
 
         try self.validateSignatures(

--- a/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+Tags.swift
@@ -77,6 +77,7 @@ extension Tag.FunctionalArea {
     @Tag public static var Sanitizer: Tag
     @Tag public static var LibraryEvoluton: Tag
     @Tag public static var LinkSwiftStaticStdlib: Tag
+    @Tag public static var Manifest: Tag
     @Tag public static var Metal: Tag
     @Tag public static var ModuleMaps: Tag
     @Tag public static var Resources: Tag
@@ -96,6 +97,7 @@ extension Tag.Feature {
     @Tag public static var BuildCache: Tag
     @Tag public static var CodeCoverage: Tag
     @Tag public static var CTargets: Tag
+    @Tag public static var Deprecation: Tag
     @Tag public static var DependencyResolution: Tag
     @Tag public static var ModuleAliasing: Tag
     @Tag public static var Mirror: Tag

--- a/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
+++ b/Sources/_InternalTestSupport/SwiftTesting+TraitConditional.swift
@@ -268,4 +268,15 @@ extension Trait where Self == Testing.ConditionTrait {
         }
     }
 
+    /// Skip test if compiler is older than 6.5.
+    public static var requireSwift6_5: Self {
+        enabled("This test requires Swift 6.5, or newer.") {
+            #if compiler(>=6.5)
+                true
+            #else
+                false
+            #endif
+        }
+    }
+
 }

--- a/Tests/CommandsTests/BuildCommandTests.swift
+++ b/Tests/CommandsTests/BuildCommandTests.swift
@@ -2036,6 +2036,126 @@ struct BuildCommandTestCases {
             #expect(hasOptRecord, "Should have .opt.yaml files in custom directory")
         }
     }
+
+    // MARK: - Product deprecation (SE-NNNN)
+
+    @Suite(
+        .tags(
+            .Feature.Deprecation,
+        ),
+    )
+    struct ProductDeprecation {
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildEmitsWarningForConsumerOfDeprecatedProduct(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    try await executeSwiftBuild(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperExperimental' from package 'producer' is unsupported: PaperExperimental is going away with no replacement.",
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                     #expect(
+                        error.stderr.contains(
+                            "warning: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+               }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildEscalatesToErrorForTargetWithTreatAllWarningsError(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    _ = try await executeSwiftBuild(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        extraArgs: ["--target", "MyLib"],
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperExperimental' from package 'producer' is unsupported: PaperExperimental is going away with no replacement.",
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                    #expect(
+                        error.stderr.contains(
+                            "warning: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildEscalatesToErrorViaXswiftcWarningsAsErrors(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    try await executeSwiftBuild(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        extraArgs: [
+                            "--target", "MyApp",
+                            "-Xswiftc", "-warnings-as-errors",
+                        ],
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func buildDoesNotWarnForNonConsumingPackage(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/producer") { fixturePath in
+                let (stdout, stderr) = try await executeSwiftBuild(
+                    fixturePath,
+                    configuration: .debug,
+                    buildSystem: buildSystem,
+                )
+                #expect(!stderr.contains("is unsupported"))
+                #expect(!stdout.contains("is unsupported"))
+            }
+        }
+    }
 }
 
 extension Triple {

--- a/Tests/CommandsTests/PackageCommandTests.swift
+++ b/Tests/CommandsTests/PackageCommandTests.swift
@@ -97,6 +97,15 @@ private func executeAddURLDependencyAndAssert(
     ),
 )
 struct PackageCommandTests {
+
+    @Suite(
+        .tags(
+            .TestSize.large,
+            .Feature.Command.Package.Resolve,
+        ),
+    )
+    enum PackageResolveCommandTests { }
+
     @Test(
         arguments: SupportedBuildSystemOnAllPlatforms,
     )
@@ -1239,6 +1248,69 @@ struct PackageCommandTests {
                 ]
             )
             // FIXME: We should also test dependencies and targets here.
+        }
+    }
+
+    @Test(
+        .tags(
+            .Feature.Command.Package.DumpPackage,
+            .Feature.Deprecation,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func dumpPackageIncludesProductDeprecation(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        let config = BuildConfiguration.debug
+        try await fixture(name: "Miscellaneous/DeprecatedProducts") { fixturePath in
+            let packageRoot = fixturePath.appending("producer")
+            let (dumpOutput, _) = try await execute(
+                ["dump-package"],
+                packagePath: packageRoot,
+                configuration: config,
+                buildSystem: buildSystem,
+            )
+            let data = Data(dumpOutput.utf8)
+            let root = try #require(
+                try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            )
+            let products = try #require(root["products"] as? [[String: Any]])
+            let byName = Dictionary(
+                uniqueKeysWithValues: products.compactMap { product -> (String, [String: Any])? in
+                    guard let name = product["name"] as? String else { return nil }
+                    return (name, product)
+                },
+            )
+
+            // Control: `Paper` has no `deprecation` key.
+            let paper = try #require(byName["Paper"])
+            #expect(paper["deprecation"] == nil)
+
+            // `PaperLegacy` uses `.renamed("Paper")` (same-package).
+            let paperLegacy = try #require(byName["PaperLegacy"])
+            let legacyDeprecation = try #require(paperLegacy["deprecation"] as? [String: Any])
+            #expect(legacyDeprecation["message"] as? String == "PaperLegacy is superseded by Paper.")
+            let legacyReplacement = try #require(legacyDeprecation["replacement"] as? [String: Any])
+            #expect(legacyReplacement["kind"] as? String == "renamed")
+            #expect(legacyReplacement["product"] as? String == "Paper")
+            #expect(legacyReplacement["package"] == nil)
+
+            // `PaperExperimental` has a message but no replacement.
+            let experimental = try #require(byName["PaperExperimental"])
+            let experimentalDeprecation = try #require(experimental["deprecation"] as? [String: Any])
+            #expect(
+                experimentalDeprecation["message"] as? String
+                    == "PaperExperimental is going away with no replacement.",
+            )
+            #expect(experimentalDeprecation["replacement"] == nil)
+
+            // `paper-tool-old` uses `.renamed(_:package:)` (cross-package).
+            let tool = try #require(byName["paper-tool-old"])
+            let toolDeprecation = try #require(tool["deprecation"] as? [String: Any])
+            let toolReplacement = try #require(toolDeprecation["replacement"] as? [String: Any])
+            #expect(toolReplacement["kind"] as? String == "renamed")
+            #expect(toolReplacement["package"] as? String == "paper-tools")
+            #expect(toolReplacement["product"] as? String == "paper-tool")
         }
     }
 

--- a/Tests/CommandsTests/PackageCommandtests+Resolve.swift
+++ b/Tests/CommandsTests/PackageCommandtests+Resolve.swift
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import _InternalTestSupport
+
+import struct SPMBuildCore.BuildSystemProvider
+
+extension PackageCommandTests.PackageResolveCommandTests {
+
+    @Suite(
+        .tags(
+            .Feature.Deprecation,
+        ),
+    )
+    struct ProductDeprecation {
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func resolveEmitsWarningForConsumerOfDeprecatedProduct(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    try await executeSwiftPackage(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperExperimental' from package 'producer' is unsupported: PaperExperimental is going away with no replacement.",
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                     #expect(
+                        error.stderr.contains(
+                            "warning: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+               }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func resolveEscalatesToErrorViaXswiftcWarningsAsErrors(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/") { fixturePath in
+                await expectThrowsCommandExecutionError(
+                    try await executeSwiftPackage(
+                        fixturePath.appending("consumer"),
+                        configuration: .debug,
+                        extraArgs: [
+                            "resolve",
+                            "-Xswiftc", "-warnings-as-errors",
+                        ],
+                        buildSystem: buildSystem,
+                    )
+                ) { error in
+                    #expect(
+                        error.stderr.contains(
+                            "error: 'consumer': product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead."
+                        ),
+                        "stdout:\n\(error.stdout)",
+                    )
+                }
+            }
+        }
+
+        @Test(
+            // .requireSwift6_5,
+            arguments: SupportedBuildSystemOnAllPlatforms,
+        )
+        func resolveDoesNotWarnForNonConsumingPackage(
+            buildSystem: BuildSystemProvider.Kind,
+        ) async throws {
+            try await fixture(name: "Miscellaneous/DeprecatedProducts/producer") { fixturePath in
+                let (_, stderr) = try await executeSwiftPackage(
+                    fixturePath,
+                    configuration: .debug,
+                    extraArgs: ["resolve"],
+                    buildSystem: buildSystem,
+                )
+                #expect(!stderr.contains("is unsupported"))
+            }
+        }
+    }
+
+
+}

--- a/Tests/PackageGraphTests/ModulesGraphTests+ProductDeprecation.swift
+++ b/Tests/PackageGraphTests/ModulesGraphTests+ProductDeprecation.swift
@@ -1,0 +1,992 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageModel
+import TSCUtility
+import Testing
+import _InternalTestSupport
+
+@_spi(DontAdoptOutsideOfSwiftPMExposedForBenchmarksAndTestsOnly)
+@testable import PackageGraph
+
+extension ModulesGraphTests {
+
+    @Suite(
+        .tags(
+            .TestSize.medium,
+            .Feature.Deprecation,
+        ),
+    )
+    struct ModulesGraphProductDeprecationTests {
+        // MARK: - Deprecation warning text (per SE-NNNN)
+
+        @Test
+        func deprecation_emitsWarningWithRenamedReplacement() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Paper/source.swift",
+                    "/Producer/Sources/PaperLegacy/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "PaperLegacy", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Paper",
+                                type: .library(.automatic),
+                                targets: ["Paper"],
+                            ),
+                            try ProductDescription(
+                                name: "PaperLegacy",
+                                type: .library(.automatic),
+                                targets: ["PaperLegacy"],
+                                deprecation: ProductDeprecation(
+                                    message: "PaperLegacy is superseded by Paper.",
+                                    replacement: .renamed("Paper"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Paper"),
+                            TargetDescription(name: "PaperLegacy", dependencies: ["Paper"]),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'PaperLegacy' from package 'producer' is unsupported: PaperLegacy is superseded by Paper. Use 'Paper' instead.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        @Test
+        func deprecation_emitsWarningWithInPackageReplacement() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/paper-tool-old/main.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "paper-tool-old", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "paper-tool-old",
+                                type: .executable,
+                                targets: ["paper-tool-old"],
+                                deprecation: ProductDeprecation(
+                                    message: "Migrate to the standalone paper-tools package.",
+                                    replacement: .renamed("paper-tool", package: "paper-tools"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "paper-tool-old", type: .executable),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'paper-tool-old' from package 'producer' is unsupported: Migrate to the standalone paper-tools package. Use 'paper-tool' from package 'paper-tools' instead.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        @Test
+        func deprecation_emitsWarningWithoutReplacement() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/PaperExperimental/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "PaperExperimental", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "PaperExperimental",
+                                type: .library(.automatic),
+                                targets: ["PaperExperimental"],
+                                deprecation: ProductDeprecation(
+                                    message: "PaperExperimental is going away with no replacement.",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "PaperExperimental"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'PaperExperimental' from package 'producer' is unsupported: PaperExperimental is going away with no replacement.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        @Test
+        func deprecation_emitsBareWarningWhenNoMessageAndNoReplacement() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Bare/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Bare", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Bare",
+                                type: .library(.automatic),
+                                targets: ["Bare"],
+                                deprecation: ProductDeprecation(
+                                    message: nil,
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Bare"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Bare' from package 'producer' is unsupported",
+                    severity: .warning,
+                )
+            }
+        }
+
+        // MARK: - Non-consumer producer emits no diagnostic
+
+        @Test
+        func deprecation_producerAloneEmitsNoDiagnostic() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles: "/Producer/Sources/PaperLegacy/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "PaperLegacy",
+                                type: .library(.automatic),
+                                targets: ["PaperLegacy"],
+                                deprecation: ProductDeprecation(
+                                    message: "old",
+                                    replacement: .renamed("New"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "PaperLegacy"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+            expectNoDiagnostics(observability.diagnostics)
+        }
+
+        // MARK: - Escalation via per-target treatAllWarnings(.error)
+
+        @Test
+        func deprecation_escalatesToErrorWhenConsumerHasTreatAllWarningsError() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .error,
+                )
+            }
+        }
+
+        // MARK: - Escalation via loadModulesGraph(treatWarningsAsErrors:)
+
+        @Test
+        func deprecation_escalatesToErrorWhenTreatWarningsAsErrorsGloballySet() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+                treatWarningsAsErrors: true,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .error,
+                )
+            }
+        }
+
+        // MARK: - Executable and plugin products
+
+        @Test
+        func deprecation_appliesToPluginProduct() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Plugins/OldPlugin/plugin.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "OldPlugin", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "OldPlugin",
+                                type: .plugin,
+                                targets: ["OldPlugin"],
+                                deprecation: ProductDeprecation(
+                                    message: nil,
+                                    replacement: .renamed("NewPlugin"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "OldPlugin",
+                                type: .plugin,
+                                pluginCapability: .buildTool,
+                            ),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'OldPlugin' from package 'producer' is unsupported: Use 'NewPlugin' instead.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        // MARK: - Extended treat-warnings-as-error coverage
+
+        /// `treatAllWarnings(.warning)` (explicit warning level) is a no-op for escalation:
+        /// the deprecation stays a warning.
+        @Test
+        func deprecation_treatAllWarningsWarningLevelDoesNotEscalate() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.warning),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// C-family `treatAllWarnings(.error)` should not escalate SwiftPM's own
+        /// deprecation diagnostic — the flag only applies to the Swift tool.
+        @Test
+        func deprecation_cTreatAllWarningsDoesNotEscalate() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .c,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                    .init(
+                                        tool: .cxx,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// A per-warning escalation via `treatWarning(name:as:)` does not escalate
+        /// the SwiftPM-emitted deprecation diagnostic. Only `treatAllWarnings(.error)`
+        /// on the Swift tool (or the global `-warnings-as-errors`) does.
+        @Test
+        func deprecation_treatSpecificWarningDoesNotEscalate() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatWarning("DeprecatedDeclaration", .error),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// Per-target escalation is scoped to the target that opted in — a second
+        /// consumer target without the setting keeps the plain warning severity.
+        @Test
+        func deprecation_perTargetEscalationDoesNotAffectOtherTargets() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/ConsumerStrict/source.swift",
+                    "/Consumer/Sources/ConsumerLoose/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "ConsumerStrict",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                            TargetDescription(
+                                name: "ConsumerLoose",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            // One error (from ConsumerStrict) and one warning (from ConsumerLoose).
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.checkUnordered(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .error,
+                )
+                result.checkUnordered(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// Two deprecated products in the producer, each consumed by a different
+        /// consumer target. Only the strict consumer's product diagnostic escalates
+        /// to an error; the loose consumer's stays a warning. Each product produces
+        /// exactly one diagnostic (from its one consumer).
+        @Test
+        func deprecation_twoProductsWithPerTargetEscalationScopedIndependently() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/ConsumerStrict/source.swift",
+                    "/Consumer/Sources/ConsumerLoose/source.swift",
+                    "/Producer/Sources/OldA/source.swift",
+                    "/Producer/Sources/OldB/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "ConsumerStrict",
+                                dependencies: [
+                                    .product(name: "OldA", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                            TargetDescription(
+                                name: "ConsumerLoose",
+                                dependencies: [
+                                    .product(name: "OldB", package: "Producer"),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "OldA",
+                                type: .library(.automatic),
+                                targets: ["OldA"],
+                                deprecation: ProductDeprecation(
+                                    message: "OldA is gone.",
+                                    replacement: .renamed("NewA"),
+                                ),
+                            ),
+                            try ProductDescription(
+                                name: "OldB",
+                                type: .library(.automatic),
+                                targets: ["OldB"],
+                                deprecation: ProductDeprecation(
+                                    message: "OldB is gone.",
+                                    replacement: .renamed("NewB"),
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "OldA"),
+                            TargetDescription(name: "OldB"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+            )
+
+            // Each product is consumed by exactly one target, so we expect one
+            // diagnostic per product with the severity determined by that target's
+            // own escalation setting.
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.checkUnordered(
+                    diagnostic: "product 'OldA' from package 'producer' is unsupported: OldA is gone. Use 'NewA' instead.",
+                    severity: .error,
+                )
+                result.checkUnordered(
+                    diagnostic: "product 'OldB' from package 'producer' is unsupported: OldB is gone. Use 'NewB' instead.",
+                    severity: .warning,
+                )
+            }
+        }
+
+        /// When both per-target `treatAllWarnings(.error)` and the global
+        /// `treatWarningsAsErrors: true` are set, the diagnostic is still an error
+        /// (idempotence).
+        @Test
+        func deprecation_bothPerTargetAndGlobalEscalationCombine() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles:
+                    "/Consumer/Sources/Consumer/source.swift",
+                    "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Consumer",
+                        path: "/Consumer",
+                        dependencies: [
+                            .localSourceControl(
+                                path: "/Producer",
+                                requirement: .upToNextMajor(from: "1.0.0"),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(
+                                name: "Consumer",
+                                dependencies: [
+                                    .product(name: "Old", package: "Producer"),
+                                ],
+                                settings: [
+                                    .init(
+                                        tool: .swift,
+                                        kind: .treatAllWarnings(.error),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                    Manifest.createFileSystemManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+                treatWarningsAsErrors: true,
+            )
+
+            try expectDiagnostics(observability.diagnostics) { result in
+                result.check(
+                    diagnostic: "product 'Old' from package 'producer' is unsupported: gone",
+                    severity: .error,
+                )
+            }
+        }
+
+        /// Global escalation via `treatWarningsAsErrors: true` still emits **no**
+        /// diagnostic when no consumer references the deprecated product.
+        @Test
+        func deprecation_globalEscalationWithNoConsumerEmitsNothing() throws {
+            let fs = InMemoryFileSystem(
+                emptyFiles: "/Producer/Sources/Old/source.swift",
+            )
+            let observability = ObservabilitySystem.makeForTesting()
+            _ = try loadModulesGraph(
+                fileSystem: fs,
+                manifests: [
+                    Manifest.createRootManifest(
+                        displayName: "Producer",
+                        path: "/Producer",
+                        products: [
+                            try ProductDescription(
+                                name: "Old",
+                                type: .library(.automatic),
+                                targets: ["Old"],
+                                deprecation: ProductDeprecation(
+                                    message: "gone",
+                                    replacement: nil,
+                                ),
+                            ),
+                        ],
+                        targets: [
+                            TargetDescription(name: "Old"),
+                        ],
+                    ),
+                ],
+                observabilityScope: observability.topScope,
+                treatWarningsAsErrors: true,
+            )
+            expectNoDiagnostics(observability.diagnostics)
+        }
+    }
+}
+

--- a/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PD_Next_LoadingTests.swift
@@ -39,4 +39,213 @@ final class PackageDescriptionNextLoadingTests: PackageDescriptionLoadingTests {
             }
         }
     }
+
+    // MARK: - Product deprecation (SE-NNNN)
+
+    func testProductDeprecationOnLibraryWithSamePackageReplacement() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(
+                        name: "Old",
+                        targets: ["Old"],
+                        deprecated: .unsupported(
+                            message: "Use New instead.",
+                            replacement: .renamed("New")
+                        )
+                    ),
+                ],
+                targets: [
+                    .target(name: "Old"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        XCTAssertEqual(product.name, "Old")
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(deprecation.message, "Use New instead.")
+        XCTAssertEqual(deprecation.replacement, .renamed("New"))
+    }
+
+    func testProductDeprecationOnLibraryWithCrossPackageReplacement() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(
+                        name: "Old",
+                        targets: ["Old"],
+                        deprecated: .unsupported(
+                            message: "Migrate to OtherPkg.",
+                            replacement: .renamed("OtherProduct", package: "other-pkg")
+                        )
+                    ),
+                ],
+                targets: [
+                    .target(name: "Old"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(
+            deprecation.replacement,
+            .renamed("OtherProduct", package: "other-pkg")
+        )
+    }
+
+    func testProductDeprecationOnLibraryWithoutReplacement() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(
+                        name: "Old",
+                        targets: ["Old"],
+                        deprecated: .unsupported(
+                            message: "Retired with no replacement."
+                        )
+                    ),
+                ],
+                targets: [
+                    .target(name: "Old"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(deprecation.message, "Retired with no replacement.")
+        XCTAssertNil(deprecation.replacement)
+    }
+
+    func testProductDeprecationOnLibraryWithEmptyUnsupported() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(
+                        name: "Old",
+                        targets: ["Old"],
+                        deprecated: .unsupported()
+                    ),
+                ],
+                targets: [
+                    .target(name: "Old"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertNil(deprecation.message)
+        XCTAssertNil(deprecation.replacement)
+    }
+
+    func testProductDeprecationOnExecutable() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .executable(
+                        name: "old-tool",
+                        targets: ["old-tool"],
+                        deprecated: .unsupported(
+                            message: "Use new-tool instead.",
+                            replacement: .renamed("new-tool", package: "tools")
+                        )
+                    ),
+                ],
+                targets: [
+                    .executableTarget(name: "old-tool"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        XCTAssertEqual(product.type, .executable)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(deprecation.message, "Use new-tool instead.")
+        XCTAssertEqual(
+            deprecation.replacement,
+            .renamed("new-tool", package: "tools")
+        )
+    }
+
+    func testProductDeprecationOnPlugin() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .plugin(
+                        name: "OldPlugin",
+                        targets: ["OldPlugin"],
+                        deprecated: .unsupported(
+                            message: "Use NewPlugin instead.",
+                            replacement: .renamed("NewPlugin")
+                        )
+                    ),
+                ],
+                targets: [
+                    .plugin(
+                        name: "OldPlugin",
+                        capability: .command(intent: .custom(verb: "old", description: "old plugin"))
+                    ),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        XCTAssertEqual(product.type, .plugin)
+        let deprecation = try XCTUnwrap(product.deprecation)
+        XCTAssertEqual(deprecation.replacement, .renamed("NewPlugin"))
+    }
+
+    func testProductWithoutDeprecatedParameterHasNilDeprecation() async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Test",
+                products: [
+                    .library(name: "Foo", targets: ["Foo"]),
+                ],
+                targets: [
+                    .target(name: "Foo"),
+                ]
+            )
+            """
+        let observability = ObservabilitySystem.makeForTesting()
+        let (manifest, _) = try await loadAndValidateManifest(content, observabilityScope: observability.topScope)
+        XCTAssertNoDiagnostics(observability.diagnostics)
+
+        let product = try XCTUnwrap(manifest.products.first)
+        XCTAssertNil(product.deprecation)
+    }
 }

--- a/Tests/PackageLoadingTests/PackageDescription_LoadingTests.swift
+++ b/Tests/PackageLoadingTests/PackageDescription_LoadingTests.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025-2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basics
+import PackageLoading
+import PackageModel
+import SourceControl
+import _InternalTestSupport
+import Testing
+
+@Suite(
+    .tags(
+        .TestSize.medium
+    )
+)
+struct PackageDescriptionLoadingTestsST {
+
+    @Test(
+        arguments: [
+            ToolsVersion.minimumRequired,
+            ToolsVersion.v6_2,
+            ToolsVersion.v6_3,
+            ToolsVersion.v6_4,
+        ]
+    )
+    func productDeprecatedParameterUnavailableAtV6_2(
+        toolVersion: ToolsVersion,
+    ) async throws {
+        let content = """
+            import PackageDescription
+            let package = Package(
+                name: "Foo",
+                products: [
+                    .library(
+                        name: "Foo",
+                        targets: ["Foo"],
+                        deprecated: .unsupported(message: "not yet available")
+                    ),
+                ],
+                targets: [
+                    .target(name: "Foo"),
+                ]
+            )
+            """
+
+        let observability = ObservabilitySystem.makeForTesting()
+        await #expect(throws: (any Error).self) {
+            try await PackageDescriptionLoadingTests.loadAndValidateManifest(
+                content,
+                toolsVersion: toolVersion,
+                packageKind: .fileSystem(.root),
+                manifestLoader: ManifestLoader(
+                    toolchain: try! UserToolchain.default,
+                ),
+                observabilityScope: observability.topScope,
+            )
+        }
+    }
+}
+
+private var isWindows: Bool {
+#if os(Windows)
+    true
+#else
+    false
+#endif
+}

--- a/Tests/PackageLoadingTests/ProductDeprecationSerializationTests.swift
+++ b/Tests/PackageLoadingTests/ProductDeprecationSerializationTests.swift
@@ -1,0 +1,317 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import PackageModel
+import Testing
+
+@testable import PackageLoading
+
+@Suite(
+    .tags(
+        .TestSize.small,
+        .FunctionalArea.Manifest,
+        .Feature.Deprecation,
+    ),
+)
+struct ProductDeprecationSerializationTests {
+
+    // MARK: - Serialization.Product.Deprecation.Replacement wire format
+
+    @Test
+    func replacementSamePackageEncodesToWireFormat() throws {
+        let replacement: Serialization.Product.Deprecation.Replacement = .renamed("NewName")
+        let encoded = try JSONEncoder().encode(replacement)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["kind"] as? String == "renamed")
+        #expect(json["product"] as? String == "NewName")
+        #expect(json["package"] == nil)
+    }
+
+    @Test
+    func replacementCrossPackageEncodesToWireFormat() throws {
+        let replacement: Serialization.Product.Deprecation.Replacement = .renamed(
+            "prod",
+            package: "pkg",
+        )
+        let encoded = try JSONEncoder().encode(replacement)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["kind"] as? String == "renamed")
+        #expect(json["product"] as? String == "prod")
+        #expect(json["package"] as? String == "pkg")
+    }
+
+    @Test
+    func replacementSamePackageDecodesFromWireFormat() throws {
+        let json = #"{"kind":"renamed","product":"NewName"}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.Replacement.self,
+            from: data,
+        )
+        guard case .renamed(let product, let package) = decoded else {
+            Issue.record("expected .renamed case, got \(decoded)")
+            return
+        }
+        #expect(product == "NewName")
+        #expect(package == nil)
+    }
+
+    @Test
+    func replacementCrossPackageDecodesFromWireFormat() throws {
+        let json = #"{"kind":"renamed","product":"prod","package":"pkg"}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.Replacement.self,
+            from: data,
+        )
+        guard case .renamed(let product, let package) = decoded else {
+            Issue.record("expected .renamed case, got \(decoded)")
+            return
+        }
+        #expect(product == "prod")
+        #expect(package == "pkg")
+    }
+
+    @Test
+    func replacementSamePackageRoundTrips() throws {
+        let original: Serialization.Product.Deprecation.Replacement = .renamed("Foo")
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.Replacement.self,
+            from: encoded,
+        )
+        guard case .renamed(let product, let package) = decoded else {
+            Issue.record("expected .renamed case, got \(decoded)")
+            return
+        }
+        #expect(product == "Foo")
+        #expect(package == nil)
+    }
+
+    @Test
+    func replacementCrossPackageRoundTrips() throws {
+        let original: Serialization.Product.Deprecation.Replacement = .renamed(
+            "q",
+            package: "p",
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.Replacement.self,
+            from: encoded,
+        )
+        guard case .renamed(let product, let package) = decoded else {
+            Issue.record("expected .renamed case, got \(decoded)")
+            return
+        }
+        #expect(product == "q")
+        #expect(package == "p")
+    }
+
+    // MARK: - Serialization.Product.Deprecation Codable
+
+    @Test
+    func deprecationWithMessageAndReplacementRoundTrips() throws {
+        let original = Serialization.Product.Deprecation(
+            message: "Use New instead.",
+            replacement: .renamed("New"),
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.self,
+            from: encoded,
+        )
+        #expect(decoded.message == "Use New instead.")
+        let replacement = try #require(decoded.replacement)
+        guard case .renamed(let product, let package) = replacement else {
+            Issue.record("expected .renamed replacement, got \(replacement)")
+            return
+        }
+        #expect(product == "New")
+        #expect(package == nil)
+    }
+
+    @Test
+    func deprecationWithMessageOnlyRoundTrips() throws {
+        let original = Serialization.Product.Deprecation(
+            message: "Retired.",
+            replacement: nil,
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.self,
+            from: encoded,
+        )
+        #expect(decoded.message == "Retired.")
+        #expect(decoded.replacement == nil)
+    }
+
+    @Test
+    func deprecationEmptyRoundTrips() throws {
+        let original = Serialization.Product.Deprecation(
+            message: nil,
+            replacement: nil,
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(
+            Serialization.Product.Deprecation.self,
+            from: encoded,
+        )
+        #expect(decoded.message == nil)
+        #expect(decoded.replacement == nil)
+    }
+
+    // MARK: - Wire → model conversion (Serialization.Product → ProductDescription)
+
+    @Test
+    func wireProductWithoutDeprecationConvertsToModelWithNilDeprecation() throws {
+        let wire = makeWireProduct(
+            name: "Foo",
+            productType: .library(type: .automatic),
+            deprecation: nil,
+        )
+        let model = try ProductDescription(wire)
+        #expect(model.name == "Foo")
+        #expect(model.deprecation == nil)
+    }
+
+    @Test
+    func wireProductWithSamePackageReplacementConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "OldLib",
+            productType: .library(type: .automatic),
+            deprecation: .init(
+                message: "Use NewLib instead.",
+                replacement: .renamed("NewLib"),
+            ),
+        )
+        let model = try ProductDescription(wire)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == "Use NewLib instead.")
+        #expect(deprecation.replacement == .renamed("NewLib"))
+    }
+
+    @Test
+    func wireProductWithCrossPackageReplacementConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "old-tool",
+            productType: .executable,
+            deprecation: .init(
+                message: "Migrate to new-tool.",
+                replacement: .renamed("new-tool", package: "tools"),
+            ),
+        )
+        let model = try ProductDescription(wire)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == "Migrate to new-tool.")
+        #expect(deprecation.replacement == .renamed("new-tool", package: "tools"))
+    }
+
+    @Test
+    func wireProductWithNoReplacementConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "Retired",
+            productType: .library(type: .automatic),
+            deprecation: .init(
+                message: "Gone.",
+                replacement: nil,
+            ),
+        )
+        let model = try ProductDescription(wire)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == "Gone.")
+        #expect(deprecation.replacement == nil)
+    }
+
+    @Test
+    func wireProductWithEmptyDeprecationConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "Foo",
+            productType: .library(type: .automatic),
+            deprecation: .init(
+                message: nil,
+                replacement: nil,
+            ),
+        )
+        let model = try ProductDescription(wire)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == nil)
+        #expect(deprecation.replacement == nil)
+    }
+
+    @Test
+    func wirePluginProductWithDeprecationConvertsToModel() throws {
+        let wire = makeWireProduct(
+            name: "OldPlugin",
+            productType: .plugin,
+            deprecation: .init(
+                message: nil,
+                replacement: .renamed("NewPlugin"),
+            ),
+        )
+        let model = try ProductDescription(wire)
+        #expect(model.type == .plugin)
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == nil)
+        #expect(deprecation.replacement == .renamed("NewPlugin"))
+    }
+
+    // MARK: - End-to-end wire → JSON → wire → model
+
+    @Test
+    func fullPipelineEndToEnd() throws {
+        let originalWire = makeWireProduct(
+            name: "OldLib",
+            productType: .library(type: .automatic),
+            deprecation: .init(
+                message: "Use NewLib instead.",
+                replacement: .renamed("NewLib"),
+            ),
+        )
+
+        let jsonData = try JSONEncoder().encode(originalWire)
+        let decodedWire = try JSONDecoder().decode(Serialization.Product.self, from: jsonData)
+        let model = try ProductDescription(decodedWire)
+
+        #expect(model.name == "OldLib")
+        let deprecation = try #require(model.deprecation)
+        #expect(deprecation.message == "Use NewLib instead.")
+        #expect(deprecation.replacement == .renamed("NewLib"))
+    }
+
+    // MARK: - Helpers
+
+    /// Constructs a `Serialization.Product` value across both `ENABLE_APPLE_PRODUCT_TYPES`
+    /// build configurations so tests compile whether or not the flag is defined.
+    private func makeWireProduct(
+        name: String,
+        productType: Serialization.Product.ProductType,
+        deprecation: Serialization.Product.Deprecation?,
+    ) -> Serialization.Product {
+        #if ENABLE_APPLE_PRODUCT_TYPES
+        return Serialization.Product(
+            name: name,
+            targets: [name],
+            productType: productType,
+            deprecation: deprecation,
+            settings: [],
+        )
+        #else
+        return Serialization.Product(
+            name: name,
+            targets: [name],
+            productType: productType,
+            deprecation: deprecation,
+        )
+        #endif
+    }
+}

--- a/Tests/PackageModelTests/ManifestTests.swift
+++ b/Tests/PackageModelTests/ManifestTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import _InternalTestSupport
+import Foundation
 import PackageModel
 import XCTest
 
@@ -1272,5 +1273,93 @@ class ManifestTests: XCTestCase {
                 XCTAssertEqual(dependency.name, "Boo")
             }
         }
+    }
+
+    func testManifestEncodingIncludesProductDeprecation() throws {
+        let products = try [
+            ProductDescription(
+                name: "PaperLegacy",
+                type: .library(.automatic),
+                targets: ["PaperLegacy"],
+                deprecation: ProductDeprecation(
+                    message: "PaperLegacy is superseded by Paper.",
+                    replacement: .renamed("Paper"),
+                ),
+            ),
+            ProductDescription(
+                name: "paper-tool-old",
+                type: .executable,
+                targets: ["paper-tool-old"],
+                deprecation: ProductDeprecation(
+                    message: "Migrate to the standalone paper-tools package.",
+                    replacement: .renamed("paper-tool", package: "paper-tools"),
+                ),
+            ),
+            ProductDescription(
+                name: "PaperExperimental",
+                type: .library(.automatic),
+                targets: ["PaperExperimental"],
+                deprecation: ProductDeprecation(
+                    message: "PaperExperimental is going away with no replacement.",
+                    replacement: nil,
+                ),
+            ),
+            ProductDescription(
+                name: "Paper",
+                type: .library(.automatic),
+                targets: ["Paper"],
+            ),
+        ]
+        let targets = try [
+            TargetDescription(name: "Paper"),
+            TargetDescription(name: "PaperLegacy"),
+            TargetDescription(name: "PaperExperimental"),
+            TargetDescription(name: "paper-tool-old"),
+        ]
+        let manifest = Manifest.createRootManifest(
+            displayName: "Paper",
+            path: "/Paper",
+            products: products,
+            targets: targets,
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(manifest)
+        let root = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any],
+        )
+        let productsJSON = try XCTUnwrap(root["products"] as? [[String: Any]])
+        XCTAssertEqual(productsJSON.count, 4)
+
+        let byName = Dictionary(uniqueKeysWithValues: productsJSON.map { product -> (String, [String: Any]) in
+            let name = product["name"] as? String ?? ""
+            return (name, product)
+        })
+
+        let renamedProduct = try XCTUnwrap(byName["PaperLegacy"])
+        let renamedDeprecation = try XCTUnwrap(renamedProduct["deprecation"] as? [String: Any])
+        XCTAssertEqual(renamedDeprecation["message"] as? String, "PaperLegacy is superseded by Paper.")
+        let renamedReplacement = try XCTUnwrap(renamedDeprecation["replacement"] as? [String: Any])
+        XCTAssertEqual(renamedReplacement["kind"] as? String, "renamed")
+        XCTAssertEqual(renamedReplacement["product"] as? String, "Paper")
+        XCTAssertNil(renamedReplacement["package"])
+
+        let crossPackageProduct = try XCTUnwrap(byName["paper-tool-old"])
+        let crossPackageDeprecation = try XCTUnwrap(crossPackageProduct["deprecation"] as? [String: Any])
+        let crossPackageReplacement = try XCTUnwrap(crossPackageDeprecation["replacement"] as? [String: Any])
+        XCTAssertEqual(crossPackageReplacement["kind"] as? String, "renamed")
+        XCTAssertEqual(crossPackageReplacement["package"] as? String, "paper-tools")
+        XCTAssertEqual(crossPackageReplacement["product"] as? String, "paper-tool")
+
+        let noReplacementProduct = try XCTUnwrap(byName["PaperExperimental"])
+        let noReplacementDeprecation = try XCTUnwrap(noReplacementProduct["deprecation"] as? [String: Any])
+        XCTAssertEqual(
+            noReplacementDeprecation["message"] as? String,
+            "PaperExperimental is going away with no replacement.",
+        )
+        XCTAssertNil(noReplacementDeprecation["replacement"])
+
+        let controlProduct = try XCTUnwrap(byName["Paper"])
+        XCTAssertNil(controlProduct["deprecation"])
     }
 }

--- a/Tests/PackageModelTests/ProductDeprecationTests.swift
+++ b/Tests/PackageModelTests/ProductDeprecationTests.swift
@@ -1,0 +1,215 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import PackageModel
+import Testing
+
+@Suite(
+    .tags(
+        .TestSize.small,
+        .FunctionalArea.Manifest,
+        .Feature.Deprecation,
+    ),
+)
+struct ProductDeprecationTests {
+
+    // MARK: - ProductDescription.deprecation storage
+
+    @Test
+    func productDescriptionWithoutDeprecation() throws {
+        let product = try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"])
+        #expect(product.deprecation == nil)
+    }
+
+    @Test
+    func productDescriptionWithDeprecationRenamed() throws {
+        let deprecation = ProductDeprecation(
+            message: "Use Bar instead.",
+            replacement: .renamed("Bar")
+        )
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let productDeprecation = try #require(product.deprecation)
+        #expect(productDeprecation.message == "Use Bar instead.")
+        #expect(productDeprecation.replacement == .renamed("Bar"))
+    }
+
+    @Test
+    func productDescriptionWithDeprecationInOtherPackage() throws {
+        let deprecation = ProductDeprecation(
+            message: "Migrate to other-package.",
+            replacement: .renamed("OtherProduct", package: "other-package")
+        )
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let productDeprecation = try #require(product.deprecation)
+        #expect(productDeprecation.replacement == .renamed("OtherProduct", package: "other-package"))
+    }
+
+    @Test
+    func productDescriptionWithDeprecationNoMessageNoReplacement() throws {
+        let deprecation = ProductDeprecation(message: nil, replacement: nil)
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let productDeprecation = try #require(product.deprecation)
+        #expect(productDeprecation.message == nil)
+        #expect(productDeprecation.replacement == nil)
+    }
+
+    // MARK: - ProductDescription Codable round-trip
+
+    @Test
+    func productDescriptionRoundTripNoDeprecation() throws {
+        let product = try ProductDescription(name: "Foo", type: .library(.automatic), targets: ["Foo"])
+        let encoded = try JSONEncoder().encode(product)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: encoded)
+        #expect(decoded.name == product.name)
+        #expect(decoded.deprecation == nil)
+    }
+
+    @Test
+    func productDescriptionRoundTripRenamedReplacement() throws {
+        let deprecation = ProductDeprecation(
+            message: "Use Bar instead.",
+            replacement: .renamed("Bar")
+        )
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let encoded = try JSONEncoder().encode(product)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: encoded)
+
+        let decodedDeprecation = try #require(decoded.deprecation)
+        #expect(decodedDeprecation.message == "Use Bar instead.")
+        #expect(decodedDeprecation.replacement == .renamed("Bar"))
+    }
+
+    @Test
+    func productDescriptionRoundTripCrossPackageReplacement() throws {
+        let deprecation = ProductDeprecation(
+            message: "Move to other package.",
+            replacement: .renamed("prod", package: "pkg")
+        )
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .executable,
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let encoded = try JSONEncoder().encode(product)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: encoded)
+        let decodedDeprecation = try #require(decoded.deprecation)
+        #expect(decodedDeprecation.replacement == .renamed("prod", package: "pkg"))
+    }
+
+    @Test
+    func productDescriptionRoundTripNoMessageNoReplacement() throws {
+        let deprecation = ProductDeprecation(message: nil, replacement: nil)
+        let product = try ProductDescription(
+            name: "Foo",
+            type: .library(.automatic),
+            targets: ["Foo"],
+            deprecation: deprecation,
+        )
+        let encoded = try JSONEncoder().encode(product)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: encoded)
+        let decodedDeprecation = try #require(decoded.deprecation)
+        #expect(decodedDeprecation.message == nil)
+        #expect(decodedDeprecation.replacement == nil)
+    }
+
+    // MARK: - Legacy JSON without deprecation field
+
+    @Test
+    func legacyJSONWithoutDeprecationFieldDecodes() throws {
+        let legacyJSON = #"{"name":"Foo","targets":["Foo"],"type":{"library":["automatic"]},"settings":[]}"#
+        let data = Data(legacyJSON.utf8)
+        let decoded = try JSONDecoder().decode(ProductDescription.self, from: data)
+        #expect(decoded.name == "Foo")
+        #expect(decoded.deprecation == nil)
+    }
+
+    // MARK: - Replacement discriminated Codable wire format
+
+    @Test
+    func replacementSamePackageEncodesAsKindAndProduct() throws {
+        let replacement: ProductDeprecation.Replacement = .renamed("NewName")
+        let encoded = try JSONEncoder().encode(replacement)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["kind"] as? String == "renamed")
+        #expect(json["product"] as? String == "NewName")
+        #expect(json["package"] == nil)
+    }
+
+    @Test
+    func replacementCrossPackageEncodesAsKindProductAndPackage() throws {
+        let replacement: ProductDeprecation.Replacement = .renamed("prod", package: "pkg")
+        let encoded = try JSONEncoder().encode(replacement)
+        let json = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(json["kind"] as? String == "renamed")
+        #expect(json["product"] as? String == "prod")
+        #expect(json["package"] as? String == "pkg")
+    }
+
+    @Test
+    func replacementDecodesSamePackageWireFormat() throws {
+        let json = #"{"kind":"renamed","product":"NewName"}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(ProductDeprecation.Replacement.self, from: data)
+        #expect(decoded == .renamed("NewName"))
+    }
+
+    @Test
+    func replacementDecodesCrossPackageWireFormat() throws {
+        let json = #"{"kind":"renamed","product":"prod","package":"pkg"}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(ProductDeprecation.Replacement.self, from: data)
+        #expect(decoded == .renamed("prod", package: "pkg"))
+    }
+
+    // MARK: - Hashable and Equatable
+
+    @Test
+    func productDeprecationEquality() {
+        let a = ProductDeprecation(message: "m", replacement: .renamed("N"))
+        let b = ProductDeprecation(message: "m", replacement: .renamed("N"))
+        let c = ProductDeprecation(message: "m", replacement: .renamed("Other"))
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test
+    func productDeprecationHashable() {
+        let a = ProductDeprecation(message: "m", replacement: .renamed("N"))
+        let b = ProductDeprecation(message: "m", replacement: .renamed("N"))
+        var set = Set<ProductDeprecation>()
+        set.insert(a)
+        set.insert(b)
+        #expect(set.count == 1)
+    }
+}


### PR DESCRIPTION
- [Swift Evolution Proposal](https://github.com/swiftlang/swift-evolution/pull/3401)
- [Pitch thread](https://forums.swift.org/t/pitch-deprecating-package-products-in-the-package-manifest/88468)

Add a `deprecated:` parameter to the `.library(...)`, `.executable(...)`, and `.plugin(...)` factory methods on `Product`. The parameter accepts a `Product.Deprecation` value describing the deprecation.

`Product.Deprecation` is constructed through a single factory, `.unsupported(message:replacement:)`, where the optional `replacement:` parameter points at the product a consumer should adopt instead. A replacement is either in the same package or in another package.

When any consumer package (or another product within the same package) depends on an unsupported product, SwiftPM emits a warning that includes the product name, the producing package's identity, the author-supplied message, and any replacement information declared by the producer.  At a minimum, this has been plumbed through to `swift package resolve`, `swift build` and `swift package dump-package`.