### PR TITLE
PackageModel: Resolve toolchain directory from path layout, not host OS

### DIFF
--- a/Sources/PackageModel/Toolchain.swift
+++ b/Sources/PackageModel/Toolchain.swift
@@ -112,22 +112,24 @@ extension Toolchain {
     public var toolchainDir: AbsolutePath {
         get throws {
             let compilerPath = try resolveSymlinks(swiftCompilerPath)
-            let os = ProcessInfo.hostOperatingSystem
-            switch os {
-            case .windows, .macOS, .linux, .android:
-                return compilerPath
-                    .parentDirectory // bin
-                    .parentDirectory // usr
-                    .parentDirectory // <toolchain>
-            case .freebsd, .openbsd:
-                return compilerPath
-                    .parentDirectory // bin
-                    .parentDirectory // local
-                    .parentDirectory // usr
-                    .parentDirectory // <toolchain>
-            case .unknown:
-                throw UnknownToolchainLayout(os: os)
+            let realSwiftPath = compilerPath.parentDirectory
+
+            let hasUsrBin = realSwiftPath.components.contains(["usr", "bin"])
+            let hasUsrLocalBin = realSwiftPath.components.contains(["usr", "local", "bin"])
+
+            let path: AbsolutePath
+            switch (hasUsrBin, hasUsrLocalBin) {
+            case (true, false):
+                path = realSwiftPath.parentDirectory.parentDirectory
+            case (false, true):
+                path = realSwiftPath.parentDirectory.parentDirectory.parentDirectory
+            case (false, false):
+                throw UnknownToolchainLayout(path: realSwiftPath)
+            case (true, true):
+                preconditionFailure()
             }
+
+            return path
         }
     }
 
@@ -164,8 +166,8 @@ extension Toolchain {
 }
 
 struct UnknownToolchainLayout: Error, CustomStringConvertible {
-    let os: OperatingSystem
+    let path: AbsolutePath
     var description: String {
-        "Unknown toolchain layout for host operating system: \(os)"
+        "Unexpected toolchain layout for Swift installation path: \(path)"
     }
 }


### PR DESCRIPTION
Replace the `ProcessInfo.hostOperatingSystem` switch in `toolchainDir` with an inspection of the resolved compiler path. The layout is now determined by whether the parent contains `usr/bin` (walk up two parents) or `usr/local/bin` (walk up three), which naturally covers Linux/macOS/Windows/Android as well as FreeBSD/OpenBSD without enumerating each OS.

Also update `UnknownToolchainLayout` to carry the offending path instead of the host OS, since the error is now about an unrecognized directory structure rather than an unsupported platform.

Issue: rdar://182101601