### PR TITLE
Fix command plugin tool dependencies missing from build output

### DIFF
--- a/Sources/SwiftBuildSupport/PIFBuilder.swift
+++ b/Sources/SwiftBuildSupport/PIFBuilder.swift
@@ -806,7 +806,21 @@ fileprivate func computeHostOnlyModuleIDsInRootPackages(in modulesGraph: Modules
     // Find the transitive closure covered by host-only targets. These are modules which should be excluded from
     // the top level build request unless they specifically need to build for the destination. Again, we only consider
     // root packages.
-    let modulesInRootPackagesReachableFromHostOnlyModuleIDs = transitiveClosure(Array(hostOnlyModulesInRootPackageIDs), successors: { moduleID in
+    func isHostOnlyPropagatingModule(_ module: ResolvedModule) -> Bool {
+        if let plugin = module.underlying as? PluginModule {
+            return plugin.capability == .buildTool
+        }
+        return module.type == .macro
+    }
+
+    let propagatingHostOnlyModuleIDs = hostOnlyModulesInRootPackageIDs.filter {
+        guard let module = rootPackageModulesByID[$0] else {
+            return false
+        }
+        return isHostOnlyPropagatingModule(module)
+    }
+
+    let modulesInRootPackagesReachableFromHostOnlyModuleIDs = transitiveClosure(Array(propagatingHostOnlyModuleIDs), successors: { moduleID in
         guard let module = rootPackageModulesByID[moduleID] else {
             return []
         }

--- a/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
+++ b/Tests/SwiftBuildSupportTests/PIFBuilderTests.swift
@@ -2377,6 +2377,72 @@ struct PIFBuilderTests {
         }
     }
 
+    @Test func commandPluginToolDependencyIncludedInAggregates() async throws {
+        let observability = ObservabilitySystem.makeForTesting()
+        let fs = InMemoryFileSystem(emptyFiles: [
+            "/Root/Sources/RootLib/RootLib.swift",
+            "/Root/Sources/PluginTool/main.swift",
+            "/Root/Plugins/MyPlugin/plugin.swift",
+            "/Root/Sources/Dep/dep.swift"
+        ])
+
+        let graph = try loadModulesGraph(
+            fileSystem: fs,
+            manifests: [
+                Manifest.createRootManifest(
+                    displayName: "Root",
+                    path: "/Root",
+                    toolsVersion: .v5_9,
+                    targets: [
+                        TargetDescription(name: "RootLib"),
+                        TargetDescription(name: "PluginTool", dependencies: ["Dep"], type: .executable),
+                        TargetDescription(name: "Dep"),
+                        TargetDescription(
+                            name: "MyPlugin",
+                            dependencies: ["PluginTool"],
+                            type: .plugin,
+                            pluginCapability: .command(
+                                intent: .custom(verb: "my-plugin", description: "does something"),
+                                permissions: []
+                            )
+                        ),
+                    ]
+                ),
+            ],
+            observabilityScope: observability.topScope
+        )
+
+        let pifBuilder = PIFBuilder(
+            graph: graph,
+            parameters: try PIFBuilderParameters.constructDefaultParametersForTesting(
+                temporaryDirectory: AbsolutePath.root.appending("tmp"),
+                addLocalRpaths: .always,
+                pluginScriptRunner: NoOpPluginScriptRunner()
+            ),
+            fileSystem: fs,
+            observabilityScope: observability.topScope
+        )
+        let (pif, _) = try await pifBuilder.constructPIF(
+            buildParameters: mockBuildParameters(destination: .host, buildSystemKind: .swiftbuild)
+        )
+
+        let errors = observability.diagnostics.filter { $0.severity == .error }
+        #expect(errors.isEmpty, "Expected no errors during PIF generation, but got: \(errors)")
+
+        let rootProject = try pif.workspace.project(named: "Root")
+        let rootLibID = try rootProject.target(named: "RootLib").common.id.value
+        let toolProductID = try rootProject.target(named: "PluginTool-product").common.id.value
+        let depModuleID = try rootProject.target(named: "Dep").common.id.value
+
+        let aggregate = try pif.workspace.project(named: "Aggregate")
+        for aggregateName in [PIFBuilder.allExcludingTestsTargetName, PIFBuilder.allIncludingTestsTargetName] {
+            let deps = Set(try aggregate.target(named: aggregateName).common.dependencies.map(\.targetId.value))
+            #expect(deps.contains(rootLibID))
+            #expect(deps.contains(toolProductID))
+            #expect(deps.contains(depModuleID))
+        }
+    }
+
     @Test func standaloneTargetIncludedInAggregates() async throws {
         let observability = ObservabilitySystem.makeForTesting()
         let fs = InMemoryFileSystem(emptyFiles: [


### PR DESCRIPTION
Fixes #10442   
Only exclude modules reachable from macros and build-tool plugins from the top-level PIF aggregate; don't propagate exclusion through command plugins.

### Motivation
Executable dependencies of `.command` plugins were incorrectly excluded from the top-level PIF aggregates, reproducing #10442 with `swift-argument-parser`.

### Modifications
This change restricts host-only exclusion propagation to macros and build-tool plugins.
Added a regression test. 

### Result
`PIFBuilderTests` passes 49/49, and `swift-argument-parser` now builds `generate-docc-reference` and `generate-manual`.