### PR TITLE
CMake: Stop setting Swift_MODULE_DIRECTORY

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -58,19 +58,16 @@ if(SwiftPM_ENABLE_RUNTIME)
   # This is unnecessary with the split runtime build, but is left here to
   # minimize disruption.
   set_target_properties(CompilerPluginSupport PROPERTIES
-    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI)
   set_target_properties(PackageDescription PROPERTIES
-    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/ManifestAPI)
   set_target_properties(PackagePlugin PROPERTIES
-    Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
     OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/pm/PluginAPI


### PR DESCRIPTION
Setting the `Swift_MODULE_DIRECTORY` property was causing phantom edges to appear in the build graph.

### Motivation:

Swift_MODULE_DIRECTORY had no effect on where the swiftmodule files actually land: these targets pass -emit-module-path explicitly in EmitSwiftInterface.cmake, which takes precedence, and the binaries are placed by the ARCHIVE/LIBRARY/RUNTIME output directory properties. Removing it therefore cannot change the built layout.

Setting the property did cause CMake to declare the build output at the path the property named, and nothing was written there. This caused ninja to have a missing output on every run, needlessly re-building these targets every time.

### Modifications:

* Remove the `Swift_MODULE_DIRECTORY` property.

### Result:

This should be a no-op for the build. Local developers should benefit from no-op incremental builds.