### PR TITLE
Ignore a non-matching SDKROOT when deriving the host Swift SDK

### DIFF
--- a/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
+++ b/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift
@@ -578,7 +578,16 @@ public struct SwiftSDK: Equatable {
         #if os(macOS)
         let darwinPlatform = darwinPlatformOverride ?? .macOS
         // Get the SDK.
-        if let value = environment["SDKROOT"] {
+        //
+        // Honor an ambient `SDKROOT` only when it targets the requested platform (or
+        // when its platform can't be determined, preserving legacy behavior). During an
+        // Xcode/`xcodebuild` build for a non-macOS destination, `SDKROOT` points at the
+        // destination SDK (e.g. iPhoneSimulator); trusting it for the macOS host SDK
+        // yields an inconsistent toolchain — a macOS `-target` paired with an iOS
+        // `-sdk` — that fails manifest compilation with "unable to load standard
+        // library" (rdar://176892456).
+        if let value = environment["SDKROOT"],
+           Self.sdkRootMatches(value, platform: darwinPlatform, fileSystem: fileSystem) ?? true {
             sdkPath = try AbsolutePath(validating: value)
         } else if let value = environment[EnvironmentKey("SWIFTPM_SDKROOT_\(darwinPlatform.xcrunName)")] {
             sdkPath = try AbsolutePath(validating: value)
@@ -632,6 +641,36 @@ public struct SwiftSDK: Equatable {
             xctestSupport: xctestSupport
         )
     }
+
+    #if os(macOS)
+    /// Determines whether the SDK rooted at `sdkRoot` targets `platform`.
+    ///
+    /// The platform is read from the `CanonicalName` in the SDK's `SDKSettings.json`
+    /// (e.g. `macosx26.5`, `iphonesimulator26.5`), each of which is prefixed by the
+    /// platform's `xcrun` name (`macosx`, `iphonesimulator`, ...).
+    ///
+    /// - Returns: `true`/`false` when the SDK's platform is known, or `nil` when it
+    ///   can't be determined (invalid path, or missing/unreadable `SDKSettings.json`),
+    ///   so callers can preserve the legacy behavior of trusting `SDKROOT` for
+    ///   non-standard SDK layouts.
+    private static func sdkRootMatches(
+        _ sdkRoot: String,
+        platform: DarwinPlatform,
+        fileSystem: any FileSystem
+    ) -> Bool? {
+        guard let path = try? Basics.AbsolutePath(validating: sdkRoot) else {
+            return nil
+        }
+        let settingsPath = path.appending("SDKSettings.json")
+        guard fileSystem.exists(settingsPath),
+              let data: Data = try? fileSystem.readFileContents(settingsPath),
+              let settings = try? JSONDecoder().decode(SDKSettings.self, from: data)
+        else {
+            return nil
+        }
+        return settings.CanonicalName.lowercased().hasPrefix(platform.xcrunName)
+    }
+    #endif
 
     /// Auxiliary platform frameworks and libraries.
     ///

--- a/Tests/PackageModelTests/SwiftSDKTests.swift
+++ b/Tests/PackageModelTests/SwiftSDKTests.swift
@@ -796,6 +796,72 @@ final class SwiftSDKTests: XCTestCase {
         #endif
     }
 
+    func testHostSDKIgnoresMismatchedSDKROOT() throws {
+        // rdar://176892456: during an `xcodebuild build` for a non-macOS destination,
+        // Xcode exports the destination SDK via `SDKROOT`. The macOS host SDK (used to
+        // compile SwiftPM manifests) must not adopt that SDK — doing so pairs a macOS
+        // `-target` with an iOS `-sdk` and fails with "unable to load standard library".
+        #if os(macOS)
+        let fs = InMemoryFileSystem()
+
+        // A destination (iOS Simulator) SDK, as exported via SDKROOT during a build.
+        let iOSSimRoot = try AbsolutePath(
+            validating: "/Xcode/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
+        )
+        try fs.createDirectory(iOSSimRoot, recursive: true)
+        try fs.writeFileContents(
+            iOSSimRoot.appending("SDKSettings.json"),
+            string: #"{"CanonicalName": "iphonesimulator26.5"}"#
+        )
+
+        // The correct macOS host SDK.
+        let macOSRoot = try AbsolutePath(validating: "/Xcode/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
+        try fs.createDirectory(macOSRoot, recursive: true)
+        try fs.writeFileContents(
+            macOSRoot.appending("SDKSettings.json"),
+            string: #"{"CanonicalName": "macosx26.5"}"#
+        )
+
+        // A non-macOS SDKROOT (the reported condition) must be ignored: the host SDK
+        // falls back to the macOS SDK instead of stamping in the iOS SDK.
+        let hostSDK = try SwiftSDK.hostSwiftSDK(
+            "/prefix/bin",
+            environment: [
+                "SDKROOT": iOSSimRoot.pathString,
+                "SWIFTPM_SDKROOT_macosx": macOSRoot.pathString,
+                "SWIFTPM_PLATFORM_PATH_macosx": "/Xcode/MacOSX.platform",
+            ],
+            fileSystem: fs
+        )
+        XCTAssertEqual(hostSDK.pathsConfiguration.sdkRootPath, macOSRoot)
+
+        // A macOS SDKROOT is still honored as before.
+        let hostSDKFromMacOSSDKROOT = try SwiftSDK.hostSwiftSDK(
+            "/prefix/bin",
+            environment: [
+                "SDKROOT": macOSRoot.pathString,
+                "SWIFTPM_PLATFORM_PATH_macosx": "/Xcode/MacOSX.platform",
+            ],
+            fileSystem: fs
+        )
+        XCTAssertEqual(hostSDKFromMacOSSDKROOT.pathsConfiguration.sdkRootPath, macOSRoot)
+
+        // An SDKROOT whose platform can't be determined (no SDKSettings.json) is trusted,
+        // preserving legacy behavior for non-standard SDK layouts.
+        let customRoot = try AbsolutePath(validating: "/custom/Some.sdk")
+        try fs.createDirectory(customRoot, recursive: true)
+        let hostSDKFromCustomSDKROOT = try SwiftSDK.hostSwiftSDK(
+            "/prefix/bin",
+            environment: [
+                "SDKROOT": customRoot.pathString,
+                "SWIFTPM_PLATFORM_PATH_macosx": "/Xcode/MacOSX.platform",
+            ],
+            fileSystem: fs
+        )
+        XCTAssertEqual(hostSDKFromCustomSDKROOT.pathsConfiguration.sdkRootPath, customRoot)
+        #endif
+    }
+
     func testSelectSDKWithMultipleMatches() throws {
         let bundles = [
             SwiftSDKBundle(


### PR DESCRIPTION
During an xcodebuild build for a non-macOS destination, SDKROOT points at the destination SDK, so the macOS host SDK adopted it and the manifest compile paired a macOS -target with an iOS -sdk ("unable to load standard library"). Honor SDKROOT only when its SDKSettings.json CanonicalName matches the requested platform; otherwise fall back to xcrun.

rdar://176892456
