### PR TITLE
GHA: Rename `required` job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -98,8 +98,8 @@ jobs:
       enable_android_sdk_build: true
       android_sdk_build_command: "swift test  --parallel --experimental-xunit-message-failure --xunit-output android-xunit.xml --filter AndroidSDKIntegrationTests #"
 
-  required:
-    name: Required
+  build-verdict:
+    name: Build Verdict
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
The job `Required` is not actually marked required and does not provide meaningful description on what the job does.  Update the job "ID" and name to "Build Verdict".