### PR TITLE
Fix explicit access of generated resource imports

### DIFF
--- a/Fixtures/Resources/ExplicitImportAccess/Package.swift
+++ b/Fixtures/Resources/ExplicitImportAccess/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "ExplicitImportAccess",
+    targets: [
+        .executableTarget(
+            name: "ExplicitImportAccess",
+            resources: [
+                .copy("resource.txt"),
+            ]
+        ),
+    ]
+)

--- a/Fixtures/Resources/ExplicitImportAccess/Sources/ExplicitImportAccess/main.swift
+++ b/Fixtures/Resources/ExplicitImportAccess/Sources/ExplicitImportAccess/main.swift
@@ -1,0 +1,3 @@
+internal import Foundation
+
+print(Bundle.module.bundlePath)

--- a/Fixtures/Resources/ExplicitImportAccess/Sources/ExplicitImportAccess/resource.txt
+++ b/Fixtures/Resources/ExplicitImportAccess/Sources/ExplicitImportAccess/resource.txt
@@ -1,0 +1,1 @@
+resource

--- a/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
+++ b/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift
@@ -422,7 +422,7 @@ public final class SwiftModuleBuildDescription {
 
         let content =
             """
-            import Foundation
+            internal import Foundation
 
             extension Foundation.Bundle {
                 static nonisolated let module: Bundle = {

--- a/Tests/BuildTests/BuildPlanTests.swift
+++ b/Tests/BuildTests/BuildPlanTests.swift
@@ -6204,6 +6204,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
 
         let resourceAccessor = fooTarget.sources.first { $0.basename == "resource_bundle_accessor.swift" }!
         let contents: String = try fs.readFileContents(resourceAccessor)
+        XCTAssertMatch(contents, .contains("internal import Foundation"))
         XCTAssertMatch(contents, .contains("extension Foundation.Bundle"))
         // Assert that `Bundle.main` is executed in the compiled binary (and not during compilation)
         // See https://bugs.swift.org/browse/SR-14555 and
@@ -6275,6 +6276,7 @@ class BuildPlanTestCase: BuildSystemProviderTestCase {
 
         let resourceAccessor = fooTarget.sources.first { $0.basename == "resource_bundle_accessor.swift" }!
         let contents: String = try fs.readFileContents(resourceAccessor)
+        XCTAssertMatch(contents, .contains("internal import Foundation"))
         XCTAssertMatch(contents, .contains("extension Foundation.Bundle"))
         // Assert that `Bundle.main` is executed in the compiled binary (and not during compilation)
         // See https://bugs.swift.org/browse/SR-14555 and

--- a/Tests/FunctionalTests/ResourcesTests.swift
+++ b/Tests/FunctionalTests/ResourcesTests.swift
@@ -228,6 +228,25 @@ struct ResourcesTests{
 
     @Test(
         .tags(
+            .Feature.Command.Build,
+        ),
+        arguments: SupportedBuildSystemOnAllPlatforms,
+    )
+    func resourceAccessorWithExplicitImportAccess(
+        buildSystem: BuildSystemProvider.Kind,
+    ) async throws {
+        try await fixture(name: "Resources/ExplicitImportAccess") { fixturePath in
+            try await executeSwiftBuild(
+                fixturePath,
+                configuration: .debug,
+                Xswiftc: ["-warnings-as-errors"],
+                buildSystem: buildSystem,
+            )
+        }
+    }
+
+    @Test(
+        .tags(
             .Feature.Command.Test,
         ),
         arguments: SupportedBuildSystemOnAllPlatforms,


### PR DESCRIPTION
## Summary

- generate the native resource bundle accessor with `internal import Foundation`
- add focused assertions for native and WASI accessors
- add an end-to-end fixture covering explicit Foundation import access with both build systems

Fixes #10163.

The SwiftBuild side is swiftlang/swift-build#1649.

## Testing

- `BuildPlanNativeTests.testSwiftBundleAccessor`
- `BuildPlanNativeTests.testSwiftWASIBundleAccessor`
- `resourceAccessorWithExplicitImportAccess` using both `.native` and `.swiftbuild`
- reproduced the failure before the change and verified both generated executables afterward with `-warnings-as-errors`