### PR TITLE
CMake: Drop old policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,6 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-if(POLICY CMP0091)
-  cmake_policy(SET CMP0091 NEW)
-endif()
-
 cmake_minimum_required(VERSION 3.24)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)


### PR DESCRIPTION
There is no need to set CMP0091 to NEW.

### Motivation:

This is a cleanup. CMP0091 was introduced in 3.15. It is already enabled by setting `cmake_minimum_required()` to 3.24.

### Modifications:

* Drop the redundant explicit CMP0091 setting.

### Result:

No-op.